### PR TITLE
feat: add search and horizontal scrollbar to project panel

### DIFF
--- a/src/components/ProjectTree/components/ProjectItem.tsx
+++ b/src/components/ProjectTree/components/ProjectItem.tsx
@@ -124,7 +124,7 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
       {/* Project Name */}
       <span
         className={cn(
-          "truncate flex-1 transition-colors",
+          "whitespace-nowrap flex-1 transition-colors",
           isGrouped ? "text-xs" : "text-sm",
           isExpanded
             ? isWorktree

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -231,15 +231,16 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     await applyProviderSelection(next.length > 0 ? next : [provider]);
   }, [applyProviderSelection, isAllProvidersSelected, selectableProviderIds, selectedProviderFilters]);
 
+  const normalizedSearchTerm = useMemo(() => searchTerm.toLowerCase(), [searchTerm]);
+
   const matchesSearch = useCallback(
     (project: (typeof projects)[number]) => {
-      if (!searchTerm) return true;
-      const term = searchTerm.toLowerCase();
+      if (!normalizedSearchTerm) return true;
       const name = (project.name ?? "").toLowerCase();
       const path = (project.actual_path ?? project.path ?? "").toLowerCase();
-      return name.includes(term) || path.includes(term);
+      return name.includes(normalizedSearchTerm) || path.includes(normalizedSearchTerm);
     },
-    [searchTerm]
+    [normalizedSearchTerm]
   );
 
   const filteredProjects = useMemo(
@@ -823,7 +824,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
         {/* Search */}
         <div className="px-3 py-2 border-b border-accent/10">
           <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50" />
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50" aria-hidden="true" focusable="false" />
             <input
               type="text"
               value={searchTerm}
@@ -834,6 +835,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
             />
             {searchTerm && (
               <button
+                type="button"
                 onClick={() => setSearchTerm("")}
                 className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground/50 hover:text-muted-foreground transition-colors"
                 aria-label={t("common.clear", "Clear")}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -9,6 +9,7 @@ import {
   PanelLeftClose,
   PanelLeft,
   RotateCcw,
+  Search,
   X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -84,6 +85,8 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     handleContextMenu,
     closeContextMenu,
   } = useProjectTreeState(groupingMode);
+
+  const [searchTerm, setSearchTerm] = useState("");
 
   // Wrap session select to also close mobile drawer
   const handleSessionSelect = useCallback(
@@ -228,28 +231,44 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     await applyProviderSelection(next.length > 0 ? next : [provider]);
   }, [applyProviderSelection, isAllProvidersSelected, selectableProviderIds, selectedProviderFilters]);
 
+  const matchesSearch = useCallback(
+    (project: (typeof projects)[number]) => {
+      if (!searchTerm) return true;
+      const term = searchTerm.toLowerCase();
+      const name = (project.name ?? "").toLowerCase();
+      const path = (project.actual_path ?? project.path ?? "").toLowerCase();
+      return name.includes(term) || path.includes(term);
+    },
+    [searchTerm]
+  );
+
   const filteredProjects = useMemo(
-    () => projects.filter(matchesProviderFilter),
-    [projects, matchesProviderFilter]
+    () => projects.filter((p) => matchesProviderFilter(p) && matchesSearch(p)),
+    [projects, matchesProviderFilter, matchesSearch]
   );
 
   const filteredDirectoryGroups = useMemo(() => {
-    if (isAllProvidersSelected) {
+    const filterFn = (p: (typeof projects)[number]) =>
+      matchesProviderFilter(p) && matchesSearch(p);
+
+    if (isAllProvidersSelected && !searchTerm) {
       return directoryGroups;
     }
 
     return directoryGroups
       .map((group) => ({
         ...group,
-        projects: group.projects.filter(matchesProviderFilter),
+        projects: group.projects.filter(filterFn),
       }))
       .filter((group) => group.projects.length > 0);
-  }, [directoryGroups, isAllProvidersSelected, matchesProviderFilter]);
+  }, [directoryGroups, isAllProvidersSelected, matchesProviderFilter, matchesSearch, searchTerm]);
 
   const { filteredWorktreeGroups, filteredUngroupedProjects } = useMemo(() => {
     const baseUngrouped = ungroupedProjects ?? projects;
+    const filterFn = (p: (typeof projects)[number]) =>
+      matchesProviderFilter(p) && matchesSearch(p);
 
-    if (isAllProvidersSelected) {
+    if (isAllProvidersSelected && !searchTerm) {
       return {
         filteredWorktreeGroups: worktreeGroups,
         filteredUngroupedProjects: baseUngrouped,
@@ -260,8 +279,8 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     const movedChildren: (typeof projects)[number][] = [];
 
     for (const group of worktreeGroups) {
-      const includeParent = matchesProviderFilter(group.parent);
-      const matchingChildren = group.children.filter(matchesProviderFilter);
+      const includeParent = filterFn(group.parent);
+      const matchingChildren = group.children.filter(filterFn);
 
       if (includeParent) {
         nextGroups.push({
@@ -273,7 +292,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       }
     }
 
-    const baseFiltered = baseUngrouped.filter(matchesProviderFilter);
+    const baseFiltered = baseUngrouped.filter(filterFn);
     const seenPaths = new Set(baseFiltered.map((project) => project.path));
     const movedChildrenToAdd = movedChildren.filter((child) => {
       if (seenPaths.has(child.path)) {
@@ -288,7 +307,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       filteredWorktreeGroups: nextGroups,
       filteredUngroupedProjects: nextUngrouped,
     };
-  }, [worktreeGroups, ungroupedProjects, projects, isAllProvidersSelected, matchesProviderFilter]);
+  }, [worktreeGroups, ungroupedProjects, projects, isAllProvidersSelected, matchesProviderFilter, matchesSearch, searchTerm]);
 
   const providerTabs = useMemo(
     () => {
@@ -801,6 +820,30 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
           </div>
         </div>
 
+        {/* Search */}
+        <div className="px-3 py-2 border-b border-accent/10">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50" />
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder={t("project.searchPlaceholder", "Search projects...")}
+              className="w-full pl-8 pr-8 py-1.5 text-xs bg-muted/30 border border-transparent rounded-md placeholder:text-muted-foreground/40 focus:outline-none focus:border-accent/30 focus:bg-muted/50 transition-colors"
+              aria-label={t("project.searchPlaceholder", "Search projects...")}
+            />
+            {searchTerm && (
+              <button
+                onClick={() => setSearchTerm("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+                aria-label={t("common.clear", "Clear")}
+              >
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </div>
+        </div>
+
         {/* Projects List */}
         <OverlayScrollbarsComponent
           className="relative flex-1 py-2"
@@ -811,7 +854,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
               autoHideDelay: 400,
             },
             overflow: {
-              x: "hidden",
+              x: "scroll",
             },
           }}
         >

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -232,7 +232,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     await applyProviderSelection(next.length > 0 ? next : [provider]);
   }, [applyProviderSelection, isAllProvidersSelected, selectableProviderIds, selectedProviderFilters]);
 
-  const normalizedSearchTerm = useMemo(() => searchTerm.toLowerCase(), [searchTerm]);
+  const normalizedSearchTerm = useMemo(() => searchTerm.trim().toLowerCase(), [searchTerm]);
 
   const matchesSearch = useCallback(
     (project: (typeof projects)[number]) => {
@@ -253,7 +253,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     const filterFn = (p: (typeof projects)[number]) =>
       matchesProviderFilter(p) && matchesSearch(p);
 
-    if (isAllProvidersSelected && !searchTerm) {
+    if (isAllProvidersSelected && !normalizedSearchTerm) {
       return directoryGroups;
     }
 
@@ -263,14 +263,14 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
         projects: group.projects.filter(filterFn),
       }))
       .filter((group) => group.projects.length > 0);
-  }, [directoryGroups, isAllProvidersSelected, matchesProviderFilter, matchesSearch, searchTerm]);
+  }, [directoryGroups, isAllProvidersSelected, matchesProviderFilter, matchesSearch, normalizedSearchTerm]);
 
   const { filteredWorktreeGroups, filteredUngroupedProjects } = useMemo(() => {
     const baseUngrouped = ungroupedProjects ?? projects;
     const filterFn = (p: (typeof projects)[number]) =>
       matchesProviderFilter(p) && matchesSearch(p);
 
-    if (isAllProvidersSelected && !searchTerm) {
+    if (isAllProvidersSelected && !normalizedSearchTerm) {
       return {
         filteredWorktreeGroups: worktreeGroups,
         filteredUngroupedProjects: baseUngrouped,
@@ -309,7 +309,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       filteredWorktreeGroups: nextGroups,
       filteredUngroupedProjects: nextUngrouped,
     };
-  }, [worktreeGroups, ungroupedProjects, projects, isAllProvidersSelected, matchesProviderFilter, matchesSearch, searchTerm]);
+  }, [worktreeGroups, ungroupedProjects, projects, isAllProvidersSelected, matchesProviderFilter, matchesSearch, normalizedSearchTerm]);
 
   const providerTabs = useMemo(
     () => {

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -87,6 +87,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
   } = useProjectTreeState(groupingMode);
 
   const [searchTerm, setSearchTerm] = useState("");
+  const searchInputId = React.useId();
 
   // Wrap session select to also close mobile drawer
   const handleSessionSelect = useCallback(
@@ -825,13 +826,16 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
         <div className="px-3 py-2 border-b border-accent/10">
           <div className="relative">
             <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50" aria-hidden="true" focusable="false" />
+            <label htmlFor={searchInputId} className="sr-only">
+              {t("project.searchPlaceholder", "Search projects...")}
+            </label>
             <input
+              id={searchInputId}
               type="text"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               placeholder={t("project.searchPlaceholder", "Search projects...")}
               className="w-full pl-8 pr-8 py-1.5 text-xs bg-muted/30 border border-transparent rounded-md placeholder:text-muted-foreground/40 focus:outline-none focus:border-accent/30 focus:bg-muted/50 transition-colors"
-              aria-label={t("project.searchPlaceholder", "Search projects...")}
             />
             {searchTerm && (
               <button

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -9,6 +9,7 @@
   "common.a11y.skipToSettings": "Skip to settings",
   "common.back": "Back",
   "common.cancel": "Cancel",
+  "common.clear": "Clear",
   "common.close": "Close",
   "common.collapse": "Collapse",
   "common.commandPalette": "Command palette",

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -26,6 +26,7 @@
   "project.notFound": "Project not found",
   "project.removePattern": "Remove pattern",
   "project.resetProviderFilters": "Reset",
+  "project.searchPlaceholder": "Search projects...",
   "project.selectToView": "Select a project to view analytics",
   "project.title": "Project:",
   "project.unhide": "Show project",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -9,6 +9,7 @@
   "common.a11y.skipToSettings": "設定へ移動",
   "common.back": "戻る",
   "common.cancel": "キャンセル",
+  "common.clear": "クリア",
   "common.close": "閉じる",
   "common.collapse": "折りたたむ",
   "common.commandPalette": "コマンドパレット",

--- a/src/i18n/locales/ja/session.json
+++ b/src/i18n/locales/ja/session.json
@@ -26,6 +26,7 @@
   "project.notFound": "プロジェクトが見つかりません",
   "project.removePattern": "パターンを削除",
   "project.resetProviderFilters": "リセット",
+  "project.searchPlaceholder": "プロジェクトを検索...",
   "project.selectToView": "分析を表示するにはプロジェクトを選択してください",
   "project.title": "プロジェクト：",
   "project.unhide": "プロジェクトを表示",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -9,6 +9,7 @@
   "common.a11y.skipToSettings": "설정으로 건너뛰기",
   "common.back": "뒤로 가기",
   "common.cancel": "취소",
+  "common.clear": "지우기",
   "common.close": "닫기",
   "common.collapse": "접기",
   "common.commandPalette": "명령 팔레트",

--- a/src/i18n/locales/ko/session.json
+++ b/src/i18n/locales/ko/session.json
@@ -26,6 +26,7 @@
   "project.notFound": "프로젝트를 찾을 수 없습니다",
   "project.removePattern": "패턴 제거",
   "project.resetProviderFilters": "초기화",
+  "project.searchPlaceholder": "프로젝트 검색...",
   "project.selectToView": "분석을 보려면 프로젝트를 선택하세요",
   "project.title": "프로젝트:",
   "project.unhide": "프로젝트 표시",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -9,6 +9,7 @@
   "common.a11y.skipToSettings": "跳转到设置",
   "common.back": "返回",
   "common.cancel": "取消",
+  "common.clear": "清除",
   "common.close": "关闭",
   "common.collapse": "折叠",
   "common.commandPalette": "命令面板",

--- a/src/i18n/locales/zh-CN/session.json
+++ b/src/i18n/locales/zh-CN/session.json
@@ -26,6 +26,7 @@
   "project.notFound": "未找到项目",
   "project.removePattern": "删除模式",
   "project.resetProviderFilters": "重置",
+  "project.searchPlaceholder": "搜索项目...",
   "project.selectToView": "选择项目以查看分析",
   "project.title": "项目：",
   "project.unhide": "显示项目",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -9,6 +9,7 @@
   "common.a11y.skipToSettings": "跳到設定",
   "common.back": "返回",
   "common.cancel": "取消",
+  "common.clear": "清除",
   "common.close": "關閉",
   "common.collapse": "摺疊",
   "common.commandPalette": "命令面板",

--- a/src/i18n/locales/zh-TW/session.json
+++ b/src/i18n/locales/zh-TW/session.json
@@ -26,6 +26,7 @@
   "project.notFound": "未找到專案",
   "project.removePattern": "移除模式",
   "project.resetProviderFilters": "重設",
+  "project.searchPlaceholder": "搜尋專案...",
   "project.selectToView": "選擇專案以查看分析",
   "project.title": "專案：",
   "project.unhide": "顯示專案",


### PR DESCRIPTION
## Summary
- Add search input to ProjectTree for filtering projects by name or path
- Enable horizontal scrollbar (`overflow.x: "hidden"` → `"scroll"`) so long project names are visible
- Search applies across all grouping modes (flat, directory, worktree)
- Add i18n keys for all 5 locales (en, ko, ja, zh-CN, zh-TW)

Closes #246

## Test plan
- [x] `pnpm tsc --build .` passes
- [x] `pnpm lint` clean (no new errors)
- [x] `pnpm run i18n:validate` passes
- [ ] Type a search term → project list filters in real time
- [ ] Long project names show horizontal scrollbar instead of being cut off
- [ ] Clear button (X) resets search

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project search: case-insensitive filtering by name or path, integrated with provider filters; search input with clear button; preserves previous grouping when no filter/search
  * Improved horizontal scrolling for the project overlay

* **Style / UI**
  * Adjusted project name overflow to prevent truncation and ensure consistent display

* **Localization**
  * Added search placeholder and “Clear” translations for EN, JA, KO, ZH-CN, ZH-TW
<!-- end of auto-generated comment: release notes by coderabbit.ai -->