### PR TITLE
fix(boot): allow other-provider-only setups to launch without ~/.claude

### DIFF
--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -151,13 +151,40 @@ export const createProjectSlice: StateCreator<
         console.log("No saved settings found");
       }
 
-      // Try default path
-      const claudePath = await api<string>("get_claude_folder_path");
-      set({ claudePath });
-      await get().loadMetadata();
-      await get().detectProviders();
-      await autoRegisterConfigDir(get);
-      await get().scanProjects();
+      // Try default Claude path. If `~/.claude` is missing but other providers
+      // (Codex, OpenCode, Cursor, …) are detected on disk, proceed without a
+      // Claude path so the user can browse the providers they actually have
+      // installed (#222).
+      try {
+        const claudePath = await api<string>("get_claude_folder_path");
+        set({ claudePath });
+        await get().loadMetadata();
+        await get().detectProviders();
+        await autoRegisterConfigDir(get);
+        await get().scanProjects();
+        return;
+      } catch (claudeFolderError) {
+        const claudeErrorMessage =
+          claudeFolderError instanceof Error
+            ? claudeFolderError.message
+            : String(claudeFolderError);
+        if (!claudeErrorMessage.includes("CLAUDE_FOLDER_NOT_FOUND:")) {
+          throw claudeFolderError;
+        }
+
+        await get().loadMetadata();
+        await get().detectProviders();
+        const detectedProviders = get().providers;
+        const hasOtherProvider = detectedProviders.some(
+          (provider) => provider.is_available && provider.id !== "claude"
+        );
+        if (!hasOtherProvider) {
+          throw claudeFolderError;
+        }
+
+        await autoRegisterConfigDir(get);
+        await get().scanProjects();
+      }
     } catch (error) {
       console.error("Failed to initialize app:", error);
       const errorMessage =
@@ -192,16 +219,18 @@ export const createProjectSlice: StateCreator<
     const { claudePath, providers } = get();
     const customClaudePaths = get().userMetadata?.settings?.customClaudePaths;
     const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
-    if (!claudePath && !hasCustomPaths) return;
+    const availableProviders = providers
+      .filter((provider) => provider.is_available)
+      .map((provider) => provider.id);
+    const scanProviders = availableProviders.length > 0 ? availableProviders : [DEFAULT_PROVIDER_ID];
+    const hasNonClaudeProviders = scanProviders.some((provider) => provider !== DEFAULT_PROVIDER_ID);
+    // Allow scanning when at least one source is available: a saved Claude path,
+    // a custom Claude path, or any non-Claude provider detected on disk (#222).
+    if (!claudePath && !hasCustomPaths && !hasNonClaudeProviders) return;
 
     set({ isLoadingProjects: true, error: null });
     try {
       const start = performance.now();
-      const availableProviders = providers
-        .filter((provider) => provider.is_available)
-        .map((provider) => provider.id);
-      const scanProviders = availableProviders.length > 0 ? availableProviders : [DEFAULT_PROVIDER_ID];
-      const hasNonClaudeProviders = scanProviders.some((provider) => provider !== DEFAULT_PROVIDER_ID);
       const settings = get().userMetadata?.settings;
       const projects = (hasNonClaudeProviders || hasCustomPaths)
         ? await api<ClaudeProject[]>("scan_all_projects", {


### PR DESCRIPTION
## Summary

Closes #222.

\`initializeApp\` errored hard on \`CLAUDE_FOLDER_NOT_FOUND\` whenever \`~/.claude\` was missing, even though the app already auto-detects Codex / OpenCode / Cursor / Cline / Aider / Gemini / ForgeCode / Antigravity from their own well-known paths. Users who only ever ran a non-Claude provider were dumped into the \"Select Claude folder\" picker with no way out — and the picker only validates Claude-shape folders, so the OpenCode data directory was rejected with the generic \`folderPicker.invalidFolder\` error.

## Why path-validator multi-provider rewrite was rejected

The issue suggested making \`validate_claude_folder\` accept multiple provider markers. That would let the picker close, but the FolderSelectorContainer then routes the path to \`setClaudePath\` / \`addCustomClaudePath\` — both of which assume Claude-shape data. An OpenCode path registered as a Claude path would silently fail to render any sessions, which is worse than the current error.

The right fix is upstream: don't force the Claude folder when other providers are already available. The validator's Claude-only behaviour stays intact.

## Change

\`projectSlice.initializeApp\`:
1. Try the saved \`claudePath\` (unchanged).
2. Try the default Claude path. If \`get_claude_folder_path\` throws \`CLAUDE_FOLDER_NOT_FOUND\`, run \`detectProviders\` and accept the launch when any non-Claude provider is available.
3. Only surface \`CLAUDE_FOLDER_NOT_FOUND\` (which triggers the FolderSelector modal) when there is genuinely nothing to read.

\`projectSlice.scanProjects\`:
- Lift the provider/scan-targets computation above the early-return guard.
- Allow scanning when at least one source exists: a saved Claude path, a custom Claude path, **or** any non-Claude provider detected on disk.
- The Tauri \`scan_all_projects\` command already handles a missing \`claudePath\` via the conditional spread, so no backend change is required.

## Test plan

- [x] \`pnpm tsc --build .\` ✅
- [x] \`pnpm vitest run\` ✅ 782 tests
- [x] \`pnpm lint\` ✅ 0 errors
- [ ] Manual: rename \`~/.claude\` to \`~/.claude.bak\` with OpenCode data present at \`~/.local/share/opencode/\` → app launches into the OpenCode tree without the FolderSelector modal
- [ ] Manual: with no providers installed → FolderSelector still appears (existing behaviour)
- [ ] Manual: with \`~/.claude\` present → existing flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced app startup reliability with improved configuration path validation and intelligent provider detection logic.
  * Application now automatically discovers and registers alternative providers when preferred options are unavailable, enabling seamless initialization regardless of system state.
  * Strengthened fallback mechanisms ensure consistent app launches across different configurations and missing provider scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->