### PR TITLE
feat: add date filter to global stats view

### DIFF
--- a/src/components/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/components/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -63,10 +63,19 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
 
     if (globalSummary) {
       return (
-        <GlobalStatsView
-          globalSummary={globalSummary}
-          globalConversationSummary={globalConversationSummary}
-        />
+        <div className="flex-1 flex flex-col overflow-auto bg-background">
+          <div className="p-3 md:p-6 pb-0">
+            <DatePickerHeader
+              dateFilter={dateFilter}
+              setDateFilter={setDateFilter}
+              className="bg-card/50 w-fit"
+            />
+          </div>
+          <GlobalStatsView
+            globalSummary={globalSummary}
+            globalConversationSummary={globalConversationSummary}
+          />
+        </div>
       );
     }
 

--- a/src/components/AnalyticsDashboard/views/GlobalStatsView.tsx
+++ b/src/components/AnalyticsDashboard/views/GlobalStatsView.tsx
@@ -19,8 +19,6 @@ import {
 import type { GlobalStatsSummary } from "../../../types";
 import { formatDuration } from "../../../utils/time";
 import { cn } from "@/lib/utils";
-import { useAppStore } from "../../../store/useAppStore";
-import { DatePickerHeader } from "../../ui/DatePickerHeader";
 import {
   MetricCard,
   SectionCard,
@@ -50,7 +48,6 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
   globalConversationSummary,
 }) => {
   const { t } = useTranslation();
-  const { dateFilter, setDateFilter } = useAppStore();
   const totalSessionTime = globalSummary.total_session_duration_minutes;
   const costSummary = useMemo(
     () =>
@@ -105,11 +102,6 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
           "Provider scope follows Project Tree provider tabs."
         )}
       </p>
-      <DatePickerHeader
-        dateFilter={dateFilter}
-        setDateFilter={setDateFilter}
-        className="bg-card/50 w-fit"
-      />
 
       {/* Metric Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4">


### PR DESCRIPTION
## Summary
- Add `DatePickerHeader` to `GlobalStatsView` so users can filter global analytics by date range
- Backend already supported date filtering via `start_date`/`end_date` params — this adds the missing UI
- Reuses existing `DatePickerHeader` component and `useAnalyticsAutoLoad` auto-refresh logic

## Test plan
- [x] Open Global Stats view (click "Global Over") and verify DatePickerHeader appears below provider scope text
- [x] Set a date range and confirm metrics update accordingly
- [x] Clear the date filter and confirm all-time stats are restored
- [x] Verify DatePickerHeader does not stretch full width (`w-fit`)

_🤖 On behalf of @grimmerk — generated with Claude Code_

## Test proof

<img width="1063" height="265" alt="截圖 2026-04-01 下午5 14 02" src="https://github.com/user-attachments/assets/f5004978-d6e4-45a4-96f1-c24446dc23fd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Optimized analytics dashboard layout with enhanced scrollability and visual organization.
  * Repositioned date picker header above statistics view with improved spacing and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->