### PR TITLE
fix: resolve unaddressed PR review comments from #38, #39, #40

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -836,7 +836,7 @@ pub async fn get_recent_edits(project_path: String) -> Result<crate::models::Rec
                                                         edit.get("old_string").and_then(|v| v.as_str()),
                                                         edit.get("new_string").and_then(|v| v.as_str())
                                                     ) {
-                                                        content = content.replace(old_str, new_str);
+                                                        content = content.replacen(old_str, new_str, 1);
                                                         lines_removed += old_str.lines().count();
                                                         lines_added += new_str.lines().count();
                                                     }
@@ -862,7 +862,7 @@ pub async fn get_recent_edits(project_path: String) -> Result<crate::models::Rec
                                         // Single edit format with oldString/newString
                                         // Only include if we have originalFile (needed for full file reconstruction)
                                         if let Some(original) = tool_use_result.get("originalFile").and_then(|v| v.as_str()) {
-                                            let content = original.replace(old_str, new_str);
+                                            let content = original.replacen(old_str, new_str, 1);
 
                                             all_edits.push(crate::models::RecentFileEdit {
                                                 file_path: file_path_str.to_string(),
@@ -995,12 +995,6 @@ pub async fn restore_file(file_path: String, content: String) -> Result<(), Stri
         if let std::path::Component::ParentDir = component {
             return Err("Invalid file path: path traversal not allowed".to_string());
         }
-    }
-
-    // Additional validation: ensure the path doesn't contain suspicious patterns
-    let path_str = file_path.as_str();
-    if path_str.contains("..") {
-        return Err("Invalid file path: parent directory references not allowed".to_string());
     }
 
     // Create parent directories if they don't exist

--- a/src/components/contentRenderer/ThinkingRenderer.tsx
+++ b/src/components/contentRenderer/ThinkingRenderer.tsx
@@ -13,8 +13,8 @@ export const ThinkingRenderer = ({ thinking }: Props) => {
 
   if (!thinking) return null;
 
-  const firstLine = thinking.split("\n")[0]?.slice(0, 100);
-  const hasMore = firstLine && thinking.length > (firstLine.length || 0);
+  const firstLine = thinking.split("\n")[0]?.slice(0, 100) || "";
+  const hasMore = thinking.length > firstLine.length || thinking.includes("\n");
 
   return (
     <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg mt-2 overflow-hidden">

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -36,6 +36,7 @@
     "updateSettings": "Update Settings"
   },
   "time": {
+    "justNow": "just now",
     "minutesAgo": "{{count}} minute ago",
     "hoursAgo": "{{count}} hour ago",
     "daysAgo": "{{count}} day ago",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -36,6 +36,7 @@
     "updateSettings": "アップデート設定"
   },
   "time": {
+    "justNow": "たった今",
     "minutesAgo": "{{count}}分前",
     "hoursAgo": "{{count}}時間前",
     "daysAgo": "{{count}}日前",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -36,6 +36,7 @@
     "updateSettings": "업데이트 설정"
   },
   "time": {
+    "justNow": "방금 전",
     "minutesAgo": "{{count}}분 전",
     "hoursAgo": "{{count}}시간 전",
     "daysAgo": "{{count}}일 전",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -36,6 +36,7 @@
     "updateSettings": "更新设置"
   },
   "time": {
+    "justNow": "刚刚",
     "minutesAgo": "{{count}}分钟前",
     "hoursAgo": "{{count}}小时前",
     "daysAgo": "{{count}}天前",

--- a/src/i18n/locales/zh-CN/components.json
+++ b/src/i18n/locales/zh-CN/components.json
@@ -625,7 +625,7 @@
     "edited": "已编辑",
     "lines": "行",
     "stats": "{{files}}个文件，{{edits}}次编辑",
-    "footerInfo": "显示每个文件的最新内容。使用「复制内容」恢复已删除的文件。"
+    "footerInfo": "显示每个文件的最新内容。点击「恢复文件」将内容写回磁盘。"
   },
   "updateIntroModal": {
     "title": "更新系统指南",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -36,6 +36,7 @@
     "updateSettings": "更新設定"
   },
   "time": {
+    "justNow": "剛剛",
     "minutesAgo": "{{count}}分鐘前",
     "hoursAgo": "{{count}}小時前",
     "daysAgo": "{{count}}天前",

--- a/src/i18n/locales/zh-TW/components.json
+++ b/src/i18n/locales/zh-TW/components.json
@@ -625,7 +625,7 @@
     "edited": "已編輯",
     "lines": "行",
     "stats": "{{files}}個檔案，{{edits}}次編輯",
-    "footerInfo": "顯示每個檔案的最新內容。使用「複製內容」恢復已刪除的檔案。"
+    "footerInfo": "顯示每個檔案的最新內容。點擊「恢復檔案」將內容寫回磁碟。"
   },
   "updateIntroModal": {
     "title": "更新系統指南",


### PR DESCRIPTION
## Summary

- Fix ThinkingRenderer `hasMore` logic for content starting with newline
- Change `replace()` to `replacen(..., 1)` for single Edit tool match in session.rs
- Remove redundant `".."` string check (already handled by `Component::ParentDir`)
- Fix Windows path normalization in RecentEditsViewer (normalize backslashes)
- Add i18n support to `getRelativeTime` function with `justNow` translation key
- Fix zh-CN/zh-TW footerInfo translations to match actual UI (restore button)

## Related PRs

Resolves unaddressed review comments from:
- #38 (Add support for thinking blocks with collapsible UI)
- #40 (feat: add Recent Edits viewer for file recovery)

## Test plan

- [ ] Verify thinking blocks show "..." indicator when content starts with newline
- [ ] Verify file edit tool only replaces first match (not all occurrences)
- [ ] Verify files like `file..bak` can be restored without path traversal error
- [ ] Verify Windows paths display correctly in RecentEditsViewer
- [ ] Verify relative time shows in correct locale (ko, en, zh-CN, zh-TW, ja)
- [ ] Verify zh-CN/zh-TW footerInfo mentions "恢复文件/恢復檔案" button

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Backend (Rust):** Use `replacen(..., 1)` for file edit reconstruction (multi- and single-edit paths) and remove redundant `".."` path check in `restore_file` (parent traversal already blocked)
> - **RecentEditsViewer:** Normalize Windows paths for language detection and file name display; show localized relative time via `getRelativeTime(..., t)` using `common.time` keys
> - **ThinkingRenderer:** Correct preview `hasMore` logic for content starting with newline
> - **i18n:** Add `time.justNow` and pluralized relative-time strings across `en/ja/ko/zh-CN/zh-TW`; update zh-CN/zh-TW `recentEdits.footerInfo` to reference the restore button
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a56b0eb045d8fb61003858ca152b1a91809d072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->