### PR TITLE
fix: apply theme-aware syntax highlighting for light mode

### DIFF
--- a/src/components/contentRenderer/ToolUseRenderer.tsx
+++ b/src/components/contentRenderer/ToolUseRenderer.tsx
@@ -22,6 +22,7 @@ import {
 import { ToolIcon } from "../ToolIcon";
 import { Renderer } from "../../shared/RendererHeader";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/contexts/theme";
 import { FileEditRenderer } from "../toolResultRenderer/FileEditRenderer";
 import { HighlightedText } from "../common";
 import {
@@ -44,6 +45,7 @@ export const ToolUseRenderer = ({
   currentMatchIndex = 0,
 }: ToolUseRendererProps) => {
   const { t } = useTranslation("components");
+  const { isDarkMode } = useTheme();
 
   const toolName = (toolUse.name as string) || "Unknown Tool";
   const toolId = (toolUse.id as string) || "";
@@ -137,7 +139,7 @@ export const ToolUseRenderer = ({
             </div>
             <div className={cn(layout.rounded, "overflow-hidden", layout.contentMaxHeight, "overflow-y-auto")}>
               <Highlight
-                theme={themes.vsDark}
+                theme={isDarkMode ? themes.vsDark : themes.vsLight}
                 code={content}
                 language={language}
               >
@@ -272,7 +274,7 @@ export const ToolUseRenderer = ({
             {t("toolUseRenderer.toolInputParameters")}
           </div>
           <Highlight
-            theme={themes.vsDark}
+            theme={isDarkMode ? themes.vsDark : themes.vsLight}
             code={JSON.stringify(toolInput, null, 2)}
             language="json"
           >

--- a/src/components/messageRenderer/ClaudeToolUseDisplay.tsx
+++ b/src/components/messageRenderer/ClaudeToolUseDisplay.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { ToolIcon } from "../ToolIcon";
 import { layout } from "@/components/renderers";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/contexts/theme";
 
 interface ClaudeToolUseDisplayProps {
   toolUse: Record<string, unknown>;
@@ -13,6 +14,7 @@ export const ClaudeToolUseDisplay: React.FC<ClaudeToolUseDisplayProps> = ({
   toolUse,
 }) => {
   const { t } = useTranslation("components");
+  const { isDarkMode } = useTheme();
   const toolName = toolUse.name || toolUse.tool || t("claudeToolUseDisplay.unknownTool");
 
   return (
@@ -30,7 +32,7 @@ export const ClaudeToolUseDisplay: React.FC<ClaudeToolUseDisplayProps> = ({
       </div>
       <div className={cn("rounded overflow-hidden overflow-y-auto", layout.contentMaxHeight)}>
         <Highlight
-          theme={themes.vsDark}
+          theme={isDarkMode ? themes.vsDark : themes.vsLight}
           code={JSON.stringify(toolUse.parameters || toolUse, null, 2)}
           language="json"
         >

--- a/src/components/messageRenderer/CommandOutputDisplay.tsx
+++ b/src/components/messageRenderer/CommandOutputDisplay.tsx
@@ -17,6 +17,7 @@ import { Terminal, Package, TestTube, Hammer, BarChart3 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { getVariantStyles, layout } from "@/components/renderers";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/contexts/theme";
 
 interface CommandOutputDisplayProps {
   stdout: string;
@@ -26,6 +27,7 @@ export const CommandOutputDisplay: React.FC<CommandOutputDisplayProps> = ({
   stdout,
 }) => {
   const { t } = useTranslation("components");
+  const { isDarkMode } = useTheme();
 
   // 다양한 출력 유형 감지
   const isTestOutput =
@@ -71,7 +73,7 @@ export const CommandOutputDisplay: React.FC<CommandOutputDisplayProps> = ({
             })}
           </div>
           <Highlight
-            theme={themes.vsDark}
+            theme={isDarkMode ? themes.vsDark : themes.vsLight}
             code={JSON.stringify(parsed, null, 2)}
             language="json"
           >

--- a/src/components/toolResultRenderer/ClaudeToolResultItem.tsx
+++ b/src/components/toolResultRenderer/ClaudeToolResultItem.tsx
@@ -17,6 +17,7 @@ import { Highlight, themes } from "prism-react-renderer";
 import { useCopyButton } from "../../hooks/useCopyButton";
 import { Renderer } from "../../shared/RendererHeader";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/contexts/theme";
 import { HighlightedText } from "../common";
 import {
   type IndexedRendererProps,
@@ -44,6 +45,7 @@ export const ClaudeToolResultItem = ({
 }: ClaudeToolResultItemProps) => {
   const { t } = useTranslation("components");
   const { renderCopyButton } = useCopyButton();
+  const { isDarkMode } = useTheme();
 
   const toolUseId = (toolResult.tool_use_id as string) || "";
   const content = toolResult.content;
@@ -177,7 +179,7 @@ export const ClaudeToolResultItem = ({
                 {code.split("\n").length} {t("toolResult.lines")}
               </span>
             </div>
-            <Highlight theme={themes.vsDark} code={code} language={language}>
+            <Highlight theme={isDarkMode ? themes.vsDark : themes.vsLight} code={code} language={language}>
               {({ className, style, tokens, getLineProps, getTokenProps }) => (
                 <pre
                   className={className}

--- a/src/components/toolResultRenderer/FallbackRenderer.tsx
+++ b/src/components/toolResultRenderer/FallbackRenderer.tsx
@@ -3,6 +3,7 @@ import { Highlight, themes } from "prism-react-renderer";
 import { useTranslation } from "react-i18next";
 import { Renderer } from "../../shared/RendererHeader";
 import { layout } from "@/components/renderers";
+import { useTheme } from "@/contexts/theme";
 
 type Props = {
   toolResult: Record<string, unknown>;
@@ -10,6 +11,7 @@ type Props = {
 
 export const FallbackRenderer = ({ toolResult }: Props) => {
   const { t } = useTranslation("components");
+  const { isDarkMode } = useTheme();
   return (
     <Renderer className="bg-card border-border">
       <Renderer.Header
@@ -20,7 +22,7 @@ export const FallbackRenderer = ({ toolResult }: Props) => {
       <Renderer.Content>
         <div className={layout.bodyText}>
           <Highlight
-            theme={themes.vsDark}
+            theme={isDarkMode ? themes.vsDark : themes.vsLight}
             code={JSON.stringify(toolResult, null, 2)}
             language="json"
           >


### PR DESCRIPTION
## Summary
- Fixed code blocks displaying dark theme in light mode
- All syntax highlighting components now respect the current theme setting

## Related Issue
Closes #47

## Changes
| File | Change |
|------|--------|
| `ToolUseRenderer.tsx` | Added `useTheme` hook, theme switching (2 locations) |
| `ClaudeToolUseDisplay.tsx` | Added `useTheme` hook, theme switching |
| `CommandOutputDisplay.tsx` | Added `useTheme` hook, theme switching |
| `ClaudeToolResultItem.tsx` | Added `useTheme` hook, theme switching |
| `FallbackRenderer.tsx` | Added `useTheme` hook, theme switching |

## Before/After
**Before (Light mode):** Code blocks use `themes.vsDark` → dark background
**After (Light mode):** Code blocks use `themes.vsLight` → light background

## Test Plan
- [x] Type check passed (`pnpm exec tsc --noEmit`)
- [x] Lint passed (0 errors)
- [ ] Manual test: Toggle to light mode and verify code blocks have light background

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code highlighting now adapts to your theme preference: All code blocks and syntax highlighting throughout the app now dynamically switch between dark and light themes to match your current display setting for improved readability and visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->