### PR TITLE
Set up Tauri build action and version sync

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,4 @@
 set dotenv-load
-set positional-arguments
 set windows-powershell := true
 
 # Put pnpm and mise tools to PATH
@@ -57,6 +56,11 @@ vite-preview:
     vite preview
 
 # Build frontend
+[windows]
+frontend-build: sync-version
+    pnpm exec tsc --build
+    pnpm exec vite build
+[unix]
 frontend-build: sync-version
     pnpm exec tsc --build .
     pnpm exec vite build


### PR DESCRIPTION
…fic recipes

Root cause: The `set positional-arguments` setting was causing the recipe name 'frontend-build' to be passed as an argument to tsc on Windows.

Changes:
- Removed `set positional-arguments` (not needed, {{ARGS}} works without it)
- Created Windows-specific frontend-build using `tsc --build` without path
- Unix version keeps using `tsc --build .` for explicit clarity

The Windows recipe avoids the `.` argument entirely, preventing any shell interpretation issues on PowerShell.

Fixes TS5083 error: Cannot read file 'frontend-build/tsconfig.json'