### PR TITLE
Release Claude Code History Viewer 0.4.0

### DIFF
--- a/.github/workflows/updater-release.yml
+++ b/.github/workflows/updater-release.yml
@@ -157,10 +157,10 @@ jobs:
               return { asset, sig };
             };
 
-            // macOS - Apple Silicon (aarch64)
+            // macOS - Apple Silicon (aarch64) - Tauri updater requires .app.tar.gz
             const macAarch64 = findAssetPair(
-              /aarch64.*\.dmg$/,
-              /aarch64.*\.dmg\.sig$/
+              /_aarch64\.app\.tar\.gz$/,
+              /_aarch64\.app\.tar\.gz\.sig$/
             );
             if (macAarch64.asset) {
               let signature = '';
@@ -177,10 +177,10 @@ jobs:
               console.log(`✅ darwin-aarch64: ${macAarch64.asset.name}`);
             }
 
-            // macOS - Intel (x86_64)
+            // macOS - Intel (x86_64) - Tauri updater requires .app.tar.gz
             const macX64 = findAssetPair(
-              /x86_64.*\.dmg$/,
-              /x86_64.*\.dmg\.sig$/
+              /_x64\.app\.tar\.gz$/,
+              /_x64\.app\.tar\.gz\.sig$/
             );
             if (macX64.asset) {
               let signature = '';


### PR DESCRIPTION
Tauri updater requires .app.tar.gz files for macOS updates, not .dmg. Updated the file patterns in generate-updater-metadata job to match the correct artifact names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS release artifact handling to use .app.tar.gz format for both ARM64 and Intel architectures, improving release infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->