### PR TITLE
fix: AppImage EGL crash on Arch Linux

### DIFF
--- a/.github/workflows/updater-release.yml
+++ b/.github/workflows/updater-release.yml
@@ -162,8 +162,7 @@ jobs:
           echo "Removing conflicting EGL/Mesa/Wayland libs..."
           pushd squashfs-root/usr/lib/ > /dev/null
           rm -fv libEGL.so* libEGL_mesa.so* libGLESv2.so* libgbm.so* \
-                 libwayland-client.so* libwayland-server.so* libwayland-egl.so* \
-                 || true
+                 libwayland-client.so* libwayland-server.so* libwayland-egl.so*
           popd > /dev/null
 
           # Inject WEBKIT_DISABLE_DMABUF_RENDERER into GTK apprun hook as defense-in-depth
@@ -178,7 +177,9 @@ jobs:
           fi
 
           # Download appimagetool for repackaging (pinned to stable release 1.9.1)
+          APPIMAGETOOL_SHA256="a2d716dcf358bcef63173cd8e9d15efbe7cd227724276a9dad5fc1ba2181ae77"
           wget -q "https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage"
+          echo "${APPIMAGETOOL_SHA256}  appimagetool-x86_64.AppImage" | sha256sum -c -
           chmod +x appimagetool-x86_64.AppImage
 
           # Repackage (APPIMAGE_EXTRACT_AND_RUN bypasses FUSE requirement on CI)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,10 @@ fn run_tauri() {
         .map(|v| !v.is_empty())
         .unwrap_or(false)
     {
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        // Only set if not already configured by the user
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
     }
 
     use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Summary

Fixes the AppImage crash on Arch Linux (and other rolling-release distros) caused by `EGL_BAD_ALLOC` when the system's `WebKitGPUProcess` loads bundled Ubuntu-compiled EGL/Mesa libraries via inherited `LD_LIBRARY_PATH`.

### Root Cause

Tauri's AppImage bundler includes `libwebkit2gtk-4.1.so.0` but **not** `WebKitGPUProcess`. The system's GPU process inherits `LD_LIBRARY_PATH` from AppRun, loads the bundled (Ubuntu-compiled) EGL libs, and crashes due to ABI mismatch with the host's Mesa 26+ drivers.

### Fix (2-Layer Strategy)

- **Layer 1 — CI pipeline** (`updater-release.yml`): Post-process the AppImage after build to remove GPU-driver-dependent libs (`libEGL`, `libGLESv2`, `libgbm`, `libwayland-*`). This forces the AppImage to use the system's native EGL stack, which is compatible with the system's `WebKitGPUProcess`. The AppImage is then repackaged with `appimagetool` and re-signed for the Tauri updater.

- **Layer 2 — Rust code** (`lib.rs`): Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` only when running inside an AppImage (`APPIMAGE` env var detection). This is defense-in-depth for edge cases like NVIDIA driver quirks. No effect on deb/rpm/native installs.

### Why not just env vars?

Setting `WEBKIT_DISABLE_COMPOSITING_MODE=1` globally disables GPU acceleration for **all** Linux users, including those on Ubuntu/Fedora where the AppImage works fine. The CI post-processing approach removes only the conflicting libs, preserving GPU acceleration on compatible systems.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — formatted
- [x] `cargo test -- --test-threads=1` — 323 passed
- [x] lint-staged hooks passed on commit
- [ ] Verify Linux AppImage build succeeds in CI (post-processing + re-sign + upload)
- [ ] Verify `latest.json` includes `linux-x86_64` platform after release
- [ ] (Ideal) Test on Arch Linux with Mesa 26+ and AMD/NVIDIA GPU

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EGL-related crashes on Linux AppImage by disabling a problematic graphics renderer mode and removing conflicting GPU driver libs for improved stability.

* **Chores**
  * Updated release pipeline to post-process, re-sign, and upload Linux artifacts (AppImage, deb, rpm) and integrate these steps with metadata generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->