### PR TITLE
fix(server): bound graceful shutdown so cchv-server exits on Ctrl+C

### DIFF
--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -394,12 +394,32 @@ pub async fn start(state: Arc<AppState>, host: &str, port: u16, dist_dir: Option
         .expect("Axum server error");
 }
 
-/// Wait for SIGINT (Ctrl+C) or SIGTERM for graceful shutdown.
+/// Wait for SIGINT (Ctrl+C) for graceful shutdown.
+///
+/// `axum::serve(...).with_graceful_shutdown(...)` waits for every in-flight
+/// request to complete before exiting. The SSE stream at `/api/events` is a
+/// long-lived response that never completes on its own, so a single Ctrl+C
+/// would otherwise hang the process indefinitely (#286).
+///
+/// To bound the wait, we spawn a fallback task after the first signal: it
+/// races a 2-second grace window against a second Ctrl+C and exits the
+/// process when either fires. The graceful path still wins for short-lived
+/// requests that drain inside the grace window.
 async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("Failed to install CTRL+C signal handler");
     eprintln!("\n🛑 Shutting down WebUI server...");
+
+    tokio::spawn(async {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                eprintln!("⚡ Force exit (second Ctrl+C).");
+            }
+            () = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
+        }
+        std::process::exit(0);
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes #286.

\`cchv-server --serve\` prints \`🛑 Shutting down WebUI server...\` on Ctrl+C but the process never actually exits — users have to spam the signal until something else kills it.

## Root cause

\`axum::serve(...).with_graceful_shutdown(...)\` waits for every in-flight request to drain before exiting. The SSE stream at \`/api/events\` is a long-lived response that never completes on its own, so graceful shutdown blocks indefinitely as long as any browser tab is connected.

## Fix

After the first Ctrl+C, spawn a fallback task that races a 2-second grace window against a second Ctrl+C and exits the process when either fires.

- Short-lived requests still drain through the graceful path inside the grace window.
- Long-lived SSE clients no longer block exit.
- Pressing Ctrl+C twice in a row gives an immediate force-exit.

## Test plan

- [x] \`cargo fmt --check\` ✅
- [ ] CI: cargo test + clippy
- [ ] Manual: \`cchv-server --serve\` → open browser → Ctrl+C → process exits within 2s
- [ ] Manual: open browser to \`/api/events\` (SSE) → Ctrl+C → process exits within 2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Server now starts a two-stage graceful shutdown: first CTRL+C begins shutdown and allows ~2 seconds for background tasks to finish; pressing CTRL+C again forces immediate exit.
* **Documentation**
  * Shutdown behavior docs updated to describe the new two-stage process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->