### PR TITLE
feat: follow symlinks at depth 1 in scan_projects

### DIFF
--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -172,7 +172,12 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         .max_depth(1)
         .into_iter()
         .filter_map(std::result::Result::ok)
-        .filter(|e| e.file_type().is_dir())
+        .filter(|e| {
+            // Accept real directories and symlinks that resolve to directories.
+            // Symlinks are only followed at depth 1 (project level), never deeper,
+            // so there is no risk of traversing outside the projects/ tree.
+            e.file_type().is_dir() || (e.file_type().is_symlink() && e.path().is_dir())
+        })
     {
         let raw_project_name = entry.file_name().to_string_lossy().to_string();
         let project_path = entry.path().to_string_lossy().to_string();


### PR DESCRIPTION
## Summary

Fixes #259

Project directories inside `projects/` that are symlinks are now included in the scan. This supports setups where sessions are shared across multiple macOS user accounts via symlinks into a shared folder (e.g. `/Users/Shared/.claude/projects/`).

The change is a single filter in `scan_projects`:

```rust
// Before: only real directories
.filter(|e| e.file_type().is_dir())

// After: real directories + symlinks that resolve to directories
.filter(|e| {
    e.file_type().is_dir()
        || (e.file_type().is_symlink() && e.path().is_dir())
})
```

Symlinks are **only followed at depth 1** (project level) — never deeper — so traversal cannot escape the `projects/` tree. The existing behaviour for all-real-directory layouts is unchanged.

## Test plan

- [ ] Normal project directories still appear as before
- [ ] Symlinked project directories now appear in the session list
- [ ] "Show JSONL File" on a session from a symlinked project correctly reveals the file in the real folder
- [ ] Dangling symlinks (pointing to a non-existent or non-directory target) are silently skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project scanning to properly recognize symbolic links pointing to project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->