### PR TITLE
fix: instantly accept custom Claude directories in folder selector

### DIFF
--- a/src/components/modals/folderSelect/FolderSelector.tsx
+++ b/src/components/modals/folderSelect/FolderSelector.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
-import { Folder, AlertCircle, ArrowLeft, CheckCircle2, HelpCircle, Settings } from "lucide-react";
+import { Folder, AlertCircle, ArrowLeft, CheckCircle2, HelpCircle } from "lucide-react";
 import { isTauri } from "@/utils/platform";
 import { api } from "@/services/api";
 import { useTranslation } from "react-i18next";
-import { useModal } from "@/contexts/modal";
-import { useAppStore } from "@/store/useAppStore";
 import {
   Dialog,
   DialogContent,
@@ -32,10 +30,6 @@ export function FolderSelector({
   const [selectedPath, setSelectedPath] = useState<string>("");
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<string>("");
-  const [isCustomPathValid, setIsCustomPathValid] = useState(false);
-  const { closeModal } = useModal();
-  const setAnalyticsCurrentView = useAppStore((s) => s.setAnalyticsCurrentView);
-  const clearAnalyticsErrors = useAppStore((s) => s.clearAnalyticsErrors);
 
   const isChangeMode = mode === "change";
 
@@ -72,7 +66,6 @@ export function FolderSelector({
   const validateAndSelectFolder = async (path: string) => {
     setIsValidating(true);
     setValidationError("");
-    setIsCustomPathValid(false);
 
     try {
       const isValid = await api<boolean>("validate_claude_folder", { path });
@@ -84,8 +77,7 @@ export function FolderSelector({
         try {
           const isCustomValid = await api<boolean>("validate_custom_claude_dir", { path });
           if (isCustomValid) {
-            setIsCustomPathValid(true);
-            setValidationError(t("folderPicker.customPathDetected"));
+            onFolderSelected(path);
           } else {
             setValidationError(t("folderPicker.invalidFolder"));
           }
@@ -146,31 +138,11 @@ export function FolderSelector({
         </Alert>
       )}
 
-      {/* Validation Error or Custom Path Guidance */}
-      {validationError && !isCustomPathValid && (
+      {/* Validation Error */}
+      {validationError && (
         <Alert variant="destructive" className="text-left">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>{validationError}</AlertDescription>
-        </Alert>
-      )}
-      {isCustomPathValid && (
-        <Alert variant="default" className="text-left">
-          <Settings className="h-4 w-4" />
-          <AlertDescription className="space-y-2">
-            <p>{t("folderPicker.customPathDetected")}</p>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                closeModal("folderSelector");
-                clearAnalyticsErrors();
-                setAnalyticsCurrentView("settings");
-              }}
-            >
-              <Settings className="h-3 w-3" />
-              {t("folderPicker.openSettings")}
-            </Button>
-          </AlertDescription>
         </Alert>
       )}
 

--- a/src/components/modals/folderSelect/FolderSelector.tsx
+++ b/src/components/modals/folderSelect/FolderSelector.tsx
@@ -71,7 +71,9 @@ export function FolderSelector({
       const isValid = await api<boolean>("validate_claude_folder", { path });
 
       if (isValid) {
-        onFolderSelected(path);
+        // Normalize: always pass the .claude path so the container can distinguish
+        const normalized = path.endsWith(".claude") ? path : `${path}/.claude`;
+        onFolderSelected(normalized);
       } else {
         // Check if this is a valid custom Claude directory (has projects/ subfolder)
         try {

--- a/src/components/modals/folderSelect/FolderSelectorContainer.tsx
+++ b/src/components/modals/folderSelect/FolderSelectorContainer.tsx
@@ -4,9 +4,19 @@ import { useModal } from "@/contexts/modal";
 import { AppErrorType } from "@/types";
 import { useEffect } from "react";
 
+/**
+ * Checks if the selected path is a standard .claude directory.
+ * Standard: path ends with ".claude" or contains a ".claude" segment.
+ */
+function isStandardClaudePath(path: string): boolean {
+  const segments = path.split(/[\\/]/);
+  return segments.includes(".claude");
+}
+
 export const FolderSelectorContainer: React.FC = () => {
   const { isOpen, closeModal, folderSelectorMode, openModal } = useModal();
-  const { setClaudePath, scanProjects, error } = useAppStore();
+  const { setClaudePath, scanProjects, addCustomClaudePath, error } =
+    useAppStore();
 
   // 에러 발생 시 자동으로 폴더 선택 모달 열기
   useEffect(() => {
@@ -16,19 +26,24 @@ export const FolderSelectorContainer: React.FC = () => {
   }, [error, openModal]);
 
   const handleFolderSelected = async (path: string) => {
-    // .claude 폴더 경로 처리
-    let claudeFolderPath = path;
-    if (!path.endsWith(".claude")) {
-      claudeFolderPath = `${path}/.claude`;
+    if (isStandardClaudePath(path)) {
+      // Standard .claude directory → set as main claudePath
+      let claudeFolderPath = path;
+      if (!path.endsWith(".claude")) {
+        claudeFolderPath = `${path}/.claude`;
+      }
+      setClaudePath(claudeFolderPath);
+    } else {
+      // Custom directory (e.g. ~/.claude-personal) → register as custom path
+      const folderName =
+        path.split(/[\\/]/).filter(Boolean).pop() ?? "custom";
+      await addCustomClaudePath(path, folderName);
     }
 
-    // 경로 설정 및 프로젝트 스캔
-    setClaudePath(claudeFolderPath);
     try {
       await scanProjects();
-    } catch (error) {
-      console.error("Failed to scan projects:", error);
-      // 에러 처리 로직 추가 (예: 사용자에게 알림)
+    } catch (err) {
+      console.error("Failed to scan projects:", err);
     }
   };
 

--- a/src/components/modals/folderSelect/FolderSelectorContainer.tsx
+++ b/src/components/modals/folderSelect/FolderSelectorContainer.tsx
@@ -4,15 +4,6 @@ import { useModal } from "@/contexts/modal";
 import { AppErrorType } from "@/types";
 import { useEffect } from "react";
 
-/**
- * Checks if the selected path is a standard .claude directory.
- * Standard: path ends with ".claude" or contains a ".claude" segment.
- */
-function isStandardClaudePath(path: string): boolean {
-  const segments = path.split(/[\\/]/);
-  return segments.includes(".claude");
-}
-
 export const FolderSelectorContainer: React.FC = () => {
   const { isOpen, closeModal, folderSelectorMode, openModal } = useModal();
   const { setClaudePath, scanProjects, addCustomClaudePath, error } =
@@ -26,21 +17,17 @@ export const FolderSelectorContainer: React.FC = () => {
   }, [error, openModal]);
 
   const handleFolderSelected = async (path: string) => {
-    if (isStandardClaudePath(path)) {
-      // Standard .claude directory → set as main claudePath
-      let claudeFolderPath = path;
-      if (!path.endsWith(".claude")) {
-        claudeFolderPath = `${path}/.claude`;
-      }
-      setClaudePath(claudeFolderPath);
-    } else {
-      // Custom directory (e.g. ~/.claude-personal) → register as custom path
-      const folderName =
-        path.split(/[\\/]/).filter(Boolean).pop() ?? "custom";
-      await addCustomClaudePath(path, folderName);
-    }
-
     try {
+      // FolderSelector normalizes standard paths to end with ".claude"
+      if (path.endsWith(".claude")) {
+        setClaudePath(path);
+      } else {
+        // Custom directory (e.g. ~/.claude-personal) → register as custom path
+        const folderName =
+          path.split(/[\\/]/).filter(Boolean).pop() ?? "custom";
+        await addCustomClaudePath(path, folderName);
+      }
+
       await scanProjects();
     } catch (err) {
       console.error("Failed to scan projects:", err);

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -205,7 +205,7 @@ export const createProjectSlice: StateCreator<
       const settings = get().userMetadata?.settings;
       const projects = (hasNonClaudeProviders || hasCustomPaths)
         ? await api<ClaudeProject[]>("scan_all_projects", {
-            claudePath,
+            ...(claudePath && { claudePath }),
             activeProviders: scanProviders,
             customClaudePaths: hasCustomPaths ? customClaudePaths : undefined,
             wslEnabled: settings?.wsl?.enabled ?? false,

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -190,7 +190,9 @@ export const createProjectSlice: StateCreator<
   scanProjects: async () => {
     const requestId = nextRequestId("scanProjects");
     const { claudePath, providers } = get();
-    if (!claudePath) return;
+    const customClaudePaths = get().userMetadata?.settings?.customClaudePaths;
+    const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
+    if (!claudePath && !hasCustomPaths) return;
 
     set({ isLoadingProjects: true, error: null });
     try {
@@ -200,8 +202,6 @@ export const createProjectSlice: StateCreator<
         .map((provider) => provider.id);
       const scanProviders = availableProviders.length > 0 ? availableProviders : [DEFAULT_PROVIDER_ID];
       const hasNonClaudeProviders = scanProviders.some((provider) => provider !== DEFAULT_PROVIDER_ID);
-      const customClaudePaths = get().userMetadata?.settings?.customClaudePaths;
-      const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
       const settings = get().userMetadata?.settings;
       const projects = (hasNonClaudeProviders || hasCustomPaths)
         ? await api<ClaudeProject[]>("scan_all_projects", {


### PR DESCRIPTION
## Summary
- **Fixes #253** — Change Folder now immediately accepts custom Claude directories (e.g. `~/.claude-personal`) instead of redirecting to Settings
- Custom paths are auto-registered via `addCustomClaudePath` and projects are scanned instantly
- Removes intermediate Settings redirect UI for a seamless one-click UX

## Changes

### `FolderSelector.tsx`
- `validate_custom_claude_dir` pass → immediately calls `onFolderSelected(path)` (was: show guidance message)
- Removed `isCustomPathValid` state, Settings redirect UI, unused imports (`Settings`, `useModal`, `useAppStore`)

### `FolderSelectorContainer.tsx`
- Added `isStandardClaudePath()` helper to detect `.claude` vs custom directories
- `.claude` path → existing `setClaudePath` flow (unchanged)
- Custom path → `addCustomClaudePath(path, folderName)` + `scanProjects()`

## Test plan
- [x] `pnpm tsc --build .` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm run i18n:validate` — 1757 keys synced
- [ ] Manual: Change Folder → select `~/.claude-personal` (with `projects/` inside) → projects appear immediately
- [ ] Manual: Change Folder → select standard `~/.claude` → works as before
- [ ] Manual: Change Folder → select invalid folder (no `projects/`) → error message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined folder validation: users now see a single, clear error alert and successful custom-folder selection proceeds immediately.

* **New Features**
  * Selected app-specific folders are auto-normalized; other folders are saved as custom paths and trigger project scanning.

* **Chores**
  * Simplified modal flow and removed extra guidance prompts for a cleaner folder-selection experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->