### PR TITLE
chore: add mattpocock skills setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,25 @@ feature/* ← 개별 기능 (develop에서 분기, develop으로 PR)
 - `main`에 직접 머지하지 않음 — 릴리즈 시에만 `develop` → `main` 머지
 - README, 스크린샷 등 사용자 문서는 릴리즈 커밋에서만 `main`에 반영
 
+## Agent skills
+
+mattpocock 스킬(`/triage`, `/to-issues`, `/diagnose`, `/improve-codebase-architecture` 등)이 참조하는 메타 설정.
+
+### Issue tracker
+
+GitHub Issues at `jhlee0409/claude-code-history-viewer`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles. `needs-info` and `wontfix` reuse existing repo labels;
+`needs-triage`, `ready-for-agent`, `ready-for-human` are added in this setup.
+See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root, lazily created
+by `/grill-with-docs`. See `docs/agents/domain.md`.
+
 ## Version Management
 
 This is a **Tauri desktop application** distributed via GitHub Releases (not npm).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,59 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## Ignore nested `CLAUDE.md` files
+
+This repo uses **claude-mem** which auto-generates `CLAUDE.md` files inside subdirectories (e.g. `src/CLAUDE.md`, `src-tauri/src/commands/CLAUDE.md`, `src/components/contentRenderer/CLAUDE.md`). These contain `<claude-mem-context>` activity logs — **NOT domain context**. Skills must:
+
+- Treat **only the root `CLAUDE.md`** as project-level guidance.
+- Treat **only `CONTEXT.md` / `CONTEXT-MAP.md` / `docs/adr/`** as domain documentation.
+- **Ignore** every nested `CLAUDE.md` regardless of depth — they're activity snapshots and may even reference unrelated projects (claude-mem cross-pollination).
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -10,13 +10,15 @@ How the engineering skills should consume this repo's domain documentation when 
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
 
-## Ignore nested `CLAUDE.md` files
+## Ignore nested `CLAUDE.md` files (if present)
 
-This repo uses **claude-mem** which auto-generates `CLAUDE.md` files inside subdirectories (e.g. `src/CLAUDE.md`, `src-tauri/src/commands/CLAUDE.md`, `src/components/contentRenderer/CLAUDE.md`). These contain `<claude-mem-context>` activity logs — **NOT domain context**. Skills must:
+`.gitignore` excludes `**/*/CLAUDE.md` — the only tracked `CLAUDE.md` is the one at the repo root. Some contributors run [claude-mem](https://github.com/jhlee0409/claude-mem) which **auto-generates untracked `CLAUDE.md` files inside subdirectories** containing `<claude-mem-context>` activity logs.
+
+Skills must:
 
 - Treat **only the root `CLAUDE.md`** as project-level guidance.
 - Treat **only `CONTEXT.md` / `CONTEXT-MAP.md` / `docs/adr/`** as domain documentation.
-- **Ignore** every nested `CLAUDE.md` regardless of depth — they're activity snapshots and may even reference unrelated projects (claude-mem cross-pollination).
+- If you encounter any nested `CLAUDE.md` (e.g. `src/CLAUDE.md`, `src-tauri/src/commands/CLAUDE.md`), **ignore it**. These are local activity snapshots — not authoritative — and may reference unrelated projects (claude-mem cross-pollination).
 
 ## File structure
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,32 @@
+# Issue tracker: GitHub
+
+Repo: **`jhlee0409/claude-code-history-viewer`**.
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Branch policy for related PRs
+
+When a skill creates or proposes a PR linked to an issue, **the base branch MUST be `develop`, never `main`**. See `CLAUDE.md` → "Branch Strategy" — `main` is release-only and only receives merges from `develop` at release time. PRs targeted at `main` will fail review.
+
+## Comment language
+
+- **All `gh issue comment` / `gh pr comment` / close-comments use English**, regardless of the issue/PR body language. (User preference, recorded in user memory.)
+- Exception: when explicitly closing an issue **as a courtesy to the reporter**, match the issue body's language (e.g. close a Chinese-body issue with a Chinese close-comment) — this is the "본문 언어에 맞게" pattern. Default is English.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -6,7 +6,8 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **Read an issue (human)**: `gh issue view <number> --comments` for plain-text reading.
+- **Read an issue (machine-parsable)**: `gh issue view <number> --json number,title,body,comments,labels --jq '{title, body, labels: [.labels[].name], comments: [.comments[].body]}'`.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
@@ -18,10 +19,10 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 When a skill creates or proposes a PR linked to an issue, **the base branch MUST be `develop`, never `main`**. See `CLAUDE.md` → "Branch Strategy" — `main` is release-only and only receives merges from `develop` at release time. PRs targeted at `main` will fail review.
 
-## Comment language
+## Comment language (repo convention)
 
-- **All `gh issue comment` / `gh pr comment` / close-comments use English**, regardless of the issue/PR body language. (User preference, recorded in user memory.)
-- Exception: when explicitly closing an issue **as a courtesy to the reporter**, match the issue body's language (e.g. close a Chinese-body issue with a Chinese close-comment) — this is the "본문 언어에 맞게" pattern. Default is English.
+- **Default for `gh issue comment` / `gh pr comment` is English**, regardless of issue/PR body language. This keeps the public review record consistent across contributors.
+- **Exception for close-comments**: when explicitly closing an issue **as a courtesy to the reporter**, match the issue body's language (e.g. close a Chinese-body issue with a Chinese close-comment).
 
 ## When a skill says "publish to the issue tracker"
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,22 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+## Repo-specific labels (out of canonical set — don't conflate)
+
+The repo also uses the following labels for project-specific workflows. They are **narrower or orthogonal** to the canonical triage roles above; do not substitute them.
+
+- `needs-spec` — queued for implementation spec analysis (narrower than `needs-triage`)
+- `spec-ready` — implementation spec PR created (narrower than `ready-for-human`)
+- `naming` — project naming and branding decisions
+- `bug`, `enhancement`, `documentation`, `question`, `duplicate`, `invalid`, `good first issue`, `help wanted` — standard GitHub categorization


### PR DESCRIPTION
## Summary

Adds the per-repo configuration that [mattpocock engineering skills](https://github.com/mattpocock/skills) (`/triage`, `/to-issues`, `/diagnose`, `/improve-codebase-architecture`, `/grill-with-docs`, etc.) expect.

## Changes

### `CLAUDE.md` — new `## Agent skills` section (after Branch Strategy)

