### PR TITLE
fix(clippy): replace sort_by + Reverse comparator with sort_by_key

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1069,7 +1069,7 @@ fn build_tool_usage_stats(tool_usage: HashMap<String, (u32, u32)>) -> Vec<ToolUs
         })
         .collect::<Vec<_>>();
 
-    tools.sort_by(|a, b| b.usage_count.cmp(&a.usage_count));
+    tools.sort_by_key(|b| std::cmp::Reverse(b.usage_count));
     tools
 }
 
@@ -1276,7 +1276,7 @@ fn get_provider_project_token_stats(
     }
 
     let total_count = all_stats.len();
-    all_stats.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+    all_stats.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
     let items = all_stats
         .into_iter()
         .skip(offset)
@@ -1545,7 +1545,7 @@ fn get_provider_session_comparison(
     };
 
     let mut sessions_by_tokens = all_sessions.clone();
-    sessions_by_tokens.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+    sessions_by_tokens.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
     let rank_by_tokens = sessions_by_tokens
         .iter()
         .position(|s| s.session_id == session_id)
@@ -1553,7 +1553,7 @@ fn get_provider_session_comparison(
         + 1;
 
     let mut sessions_by_duration = all_sessions.clone();
-    sessions_by_duration.sort_by(|a, b| b.duration_seconds.cmp(&a.duration_seconds));
+    sessions_by_duration.sort_by_key(|b| std::cmp::Reverse(b.duration_seconds));
     let rank_by_duration = sessions_by_duration
         .iter()
         .position(|s| s.session_id == session_id)
@@ -1868,7 +1868,7 @@ pub async fn get_project_token_stats(
 
     // Sort by total tokens (descending)
     let mut all_stats = all_stats;
-    all_stats.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+    all_stats.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
 
     // Apply pagination
     let paginated_items: Vec<SessionTokenStats> =
@@ -2038,7 +2038,7 @@ pub async fn get_project_stats_summary(
         .collect();
     summary
         .most_used_tools
-        .sort_by(|a, b| b.usage_count.cmp(&a.usage_count));
+        .sort_by_key(|b| std::cmp::Reverse(b.usage_count));
 
     summary.daily_stats = daily_stats_map.into_values().collect();
     summary.daily_stats.sort_by(|a, b| a.date.cmp(&b.date));
@@ -2249,7 +2249,7 @@ pub async fn get_session_comparison(
 
     // Sort by tokens to find rank
     let mut sessions_by_tokens = all_sessions.clone();
-    sessions_by_tokens.sort_by(|a, b| b.total_tokens.cmp(&a.total_tokens));
+    sessions_by_tokens.sort_by_key(|b| std::cmp::Reverse(b.total_tokens));
 
     let rank_by_tokens = sessions_by_tokens
         .iter()
@@ -2259,7 +2259,7 @@ pub async fn get_session_comparison(
 
     // Sort by duration to find rank
     let mut sessions_by_duration = all_sessions.clone();
-    sessions_by_duration.sort_by(|a, b| b.duration_seconds.cmp(&a.duration_seconds));
+    sessions_by_duration.sort_by_key(|b| std::cmp::Reverse(b.duration_seconds));
 
     let rank_by_duration = sessions_by_duration
         .iter()
@@ -2574,7 +2574,7 @@ pub async fn get_global_stats_summary(
         .collect();
     summary
         .most_used_tools
-        .sort_by(|a, b| b.usage_count.cmp(&a.usage_count));
+        .sort_by_key(|b| std::cmp::Reverse(b.usage_count));
 
     summary.provider_distribution = provider_stats_map
         .into_iter()
@@ -2593,7 +2593,7 @@ pub async fn get_global_stats_summary(
         .collect();
     summary
         .provider_distribution
-        .sort_by(|a, b| b.tokens.cmp(&a.tokens));
+        .sort_by_key(|b| std::cmp::Reverse(b.tokens));
 
     summary.model_distribution = model_usage_map
         .into_iter()
@@ -2621,7 +2621,7 @@ pub async fn get_global_stats_summary(
         .collect();
     summary
         .model_distribution
-        .sort_by(|a, b| b.token_count.cmp(&a.token_count));
+        .sort_by_key(|b| std::cmp::Reverse(b.token_count));
 
     summary.top_projects = project_stats_map
         .into_iter()
@@ -2634,7 +2634,9 @@ pub async fn get_global_stats_summary(
             },
         )
         .collect();
-    summary.top_projects.sort_by(|a, b| b.tokens.cmp(&a.tokens));
+    summary
+        .top_projects
+        .sort_by_key(|b| std::cmp::Reverse(b.tokens));
     summary.top_projects.truncate(10);
 
     summary.daily_stats = daily_stats_map.into_values().collect();

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -485,14 +485,12 @@ fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
                         .map(String::from);
                 }
             }
-            "turn_context" => {
-                if model.is_none() {
-                    if let Some(payload) = val.get("payload") {
-                        model = payload
-                            .get("model")
-                            .and_then(|v| v.as_str())
-                            .map(String::from);
-                    }
+            "turn_context" if model.is_none() => {
+                if let Some(payload) = val.get("payload") {
+                    model = payload
+                        .get("model")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
                 }
             }
             "response_item" => {


### PR DESCRIPTION
## Summary

CI's \`Lint & Format\` job on develop has been failing because clippy 1.93 flags the \`sort_by(|a, b| b.X.cmp(&a.X))\` pattern in \`src/commands/stats.rs\`. Twelve occurrences, all descending sorts on numeric primitive fields. Mechanical replacement with \`sort_by_key(|b| std::cmp::Reverse(b.X))\` — behavior identical, only spelling changes.

Ascending sorts (e.g. \`daily_stats.sort_by(|a, b| a.date.cmp(&b.date))\`) untouched because the key type is \`String\`, and \`sort_by_key\` would force a clone per element.

## Why now

Three stacked PRs (#271/#272/#274) for issue #270 are blocked by this preexisting failure. Cleanup PR first so the chain can ship clean.

## Test plan

- [x] \`cargo check --all-features\` — clean
- [x] \`cargo test --lib --all-features -- --test-threads=1\` — 442 passed
- [x] \`cargo fmt --all -- --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized descending sorting across multiple statistics and summary views to a consistent, clearer implementation.
  * Simplified session-data extraction logic to avoid redundant checks while preserving existing behavior.
  * Minor cleanups to sorting and truncation steps to improve readability and reduce duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->