### PR TITLE
feat: support custom Claude config directories

### DIFF
--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -118,6 +118,44 @@ pub async fn validate_custom_claude_dir(path: String) -> Result<bool, String> {
     }
 }
 
+/// Detect `CLAUDE_CONFIG_DIR` environment variable and return the path if valid.
+///
+/// Returns `Some(path)` if the env var is set and points to a valid Claude
+/// configuration directory (has a `projects/` subfolder). Returns `None` otherwise.
+#[tauri::command]
+pub async fn detect_claude_config_dir() -> Result<Option<String>, String> {
+    let raw = match std::env::var("CLAUDE_CONFIG_DIR") {
+        Ok(val) if !val.trim().is_empty() => val.trim().to_string(),
+        _ => return Ok(None),
+    };
+
+    // Expand ~ to home directory
+    let expanded = if raw.starts_with('~') {
+        match dirs::home_dir() {
+            Some(home) => {
+                let rest = raw
+                    .strip_prefix("~/")
+                    .or_else(|| raw.strip_prefix('~'))
+                    .unwrap_or("");
+                home.join(rest).to_string_lossy().to_string()
+            }
+            None => raw,
+        }
+    } else {
+        raw
+    };
+
+    let path = PathBuf::from(&expanded);
+    if !path.is_absolute() {
+        return Ok(None);
+    }
+
+    match crate::utils::validate_custom_claude_path(&path) {
+        Ok(_) => Ok(Some(expanded)),
+        Err(_) => Ok(None),
+    }
+}
+
 #[tauri::command]
 pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, String> {
     #[cfg(debug_assertions)]
@@ -537,5 +575,58 @@ mod tests {
             // Should not error if path is valid repo
             panic!("get_git_log failed: {}", result.unwrap_err());
         }
+    }
+
+    // Tests for detect_claude_config_dir
+    #[tokio::test]
+    async fn test_detect_config_dir_unset() {
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+        let result = detect_claude_config_dir().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_detect_config_dir_empty() {
+        std::env::set_var("CLAUDE_CONFIG_DIR", "");
+        let result = detect_claude_config_dir().await.unwrap();
+        assert!(result.is_none());
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    #[tokio::test]
+    async fn test_detect_config_dir_valid() {
+        let temp_dir = TempDir::new().unwrap();
+        let projects_dir = temp_dir.path().join("projects");
+        fs::create_dir_all(&projects_dir).unwrap();
+
+        std::env::set_var(
+            "CLAUDE_CONFIG_DIR",
+            temp_dir.path().to_string_lossy().to_string(),
+        );
+        let result = detect_claude_config_dir().await.unwrap();
+        assert!(result.is_some());
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    #[tokio::test]
+    async fn test_detect_config_dir_invalid_no_projects() {
+        let temp_dir = TempDir::new().unwrap();
+        // No projects/ subdirectory
+
+        std::env::set_var(
+            "CLAUDE_CONFIG_DIR",
+            temp_dir.path().to_string_lossy().to_string(),
+        );
+        let result = detect_claude_config_dir().await.unwrap();
+        assert!(result.is_none());
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    #[tokio::test]
+    async fn test_detect_config_dir_relative_path() {
+        std::env::set_var("CLAUDE_CONFIG_DIR", "relative/path");
+        let result = detect_claude_config_dir().await.unwrap();
+        assert!(result.is_none());
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
     }
 }

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -129,16 +129,15 @@ pub async fn detect_claude_config_dir() -> Result<Option<String>, String> {
         _ => return Ok(None),
     };
 
-    // Expand ~ to home directory
-    let expanded = if raw.starts_with('~') {
+    // Expand ~ to home directory (only exact "~" or "~/..." patterns)
+    let expanded = if raw == "~" {
         match dirs::home_dir() {
-            Some(home) => {
-                let rest = raw
-                    .strip_prefix("~/")
-                    .or_else(|| raw.strip_prefix('~'))
-                    .unwrap_or("");
-                home.join(rest).to_string_lossy().to_string()
-            }
+            Some(home) => home.to_string_lossy().to_string(),
+            None => raw,
+        }
+    } else if let Some(rest) = raw.strip_prefix("~/") {
+        match dirs::home_dir() {
+            Some(home) => home.join(rest).to_string_lossy().to_string(),
             None => raw,
         }
     } else {
@@ -259,11 +258,20 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
 }
 
 #[cfg(test)]
+#[allow(clippy::await_holding_lock)] // env var tests are sync internally; no real suspension
 mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Write;
+    use std::sync::{LazyLock, Mutex, MutexGuard};
     use tempfile::TempDir;
+
+    /// Mutex to serialize tests that modify the `CLAUDE_CONFIG_DIR` environment variable.
+    static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        ENV_MUTEX.lock().unwrap()
+    }
 
     fn create_test_jsonl_file(dir: &PathBuf, filename: &str, content: &str) {
         let file_path = dir.join(filename);
@@ -578,8 +586,10 @@ mod tests {
     }
 
     // Tests for detect_claude_config_dir
+    // All tests use ENV_MUTEX to prevent race conditions on the global env var.
     #[tokio::test]
     async fn test_detect_config_dir_unset() {
+        let _guard = lock_env();
         std::env::remove_var("CLAUDE_CONFIG_DIR");
         let result = detect_claude_config_dir().await.unwrap();
         assert!(result.is_none());
@@ -587,6 +597,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_detect_config_dir_empty() {
+        let _guard = lock_env();
         std::env::set_var("CLAUDE_CONFIG_DIR", "");
         let result = detect_claude_config_dir().await.unwrap();
         assert!(result.is_none());
@@ -595,6 +606,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_detect_config_dir_valid() {
+        let _guard = lock_env();
         let temp_dir = TempDir::new().unwrap();
         let projects_dir = temp_dir.path().join("projects");
         fs::create_dir_all(&projects_dir).unwrap();
@@ -610,6 +622,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_detect_config_dir_invalid_no_projects() {
+        let _guard = lock_env();
         let temp_dir = TempDir::new().unwrap();
         // No projects/ subdirectory
 
@@ -624,6 +637,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_detect_config_dir_relative_path() {
+        let _guard = lock_env();
         std::env::set_var("CLAUDE_CONFIG_DIR", "relative/path");
         let result = detect_claude_config_dir().await.unwrap();
         assert!(result.is_none());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,8 +33,8 @@ use crate::commands::{
         search_all_providers,
     },
     project::{
-        get_claude_folder_path, get_git_log, scan_projects, validate_claude_folder,
-        validate_custom_claude_dir,
+        detect_claude_config_dir, get_claude_folder_path, get_git_log, scan_projects,
+        validate_claude_folder, validate_custom_claude_dir,
     },
     session::{
         delete_session, get_recent_edits, get_session_message_count, get_session_subagents,
@@ -118,6 +118,7 @@ fn run_tauri() {
             get_claude_folder_path,
             validate_claude_folder,
             validate_custom_claude_dir,
+            detect_claude_config_dir,
             scan_projects,
             get_git_log,
             load_project_sessions,

--- a/src/components/modals/folderSelect/FolderSelector.tsx
+++ b/src/components/modals/folderSelect/FolderSelector.tsx
@@ -35,6 +35,7 @@ export function FolderSelector({
   const [isCustomPathValid, setIsCustomPathValid] = useState(false);
   const { closeModal } = useModal();
   const setAnalyticsCurrentView = useAppStore((s) => s.setAnalyticsCurrentView);
+  const clearAnalyticsErrors = useAppStore((s) => s.clearAnalyticsErrors);
 
   const isChangeMode = mode === "change";
 
@@ -162,6 +163,7 @@ export function FolderSelector({
               size="sm"
               onClick={() => {
                 closeModal("folderSelector");
+                clearAnalyticsErrors();
                 setAnalyticsCurrentView("settings");
               }}
             >

--- a/src/components/modals/folderSelect/FolderSelector.tsx
+++ b/src/components/modals/folderSelect/FolderSelector.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import { Folder, AlertCircle, ArrowLeft, CheckCircle2, HelpCircle } from "lucide-react";
+import { Folder, AlertCircle, ArrowLeft, CheckCircle2, HelpCircle, Settings } from "lucide-react";
 import { isTauri } from "@/utils/platform";
 import { api } from "@/services/api";
 import { useTranslation } from "react-i18next";
+import { useModal } from "@/contexts/modal";
+import { useAppStore } from "@/store/useAppStore";
 import {
   Dialog,
   DialogContent,
@@ -30,6 +32,9 @@ export function FolderSelector({
   const [selectedPath, setSelectedPath] = useState<string>("");
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<string>("");
+  const [isCustomPathValid, setIsCustomPathValid] = useState(false);
+  const { closeModal } = useModal();
+  const setAnalyticsCurrentView = useAppStore((s) => s.setAnalyticsCurrentView);
 
   const isChangeMode = mode === "change";
 
@@ -66,6 +71,7 @@ export function FolderSelector({
   const validateAndSelectFolder = async (path: string) => {
     setIsValidating(true);
     setValidationError("");
+    setIsCustomPathValid(false);
 
     try {
       const isValid = await api<boolean>("validate_claude_folder", { path });
@@ -73,7 +79,18 @@ export function FolderSelector({
       if (isValid) {
         onFolderSelected(path);
       } else {
-        setValidationError(t("folderPicker.invalidFolder"));
+        // Check if this is a valid custom Claude directory (has projects/ subfolder)
+        try {
+          const isCustomValid = await api<boolean>("validate_custom_claude_dir", { path });
+          if (isCustomValid) {
+            setIsCustomPathValid(true);
+            setValidationError(t("folderPicker.customPathDetected"));
+          } else {
+            setValidationError(t("folderPicker.invalidFolder"));
+          }
+        } catch {
+          setValidationError(t("folderPicker.invalidFolder"));
+        }
       }
     } catch {
       setValidationError(t("folderPicker.validationError"));
@@ -128,11 +145,30 @@ export function FolderSelector({
         </Alert>
       )}
 
-      {/* Validation Error */}
-      {validationError && (
+      {/* Validation Error or Custom Path Guidance */}
+      {validationError && !isCustomPathValid && (
         <Alert variant="destructive" className="text-left">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>{validationError}</AlertDescription>
+        </Alert>
+      )}
+      {isCustomPathValid && (
+        <Alert variant="default" className="text-left">
+          <Settings className="h-4 w-4" />
+          <AlertDescription className="space-y-2">
+            <p>{t("folderPicker.customPathDetected")}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                closeModal("folderSelector");
+                setAnalyticsCurrentView("settings");
+              }}
+            >
+              <Settings className="h-3 w-3" />
+              {t("folderPicker.openSettings")}
+            </Button>
+          </AlertDescription>
         </Alert>
       )}
 

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -7,6 +7,8 @@
   "folderPicker.helpDetails": "• Claude Desktop app must be run at least once to create the folder\n• Windows: C:\\Users\\[username]\\.claude\n• macOS: /Users/[username]/.claude or ~/.claude\n• Linux: /home/[username]/.claude or ~/.claude",
   "folderPicker.homeNotFound": "Could not find .claude folder in home directory. Please select the .claude folder or a parent folder containing it.",
   "folderPicker.invalidFolder": "Cannot find Claude data in the selected folder. Please select the .claude folder.",
+  "folderPicker.customPathDetected": "This folder contains Claude data but is not the default .claude directory. You can add it as a custom directory in Settings.",
+  "folderPicker.openSettings": "Open Settings",
   "folderPicker.newFolder": "Select a new Claude folder or parent folder.",
   "folderPicker.notFound": "Claude folder not found",
   "folderPicker.select": ".claude folder selection",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -7,6 +7,8 @@
   "folderPicker.helpDetails": "• Claude Desktopアプリを一度でも実行してフォルダを作成する必要があります\n• Windows: C:\\Users\\[ユーザー名]\\.claude\n• macOS: /Users/[ユーザー名]/.claude または ~/.claude\n• Linux: /home/[ユーザー名]/.claude または ~/.claude",
   "folderPicker.homeNotFound": "ホームディレクトリで.claudeフォルダが見つかりませんでした。.claudeフォルダまたはそれを含む親フォルダを選択してください。",
   "folderPicker.invalidFolder": "選択したフォルダにClaudeデータが見つかりません。.claudeフォルダを選択してください。",
+  "folderPicker.customPathDetected": "このフォルダにはClaudeデータがありますが、デフォルトの.claudeディレクトリではありません。設定でカスタムディレクトリとして追加できます。",
+  "folderPicker.openSettings": "設定を開く",
   "folderPicker.newFolder": "新しいClaudeフォルダまたは親フォルダを選択してください。",
   "folderPicker.notFound": "Claudeフォルダが見つかりません",
   "folderPicker.select": ".claudeフォルダを選択",

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -7,6 +7,8 @@
   "folderPicker.helpDetails": "• Claude Desktop 앱을 한 번이라도 실행해야 폴더가 생성됩니다\n• Windows: C:\\Users\\[사용자명]\\.claude\n• macOS: /Users/[사용자명]/.claude 또는 ~/.claude\n• Linux: /home/[사용자명]/.claude 또는 ~/.claude",
   "folderPicker.homeNotFound": "홈 디렉토리에서 .claude 폴더를 찾을 수 없습니다. .claude 폴더 또는 이를 포함하는 상위 폴더를 선택해주세요.",
   "folderPicker.invalidFolder": "선택한 폴더에서 Claude 데이터를 찾을 수 없습니다. .claude 폴더를 선택해주세요.",
+  "folderPicker.customPathDetected": "이 폴더에 Claude 데이터가 있지만 기본 .claude 디렉토리가 아닙니다. 설정에서 커스텀 디렉토리로 추가할 수 있습니다.",
+  "folderPicker.openSettings": "설정 열기",
   "folderPicker.newFolder": "새로운 Claude 폴더 또는 상위 폴더를 선택해주세요.",
   "folderPicker.notFound": "Claude 폴더를 찾을 수 없습니다",
   "folderPicker.select": ".claude 폴더 선택",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -7,6 +7,8 @@
   "folderPicker.helpDetails": "• 需要先运行Claude Desktop应用才能创建文件夹\n• Windows: C:\\Users\\[用户名]\\.claude\n• macOS: /Users/[用户名]/.claude 或 ~/.claude\n• Linux: /home/[用户名]/.claude 或 ~/.claude",
   "folderPicker.homeNotFound": "在主目录中找不到.claude文件夹。请选择.claude文件夹或包含它的上级文件夹。",
   "folderPicker.invalidFolder": "在选择的文件夹中找不到Claude数据。请选择.claude文件夹。",
+  "folderPicker.customPathDetected": "此文件夹包含Claude数据，但不是默认的.claude目录。您可以在设置中将其添加为自定义目录。",
+  "folderPicker.openSettings": "打开设置",
   "folderPicker.newFolder": "请选择新的Claude文件夹或其上级文件夹。",
   "folderPicker.notFound": "找不到Claude文件夹",
   "folderPicker.select": "选择.claude文件夹",

--- a/src/i18n/locales/zh-TW/settings.json
+++ b/src/i18n/locales/zh-TW/settings.json
@@ -7,6 +7,8 @@
   "folderPicker.helpDetails": "• 需要先執行Claude Desktop應用程式才能建立資料夾\n• Windows: C:\\Users\\[使用者名稱]\\.claude\n• macOS: /Users/[使用者名稱]/.claude 或 ~/.claude\n• Linux: /home/[使用者名稱]/.claude 或 ~/.claude",
   "folderPicker.homeNotFound": "在主目錄中找不到.claude資料夾。請選擇.claude資料夾或包含它的上層資料夾。",
   "folderPicker.invalidFolder": "在選擇的資料夾中找不到Claude資料。請選擇.claude資料夾。",
+  "folderPicker.customPathDetected": "此資料夾包含Claude資料，但不是預設的.claude目錄。您可以在設定中將其新增為自訂目錄。",
+  "folderPicker.openSettings": "開啟設定",
   "folderPicker.newFolder": "請選擇新的Claude資料夾或其上層資料夾。",
   "folderPicker.notFound": "找不到Claude資料夾",
   "folderPicker.select": "選擇.claude資料夾",

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -82,6 +82,28 @@ const isTauriAvailable = () => {
 };
 
 // ============================================================================
+// CLAUDE_CONFIG_DIR Auto-detection
+// ============================================================================
+
+/** Auto-register CLAUDE_CONFIG_DIR as a custom directory if not already present. */
+async function autoRegisterConfigDir(get: () => FullAppStore): Promise<void> {
+  try {
+    const detected = await api<string | null>("detect_claude_config_dir");
+    if (!detected) return;
+
+    const existing = get().userMetadata?.settings?.customClaudePaths ?? [];
+    const alreadyRegistered = existing.some((cp) => cp.path === detected);
+    if (alreadyRegistered) return;
+
+    await get().addCustomClaudePath(detected, "CLAUDE_CONFIG_DIR");
+  } catch {
+    if (import.meta.env.DEV) {
+      console.warn("[autoRegisterConfigDir] Failed to detect CLAUDE_CONFIG_DIR");
+    }
+  }
+}
+
+// ============================================================================
 // Slice Creator
 // ============================================================================
 
@@ -118,6 +140,7 @@ export const createProjectSlice: StateCreator<
             set({ claudePath: savedPath });
             await get().loadMetadata();
             await get().detectProviders();
+            await autoRegisterConfigDir(get);
             await get().scanProjects();
             return;
           }
@@ -131,6 +154,7 @@ export const createProjectSlice: StateCreator<
       set({ claudePath });
       await get().loadMetadata();
       await get().detectProviders();
+      await autoRegisterConfigDir(get);
       await get().scanProjects();
     } catch (error) {
       console.error("Failed to initialize app:", error);

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -91,8 +91,10 @@ async function autoRegisterConfigDir(get: () => FullAppStore): Promise<void> {
     const detected = await api<string | null>("detect_claude_config_dir");
     if (!detected) return;
 
+    const normalize = (p: string) => p.replace(/[\\/]+$/, "");
+    const normalizedDetected = normalize(detected);
     const existing = get().userMetadata?.settings?.customClaudePaths ?? [];
-    const alreadyRegistered = existing.some((cp) => cp.path === detected);
+    const alreadyRegistered = existing.some((cp) => normalize(cp.path) === normalizedDetected);
     if (alreadyRegistered) return;
 
     await get().addCustomClaudePath(detected, "CLAUDE_CONFIG_DIR");

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -291,6 +291,7 @@ export interface AppStoreActions {
   isProjectHidden: (projectPath: string) => boolean;
   hideProject: (projectPath: string) => Promise<void>;
   unhideProject: (projectPath: string) => Promise<void>;
+  addCustomClaudePath: (path: string, label?: string) => Promise<void>;
   addHiddenPattern: (pattern: string) => Promise<void>;
   removeHiddenPattern: (pattern: string) => Promise<void>;
   clearMetadataError: () => void;


### PR DESCRIPTION
## Summary
- Auto-detect `CLAUDE_CONFIG_DIR` env var at app startup and register as custom directory (Closes #253)
- Show guidance message in folder picker when custom path is selected (instead of dead-end error)
- Redirect to Settings > Custom Directories for path management

## Changes

### Backend (Rust)
- New `detect_claude_config_dir` Tauri command in `project.rs`
  - Reads `CLAUDE_CONFIG_DIR` env var
  - Expands `~` via `dirs::home_dir()`
  - Validates with existing `validate_custom_claude_path()`
  - Returns `Option<String>` (path or None)
- 5 unit tests covering: unset, empty, valid, invalid (no projects/), relative path
- Registered in `lib.rs` invoke handler

### Frontend (TypeScript/React)
- `projectSlice.ts`: `autoRegisterConfigDir()` helper called in `initializeApp`
  - Runs after settings load (timing-safe duplicate check)
  - Persists via `addCustomClaudePath` (reuses existing Custom Directories infra)
  - Never overrides `claudePath` (eng review: downstream code hardcodes `.claude` checks)
- `FolderSelector.tsx`: fallback validation with `validate_custom_claude_dir`
  - Custom path detected → guidance message with "Open Settings" button
  - Both validations fail → existing error message (no behavior change)
- `types.ts`: added `addCustomClaudePath` to `AppStoreActions` type

### i18n
- 2 new keys × 5 languages: `customPathDetected`, `openSettings`

## Design decisions
- `CLAUDE_CONFIG_DIR` is ALWAYS added to `customClaudePaths`, never to `claudePath`
  (rename.rs and other downstream code hardcodes `.claude` path validation)
- Folder picker stays `.claude`-only; custom paths go through Custom Directories
- Auto-detection persists on first run; subsequent startups skip if already registered

## Test plan
- [x] `cargo test -- --test-threads=1` — 425 passed (5 new)
- [x] `pnpm vitest run` — 735 passed
- [x] `pnpm tsc --build .` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm run i18n:validate` — 1757 keys synced
- [ ] Manual: set `CLAUDE_CONFIG_DIR=~/.claude-personal` → launch app → verify projects appear
- [ ] Manual: folder picker → select custom dir → verify guidance message + Settings redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects and registers Claude configuration directories from the CLAUDE_CONFIG_DIR environment variable.
  * Folder selector now recognizes Claude data in non-default locations and offers a prompt to open Settings to add it as a custom path.
  * Added a store action to register custom Claude paths programmatically.

* **Localization**
  * UI strings added for English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Added unit tests covering env-var detection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->