### PR TITLE
fix(ui): clamp context menus to panel bounds and close on scroll

### DIFF
--- a/src/components/ProjectContextMenu.tsx
+++ b/src/components/ProjectContextMenu.tsx
@@ -6,10 +6,11 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import type { ClaudeProject } from "../types";
+import { computeMenuPosition, type Boundary } from "@/utils/contextMenu";
 
 interface ProjectContextMenuProps {
   project: ClaudeProject;
-  position: { x: number; y: number };
+  position: { x: number; y: number; boundary?: Boundary | null };
   onClose: () => void;
   onHide: (projectPath: string) => void;
   onUnhide: (projectPath: string) => void;
@@ -26,7 +27,7 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
 }) => {
   const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement>(null);
-  const [adjustedPosition, setAdjustedPosition] = useState(position);
+  const [adjustedPosition, setAdjustedPosition] = useState({ x: position.x, y: position.y });
 
   // Close on click outside
   useEffect(() => {
@@ -50,27 +51,42 @@ export const ProjectContextMenu: React.FC<ProjectContextMenuProps> = ({
     };
   }, [onClose]);
 
-  // Adjust position if menu would go off-screen
+  // Close on scroll or resize. Arm one animation frame after mount so a
+  // synchronous scroll burst during the click-to-open sequence can't close
+  // the menu immediately. Capture phase on scroll catches scroll on any
+  // descendant (scroll events don't bubble, but capture flows root → target).
+  // removeEventListener must match the capture flag or the listener leaks.
+  useEffect(() => {
+    let armed = false;
+    const raf = requestAnimationFrame(() => {
+      armed = true;
+    });
+    const handleScroll = () => {
+      if (armed) onClose();
+    };
+    const handleResize = () => {
+      if (armed) onClose();
+    };
+    document.addEventListener("scroll", handleScroll, { capture: true, passive: true });
+    window.addEventListener("resize", handleResize);
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener("scroll", handleScroll, { capture: true });
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [onClose]);
+
+  // Adjust position if the menu would overflow the boundary (or viewport if absent).
   useLayoutEffect(() => {
     if (menuRef.current) {
       const rect = menuRef.current.getBoundingClientRect();
-      const windowWidth = window.innerWidth;
-      const windowHeight = window.innerHeight;
-
-      let x = position.x;
-      let y = position.y;
-
-      if (x + rect.width > windowWidth) {
-        x = windowWidth - rect.width - 8;
-      }
-      if (y + rect.height > windowHeight) {
-        y = windowHeight - rect.height - 8;
-      }
-
-      x = Math.max(8, x);
-      y = Math.max(8, y);
-
-      setAdjustedPosition({ x, y });
+      setAdjustedPosition(
+        computeMenuPosition(
+          { x: position.x, y: position.y },
+          { width: rect.width, height: rect.height },
+          position.boundary,
+        ),
+      );
     }
   }, [position]);
 

--- a/src/components/ProjectTree/hooks/useProjectTreeState.ts
+++ b/src/components/ProjectTree/hooks/useProjectTreeState.ts
@@ -39,9 +39,12 @@ export function useProjectTreeState(groupingMode: GroupingMode) {
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, project: ClaudeProject) => {
       e.preventDefault();
+      const boundary = e.currentTarget
+        .closest<HTMLElement>("[data-menu-boundary]")
+        ?.getBoundingClientRect() ?? null;
       setContextMenu({
         project,
-        position: { x: e.clientX, y: e.clientY },
+        position: { x: e.clientX, y: e.clientY, boundary },
       });
     },
     []

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -616,6 +616,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
         id={asideId}
         aria-label={t("project.explorer")}
         tabIndex={-1}
+        data-menu-boundary
         className={cn("flex-shrink-0 bg-sidebar border-r-0 flex h-full", isResizing && "select-none")}
         style={sidebarStyle}
       >
@@ -670,6 +671,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       id={asideId}
       aria-label={t("project.explorer")}
       tabIndex={-1}
+      data-menu-boundary
       className={cn("flex-shrink-0 bg-sidebar border-r-0 flex h-full", !width && (!onToggleCollapse && onClose ? "w-full" : "w-64"), isResizing && "select-none")}
       style={sidebarStyle}
     >

--- a/src/components/ProjectTree/types.ts
+++ b/src/components/ProjectTree/types.ts
@@ -2,10 +2,11 @@
 import type { ClaudeProject, ClaudeSession } from "../../types";
 import type { GroupingMode } from "../../types/metadata.types";
 import type { WorktreeGroup, DirectoryGroup } from "../../utils/worktreeUtils";
+import type { Boundary } from "../../utils/contextMenu";
 
 export interface ContextMenuState {
   project: ClaudeProject;
-  position: { x: number; y: number };
+  position: { x: number; y: number; boundary?: Boundary | null };
 }
 
 export interface ProjectTreeProps {

--- a/src/components/SessionItem/SessionItem.tsx
+++ b/src/components/SessionItem/SessionItem.tsx
@@ -7,6 +7,9 @@ import { SessionNameEditor } from "./components/SessionNameEditor";
 import { SessionContextMenu } from "./components/SessionContextMenu";
 import { SessionMeta } from "./components/SessionMeta";
 import type { SessionItemProps } from "./types";
+import type { Boundary } from "@/utils/contextMenu";
+
+type ContextMenuPosition = { x: number; y: number; boundary?: Boundary | null };
 
 export const SessionItem: React.FC<SessionItemProps> = ({
   session,
@@ -16,7 +19,7 @@ export const SessionItem: React.FC<SessionItemProps> = ({
   formatTimeAgo,
 }) => {
   const editing = useSessionEditing(session);
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [contextMenu, setContextMenu] = useState<ContextMenuPosition | null>(null);
 
   const handleClick = useCallback(() => {
     if (!editing.isEditing && !isSelected) {
@@ -25,10 +28,13 @@ export const SessionItem: React.FC<SessionItemProps> = ({
   }, [editing.isEditing, isSelected, onSelect]);
 
   const handleContextMenu = useCallback(
-    (e: React.MouseEvent) => {
+    (e: React.MouseEvent<HTMLElement>) => {
       e.preventDefault();
       editing.setIsContextMenuOpen(false);
-      setContextMenu({ x: e.clientX, y: e.clientY });
+      const boundary = e.currentTarget
+        .closest<HTMLElement>("[data-menu-boundary]")
+        ?.getBoundingClientRect() ?? null;
+      setContextMenu({ x: e.clientX, y: e.clientY, boundary });
     },
     [editing]
   );

--- a/src/components/SessionItem/components/SessionContextMenu.tsx
+++ b/src/components/SessionItem/components/SessionContextMenu.tsx
@@ -12,9 +12,10 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
+import { computeMenuPosition, type Boundary } from "@/utils/contextMenu";
 
 interface SessionContextMenuProps {
-  position: { x: number; y: number };
+  position: { x: number; y: number; boundary?: Boundary | null };
   hasCustomName: boolean;
   supportsNativeRename: boolean;
   providerId: string;
@@ -46,7 +47,7 @@ export const SessionContextMenu: React.FC<SessionContextMenuProps> = ({
 }) => {
   const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement>(null);
-  const [adjustedPosition, setAdjustedPosition] = useState(position);
+  const [adjustedPosition, setAdjustedPosition] = useState({ x: position.x, y: position.y });
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -66,20 +67,41 @@ export const SessionContextMenu: React.FC<SessionContextMenuProps> = ({
     };
   }, [onClose]);
 
+  // Close on scroll or resize. Arm one animation frame after mount so a
+  // synchronous scroll burst during the click-to-open sequence can't close
+  // the menu immediately. Capture phase on scroll catches scroll on any
+  // descendant (scroll events don't bubble, but capture flows root → target).
+  // removeEventListener must match the capture flag or the listener leaks.
+  useEffect(() => {
+    let armed = false;
+    const raf = requestAnimationFrame(() => {
+      armed = true;
+    });
+    const handleScroll = () => {
+      if (armed) onClose();
+    };
+    const handleResize = () => {
+      if (armed) onClose();
+    };
+    document.addEventListener("scroll", handleScroll, { capture: true, passive: true });
+    window.addEventListener("resize", handleResize);
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener("scroll", handleScroll, { capture: true });
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [onClose]);
+
   useLayoutEffect(() => {
     if (menuRef.current) {
       const rect = menuRef.current.getBoundingClientRect();
-      let x = position.x;
-      let y = position.y;
-      if (x + rect.width > window.innerWidth) {
-        x = window.innerWidth - rect.width - 8;
-      }
-      if (y + rect.height > window.innerHeight) {
-        y = window.innerHeight - rect.height - 8;
-      }
-      x = Math.max(8, x);
-      y = Math.max(8, y);
-      setAdjustedPosition({ x, y });
+      setAdjustedPosition(
+        computeMenuPosition(
+          { x: position.x, y: position.y },
+          { width: rect.width, height: rect.height },
+          position.boundary,
+        ),
+      );
     }
   }, [position]);
 

--- a/src/test/ProjectContextMenu.test.tsx
+++ b/src/test/ProjectContextMenu.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Integration tests for ProjectContextMenu listener wiring.
+ * Verifies scroll-close, resize-close, rAF arm guard, and cleanup symmetry.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { ProjectContextMenu } from "../components/ProjectContextMenu";
+import type { ClaudeProject } from "../types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const project: ClaudeProject = {
+  name: "demo",
+  path: "/tmp/demo",
+  actual_path: "/tmp/demo",
+  session_count: 0,
+  last_modified: new Date().toISOString(),
+  provider: "claude",
+};
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof ProjectContextMenu>> = {}) {
+  return {
+    project,
+    position: { x: 100, y: 100 },
+    onClose: vi.fn(),
+    onHide: vi.fn(),
+    onUnhide: vi.fn(),
+    isHidden: false,
+    ...overrides,
+  };
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+describe("ProjectContextMenu listener wiring", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("closes on document scroll after the rAF arm", async () => {
+    const onClose = vi.fn();
+    render(<ProjectContextMenu {...makeProps({ onClose })} />);
+    await nextFrame();
+    document.dispatchEvent(new Event("scroll"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on window resize after the rAF arm", async () => {
+    const onClose = vi.fn();
+    render(<ProjectContextMenu {...makeProps({ onClose })} />);
+    await nextFrame();
+    window.dispatchEvent(new Event("resize"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores scroll fired before the rAF arm (synchronous scroll burst on mount)", () => {
+    const onClose = vi.fn();
+    render(<ProjectContextMenu {...makeProps({ onClose })} />);
+    document.dispatchEvent(new Event("scroll"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("removes both listeners on unmount (cleanup symmetric with capture flag)", async () => {
+    const onClose = vi.fn();
+    const { unmount } = render(<ProjectContextMenu {...makeProps({ onClose })} />);
+    await nextFrame();
+    unmount();
+    document.dispatchEvent(new Event("scroll"));
+    window.dispatchEvent(new Event("resize"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/SessionContextMenu.test.tsx
+++ b/src/test/SessionContextMenu.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Integration tests for SessionContextMenu listener wiring.
+ * Verifies scroll-close, resize-close, rAF arm guard, and cleanup symmetry.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { SessionContextMenu } from "../components/SessionItem/components/SessionContextMenu";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof SessionContextMenu>> = {}) {
+  return {
+    position: { x: 100, y: 100 },
+    hasCustomName: false,
+    supportsNativeRename: false,
+    providerId: "claude",
+    onClose: vi.fn(),
+    onRenameClick: vi.fn(),
+    onResetCustomName: vi.fn(),
+    onNativeRenameClick: vi.fn(),
+    onCopySessionId: vi.fn(),
+    onCopyResumeCommand: vi.fn(),
+    onCopyFilePath: vi.fn(),
+    onRevealInFinder: vi.fn(),
+    onDeleteSession: vi.fn(),
+    ...overrides,
+  };
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+describe("SessionContextMenu listener wiring", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("closes on document scroll after the rAF arm", async () => {
+    const onClose = vi.fn();
+    render(<SessionContextMenu {...makeProps({ onClose })} />);
+    await nextFrame();
+    document.dispatchEvent(new Event("scroll"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on window resize after the rAF arm", async () => {
+    const onClose = vi.fn();
+    render(<SessionContextMenu {...makeProps({ onClose })} />);
+    await nextFrame();
+    window.dispatchEvent(new Event("resize"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores scroll fired before the rAF arm (synchronous scroll burst on mount)", () => {
+    const onClose = vi.fn();
+    render(<SessionContextMenu {...makeProps({ onClose })} />);
+    document.dispatchEvent(new Event("scroll"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("removes both listeners on unmount (cleanup symmetric with capture flag)", async () => {
+    const onClose = vi.fn();
+    const { unmount } = render(<SessionContextMenu {...makeProps({ onClose })} />);
+    await nextFrame();
+    unmount();
+    document.dispatchEvent(new Event("scroll"));
+    window.dispatchEvent(new Event("resize"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/contextMenu.test.ts
+++ b/src/utils/contextMenu.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { computeMenuPosition, type Boundary } from "./contextMenu";
+
+const boundary: Boundary = { left: 0, top: 0, right: 400, bottom: 800 };
+const menu = { width: 200, height: 120 };
+
+describe("computeMenuPosition", () => {
+  it("returns the cursor when the menu fits inside the boundary", () => {
+    expect(
+      computeMenuPosition({ x: 100, y: 100 }, menu, boundary),
+    ).toEqual({ x: 100, y: 100 });
+  });
+
+  it("flips x when the cursor is near the boundary right edge", () => {
+    // 250 + 200 = 450 > 400 - 8 → flip to 250 - 200 = 50
+    expect(
+      computeMenuPosition({ x: 250, y: 100 }, menu, boundary),
+    ).toEqual({ x: 50, y: 100 });
+  });
+
+  it("flips y when the cursor is near the boundary bottom edge", () => {
+    // 750 + 120 = 870 > 800 - 8 → flip to 750 - 120 = 630
+    expect(
+      computeMenuPosition({ x: 100, y: 750 }, menu, boundary),
+    ).toEqual({ x: 100, y: 630 });
+  });
+
+  it("flips both axes when near the corner", () => {
+    expect(
+      computeMenuPosition({ x: 390, y: 790 }, menu, boundary),
+    ).toEqual({ x: 190, y: 670 });
+  });
+
+  it("clamps to left edge with padding when the menu is wider than the boundary", () => {
+    const narrow: Boundary = { left: 0, top: 0, right: 150, bottom: 800 };
+    // menu.width 200 > 150 - 16 → flip produces negative, clamp pulls to left+padding
+    const result = computeMenuPosition({ x: 80, y: 100 }, menu, narrow);
+    expect(result.x).toBe(narrow.left + 8);
+    expect(result.y).toBe(100);
+  });
+
+  it("clamps to top edge with padding when the menu is taller than the boundary", () => {
+    const short: Boundary = { left: 0, top: 0, right: 400, bottom: 80 };
+    const result = computeMenuPosition({ x: 100, y: 40 }, menu, short);
+    expect(result.x).toBe(100);
+    expect(result.y).toBe(short.top + 8);
+  });
+
+  it("falls back to the viewport when boundary is null", () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, "innerWidth", { value: 1000, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
+    try {
+      // cursor at 900, menu 200 → 1100 > 1000 - 8 → flip to 700
+      const result = computeMenuPosition({ x: 900, y: 100 }, menu, null);
+      expect(result).toEqual({ x: 700, y: 100 });
+    } finally {
+      Object.defineProperty(window, "innerWidth", { value: originalInnerWidth, configurable: true });
+      Object.defineProperty(window, "innerHeight", { value: originalInnerHeight, configurable: true });
+    }
+  });
+
+  it("respects a custom padding", () => {
+    // padding = 20 → trigger flip at 250 + 200 = 450 > 400 - 20 = 380 (still flips)
+    // clamp: max(0 + 20, min(50, 400 - 200 - 20)) = max(20, 50) = 50
+    expect(
+      computeMenuPosition({ x: 250, y: 100 }, menu, boundary, 20),
+    ).toEqual({ x: 50, y: 100 });
+  });
+
+  it("keeps x within a sidebar-rooted boundary when the menu is wider than the panel", () => {
+    // Simulates a narrow sidebar at left=20 (real apps with resizable panels)
+    const sidebar: Boundary = { left: 20, top: 0, right: 180, bottom: 800 };
+    const result = computeMenuPosition({ x: 120, y: 100 }, menu, sidebar);
+    // menu.width 200 > 180 - 20 - 16 = 144 → flip goes negative, clamp pulls to left+padding
+    expect(result.x).toBe(sidebar.left + 8);
+    expect(result.x).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/contextMenu.ts
+++ b/src/utils/contextMenu.ts
@@ -1,0 +1,35 @@
+export type Boundary = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+export function computeMenuPosition(
+  cursor: { x: number; y: number },
+  menu: { width: number; height: number },
+  boundary?: Boundary | null,
+  padding = 8,
+): { x: number; y: number } {
+  const b: Boundary = boundary ?? {
+    left: 0,
+    top: 0,
+    right: window.innerWidth,
+    bottom: window.innerHeight,
+  };
+
+  let x = cursor.x;
+  let y = cursor.y;
+
+  if (x + menu.width > b.right - padding) {
+    x = cursor.x - menu.width;
+  }
+  if (y + menu.height > b.bottom - padding) {
+    y = cursor.y - menu.height;
+  }
+
+  x = Math.max(b.left + padding, Math.min(x, b.right - menu.width - padding));
+  y = Math.max(b.top + padding, Math.min(y, b.bottom - menu.height - padding));
+
+  return { x, y };
+}

--- a/src/utils/contextMenu.ts
+++ b/src/utils/contextMenu.ts
@@ -5,6 +5,19 @@ export type Boundary = {
   bottom: number;
 };
 
+/**
+ * Compute a context menu position that flips to the opposite side of the cursor
+ * when it would overflow the boundary's right or bottom edge, then clamps the
+ * result inside the boundary with the given padding.
+ *
+ * When `boundary` is null or undefined, falls back to the viewport
+ * (`window.innerWidth` / `window.innerHeight`).
+ *
+ * Overflow policy: when the menu is larger than the boundary minus 2× padding
+ * on either axis, the menu is pinned to the left/top edge and overflows the
+ * opposite edge. This is intentional — pinning is preferred over hiding the
+ * menu entirely.
+ */
 export function computeMenuPosition(
   cursor: { x: number; y: number },
   menu: { width: number; height: number },


### PR DESCRIPTION
## Summary

Follow-up to #268. That PR fixed the containing-block bug by portaling both right-click context menus to `document.body`. Two UX gaps surfaced once the menus were free-floating:

1. **Menu overflows the sidebar's right edge.** The clamp was viewport-based. With a 380px sidebar in a 1400px viewport, `cursorX + menuWidth` still fit the viewport, so no clamp fired and the menu floated out over the message viewer.
2. **Menu stays pinned when the list scrolls.** Portaled + `position: fixed` means scrolling the virtualized session list did nothing. Native desktop menus (Finder, Explorer) close on scroll. This is also a correctness concern — a virtualized `SessionItem` can unmount while the portaled menu keeps stale-closure action handlers alive.

## Changes

- `src/utils/contextMenu.ts` (new) — `computeMenuPosition` pure function. Flips the menu to the opposite side of the cursor when it would overflow the boundary, then clamps into bounds with 8px padding. Boundary is a plain `{left,top,right,bottom}` object with internal viewport fallback (test-friendly, no jsdom `DOMRect` dependency).
- `src/components/ProjectTree/index.tsx` — mark both `<aside>` branches (collapsed + expanded) with `data-menu-boundary`. Single marker covers desktop sidebar and mobile Sheet because `ProjectTree` is rendered in both.
- `src/components/SessionItem/SessionItem.tsx` + `src/components/ProjectTree/hooks/useProjectTreeState.ts` — at right-click time, resolve the nearest boundary via `e.currentTarget.closest('[data-menu-boundary]')?.getBoundingClientRect() ?? null` and pass it through. No marker found → viewport fallback (current behavior).
- `src/components/SessionItem/components/SessionContextMenu.tsx` + `src/components/ProjectContextMenu.tsx` — replace inline clamp with `computeMenuPosition`. Add `document.addEventListener("scroll", onClose, { capture: true, passive: true })` and `window.addEventListener("resize", onClose)`. Both armed one animation frame after mount so a synchronous scroll burst during the click-to-open sequence can't close the menu immediately. Cleanup matches the capture flag.

## Tests

- `src/utils/contextMenu.test.ts` — 9 unit cases: fit, flip-x, flip-y, flip-both, menu-wider-than-boundary, menu-taller-than-boundary, viewport fallback, custom padding, and positivity when menu exceeds a sidebar-rooted boundary.
- `src/test/SessionContextMenu.test.tsx` + `src/test/ProjectContextMenu.test.tsx` — 4 integration cases each: scroll-close after rAF, resize-close after rAF, pre-rAF scroll ignored, cleanup symmetry on unmount.

## Test plan

- [x] `pnpm tsc --build .` — clean
- [x] `pnpm lint` — clean (pre-existing unrelated warning in `GlobalSearchModal.tsx`)
- [x] `pnpm vitest run` — 768/768 pass (prior 751 + 17 new)
- [x] Manual: right-click session near sidebar right edge → flips left, stays in panel
- [x] Manual: right-click near viewport bottom → flips up
- [x] Manual: scroll the session list with menu open → menu closes
- [x] Manual: resize window with menu open → menu closes
- [x] Manual: drag-resize sidebar with menu open → menu closes via existing outside-click
- [x] Manual: outside-click + ESC still close (regression)
- [x] Manual: every menu action still works (Rename, Copy Session ID, Delete, Copy path, Hide project, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context menus now close on scroll or resize (with a short safeguard to avoid immediate closure during opening).
  * Context menus are positioned more intelligently and now respect nearby panel/container boundaries to avoid overflow.

* **Tests**
  * Added comprehensive tests covering positioning, boundary handling, flipping/clamping behavior, and the scroll/resize close workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->