### PR TITLE
fix: downgrade mdast-util-gfm-autolink-literal for WebKit compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
   "pnpm": {
     "overrides": {
       "vite": "^7.1.12",
-      "prismjs": "^1.30.0"
+      "prismjs": "^1.30.0",
+      "mdast-util-gfm-autolink-literal": "2.0.0"
     },
     "ignoredBuiltDependencies": [
       "@tailwindcss/oxide",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   vite: ^7.1.12
   prismjs: ^1.30.0
+  mdast-util-gfm-autolink-literal: 2.0.0
 
 importers:
 
@@ -2772,8 +2773,8 @@ packages:
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
-  mdast-util-gfm-autolink-literal@2.0.1:
-    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+  mdast-util-gfm-autolink-literal@2.0.0:
+    resolution: {integrity: sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==}
 
   mdast-util-gfm-footnote@2.1.0:
     resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
@@ -6330,7 +6331,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-autolink-literal@2.0.1:
+  mdast-util-gfm-autolink-literal@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       ccount: 2.0.1
@@ -6378,7 +6379,7 @@ snapshots:
   mdast-util-gfm@3.1.0:
     dependencies:
       mdast-util-from-markdown: 2.0.2
-      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-autolink-literal: 2.0.0
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0


### PR DESCRIPTION
## Summary

- Downgrade `mdast-util-gfm-autolink-literal` from 2.0.1 to 2.0.0 via pnpm overrides to fix app crash on macOS < 13

## Problem

v2.0.1 introduced a lookbehind assertion (`(?<=^|\s|\p{P}|\p{S})`) in the email autolink regex. Lookbehind is only supported in Safari 16.4+ (macOS 13 Ventura+). Users on macOS 10.15–12 hit a fatal `Invalid regular expression: invalid group specifier name` error on app launch, since Tauri uses the system WKWebView.

**Root cause**: `mdast-util-gfm-autolink-literal@2.0.1` → loaded via `remark-gfm` → `react-markdown`

## Fix

Added `"mdast-util-gfm-autolink-literal": "2.0.0"` to `pnpm.overrides`. v2.0.0 uses a runtime `previous()` function with `unicodeWhitespace`/`unicodePunctuation` checks instead of lookbehind — functionally identical, fully WebKit-compatible.

## Test plan

- [x] Verified 2.0.0 source has no lookbehind assertions
- [x] Verified production build bundle contains no lookbehind
- [x] TypeScript build passes
- [x] ESLint passes
- [x] All 697 tests pass

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency override configuration to ensure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->