### PR TITLE
fix: add missing model pricing for Opus 4.6, Sonnet 4.6, Haiku 4.5

### DIFF
--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -33,10 +33,13 @@ interface ModelPricing {
 
 const MODEL_PRICING: Record<string, ModelPricing> = {
   // Claude models
+  'claude-opus-4-6': { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.50 },
   'claude-opus-4-5': { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.50 },
   'claude-opus-4': { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.50 },
+  'claude-sonnet-4-6': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
   'claude-sonnet-4-5': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
   'claude-sonnet-4': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
+  'claude-haiku-4-5': { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.10 },
   'claude-3-5-sonnet': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
   'claude-3-5-haiku': { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.10 },
   'claude-3-haiku': { input: 0.25, output: 1.25, cacheWrite: 0.30, cacheRead: 0.03 },


### PR DESCRIPTION
## Summary
- Added `claude-opus-4-6` pricing ($5/$25) — was incorrectly matching `claude-opus-4` ($15/$75), **overestimating cost by 3x**
- Added `claude-haiku-4-5` pricing ($1/$5) — was falling back to default ($3/$15), **overestimating cost by 3x**
- Added `claude-sonnet-4-6` pricing ($3/$15) — was matching correctly via `claude-sonnet-4` substring, but added for explicit coverage

## Root cause
`findModelPricing()` uses `includes()` for substring matching. New model IDs like `claude-opus-4-6` and `claude-haiku-4-5-20251001` either matched wrong entries or matched nothing.

## Verified against
- [Anthropic official pricing](https://platform.claude.com/docs/en/about-claude/pricing)
- Actual model names from `~/.claude/projects/` JSONL data

## Test plan
- [ ] Verify estimated cost decreases for users of Opus 4.6 and Haiku 4.5
- [ ] Verify pricing coverage percentage increases

_🤖 On behalf of @grimmerk — generated with Claude Code_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded model coverage with pricing data for three additional Claude models: Opus 4.6, Sonnet 4.6, and Haiku 4.5, enabling more accurate cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->