### PR TITLE
fix(session-list): bump fixed row height to fit 2-line wrapped names

### DIFF
--- a/src/components/ProjectTree/components/SessionList.tsx
+++ b/src/components/ProjectTree/components/SessionList.tsx
@@ -11,8 +11,13 @@ import { useAppStore } from "@/store/useAppStore";
 import type { SessionListProps } from "../types";
 import type { ClaudeSession } from "../../../types";
 
-// SessionItem의 대략적인 높이 (py-2.5 + 내용)
-const SESSION_ITEM_HEIGHT = 72;
+// SessionItem fixed row height. Sized to fit a 2-line wrapped name:
+//   py-2.5 (20px) + name 2 × text-xs/leading-relaxed (39px)
+//   + gap-1.5 (6px) + meta text-2xs (15px) ≈ 80px → 88px with safety margin.
+// Bumping this matters because react-window's FixedSizeList stacks rows at
+// `index * height`; a row taller than the height visually overlaps the next
+// row (#284). line-clamp-2 caps the worst case at 2 lines.
+const SESSION_ITEM_HEIGHT = 88;
 // Virtual scroll을 적용할 최소 세션 수
 const VIRTUALIZATION_THRESHOLD = 20;
 // Virtual list의 최대 표시 높이


### PR DESCRIPTION
## Summary

Closes #284.

\`SessionList\` virtualises rendering once a project has 20+ sessions. The row height was hard-coded at \`72px\` but \`SessionNameEditor\` wraps long names to two lines via \`line-clamp-2\`, producing ~80px-tall rows. Since react-window's \`FixedSizeList\` strictly positions each row at \`index * height\`, taller rows visually overlap the next row whenever a name wraps.

## Math

| Layer | Tailwind | Computed |
|---|---|---|
| outer \`py-2.5\` (top + bottom) | \`py-2.5\` | 20px |
| name 2 × \`text-xs leading-relaxed\` | line-clamp-2 | 39px |
| flex \`gap-1.5\` | gap-1.5 | 6px |
| meta \`text-2xs\` (1 line) | text-2xs | ~15px |
| **total** | | **~80px** |

Bumped to \`88px\` for safety margin.

## Notes

- Non-virtualised path (<20 sessions, \`VIRTUALIZATION_THRESHOLD\`) flows via \`space-y-1\` and is unaffected.
- All 26 existing \`SessionList.test.tsx\` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session list now properly displays longer session names across multiple lines without truncation, improving readability and usability of session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->