### PR TITLE
fix: render context menus in a portal so they anchor to the cursor

### DIFF
--- a/src/components/ProjectContextMenu.tsx
+++ b/src/components/ProjectContextMenu.tsx
@@ -1,5 +1,6 @@
 // src/components/ProjectContextMenu.tsx
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useLayoutEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { EyeOff, Eye, Copy } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -50,7 +51,7 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
   }, [onClose]);
 
   // Adjust position if menu would go off-screen
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (menuRef.current) {
       const rect = menuRef.current.getBoundingClientRect();
       const windowWidth = window.innerWidth;
@@ -65,6 +66,9 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
       if (y + rect.height > windowHeight) {
         y = windowHeight - rect.height - 8;
       }
+
+      x = Math.max(8, x);
+      y = Math.max(8, y);
 
       setAdjustedPosition({ x, y });
     }
@@ -102,7 +106,7 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
     "transition-colors cursor-pointer"
   );
 
-  return (
+  return createPortal(
     <div
       ref={menuRef}
       className={cn(
@@ -148,6 +152,7 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
           )}
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };

--- a/src/components/SessionItem/components/SessionContextMenu.tsx
+++ b/src/components/SessionItem/components/SessionContextMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   Pencil,
   RotateCcw,
@@ -96,7 +97,7 @@ export const SessionContextMenu: React.FC<SessionContextMenuProps> = ({
     };
   };
 
-  return (
+  return createPortal(
     <div
       ref={menuRef}
       role="menu"
@@ -172,6 +173,7 @@ export const SessionContextMenu: React.FC<SessionContextMenuProps> = ({
           <span>{t("session.deleteSession", "Delete Session")}</span>
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };


### PR DESCRIPTION
## Summary

The right-click context menus on session and project items were rendering detached from the cursor — offset horizontally, sometimes clipped against the pane edge.

**Root cause:** `SessionList` uses `react-window`'s `FixedSizeList`, whose outer scroll container has `will-change: transform`. Per CSS spec, `will-change: transform` (like `transform` itself) creates a new containing block for descendants with `position: fixed`. The context menu is rendered as a descendant of that scroll container, so its `fixed` coordinates were being resolved relative to the virtualized scroll box instead of the viewport.

**Fix:** render both context menus via `createPortal(..., document.body)` so they escape the transformed ancestor and anchor to `clientX`/`clientY` as intended.

Also switched `ProjectContextMenu`'s off-screen adjustment from `useEffect` to `useLayoutEffect` and added a `Math.max(8, …)` clamp, matching the logic already in `SessionContextMenu` — prevents a single-frame flash at the wrong position and keeps the menu from popping off the top/left edges.

## Changes

- `src/components/SessionItem/components/SessionContextMenu.tsx` — wrap return in `createPortal`
- `src/components/ProjectContextMenu.tsx` — wrap return in `createPortal`, `useLayoutEffect` + edge clamp

## Test plan

- [x] `pnpm tsc --build .` — clean
- [x] `pnpm lint` — clean (pre-existing unrelated warning in `GlobalSearchModal.tsx`)
- [x] `pnpm vitest run` — 735/735 pass
- [ ] Manual: right-click a session item inside the virtualized list — menu should appear directly under the cursor, not floating off to the right
- [ ] Manual: right-click near the viewport edge — menu should slide back in-bounds as before
- [ ] Manual: right-click a project in `ProjectTree` — menu should anchor correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context menu positioning and rendering behavior for more reliable UI placement across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->