### PR TITLE
feat: prefill GitHub issue form with feedback data

### DIFF
--- a/src/components/modals/feedback/FeedbackModal.tsx
+++ b/src/components/modals/feedback/FeedbackModal.tsx
@@ -103,7 +103,25 @@ export const FeedbackModal = ({ isOpen, onClose }: FeedbackModalProps) => {
 
   const handleOpenGitHub = async () => {
     try {
-      await invoke("open_github_issues");
+      const trimmedSubject = subject.trim();
+      const trimmedBody = body.trim();
+
+      if (trimmedSubject.length > 100 || trimmedBody.length > 1000) {
+        alert(t("feedback.lengthExceeded"));
+        return;
+      }
+
+      const feedback =
+        trimmedSubject && trimmedBody
+          ? {
+              subject: trimmedSubject,
+              body: trimmedBody,
+              include_system_info: includeSystemInfo,
+              feedback_type: feedbackType,
+            }
+          : null;
+
+      await invoke("open_github_issues", { feedback });
     } catch (error) {
       console.error("Failed to open GitHub:", error);
       alert(t("feedback.openGitHubError"));

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -392,6 +392,7 @@
   "feedback.preview": "Preview",
   "feedback.sendEmail": "Send via Email",
   "feedback.sendError": "Failed to send feedback. Please try again.",
+  "feedback.lengthExceeded": "Subject must be 100 characters or less and body must be 1000 characters or less.",
   "feedback.sendingEmail": "Sending...",
   "feedback.subject": "Subject",
   "feedback.subjectPlaceholder": "Please enter a brief subject",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -392,6 +392,7 @@
   "feedback.preview": "プレビュー",
   "feedback.sendEmail": "メールで送る",
   "feedback.sendError": "フィードバックの送信に失敗しました。もう一度お試しください。",
+  "feedback.lengthExceeded": "タイトルは100文字以内、本文は1000文字以内にしてください。",
   "feedback.sendingEmail": "送信中...",
   "feedback.subject": "件名",
   "feedback.subjectPlaceholder": "簡単な件名を入力してください",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -392,6 +392,7 @@
   "feedback.preview": "미리보기",
   "feedback.sendEmail": "이메일로 보내기",
   "feedback.sendError": "피드백 전송에 실패했습니다. 다시 시도해주세요.",
+  "feedback.lengthExceeded": "제목은 100자, 내용은 1000자 이하여야 합니다.",
   "feedback.sendingEmail": "전송 중...",
   "feedback.subject": "제목",
   "feedback.subjectPlaceholder": "간단한 제목을 입력해주세요",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -392,6 +392,7 @@
   "feedback.preview": "预览",
   "feedback.sendEmail": "通过邮件发送",
   "feedback.sendError": "发送反馈失败。请重试。",
+  "feedback.lengthExceeded": "标题不超过100个字符，内容不超过1000个字符。",
   "feedback.sendingEmail": "发送中...",
   "feedback.subject": "主题",
   "feedback.subjectPlaceholder": "请输入简短的主题",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -392,6 +392,7 @@
   "feedback.preview": "預覽",
   "feedback.sendEmail": "透過電子郵件發送",
   "feedback.sendError": "發送意見回馔失敗。請重試。",
+  "feedback.lengthExceeded": "標題不超過100個字元，內容不超過1000個字元。",
   "feedback.sendingEmail": "發送中...",
   "feedback.subject": "主題",
   "feedback.subjectPlaceholder": "請輸入簡短的主題",


### PR DESCRIPTION
## Summary
- Prefill GitHub issue form with feedback data (title, body, system info, labels) via URL query parameters when creating a GitHub issue
- Added dual-layer length validation: frontend (100/1000 chars) and backend (200/2000 chars)
- Added `feedback.lengthExceeded` i18n key across all 5 locales

Closes #82

## Test plan
- [ ] Fill out feedback form → click "Open GitHub Issue" → verify GitHub issue page has prefilled title, body, and labels
- [ ] Click "Open GitHub Issue" without filling the form → verify empty issue page opens (backward compatible)
- [ ] Include special characters (`"`, `&`, `=`, newlines) in the body → verify proper URL encoding
- [ ] Toggle system info ON → verify system info appears at the bottom of the body
- [ ] Verify label mapping by feedback type: bug → bug, feature/improvement → enhancement, other → no label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added input validation for feedback submission with character limits (100 chars for subject, 1000 chars for body).

* **Localization**
  * Added localized messages for feedback validation across English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->