Pointers to per-skill configuration files under `docs/agents/`.

### `docs/agents/issue-tracker.md`

GitHub `gh` CLI workflow + this repo's project conventions:
- **Branch policy**: PRs target `develop`, not `main` (per CLAUDE.md Branch Strategy — `main` is release-only)
- **Comment language**: English by default; close-comments may match the issue body language as a courtesy to the reporter
- Repo slug pinned: `jhlee0409/claude-code-history-viewer`

### `docs/agents/triage-labels.md` — 5 canonical roles

| Canonical | Repo label | Status |
|---|---|---|
| `needs-triage` | `needs-triage` | new (added) |
| `needs-info` | `needs-info` | reuse |
| `ready-for-agent` | `ready-for-agent` | new (added) |
| `ready-for-human` | `ready-for-human` | new (added) |
| `wontfix` | `wontfix` | reuse |

Repo-specific labels (`needs-spec`, `spec-ready`, `naming`) are documented as out-of-canonical — don't substitute.

### `docs/agents/domain.md` — single-context layout

`CONTEXT.md` + `docs/adr/` at the repo root, lazily created by `/grill-with-docs`. Includes explicit guard that **nested `CLAUDE.md` files are claude-mem activity logs, not domain context** — skills should ignore them.

## GitHub labels (already created on remote)

```
needs-triage     #FFC107  Maintainer needs to evaluate this issue
ready-for-agent  #0E8A16  Fully specified, AFK-agent ready
ready-for-human  #1D76DB  Requires human implementation
```

## Test plan

- [x] `gh label list` confirms 3 new labels exist
- [x] CLAUDE.md ↔ docs/agents/* cross-file consistency verified
- [ ] Manual: invoke `/triage` on a recent issue and confirm it applies labels from this repo's vocabulary

🤖 Generated with [Claude Code](https://claude.com/claude-code)