### PR TITLE
feat: bold named sessions, italic unnamed sessions in session list

### DIFF
--- a/src-tauri/src/commands/archive.rs
+++ b/src-tauri/src/commands/archive.rs
@@ -1456,6 +1456,7 @@ pub async fn get_expiring_sessions(
                     has_tool_use: false,
                     has_errors: false,
                     summary,
+                    is_renamed: false,
                     provider: None,
                     storage_type: None,
                 };

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -53,7 +53,7 @@ struct SessionMetadataCache {
     entries: HashMap<String, CachedSessionMetadata>,
 }
 
-const CACHE_VERSION: u32 = 7;
+const CACHE_VERSION: u32 = 8;
 
 /// Get the cache file path for a project
 fn get_cache_path(project_path: &str) -> PathBuf {
@@ -544,6 +544,7 @@ fn extract_session_metadata_internal(
             has_tool_use,
             has_errors,
             summary: final_summary,
+            is_renamed: rename_name.is_some(),
             provider: None,
             storage_type: None,
         },

--- a/src-tauri/src/models/session.rs
+++ b/src-tauri/src/models/session.rs
@@ -57,6 +57,9 @@ pub struct ClaudeSession {
     pub has_tool_use: bool,
     pub has_errors: bool,
     pub summary: Option<String>,
+    /// Whether this session was explicitly renamed via the /rename command
+    #[serde(default)]
+    pub is_renamed: bool,
     /// Provider identifier (claude, codex, opencode)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
@@ -92,6 +95,7 @@ mod tests {
             has_tool_use: true,
             has_errors: false,
             summary: Some("Test conversation".to_string()),
+            is_renamed: false,
             provider: None,
             storage_type: None,
         };

--- a/src-tauri/src/models/snapshot_tests.rs
+++ b/src-tauri/src/models/snapshot_tests.rs
@@ -231,6 +231,7 @@ mod session_snapshots {
             has_tool_use: true,
             has_errors: false,
             summary: Some("Test conversation summary".to_string()),
+            is_renamed: false,
             provider: None,
             storage_type: None,
         };

--- a/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__session_snapshots__claude_session.snap
+++ b/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__session_snapshots__claude_session.snap
@@ -13,5 +13,6 @@ expression: session
   "last_modified": "2025-01-01T12:00:00Z",
   "has_tool_use": true,
   "has_errors": false,
-  "summary": "Test conversation summary"
+  "summary": "Test conversation summary",
+  "is_renamed": false
 }

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -232,6 +232,7 @@ pub fn load_sessions(
                     has_tool_use: info.has_tool_use,
                     has_errors: false,
                     summary: info.summary,
+                    is_renamed: false,
                     provider: Some("codex".to_string()),
                     storage_type: None,
                 });

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -303,6 +303,7 @@ pub fn load_sessions(
                 has_tool_use: false,
                 has_errors: false,
                 summary: title,
+                is_renamed: false,
                 provider: Some("opencode".to_string()),
                 storage_type: Some("json".to_string()),
             });
@@ -737,6 +738,7 @@ fn load_sessions_from_db(base_path: &str, project_id: &str) -> Option<Vec<Claude
                 has_tool_use: false,
                 has_errors: false,
                 summary: if title.is_empty() { None } else { Some(title) },
+                is_renamed: false,
                 provider: Some("opencode".to_string()),
                 storage_type: Some("sqlite".to_string()),
             })

--- a/src/components/SessionItem/SessionItem.tsx
+++ b/src/components/SessionItem/SessionItem.tsx
@@ -55,6 +55,7 @@ export const SessionItem: React.FC<SessionItemProps> = ({
             displayName={editing.displayName}
             hasCustomName={editing.hasCustomName}
             hasClaudeCodeName={editing.hasClaudeCodeName}
+            isNamed={editing.isNamed}
             isSelected={isSelected}
             isContextMenuOpen={editing.isContextMenuOpen}
             providerId={editing.providerId}

--- a/src/components/SessionItem/components/SessionNameEditor.tsx
+++ b/src/components/SessionItem/components/SessionNameEditor.tsx
@@ -32,6 +32,7 @@ export const SessionNameEditor: React.FC<SessionNameEditorProps> = ({
   displayName,
   hasCustomName,
   hasClaudeCodeName,
+  isNamed,
   isSelected,
   isContextMenuOpen,
   providerId,
@@ -154,7 +155,7 @@ export const SessionNameEditor: React.FC<SessionNameEditorProps> = ({
             </TooltipContent>
           </Tooltip>
         )}
-        <span className="flex-1">
+        <span className={cn("flex-1", isNamed ? "font-bold" : "italic opacity-70")}>
           {displayName || t("session.summaryNotFound", "No summary")}
         </span>
       </span>

--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -40,6 +40,7 @@ export function useSessionEditing(session: ClaudeSession) {
   const hasClaudeCodeNamePattern = /^\[.+?\]\s/.test(localSummary ?? "");
   const hasClaudeCodeName =
     providerId === "claude" && (hasClaudeCodeNameMeta || hasClaudeCodeNamePattern);
+  const isNamed = hasCustomName || hasClaudeCodeName || !!session.is_renamed;
 
   const startEditing = useCallback(() => {
     setEditValue(displayName || "");
@@ -203,6 +204,7 @@ export function useSessionEditing(session: ClaudeSession) {
     displayName,
     hasCustomName,
     hasClaudeCodeName,
+    isNamed,
     providerId,
     supportsNativeRename,
     isArchivedCodexSession,

--- a/src/components/SessionItem/types.ts
+++ b/src/components/SessionItem/types.ts
@@ -19,6 +19,7 @@ export interface SessionNameEditorProps {
   displayName: string | undefined;
   hasCustomName: boolean;
   hasClaudeCodeName: boolean;
+  isNamed: boolean;
   isSelected: boolean;
   isContextMenuOpen: boolean;
   providerId: string;

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -71,6 +71,8 @@ export interface ClaudeSession {
   has_tool_use: boolean;
   has_errors: boolean;
   summary?: string;
+  /** Whether this session was explicitly renamed via the /rename command */
+  is_renamed?: boolean;
   relevance?: number;
   /** Provider identifier (claude, codex, opencode) */
   provider?: ProviderId;


### PR DESCRIPTION
**Relates to #204.**                                                                                                                                                                                                                                                                                                                                       
Following up on the /rename session name display feature — this adds a visual distinction between sessions that have been explicitly named and those showing their first prompt as a fallback title:

  - Named sessions (via /rename, CCHV custom rename, or CLI sync) → bold
  - Unnamed sessions (showing first message as fallback) → italic

**How it works**                                                                                                                                           
The Rust session parser already detects /rename command output and stores it as rename_name. This PR exposes that as an is_renamed: bool field on ClaudeSession, which is then used on the frontend to compute isNamed and apply the appropriate styling in SessionNameEditor. 

Cache version bumped to 8 to force a re-parse so the new field is correctly populated for existing sessions.                                                                
   
 **Changes**                                                                                                                                                                     
  
  - ClaudeSession Rust struct: add is_renamed: bool                                                                                                                           
  - Session parser (load.rs): set is_renamed: rename_name.is_some(), bump cache version to 8
  - TypeScript ClaudeSession type: add is_renamed?: boolean                                                                                                                   
  - useSessionEditing: compute isNamed (union of /rename, custom name, CLI sync)                                                                                              
  - SessionNameEditor: apply font-bold / italic opacity-70 based on isNamed                                                                                                   
                                                                                                                                                                              
Tested on macOS Tahoe. Happy to adjust styling or approach if needed.

Co-Authored-By: Claude Sonnet 4.6