### PR TITLE
feat(filter): expose Show Sub-agent Messages toggle in header dropdown

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -78,6 +78,7 @@
   "common.settings.font.120": "Extra Large",
   "common.settings.font.130": "Maximum",
   "common.settings.font.title": "Font Size",
+  "common.settings.filter.showSubagentMessages": "Show Sub-agent Messages",
   "common.settings.filter.showSystemMessages": "Show System Messages",
   "common.settings.filter.title": "Filter",
   "common.settings.language.description": "Select your preferred language",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -78,6 +78,7 @@
   "common.settings.font.120": "さらに大きく",
   "common.settings.font.130": "最大",
   "common.settings.font.title": "文字サイズ",
+  "common.settings.filter.showSubagentMessages": "サブエージェントメッセージを表示",
   "common.settings.filter.showSystemMessages": "システムメッセージを表示",
   "common.settings.filter.title": "フィルター",
   "common.settings.language.description": "お好みの言語を選択してください",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -78,6 +78,7 @@
   "common.settings.font.120": "더 크게",
   "common.settings.font.130": "최대",
   "common.settings.font.title": "글자 크기",
+  "common.settings.filter.showSubagentMessages": "서브에이전트 메시지 표시",
   "common.settings.filter.showSystemMessages": "시스템 메시지 표시",
   "common.settings.filter.title": "필터",
   "common.settings.language.description": "선호하는 언어를 선택하세요",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -78,6 +78,7 @@
   "common.settings.font.120": "更大",
   "common.settings.font.130": "最大",
   "common.settings.font.title": "字体大小",
+  "common.settings.filter.showSubagentMessages": "显示子代理消息",
   "common.settings.filter.showSystemMessages": "显示系统消息",
   "common.settings.filter.title": "筛选",
   "common.settings.language.description": "选择您偏好的语言",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -78,6 +78,7 @@
   "common.settings.font.120": "更大",
   "common.settings.font.130": "最大",
   "common.settings.font.title": "字體大小",
+  "common.settings.filter.showSubagentMessages": "顯示子代理訊息",
   "common.settings.filter.showSystemMessages": "顯示系統訊息",
   "common.settings.filter.title": "篩選",
   "common.settings.language.description": "選擇您偏好的語言",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-05-06T10:57:43.460Z
- * 총 키 개수: 1767
+ * 생성 시간: 2026-05-06T14:47:50.584Z
+ * 총 키 개수: 1768
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (159개)
+ * common namespace의 번역 키 (160개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -128,6 +128,7 @@ export type CommonKeys =
   | 'common.settings.changeFolder'
   | 'common.settings.checkUpdate'
   | 'common.settings.checking'
+  | 'common.settings.filter.showSubagentMessages'
   | 'common.settings.filter.showSystemMessages'
   | 'common.settings.filter.title'
   | 'common.settings.font.100'
@@ -2256,6 +2257,7 @@ export type TranslationKey =
   | 'common.settings.changeFolder'
   | 'common.settings.checkUpdate'
   | 'common.settings.checking'
+  | 'common.settings.filter.showSubagentMessages'
   | 'common.settings.filter.showSystemMessages'
   | 'common.settings.filter.title'
   | 'common.settings.font.100'

--- a/src/layouts/Header/SettingDropdown/FilterMenuGroup.tsx
+++ b/src/layouts/Header/SettingDropdown/FilterMenuGroup.tsx
@@ -4,12 +4,18 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
 import { useTranslation } from "react-i18next";
-import { Eye } from "lucide-react";
+import { Bot, Eye } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
 
 export const FilterMenuGroup = () => {
   const { t } = useTranslation();
-  const { showSystemMessages, setShowSystemMessages } = useAppStore();
+  const {
+    showSystemMessages,
+    setShowSystemMessages,
+    excludeSidechain,
+    setExcludeSidechain,
+  } = useAppStore();
+  const showSubagentMessages = !excludeSidechain;
 
   return (
     <>
@@ -32,6 +38,27 @@ export const FilterMenuGroup = () => {
         </span>
         <Switch
           checked={showSystemMessages}
+          aria-hidden="true"
+          tabIndex={-1}
+          className="ml-2"
+        />
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        role="menuitemcheckbox"
+        aria-checked={showSubagentMessages}
+        onSelect={(e) => {
+          e.preventDefault();
+          setExcludeSidechain(!excludeSidechain);
+        }}
+      >
+        <Bot className="mr-2 h-4 w-4 text-foreground" />
+        <span className="flex-1">
+          {t("common.settings.filter.showSubagentMessages", {
+            defaultValue: "서브에이전트 메시지 표시",
+          })}
+        </span>
+        <Switch
+          checked={showSubagentMessages}
           aria-hidden="true"
           tabIndex={-1}
           className="ml-2"


### PR DESCRIPTION
## Summary

\`excludeSidechain\` already filters sub-agent (sidechain) messages out of the chat view, defaults to \`true\`, and \`setExcludeSidechain\` exists in the store — but **no UI surfaces the toggle**. Users have no way to confirm the filter is on, recover from a corrupted preference, or opt into seeing sidechain messages without opening DevTools.

## Change

Mirror the existing \`Show System Messages\` switch in \`FilterMenuGroup\`: add a sibling \`DropdownMenuItem\` bound to \`setExcludeSidechain\`, framed positively (\"Show Sub-agent Messages\", checked = filter off) for consistency with the system-messages toggle. Uses the \`Bot\` icon to match the existing SubAgent Sessions panel terminology.

i18n keys added to all five locales:

| Locale | Translation |
|---|---|
| en | Show Sub-agent Messages |
| ko | 서브에이전트 메시지 표시 |
| ja | サブエージェントメッセージを表示 |
| zh-CN | 显示子代理消息 |
| zh-TW | 顯示子代理訊息 |

## Why this matters

- **#282** users complain about sub-agent clutter without realising the default-on filter exists. Surfacing the toggle makes the feature discoverable.
- A corrupted \`excludeSidechain: false\` in localStorage previously left users with no recovery path other than DevTools.
- The store setter already triggers \`selectProject\` + \`selectSession\` re-fetch, so toggling immediately updates the visible data.

## Test plan

- [x] \`pnpm tsc --build .\` ✅
- [x] \`pnpm vitest run\` ✅ 782 tests
- [x] \`pnpm run i18n:validate\` ✅ 1768 keys synced across 5 locales
- [x] \`pnpm lint\` ✅ 0 errors
- [ ] Manual: open header settings dropdown → toggle "Show Sub-agent Messages" on → confirm sidechain messages appear in chat view → toggle off → confirm they hide again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new settings filter option to allow users to toggle the display of sub-agent messages with a dedicated icon indicator.

* **Localization**
  * Implemented multi-language support for the new sub-agent messages filter across five languages: English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->