### PR TITLE
feat(cli): add --session <uuid> flag for external session launching

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,0 +1,176 @@
+//! CLI argument parsing for the desktop binary.
+//!
+//! The `--serve` flag (`WebUI` headless mode) is handled inline in `lib.rs` for
+//! historical reasons. This module adds a `--session <value>` flag that asks
+//! the GUI to preload a specific Claude Code session at startup. The resolved
+//! hint is exposed to the frontend via the `get_startup_session_hint` Tauri
+//! command; the React side then navigates to that session once projects are
+//! loaded.
+//!
+//! Commit A (this change) accepts UUID / UUID-prefix values only. Commit B
+//! extends the parser to accept paths, sesslog folder names, and free-text
+//! titles.
+
+use serde::Serialize;
+use tauri::State;
+
+/// Newtype wrapper so we can pass `Option<SessionHint>` through Tauri's typed
+/// managed-state API. `tauri::State<T>` keys by type, so wrapping in a named
+/// struct avoids any accidental collision with a future `Option<T>` managed by
+/// another subsystem.
+#[derive(Default)]
+pub struct StartupSessionHint(pub Option<SessionHint>);
+
+/// Tauri command returning the CLI-supplied session hint, if any.
+///
+/// The frontend calls this on mount after projects have loaded; `None` means
+/// "no preload requested, run the normal UI".
+#[tauri::command]
+#[must_use]
+pub fn get_startup_session_hint(state: State<'_, StartupSessionHint>) -> Option<SessionHint> {
+    state.0.clone()
+}
+
+/// A CLI-supplied hint asking the frontend to preload a specific session.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionHint {
+    /// Resolution strategy. In Commit A this is only [`SessionHintKind::Uuid`].
+    pub kind: SessionHintKind,
+    /// The raw value as supplied on the command line.
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionHintKind {
+    Uuid,
+}
+
+/// Parse `--session <value>` or `--session=<value>` from a raw argv vec.
+///
+/// Returns `None` if the flag is absent, the value is missing, or the value
+/// does not look like a UUID or UUID prefix.
+#[must_use]
+pub fn parse_session_hint(args: &[String]) -> Option<SessionHint> {
+    let raw = extract_flag_value(args, "--session")?;
+    if is_uuid_like(&raw) {
+        Some(SessionHint {
+            kind: SessionHintKind::Uuid,
+            value: raw,
+        })
+    } else {
+        None
+    }
+}
+
+/// Extract the value of `--flag=value` or `--flag value` from argv.
+///
+/// A flag without a following value (or followed by another flag starting
+/// with `--`) yields `None`.
+fn extract_flag_value(args: &[String], flag: &str) -> Option<String> {
+    let prefix = format!("{flag}=");
+    for (idx, arg) in args.iter().enumerate() {
+        if let Some(after) = arg.strip_prefix(&prefix) {
+            if after.is_empty() {
+                return None;
+            }
+            return Some(after.to_string());
+        }
+        if arg == flag {
+            return args
+                .get(idx + 1)
+                .filter(|next| !next.starts_with("--"))
+                .cloned();
+        }
+    }
+    None
+}
+
+/// A UUID is 36 chars with four dashes; a prefix is any 8-35 char slice of
+/// the canonical form. We accept anything hex-or-dash of length 8..=36.
+fn is_uuid_like(value: &str) -> bool {
+    let len = value.len();
+    if !(8..=36).contains(&len) {
+        return false;
+    }
+    value.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn returns_none_when_no_flag_present() {
+        let args = argv(&["app", "--serve"]);
+        assert!(parse_session_hint(&args).is_none());
+    }
+
+    #[test]
+    fn parses_space_separated_uuid() {
+        let args = argv(&["app", "--session", "1265cd74-caa9-472e-b343-c4f44b5cf12c"]);
+        let hint = parse_session_hint(&args).expect("hint");
+        assert_eq!(hint.kind, SessionHintKind::Uuid);
+        assert_eq!(hint.value, "1265cd74-caa9-472e-b343-c4f44b5cf12c");
+    }
+
+    #[test]
+    fn parses_equals_form() {
+        let args = argv(&["app", "--session=1265cd74-caa9-472e-b343-c4f44b5cf12c"]);
+        let hint = parse_session_hint(&args).expect("hint");
+        assert_eq!(hint.value, "1265cd74-caa9-472e-b343-c4f44b5cf12c");
+    }
+
+    #[test]
+    fn accepts_uuid_prefix() {
+        let args = argv(&["app", "--session", "1265cd74"]);
+        let hint = parse_session_hint(&args).expect("hint");
+        assert_eq!(hint.value, "1265cd74");
+    }
+
+    #[test]
+    fn rejects_non_hex_value() {
+        let args = argv(&["app", "--session", "hello-world-not-a-uuid"]);
+        // "hello-world-not-a-uuid" contains non-hex chars — rejected.
+        assert!(parse_session_hint(&args).is_none());
+    }
+
+    #[test]
+    fn rejects_too_short_value() {
+        let args = argv(&["app", "--session", "1265cd7"]);
+        assert!(parse_session_hint(&args).is_none());
+    }
+
+    #[test]
+    fn rejects_too_long_value() {
+        let args = argv(&[
+            "app",
+            "--session",
+            "1265cd74-caa9-472e-b343-c4f44b5cf12c-extra",
+        ]);
+        assert!(parse_session_hint(&args).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_flag_value_is_another_flag() {
+        let args = argv(&["app", "--session", "--serve"]);
+        assert!(parse_session_hint(&args).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_flag_has_no_following_argument() {
+        let args = argv(&["app", "--session"]);
+        assert!(parse_session_hint(&args).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_equals_form_has_empty_value() {
+        let args = argv(&["app", "--session="]);
+        assert!(parse_session_hint(&args).is_none());
+    }
+}

--- a/src-tauri/src/commands/session/delete.rs
+++ b/src-tauri/src/commands/session/delete.rs
@@ -60,6 +60,7 @@ pub async fn delete_session(file_path: String) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;
 
@@ -91,6 +92,7 @@ mod tests {
         assert_eq!(err, "Invalid session ID format");
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn reject_symlink() {
         let dir = TempDir::new().unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cli;
 pub mod commands;
 pub mod models;
 pub mod providers;
@@ -97,6 +98,12 @@ fn run_tauri() {
 
     use std::sync::{Arc, Mutex};
 
+    // Parse CLI args for a session preload hint (e.g. `--session <uuid>`).
+    // A missing or unrecognized value yields None; the GUI then runs as usual.
+    let startup_session_hint = cli::StartupSessionHint(cli::parse_session_hint(
+        &std::env::args().collect::<Vec<_>>(),
+    ));
+
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
@@ -110,11 +117,13 @@ fn run_tauri() {
 
     builder
         .manage(MetadataState::default())
+        .manage(startup_session_hint)
         .manage(Arc::new(Mutex::new(None))
             as Arc<
                 Mutex<Option<notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>>>,
             >)
         .invoke_handler(tauri::generate_handler![
+            crate::cli::get_startup_session_hint,
             get_claude_folder_path,
             validate_claude_folder,
             validate_custom_claude_dir,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "./store/useAppStore";
 import { useAnalytics } from "./hooks/useAnalytics";
@@ -17,6 +17,10 @@ import {
   type GroupingMode,
 } from "./types";
 import { getProviderLabel, normalizeProviderIds } from "./utils/providers";
+import {
+  fetchStartupSessionHint,
+  preloadSessionFromCli,
+} from "./lib/preloadSession";
 
 import "./App.css";
 
@@ -117,6 +121,23 @@ function App() {
       { providers: labels.join(", ") }
     );
   }, [activeProviders, t]);
+
+  // One-shot guard so `--session <uuid>` preload fires exactly once per
+  // process, even if project loading renders multiple times.
+  const cliPreloadAttempted = useRef(false);
+
+  useEffect(() => {
+    if (cliPreloadAttempted.current) return;
+    if (isLoadingProjects || projects.length === 0) return;
+    cliPreloadAttempted.current = true;
+    void preloadSessionFromCli({
+      getStartupSessionHint: fetchStartupSessionHint,
+      projects,
+      selectProject,
+      selectSession,
+      t: (key, fallback) => t(key, fallback ?? key),
+    });
+  }, [isLoadingProjects, projects, selectProject, selectSession, t]);
 
   // Local state
   const [isViewingGlobalStats, setIsViewingGlobalStats] = useState(false);

--- a/src/lib/preloadSession.test.ts
+++ b/src/lib/preloadSession.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import type { ClaudeProject, ClaudeSession } from "@/types";
+import {
+  preloadSessionFromCli,
+  type PreloadDependencies,
+  type SessionHint,
+} from "./preloadSession";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("@/services/api", () => ({
+  api: vi.fn(),
+}));
+
+vi.mock("@/store/useAppStore", () => ({
+  useAppStore: {
+    getState: () => ({ excludeSidechain: false }),
+  },
+}));
+
+import { api } from "@/services/api";
+
+const UUID = "1265cd74-caa9-472e-b343-c4f44b5cf12c";
+
+const project: ClaudeProject = {
+  name: "demo",
+  path: "/home/.claude/projects/demo",
+  actual_path: "/home/user/demo",
+  session_count: 1,
+  message_count: 5,
+  last_modified: "2026-04-15T00:00:00Z",
+};
+
+const session: ClaudeSession = {
+  session_id: "demo-id",
+  actual_session_id: UUID,
+  file_path: "/home/.claude/projects/demo/1265cd74-caa9-472e-b343-c4f44b5cf12c.jsonl",
+  project_name: "demo",
+  message_count: 5,
+  first_message_time: "2026-04-15T00:00:00Z",
+  last_message_time: "2026-04-15T00:01:00Z",
+  last_modified: "2026-04-15T00:01:00Z",
+  has_tool_use: false,
+  has_errors: false,
+};
+
+function makeDeps(overrides: Partial<PreloadDependencies> = {}): PreloadDependencies {
+  return {
+    getStartupSessionHint: vi.fn().mockResolvedValue(null),
+    projects: [],
+    selectProject: vi.fn().mockResolvedValue(undefined),
+    selectSession: vi.fn().mockResolvedValue(undefined),
+    t: (_k: string, fallback?: string) => fallback ?? "Session not found",
+    ...overrides,
+  };
+}
+
+describe("preloadSessionFromCli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("no-ops when there is no startup hint", async () => {
+    const deps = makeDeps();
+    const result = await preloadSessionFromCli(deps);
+    expect(result).toEqual({ handled: false, matched: false });
+    expect(deps.selectProject).not.toHaveBeenCalled();
+    expect(deps.selectSession).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("opens a matching session across projects", async () => {
+    vi.mocked(api).mockResolvedValueOnce([session] as unknown as never);
+    const hint: SessionHint = { kind: "uuid", value: UUID };
+    const deps = makeDeps({
+      getStartupSessionHint: vi.fn().mockResolvedValue(hint),
+      projects: [project],
+    });
+
+    const result = await preloadSessionFromCli(deps);
+
+    expect(result).toEqual({ handled: true, matched: true });
+    expect(api).toHaveBeenCalledWith("load_project_sessions", {
+      projectPath: project.path,
+      excludeSidechain: false,
+    });
+    expect(deps.selectProject).toHaveBeenCalledWith(project);
+    expect(deps.selectSession).toHaveBeenCalledWith(session);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("matches a UUID prefix", async () => {
+    vi.mocked(api).mockResolvedValueOnce([session] as unknown as never);
+    const deps = makeDeps({
+      getStartupSessionHint: vi.fn().mockResolvedValue({
+        kind: "uuid",
+        value: "1265cd74",
+      } as SessionHint),
+      projects: [project],
+    });
+
+    const result = await preloadSessionFromCli(deps);
+
+    expect(result.matched).toBe(true);
+    expect(deps.selectSession).toHaveBeenCalledWith(session);
+  });
+
+  it("shows a toast and reports matched=false when session is missing", async () => {
+    vi.mocked(api).mockResolvedValueOnce([] as unknown as never);
+    const deps = makeDeps({
+      getStartupSessionHint: vi.fn().mockResolvedValue({
+        kind: "uuid",
+        value: UUID,
+      } as SessionHint),
+      projects: [project],
+    });
+
+    const result = await preloadSessionFromCli(deps);
+
+    expect(result).toEqual({ handled: true, matched: false });
+    expect(deps.selectProject).not.toHaveBeenCalled();
+    expect(deps.selectSession).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Session not found");
+  });
+
+  it("tolerates individual project-load failures and keeps scanning", async () => {
+    const projectA: ClaudeProject = { ...project, name: "a", path: "/a" };
+    const projectB: ClaudeProject = { ...project, name: "b", path: "/b" };
+    vi.mocked(api)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce([session] as unknown as never);
+
+    const deps = makeDeps({
+      getStartupSessionHint: vi.fn().mockResolvedValue({
+        kind: "uuid",
+        value: UUID,
+      } as SessionHint),
+      projects: [projectA, projectB],
+    });
+
+    const result = await preloadSessionFromCli(deps);
+
+    expect(result.matched).toBe(true);
+    expect(deps.selectProject).toHaveBeenCalledWith(projectB);
+  });
+
+  it("ignores unsupported hint kinds without crashing", async () => {
+    const deps = makeDeps({
+      getStartupSessionHint: vi.fn().mockResolvedValue({
+        kind: "future",
+        value: "irrelevant",
+      } as unknown as SessionHint),
+    });
+
+    const result = await preloadSessionFromCli(deps);
+
+    expect(result).toEqual({ handled: true, matched: false });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/preloadSession.ts
+++ b/src/lib/preloadSession.ts
@@ -1,0 +1,131 @@
+/**
+ * CLI-driven session preload.
+ *
+ * When the desktop app is launched with `--session <uuid>`, the Rust side
+ * stashes a {@link SessionHint} that the frontend retrieves via the
+ * `get_startup_session_hint` command. This module resolves that hint against
+ * the loaded project list and calls the existing `selectProject` /
+ * `selectSession` actions — the same flow the GlobalSearch modal uses for
+ * cross-project navigation.
+ *
+ * Commit A handles `kind: "uuid"` only. Commit B will extend this to path,
+ * name, and sesslog folder hints.
+ */
+
+import { toast } from "sonner";
+import { api } from "@/services/api";
+import { useAppStore } from "@/store/useAppStore";
+import type { ClaudeProject, ClaudeSession } from "@/types";
+
+export interface SessionHint {
+  kind: "uuid";
+  value: string;
+}
+
+/** Translator function compatible with `i18next`'s `t()`. */
+export type Translator = (key: string, fallback?: string) => string;
+
+export interface PreloadDependencies {
+  /** Retrieves the startup hint, if any. Injected for testability. */
+  getStartupSessionHint: () => Promise<SessionHint | null>;
+  /** List of known projects — usually from the app store after initial load. */
+  projects: ClaudeProject[];
+  /** Select a project (mirrors store action). */
+  selectProject: (project: ClaudeProject) => Promise<void>;
+  /** Select a session (mirrors store action). */
+  selectSession: (session: ClaudeSession) => Promise<void>;
+  /** i18n translator for the not-found toast. */
+  t: Translator;
+}
+
+/**
+ * Default implementation of {@link PreloadDependencies.getStartupSessionHint}
+ * that calls the Tauri / WebUI backend.
+ */
+export async function fetchStartupSessionHint(): Promise<SessionHint | null> {
+  try {
+    return await api<SessionHint | null>("get_startup_session_hint");
+  } catch (error) {
+    // Command not registered (e.g. older backend) — treat as absent.
+    console.warn("get_startup_session_hint unavailable:", error);
+    return null;
+  }
+}
+
+/**
+ * Find a session matching a UUID or UUID-prefix across the given project's
+ * loaded sessions.
+ */
+function matchSession(
+  sessions: ClaudeSession[],
+  uuidOrPrefix: string,
+): ClaudeSession | undefined {
+  const lower = uuidOrPrefix.toLowerCase();
+  return sessions.find((s) => {
+    const actual = s.actual_session_id?.toLowerCase() ?? "";
+    const id = s.session_id?.toLowerCase() ?? "";
+    return actual === lower || id === lower || actual.startsWith(lower) || id.startsWith(lower);
+  });
+}
+
+/**
+ * Resolve a UUID hint by scanning every known project's session list.
+ *
+ * Each non-claude provider gets its own `load_provider_sessions` call; the
+ * default claude provider uses `load_project_sessions`. Mirrors the scan in
+ * `GlobalSearchModal.handleSelectResult`.
+ */
+async function findSessionAcrossProjects(
+  uuid: string,
+  projects: ClaudeProject[],
+): Promise<{ project: ClaudeProject; session: ClaudeSession } | null> {
+  for (const project of projects) {
+    try {
+      const providerId = project.provider ?? "claude";
+      const { excludeSidechain } = useAppStore.getState();
+      const projectSessions = await api<ClaudeSession[]>(
+        providerId !== "claude" ? "load_provider_sessions" : "load_project_sessions",
+        providerId !== "claude"
+          ? { provider: providerId, projectPath: project.path, excludeSidechain }
+          : { projectPath: project.path, excludeSidechain },
+      );
+      const session = matchSession(projectSessions, uuid);
+      if (session) {
+        return { project, session };
+      }
+    } catch (error) {
+      console.warn(`preloadSession: failed to scan project ${project.name}:`, error);
+    }
+  }
+  return null;
+}
+
+/**
+ * Main entry point. Called once after projects are loaded. If no hint is
+ * present, returns a benign `{ handled: false }`. If a hint is present but
+ * no session matches, shows a toast and returns `{ handled: true,
+ * matched: false }`.
+ */
+export async function preloadSessionFromCli(
+  deps: PreloadDependencies,
+): Promise<{ handled: boolean; matched: boolean }> {
+  const hint = await deps.getStartupSessionHint();
+  if (!hint) {
+    return { handled: false, matched: false };
+  }
+  if (hint.kind !== "uuid") {
+    // Commit A: unrecognized kinds are ignored rather than crashing.
+    console.warn(`preloadSession: unsupported hint kind "${hint.kind}"`);
+    return { handled: true, matched: false };
+  }
+
+  const match = await findSessionAcrossProjects(hint.value, deps.projects);
+  if (!match) {
+    toast.error(deps.t("globalSearch.sessionNotFound", "Session not found"));
+    return { handled: true, matched: false };
+  }
+
+  await deps.selectProject(match.project);
+  await deps.selectSession(match.session);
+  return { handled: true, matched: true };
+}


### PR DESCRIPTION
Closes #260.

Adds a `--session <value>` flag so the viewer can be launched pre-focused on a specific session from the shell, the same way you would `typora some.md` to open a markdown document.

This is **Stage A** of the two-stage proposal in #260: accepts a full session UUID or UUID prefix (8..=36 hex/dash chars). Stage B (path / session title / sesslog folder name) is scoped as a potential follow-up and not in this PR.

#### What's in this PR

Two commits, both with tests:

- [`020b493`](https://github.com/djdarcy/dazzle-claude-code-history-viewer/commit/020b493) — small prep fix: cfg-gate the unix-only `std::os::unix::fs::symlink` import in `session/delete.rs` tests so `cargo test` compiles on Windows. Unrelated to `--session` itself, but unblocks running the full test suite on Windows.
- [`d3c7ef5`](https://github.com/djdarcy/dazzle-claude-code-history-viewer/commit/d3c7ef5) — the feature: `--session <uuid>` flag with parser, Tauri command, React preload hook, and tests.

#### Behavior

On startup, after the projects scan completes, the viewer navigates into the requested session using the existing `selectProject` / `selectSession` store actions — same flow as `GlobalSearchModal.handleSelectResult`'s scan-all-projects path. If the session is missing, it shows the existing `globalSearch.sessionNotFound` toast (no new i18n keys required).

#### Files

- `src-tauri/src/cli.rs` (new) — std-only argv parser, `SessionHint { kind, value }`, `StartupSessionHint` managed-state newtype, and the `get_startup_session_hint` Tauri command. 10 unit tests covering present/absent/malformed input.
- `src-tauri/src/lib.rs` — parse `std::env::args()` early in `run_tauri()` (mirrors existing `--serve` pattern), `.manage()` the hint, register the command.
- `src/lib/preloadSession.ts` (new) — dependency-injected helper that resolves the hint and calls the existing store actions.
- `src/lib/preloadSession.test.ts` (new) — 6 vitest cases (no-hint no-op, happy path, UUID-prefix match, missing-session toast, tolerates per-project load failures, ignores unsupported kinds).
- `src/App.tsx` — `useEffect` + `useRef` one-shot guard that fires once projects load.
- `src-tauri/src/commands/session/delete.rs` — cfg-gate the unix-only symlink test (prep commit).

#### Dependencies

None new. The parser is `std`-only; React side uses existing `api.ts` helper and `sonner` toast.

#### Testing

Quality gate, all passing on Windows 11:

- `pnpm tsc --build .`
- `pnpm vitest run` — 741 passed, 0 failed (includes 6 new)
- `pnpm lint` — no new errors
- `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1` — 20+ passed (10 new)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings` — clean (requires `pnpm build` first to populate `dist/` for the webui-server `rust-embed`, as expected)
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — clean
- `pnpm run i18n:validate` — clean

End-to-end manually verified: `pnpm tauri:dev -- -- --session <uuid>` launches the viewer and auto-navigates into the requested session. Visual confirmation via loading a known long session and verifying content matched.

#### Proposed Test plan for reviewer

- [ ] Run `pnpm tauri:dev -- -- --session <any-real-uuid-from-your-~/.claude/projects/>` — viewer should open pre-focused on that session.
- [ ] Run with a UUID prefix (e.g. first 8 chars) — should behave the same.
- [ ] Run with a malformed value (e.g. `--session not-a-uuid`) — should be silently ignored, viewer runs normally.
- [ ] Launch without `--session` — behavior unchanged.
- [ ] Launch with `--session <unknown-uuid>` — should show the "session not found" toast and run normally.

#### Some open design questions (also in #260)

Happy to adjust this PR toward whatever shape you prefer:

1. **CLI parsing**: std-only parser vs. adopting `tauri-plugin-cli`.
2. **Second-invocation behavior**: deferred to a separate follow-up PR using `tauri-plugin-single-instance`.
3. **Scope of Stage B**: upstream-bound or fork-only.

#### Notes for reviewer

- Conventional Commits used to match the style I saw in `develop`'s recent history. Let me know if you'd like the commit messages reshaped.
- The prep commit (`020b493`) is genuinely independent of the feature. If you'd prefer it split it into its own PR, I can do that instead.

Thanks for the review and hopefully adding!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line session preloading: Start the application with a session identifier argument to automatically load that specific session after projects finish loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->