### PR TITLE
Remove unused elapsed variable warning

### DIFF
--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -48,6 +48,7 @@ pub async fn validate_claude_folder(path: String) -> Result<bool, String> {
 
 #[tauri::command]
 pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, String> {
+    #[cfg(debug_assertions)]
     let start_time = std::time::Instant::now();
     let projects_path = PathBuf::from(&claude_path).join("projects");
 
@@ -110,10 +111,12 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
 
     projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
 
-    let elapsed = start_time.elapsed();
     #[cfg(debug_assertions)]
-    println!("📊 scan_projects 성능: {}개 프로젝트, {}ms 소요", 
-             projects.len(), elapsed.as_millis());
+    {
+        let elapsed = start_time.elapsed();
+        println!("📊 scan_projects 성능: {}개 프로젝트, {}ms 소요",
+                 projects.len(), elapsed.as_millis());
+    }
 
     Ok(projects)
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -11,6 +11,7 @@ pub async fn load_project_sessions(
     project_path: String,
     exclude_sidechain: Option<bool>,
 ) -> Result<Vec<ClaudeSession>, String> {
+    #[cfg(debug_assertions)]
     let start_time = std::time::Instant::now();
     let mut sessions = Vec::new();
 
@@ -272,10 +273,12 @@ pub async fn load_project_sessions(
         }
     }
 
-    let elapsed = start_time.elapsed();
     #[cfg(debug_assertions)]
-    println!("📊 load_project_sessions 성능: {}개 세션, {}ms 소요", 
-             sessions.len(), elapsed.as_millis());
+    {
+        let elapsed = start_time.elapsed();
+        println!("📊 load_project_sessions 성능: {}개 세션, {}ms 소요",
+                 sessions.len(), elapsed.as_millis());
+    }
 
     Ok(sessions)
 }
@@ -392,6 +395,7 @@ pub async fn load_session_messages_paginated(
     limit: usize,
     exclude_sidechain: Option<bool>,
 ) -> Result<MessagePage, String> {
+    #[cfg(debug_assertions)]
     let start_time = std::time::Instant::now();
     use std::io::{BufRead, BufReader};
     use std::fs::File;
@@ -514,9 +518,11 @@ pub async fn load_session_messages_paginated(
     let has_more = start_idx > 0;
     let next_offset = offset + messages.len();
     
-    let elapsed = start_time.elapsed();
     #[cfg(debug_assertions)]
-    eprintln!("📊 load_session_messages_paginated 성능: {}개 메시지, {}ms 소요", messages.len(), elapsed.as_millis());
+    {
+        let elapsed = start_time.elapsed();
+        eprintln!("📊 load_session_messages_paginated 성능: {}개 메시지, {}ms 소요", messages.len(), elapsed.as_millis());
+    }
     #[cfg(debug_assertions)]
     eprintln!("Result: {} messages returned, has_more={}, next_offset={}", messages.len(), has_more, next_offset);
     

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claude Code History Viewer",
-  "version": "1.0.0-beta.4",
+  "version": "0.4.0",
   "identifier": "com.claude.history-viewer",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
- Wrap debug timing code (start_time, elapsed) in #[cfg(debug_assertions)] blocks to prevent unused variable warnings in release builds
- Change version to "0.4.0" for MSI compatibility (0.x indicates beta)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized debug logging to display only in development builds, reducing output clutter in production releases.
  * Updated application configuration version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->