### PR TITLE
fix(message-meta): fall back to estimated cost when costUSD is absent

### DIFF
--- a/src/components/messageRenderer/AssistantMessageDetails.tsx
+++ b/src/components/messageRenderer/AssistantMessageDetails.tsx
@@ -3,6 +3,10 @@ import { HelpCircle, DollarSign, Clock } from 'lucide-react';
 import type { ClaudeMessage } from '../../types';
 import { useTranslation } from 'react-i18next';
 import { layout } from '@/components/renderers';
+import {
+  calculateModelPrice,
+  hasExplicitModelPricing,
+} from '@/components/AnalyticsDashboard/utils/calculations';
 
 interface AssistantMessageDetailsProps {
   message: ClaudeMessage;
@@ -33,15 +37,36 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
     return null;
   }
 
+  // Modern Claude Code stopped writing `costUSD` to its JSONL files. When it's
+  // missing but we have a model + usage payload, fall back to the same pricing
+  // table the analytics dashboard uses so the cost slot doesn't disappear (#194).
+  // Mark the value as estimated so users know it's not authoritative.
+  const explicitCost = costUSD !== undefined && costUSD > 0 ? costUSD : null;
+  const estimatedCost =
+    explicitCost == null && usage && hasExplicitModelPricing(model)
+      ? calculateModelPrice(
+          model,
+          usage.input_tokens ?? 0,
+          usage.output_tokens ?? 0,
+          usage.cache_creation_input_tokens ?? 0,
+          usage.cache_read_input_tokens ?? 0,
+        )
+      : 0;
+  const displayCost = explicitCost ?? (estimatedCost > 0 ? estimatedCost : null);
+  const isEstimated = displayCost != null && explicitCost == null;
+
   return (
     <div className={`flex items-center justify-start mt-1.5 ${layout.iconSpacing} ${layout.smallText} text-muted-foreground flex-wrap gap-y-1`}>
       <span>{t('assistantMessageDetails.model')}: {model}</span>
 
-      {/* Cost display */}
-      {costUSD !== undefined && costUSD > 0 && (
-        <span className={`flex items-center text-success ${layout.iconSpacing}`}>
+      {/* Cost display (authoritative when costUSD present, otherwise estimated from pricing table) */}
+      {displayCost != null && (
+        <span
+          className={`flex items-center text-success ${layout.iconSpacing}`}
+          title={isEstimated ? t('assistantMessageDetails.costEstimated', { defaultValue: 'Estimated from token usage; the source JSONL did not include costUSD.' }) : undefined}
+        >
           <DollarSign className={layout.iconSizeSmall} />
-          <span>{formatCost(costUSD)}</span>
+          <span>{isEstimated ? `~${formatCost(displayCost)}` : formatCost(displayCost)}</span>
         </span>
       )}
 
@@ -75,7 +100,12 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
             {usage.cache_creation_input_tokens ? <p>{t('assistantMessageDetails.cacheCreation')}: {usage.cache_creation_input_tokens.toLocaleString()}</p> : null}
             {usage.cache_read_input_tokens ? <p>{t('assistantMessageDetails.cacheRead')}: {usage.cache_read_input_tokens.toLocaleString()}</p> : null}
             {usage.service_tier ? <p>{t('assistantMessageDetails.tier')}: {usage.service_tier}</p> : null}
-            {costUSD !== undefined && <p className="mt-1 pt-1 border-t border-border">{t('assistantMessageDetails.cost', { defaultValue: 'Cost' })}: {formatCost(costUSD)}</p>}
+            {displayCost != null && (
+              <p className="mt-1 pt-1 border-t border-border">
+                {t('assistantMessageDetails.cost', { defaultValue: 'Cost' })}: {isEstimated ? `~${formatCost(displayCost)}` : formatCost(displayCost)}
+                {isEstimated ? <span className="ml-1 opacity-70">({t('assistantMessageDetails.estimated', { defaultValue: 'estimated' })})</span> : null}
+              </p>
+            )}
             {durationMs !== undefined && <p>{t('assistantMessageDetails.duration', { defaultValue: 'Duration' })}: {formatDuration(durationMs)}</p>}
             <div className="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-x-4 border-x-transparent border-t-4 border-t-popover" aria-hidden="true"></div>
           </div>

--- a/src/i18n/locales/en/renderers.json
+++ b/src/i18n/locales/en/renderers.json
@@ -38,6 +38,8 @@
   "renderers.agentTool.messages": "{{count}} messages",
   "assistantMessageDetails.cacheCreation": "Cache Creation",
   "assistantMessageDetails.cacheRead": "Cache Read",
+  "assistantMessageDetails.costEstimated": "Estimated from token usage; the source JSONL did not include costUSD.",
+  "assistantMessageDetails.estimated": "estimated",
   "assistantMessageDetails.input": "Input",
   "assistantMessageDetails.model": "Model",
   "assistantMessageDetails.output": "Output",

--- a/src/i18n/locales/ja/renderers.json
+++ b/src/i18n/locales/ja/renderers.json
@@ -38,6 +38,8 @@
   "renderers.agentTool.messages": "{{count}}件のメッセージ",
   "assistantMessageDetails.cacheCreation": "キャッシュ作成",
   "assistantMessageDetails.cacheRead": "キャッシュ読み取り",
+  "assistantMessageDetails.costEstimated": "トークン使用量から推定した値です。元のJSONLにcostUSDが含まれていません。",
+  "assistantMessageDetails.estimated": "推定",
   "assistantMessageDetails.input": "入力",
   "assistantMessageDetails.model": "モデル",
   "assistantMessageDetails.output": "出力",

--- a/src/i18n/locales/ko/renderers.json
+++ b/src/i18n/locales/ko/renderers.json
@@ -38,6 +38,8 @@
   "renderers.agentTool.messages": "{{count}}개 메시지",
   "assistantMessageDetails.cacheCreation": "캐시 생성",
   "assistantMessageDetails.cacheRead": "캐시 읽기",
+  "assistantMessageDetails.costEstimated": "토큰 사용량으로 추정한 값입니다. 원본 JSONL에 costUSD 값이 없습니다.",
+  "assistantMessageDetails.estimated": "추정",
   "assistantMessageDetails.input": "입력",
   "assistantMessageDetails.model": "모델",
   "assistantMessageDetails.output": "출력",

--- a/src/i18n/locales/zh-CN/renderers.json
+++ b/src/i18n/locales/zh-CN/renderers.json
@@ -38,6 +38,8 @@
   "renderers.agentTool.messages": "{{count}} 条消息",
   "assistantMessageDetails.cacheCreation": "缓存创建",
   "assistantMessageDetails.cacheRead": "缓存读取",
+  "assistantMessageDetails.costEstimated": "根据令牌用量估算；源 JSONL 不包含 costUSD。",
+  "assistantMessageDetails.estimated": "估算",
   "assistantMessageDetails.input": "输入",
   "assistantMessageDetails.model": "模型",
   "assistantMessageDetails.output": "输出",

--- a/src/i18n/locales/zh-TW/renderers.json
+++ b/src/i18n/locales/zh-TW/renderers.json
@@ -38,6 +38,8 @@
   "renderers.agentTool.messages": "{{count}} 則訊息",
   "assistantMessageDetails.cacheCreation": "快取建立",
   "assistantMessageDetails.cacheRead": "快取讀取",
+  "assistantMessageDetails.costEstimated": "依據權杖用量估算；來源 JSONL 不包含 costUSD。",
+  "assistantMessageDetails.estimated": "估算",
   "assistantMessageDetails.input": "輸入",
   "assistantMessageDetails.model": "模型",
   "assistantMessageDetails.output": "輸出",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-05-06T14:47:50.584Z
- * 총 키 개수: 1768
+ * 생성 시간: 2026-05-06T15:19:30.989Z
+ * 총 키 개수: 1770
  * Namespace 수: 11
  */
 
@@ -1348,7 +1348,7 @@ export type MessageKeys =
   | 'navigator.userOnly';
 
 /**
- * renderers namespace의 번역 키 (378개)
+ * renderers namespace의 번역 키 (380개)
  * 파일: locales/{lang}/renderers.json
  */
 export type RenderersKeys =
@@ -1380,6 +1380,8 @@ export type RenderersKeys =
   | 'agentTaskGroup.transcript'
   | 'assistantMessageDetails.cacheCreation'
   | 'assistantMessageDetails.cacheRead'
+  | 'assistantMessageDetails.costEstimated'
+  | 'assistantMessageDetails.estimated'
   | 'assistantMessageDetails.input'
   | 'assistantMessageDetails.model'
   | 'assistantMessageDetails.output'
@@ -2085,6 +2087,8 @@ export type TranslationKey =
   | 'analytics.weeklyActivity'
   | 'assistantMessageDetails.cacheCreation'
   | 'assistantMessageDetails.cacheRead'
+  | 'assistantMessageDetails.costEstimated'
+  | 'assistantMessageDetails.estimated'
   | 'assistantMessageDetails.input'
   | 'assistantMessageDetails.model'
   | 'assistantMessageDetails.output'


### PR DESCRIPTION
## Summary

Closes #194.

Modern Claude Code stopped writing the \`costUSD\` field to its JSONL sessions (only \`durationMs\` is still emitted). The cost slot in \`AssistantMessageDetails\` has been silently empty for users on recent client versions, even though the token-usage data is still there.

## Root cause

\`AssistantMessageDetails\` only renders the cost row when \`costUSD !== undefined && costUSD > 0\`. With Claude Code v1.x JSONLs no longer carrying \`costUSD\`, that guard short-circuits and the green \`$\` line disappears. The screenshot in the bug report shows the gap where the cost used to be.

## Fix

Reuse the existing \`calculateModelPrice\` helper in \`AnalyticsDashboard/utils/calculations.ts\` (which already powers the analytics dashboard cost charts) to estimate cost from the message's token usage when \`costUSD\` is absent and the model has explicit pricing in the table.

- Authoritative \`costUSD\` values still take precedence and render unchanged.
- Estimated values are prefixed with \`~\` and carry a tooltip explaining they were derived from token usage. The hover tooltip footer also notes \`(estimated)\`.
- When the model has no pricing entry, the slot stays hidden (better than misleading the user with the default fallback price).

## i18n

Two new keys added to all five locales:
| Key | en |
|---|---|
| \`assistantMessageDetails.costEstimated\` | Tooltip text on the inline pill |
| \`assistantMessageDetails.estimated\` | Suffix used inside the hover tooltip |

## Test plan

- [x] \`pnpm tsc --build .\` ✅
- [x] \`pnpm vitest run\` ✅ 782 tests
- [x] \`pnpm run i18n:validate\` ✅ 1770 keys synced across 5 locales
- [x] \`pnpm lint\` ✅ 0 errors
- [ ] Manual: open a session whose JSONL lacks \`costUSD\` — assistant rows now show \`~\$X.XXXX\` next to the model name, with the tooltip hint
- [ ] Manual: open an older session that still has \`costUSD\` — value renders without \`~\` and tooltip stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added estimated cost calculation for assistant messages when cost data is unavailable, displaying it alongside actual costs with clear "estimated" indicators.

* **Documentation**
  * Added internationalization support for estimated cost information in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->