### PR TITLE
feat: auto-refresh sessions and auto-scroll on new messages

### DIFF
--- a/src/components/MessageViewer/hooks/useScrollNavigation.ts
+++ b/src/components/MessageViewer/hooks/useScrollNavigation.ts
@@ -307,16 +307,16 @@ export const useScrollNavigation = ({
     const prevLength = prevMessagesLengthRef.current;
     prevMessagesLengthRef.current = messagesLength;
 
-    // Only auto-scroll when messages are appended (not on initial load or session switch)
     if (
       prevLength > 0 &&
       messagesLength > prevLength &&
       isNearBottomRef.current &&
       scrollReadyForSessionId === selectedSessionId
     ) {
-      requestAnimationFrame(() => {
+      const rafId = requestAnimationFrame(() => {
         scrollToBottom();
       });
+      return () => cancelAnimationFrame(rafId);
     }
   }, [messagesLength, scrollToBottom, scrollReadyForSessionId, selectedSessionId]);
 

--- a/src/components/MessageViewer/hooks/useScrollNavigation.ts
+++ b/src/components/MessageViewer/hooks/useScrollNavigation.ts
@@ -261,6 +261,12 @@ export const useScrollNavigation = ({
     let scrollElementRef: HTMLElement | null = null;
 
     const handleScroll = () => {
+      // Update near-bottom ref immediately for accurate auto-scroll decisions
+      const vp = getScrollViewport();
+      if (vp) {
+        isNearBottomRef.current = vp.scrollHeight - vp.scrollTop - vp.clientHeight < SCROLL_THRESHOLD_PX;
+      }
+
       if (throttleTimer) return;
 
       throttleTimer = setTimeout(() => {
@@ -270,7 +276,6 @@ export const useScrollNavigation = ({
             const { scrollTop, scrollHeight, clientHeight } = viewport;
             const isNearBottom = scrollHeight - scrollTop - clientHeight < SCROLL_THRESHOLD_PX;
             const isNearTop = scrollTop < SCROLL_THRESHOLD_PX;
-            isNearBottomRef.current = isNearBottom;
             setShowScrollToBottom(!isNearBottom && messagesLength > MIN_MESSAGES_FOR_SCROLL_BUTTONS);
             setShowScrollToTop(!isNearTop && messagesLength > MIN_MESSAGES_FOR_SCROLL_BUTTONS);
           }
@@ -302,6 +307,11 @@ export const useScrollNavigation = ({
     };
   }, [messagesLength, getScrollViewport]);
 
+  // Reset prevMessagesLength on session switch
+  useEffect(() => {
+    prevMessagesLengthRef.current = 0;
+  }, [selectedSessionId]);
+
   // Auto-scroll to bottom when new messages arrive and user was already at bottom
   useEffect(() => {
     const prevLength = prevMessagesLengthRef.current;
@@ -311,6 +321,7 @@ export const useScrollNavigation = ({
       prevLength > 0 &&
       messagesLength > prevLength &&
       isNearBottomRef.current &&
+      !targetMessageUuid &&
       scrollReadyForSessionId === selectedSessionId
     ) {
       const rafId = requestAnimationFrame(() => {
@@ -318,7 +329,7 @@ export const useScrollNavigation = ({
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [messagesLength, scrollToBottom, scrollReadyForSessionId, selectedSessionId]);
+  }, [messagesLength, scrollToBottom, scrollReadyForSessionId, selectedSessionId, targetMessageUuid]);
 
   return {
     showScrollToTop,

--- a/src/components/MessageViewer/hooks/useScrollNavigation.ts
+++ b/src/components/MessageViewer/hooks/useScrollNavigation.ts
@@ -63,6 +63,9 @@ export const useScrollNavigation = ({
   // 스크롤이 완료된 세션 ID (현재 세션과 비교하여 오버레이 표시 여부 결정)
   const [scrollReadyForSessionId, setScrollReadyForSessionId] = useState<string | null>(null);
   const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks whether user is near bottom for auto-scroll on new messages
+  const isNearBottomRef = useRef(true);
+  const prevMessagesLengthRef = useRef(0);
 
   // Helper to get the scroll viewport element
   const getScrollViewport = useCallback(() => {
@@ -267,6 +270,7 @@ export const useScrollNavigation = ({
             const { scrollTop, scrollHeight, clientHeight } = viewport;
             const isNearBottom = scrollHeight - scrollTop - clientHeight < SCROLL_THRESHOLD_PX;
             const isNearTop = scrollTop < SCROLL_THRESHOLD_PX;
+            isNearBottomRef.current = isNearBottom;
             setShowScrollToBottom(!isNearBottom && messagesLength > MIN_MESSAGES_FOR_SCROLL_BUTTONS);
             setShowScrollToTop(!isNearTop && messagesLength > MIN_MESSAGES_FOR_SCROLL_BUTTONS);
           }
@@ -297,6 +301,24 @@ export const useScrollNavigation = ({
       }
     };
   }, [messagesLength, getScrollViewport]);
+
+  // Auto-scroll to bottom when new messages arrive and user was already at bottom
+  useEffect(() => {
+    const prevLength = prevMessagesLengthRef.current;
+    prevMessagesLengthRef.current = messagesLength;
+
+    // Only auto-scroll when messages are appended (not on initial load or session switch)
+    if (
+      prevLength > 0 &&
+      messagesLength > prevLength &&
+      isNearBottomRef.current &&
+      scrollReadyForSessionId === selectedSessionId
+    ) {
+      requestAnimationFrame(() => {
+        scrollToBottom();
+      });
+    }
+  }, [messagesLength, scrollToBottom, scrollReadyForSessionId, selectedSessionId]);
 
   return {
     showScrollToTop,

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
 import { useAppStore } from "@/store/useAppStore";
 import { useLanguageStore } from "@/store/useLanguageStore";
 import { type SupportedLanguage } from "@/i18n";
 import { useTranslation } from "react-i18next";
+import { useFileWatcher } from "./useFileWatcher";
 
 /**
  * App initialization side effects:
@@ -22,6 +23,24 @@ export function useAppInitialization(deps: {
   const selectSession = useAppStore((s) => s.selectSession);
   const fontScale = useAppStore((s) => s.fontScale);
   const highContrast = useAppStore((s) => s.highContrast);
+  const watcherEnabled = useAppStore((s) => s.watcherEnabled);
+  const triggerSessionRefresh = useAppStore((s) => s.triggerSessionRefresh);
+  const triggerProjectRefresh = useAppStore((s) => s.triggerProjectRefresh);
+
+  const handleSessionChanged = useCallback(
+    (event: { projectPath: string; sessionPath: string }) => {
+      triggerSessionRefresh(event.projectPath, event.sessionPath);
+      triggerProjectRefresh(event.projectPath);
+    },
+    [triggerSessionRefresh, triggerProjectRefresh]
+  );
+
+  // File watcher: auto-refresh when session files change on disk
+  useFileWatcher({
+    onSessionChanged: handleSessionChanged,
+    enabled: watcherEnabled,
+    debounceMs: 500,
+  });
 
   // Language loading + app initialization
   useEffect(() => {

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -37,7 +37,7 @@ export function useAppInitialization(deps: {
   useFileWatcher({
     onSessionChanged: handleSessionChanged,
     enabled: watcherEnabled,
-    debounceMs: 500,
+    debounceMs: 100,
   });
 
   // Language loading + app initialization

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -25,14 +25,12 @@ export function useAppInitialization(deps: {
   const highContrast = useAppStore((s) => s.highContrast);
   const watcherEnabled = useAppStore((s) => s.watcherEnabled);
   const triggerSessionRefresh = useAppStore((s) => s.triggerSessionRefresh);
-  const triggerProjectRefresh = useAppStore((s) => s.triggerProjectRefresh);
 
   const handleSessionChanged = useCallback(
     (event: { projectPath: string; sessionPath: string }) => {
       triggerSessionRefresh(event.projectPath, event.sessionPath);
-      triggerProjectRefresh(event.projectPath);
     },
-    [triggerSessionRefresh, triggerProjectRefresh]
+    [triggerSessionRefresh]
   );
 
   // File watcher: auto-refresh when session files change on disk


### PR DESCRIPTION
## Summary

- Connect the existing (but unused) file watcher to auto-refresh sessions when JSONL files change on disk
- Add stick-to-bottom auto-scroll: when new messages arrive and user is near bottom, auto-scroll to latest message
- If user scrolls up, auto-scroll stops — resumes when user scrolls back to bottom

## How it works

All infrastructure already existed but was disconnected:

```
watcher.rs (Rust) → emits session-file-changed event
    ↓
useFileWatcher.ts (hook) → listens to Tauri events ← NOW CONNECTED
    ↓
watcherSlice.ts (store) → triggerSessionRefresh() ← NOW TRIGGERED
    ↓
selectSession() → reloads messages from disk
    ↓
useScrollNavigation → auto-scrolls if near bottom ← NOW TRACKS POSITION
```

## Changes

| File | Change |
|------|--------|
| `useAppInitialization.ts` | Connect `useFileWatcher` → `triggerSessionRefresh` + `triggerProjectRefresh` |
| `useScrollNavigation.ts` | Track `isNearBottomRef`, auto-scroll when `messagesLength` increases |

## Test plan

- [x] TypeScript build passes
- [x] ESLint clean
- [ ] Manual: open a session, run Claude Code in terminal → messages appear automatically
- [ ] Manual: scroll up during active session → auto-scroll stops
- [ ] Manual: scroll back to bottom → auto-scroll resumes

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages auto-scroll to the bottom when new messages are appended while you’re viewing the latest content, keeping the conversation up-to-date without manual scrolling.
  * The app watches session files on disk and automatically refreshes affected sessions when external changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->