### PR TITLE
fix: improve session summary fallback with multi-tier extraction

### DIFF
--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -375,7 +375,11 @@ fn extract_session_metadata_internal(
                         if let Some(ref content) = msg.content {
                             let user_text = extract_user_text(content);
                             if first_user_content.is_none() {
-                                first_user_content.clone_from(&user_text);
+                                // Only store genuine user text (skip command displays like "/init")
+                                let is_command = matches!(content, serde_json::Value::String(text) if !is_genuine_user_text(text));
+                                if !is_command {
+                                    first_user_content.clone_from(&user_text);
+                                }
                             }
                             if let Some(text) = user_text {
                                 last_user_content = Some(text);


### PR DESCRIPTION
## Summary
- Reduces "session summary not found" cases by adding a multi-tier fallback chain
- When no explicit `type: "summary"` message exists, falls back to: first user message → first assistant text (captures resume summaries) → last user message
- Added `extract_assistant_text()` for extracting meaningful assistant content (min 10 chars, truncated to 100)
- No changes to `IncrementalParseState` — fully backward compatible

## Test plan
- [x] 220 Rust tests pass (`cargo test -- --test-threads=1`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] `cargo fmt` check passes
- [ ] Manual test: open sessions that previously showed "session summary not found" and verify meaningful titles appear

Closes #104

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session loading and restoration by adding multi-tier fallback sources (initial user message, assistant text, recent user message) and refining summary resolution so sessions resume more consistently when primary summaries are missing.
  * Ensured fallbacks are preserved and applied during incremental parsing and long-running resumes.

* **Chores**
  * Added tests covering the new fallback and resume behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->