### PR TITLE
fix: improve cross-platform compatibility for build commands

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",
-    "beforeDevCommand": "$npm_execpath run dev",
-    "beforeBuildCommand": "$npm_execpath run build"
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## 🎯 목적

PR #4의 멀티 패키지 매니저 지원을 유지하면서 크로스 플랫폼 호환성을 개선합니다.

## 🐛 문제점

PR #4에서 `tauri.conf.json`에 `$npm_execpath`를 사용했는데, 이는 플랫폼별로 다른 문법을 사용합니다:

- **Unix/macOS**: `$npm_execpath` 작동 ✅
- **Windows CMD**: `%npm_execpath%` 필요 ❌
- **Windows PowerShell**: `$env:npm_execpath` 필요 ❌

Tauri는 이 명령어를 쉘에서 직접 실행하므로 플랫폼 의존적입니다.

## ✅ 해결 방법

```diff
# src-tauri/tauri.conf.json
- "beforeDevCommand": "$npm_execpath run dev",
- "beforeBuildCommand": "$npm_execpath run build"
+ "beforeDevCommand": "npm run dev",
+ "beforeBuildCommand": "npm run build"
```

`package.json`은 `$npm_execpath` 유지 (npm이 안전하게 처리)

## 🧠 동작 원리

1. Tauri가 `npm run dev/build` 실행
2. npm이 현재 패키지 매니저 컨텍스트에서 package.json 스크립트 실행
3. package.json의 `$npm_execpath`가 올바른 패키지 매니저로 해석됨

**결과:**
- ✅ npm, yarn, pnpm, bun 모두 지원
- ✅ Windows, macOS, Linux 모두 호환
- ✅ 55개 테스트 모두 통과

## 🔗 관련 PR

- #4 - 원본 멀티 패키지 매니저 지원 PR

## 📝 테스트

```bash
pnpm test:run
# ✓ Test Files  1 passed (1)
# ✓ Tests      55 passed (55)
```

---

**`$npm_execpath` 사용 위치:**
- ✅ `package.json` 스크립트 내부 (npm이 처리)
- ❌ `tauri.conf.json` 명령어 (쉘이 직접 실행)

이 접근방식으로 모든 플랫폼과 패키지 매니저를 지원합니다! 🎉

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Tauri `beforeDevCommand`/`beforeBuildCommand` to `npm run` for cross-platform compatibility.
> 
> - **Build/Config**:
>   - Update `src-tauri/tauri.conf.json` to use `npm run dev` and `npm run build` for `beforeDevCommand` and `beforeBuildCommand`, replacing `$npm_execpath` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8633db6337440f8d3c8a440d288831525c7f18f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 빌드 프로세스 설정 최적화

---

**참고:** 이번 변경사항은 개발 및 빌드 프로세스의 내부 구성 개선으로, 사용자 경험에는 직접적인 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->