### PR TITLE
feat(session): add codex resume support and cd prefix for resume command

### DIFF
--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -186,9 +186,18 @@ export function useSessionEditing(session: ClaudeSession) {
     [handleCopyToClipboard, session.actual_session_id, t]
   );
 
+  const projectCwd = useAppStore(
+    (state) =>
+      state.projects.find((p) => p.name === session.project_name)?.actual_path
+  );
+
   const handleCopyResumeCommand = useCallback(
     (e: React.MouseEvent) => {
-      const resumeCommand = getResumeCommand(providerId, session.actual_session_id);
+      const resumeCommand = getResumeCommand(
+        providerId,
+        session.actual_session_id,
+        projectCwd
+      );
       if (!resumeCommand) {
         e.stopPropagation();
         setIsContextMenuOpen(false);
@@ -199,10 +208,15 @@ export function useSessionEditing(session: ClaudeSession) {
       return handleCopyToClipboard(
         e,
         resumeCommand,
-        t("session.copiedResumeCommand", "Resume command copied")
+        projectCwd
+          ? t("session.copiedResumeCommand", "Resume command copied")
+          : t(
+              "session.copiedResumeCommandNoCwd",
+              "Resume command copied (working directory unknown)"
+            )
       );
     },
-    [handleCopyToClipboard, providerId, session.actual_session_id, t]
+    [handleCopyToClipboard, projectCwd, providerId, session.actual_session_id, t]
   );
 
   const handleCopyFilePath = useCallback(

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -91,6 +91,7 @@
   "session.cliSync.title": "Session name synced with CLI",
   "session.copiedFilePath": "File path copied",
   "session.copiedResumeCommand": "Resume command copied",
+  "session.copiedResumeCommandNoCwd": "Resume command copied (working directory unknown)",
   "session.copiedSessionId": "Session ID copied",
   "session.copyFilePath": "Copy File Path",
   "session.showJsonlFile": "Show JSONL File",

--- a/src/i18n/locales/ja/session.json
+++ b/src/i18n/locales/ja/session.json
@@ -91,6 +91,7 @@
   "session.cliSync.title": "セッション名がCLIと同期済み",
   "session.copiedFilePath": "ファイルパスをコピーしました",
   "session.copiedResumeCommand": "再開コマンドをコピーしました",
+  "session.copiedResumeCommandNoCwd": "再開コマンドをコピーしました（作業ディレクトリ不明）",
   "session.copiedSessionId": "セッションIDをコピーしました",
   "session.copyFilePath": "ファイルパスをコピー",
   "session.showJsonlFile": "JSONLファイルを表示",

--- a/src/i18n/locales/ko/session.json
+++ b/src/i18n/locales/ko/session.json
@@ -91,6 +91,7 @@
   "session.cliSync.title": "세션 이름이 CLI와 동기화됨",
   "session.copiedFilePath": "파일 경로가 복사되었습니다",
   "session.copiedResumeCommand": "재개 명령어가 복사되었습니다",
+  "session.copiedResumeCommandNoCwd": "재개 명령어가 복사되었습니다 (작업 디렉터리 미상)",
   "session.copiedSessionId": "세션 ID가 복사되었습니다",
   "session.copyFilePath": "파일 경로 복사",
   "session.showJsonlFile": "JSONL 파일 보기",

--- a/src/i18n/locales/zh-CN/session.json
+++ b/src/i18n/locales/zh-CN/session.json
@@ -91,6 +91,7 @@
   "session.cliSync.title": "会话名称已与CLI同步",
   "session.copiedFilePath": "文件路径已复制",
   "session.copiedResumeCommand": "恢复命令已复制",
+  "session.copiedResumeCommandNoCwd": "恢复命令已复制（未知工作目录）",
   "session.copiedSessionId": "会话ID已复制",
   "session.copyFilePath": "复制文件路径",
   "session.showJsonlFile": "显示 JSONL 文件",

--- a/src/i18n/locales/zh-TW/session.json
+++ b/src/i18n/locales/zh-TW/session.json
@@ -91,6 +91,7 @@
   "session.cliSync.title": "會話名稱已與CLI同步",
   "session.copiedFilePath": "檔案路徑已複製",
   "session.copiedResumeCommand": "恢復命令已複製",
+  "session.copiedResumeCommandNoCwd": "恢復命令已複製（未知工作目錄）",
   "session.copiedSessionId": "會話ID已複製",
   "session.copyFilePath": "複製檔案路徑",
   "session.showJsonlFile": "顯示 JSONL 檔案",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-05-06T15:19:30.989Z
- * 총 키 개수: 1770
+ * 생성 시간: 2026-05-07T02:16:11.536Z
+ * 총 키 개수: 1771
  * Namespace 수: 11
  */
 
@@ -392,7 +392,7 @@ export type AnalyticsKeys =
   | 'analytics.weeklyActivity';
 
 /**
- * session namespace의 번역 키 (196개)
+ * session namespace의 번역 키 (197개)
  * 파일: locales/{lang}/session.json
  */
 export type SessionKeys =
@@ -488,6 +488,7 @@ export type SessionKeys =
   | 'session.cliSync.title'
   | 'session.copiedFilePath'
   | 'session.copiedResumeCommand'
+  | 'session.copiedResumeCommandNoCwd'
   | 'session.copiedSessionId'
   | 'session.copyFilePath'
   | 'session.copyResumeCommand'
@@ -2787,6 +2788,7 @@ export type TranslationKey =
   | 'session.cliSync.title'
   | 'session.copiedFilePath'
   | 'session.copiedResumeCommand'
+  | 'session.copiedResumeCommandNoCwd'
   | 'session.copiedSessionId'
   | 'session.copyFilePath'
   | 'session.copyResumeCommand'

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -87,6 +87,22 @@ describe("providers utils", () => {
     expect(getResumeCommand("codex", "abc", "/Users/foo/proj")).toBe(
       "cd '/Users/foo/proj' && codex resume abc"
     );
+    expect(getResumeCommand("forgecode", "abc", "/Users/foo/proj")).toBe(
+      "cd '/Users/foo/proj' && forge conversation resume abc"
+    );
+  });
+
+  it("getResumeCommand rejects session ids with shell-meaningful chars", () => {
+    // Defense-in-depth: even though CLIs only emit UUID-like IDs, a crafted
+    // JSONL must not be able to extend the clipboard command.
+    expect(getResumeCommand("claude", "abc; rm -rf /")).toBeNull();
+    expect(getResumeCommand("codex", "abc && evil")).toBeNull();
+    expect(getResumeCommand("claude", "abc def")).toBeNull();
+    expect(getResumeCommand("claude", "$(whoami)")).toBeNull();
+    // Allowed charset: alnum, underscore, hyphen.
+    expect(getResumeCommand("claude", "abc-123_XYZ")).toBe(
+      "claude --resume abc-123_XYZ"
+    );
   });
 
   it("omits the cd prefix when cwd is empty or missing", () => {

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -66,13 +66,44 @@ describe("providers utils", () => {
     expect(getResumeCommand("forgecode", "conversation-123")).toBe(
       "forge conversation resume conversation-123"
     );
-    expect(getResumeCommand("codex", "conversation-123")).toBeNull();
+  });
+
+  it("returns the codex resume subcommand for codex sessions", () => {
+    expect(getResumeCommand("codex", "abc-123")).toBe("codex resume abc-123");
   });
 
   it("getResumeCommand fails closed for unknown provider strings", () => {
     expect(getResumeCommand("not-a-real-provider", "abc")).toBeNull();
     expect(getResumeCommand(undefined, "abc")).toBeNull();
     expect(getResumeCommand("claude", "")).toBeNull();
+    // Aider has no resume CLI command — must stay null even after future additions.
+    expect(getResumeCommand("aider", "abc")).toBeNull();
+  });
+
+  it("prefixes the resume command with `cd` when cwd is provided", () => {
+    expect(getResumeCommand("claude", "abc", "/Users/foo/proj")).toBe(
+      "cd '/Users/foo/proj' && claude --resume abc"
+    );
+    expect(getResumeCommand("codex", "abc", "/Users/foo/proj")).toBe(
+      "cd '/Users/foo/proj' && codex resume abc"
+    );
+  });
+
+  it("omits the cd prefix when cwd is empty or missing", () => {
+    expect(getResumeCommand("claude", "abc", undefined)).toBe(
+      "claude --resume abc"
+    );
+    expect(getResumeCommand("claude", "abc", "")).toBe("claude --resume abc");
+  });
+
+  it("single-quotes paths with spaces and escapes embedded apostrophes", () => {
+    expect(getResumeCommand("claude", "abc", "/Users/me/My Stuff")).toBe(
+      "cd '/Users/me/My Stuff' && claude --resume abc"
+    );
+    // POSIX trick: close quote, escaped literal apostrophe, reopen quote.
+    expect(getResumeCommand("codex", "abc", "/tmp/it's-mine")).toBe(
+      "cd '/tmp/it'\\''s-mine' && codex resume abc"
+    );
   });
 
   it("detects whether current scope has any supported provider", () => {

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -52,6 +52,7 @@ const session: ClaudeSession & { provider: string; is_renamed: boolean } = {
 describe("useSessionEditing clipboard actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAppStore.setState({ projects: [] });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -3,7 +3,8 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { useSessionEditing } from "@/components/SessionItem/hooks/useSessionEditing";
-import type { ClaudeSession } from "@/types";
+import { useAppStore } from "@/store/useAppStore";
+import type { ClaudeProject, ClaudeSession } from "@/types";
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>();
@@ -132,8 +133,52 @@ describe("useSessionEditing clipboard actions", () => {
       } as unknown as React.MouseEvent);
     });
 
+    // No matching project in the store, so the cd prefix is omitted and the
+    // toast falls back to the no-cwd variant.
     expect(writeText).toHaveBeenCalledWith("forge conversation resume conv-1");
+    expect(toast.success).toHaveBeenCalledWith(
+      "Resume command copied (working directory unknown)"
+    );
+  });
+
+  it("prefixes the codex resume command with cd when project cwd is known", async () => {
+    const project: ClaudeProject = {
+      name: session.project_name,
+      path: "~/.codex/sessions/-Users-jack-my-proj",
+      actual_path: "/Users/jack/my-proj",
+      session_count: 1,
+      message_count: 1,
+      last_modified: session.last_modified,
+      provider: "codex",
+    };
+    useAppStore.setState({ projects: [project] });
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const { result } = renderHook(() =>
+      useSessionEditing({
+        ...session,
+        provider: "codex",
+        actual_session_id: "abc-123",
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleCopyResumeCommand({
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      "cd '/Users/jack/my-proj' && codex resume abc-123"
+    );
     expect(toast.success).toHaveBeenCalledWith("Resume command copied");
+
+    useAppStore.setState({ projects: [] });
   });
 
   it("reports copy failure when fallback cannot write clipboard payload", async () => {

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -181,6 +181,14 @@ export function getResumeCommand(
     return null;
   }
 
+  // Fail-closed: sessionId is interpolated unquoted into a shell command that
+  // the user pastes into their terminal. Only allow the charset CLIs actually
+  // emit (UUIDs, hex hashes) so a crafted/corrupted JSONL can't extend the
+  // command past the resume invocation.
+  if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
+    return null;
+  }
+
   if (provider == null || !PROVIDER_IDS.includes(provider as ProviderId)) {
     return null;
   }

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -60,7 +60,7 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
   codex: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
-    supportsResumeCommand: false,
+    supportsResumeCommand: true,
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
@@ -166,9 +166,16 @@ export function supportsResumeCommand(provider?: ProviderId | string): boolean {
   return PROVIDER_SESSION_CAPABILITIES[provider as ProviderId].supportsResumeCommand;
 }
 
+// Single-quote a path for safe shell interpolation. Always quotes (cheap and
+// robust for arbitrary paths); a literal `'` is escaped as `'\''`.
+function shellQuotePath(p: string): string {
+  return `'${p.replace(/'/g, "'\\''")}'`;
+}
+
 export function getResumeCommand(
   provider: ProviderId | string | undefined,
-  sessionId: string
+  sessionId: string,
+  cwd?: string
 ): string | null {
   if (!sessionId) {
     return null;
@@ -178,14 +185,23 @@ export function getResumeCommand(
     return null;
   }
 
+  let resume: string | null;
   switch (provider as ProviderId) {
     case "claude":
-      return `claude --resume ${sessionId}`;
+      resume = `claude --resume ${sessionId}`;
+      break;
+    case "codex":
+      resume = `codex resume ${sessionId}`;
+      break;
     case "forgecode":
-      return `forge conversation resume ${sessionId}`;
+      resume = `forge conversation resume ${sessionId}`;
+      break;
     default:
-      return null;
+      resume = null;
   }
+
+  if (resume == null) return null;
+  return cwd ? `cd ${shellQuotePath(cwd)} && ${resume}` : resume;
 }
 
 export function supportsSessionDeletion(provider?: ProviderId | string): boolean {


### PR DESCRIPTION
## Summary

- The right-click context menu's **"Copy Resume Command"** now supports **codex** sessions (copies `codex resume <id>`), in addition to the existing claude / forgecode support.
- The copied command now starts with `cd '<project_cwd>' && ` so pasting drops you in the conversation's original working directory before resuming. The path comes from `ClaudeProject.actual_path` looked up by `session.project_name`.
- When `actual_path` cannot be resolved (project missing from the store, archived sessions, etc.), it falls back to the plain command and the toast switches to a new key `session.copiedResumeCommandNoCwd` to make the missing-cwd case explicit.
- Path quoting always wraps in single quotes; embedded `'` characters are escaped via the POSIX `'\''` sequence so paths with spaces or apostrophes remain shell-safe.

## Why

`claude --resume <id>` (and `codex resume <id>`) only works correctly from the directory where the original session was recorded. Pasting the bare command from any other shell prompt usually fails or starts in the wrong project, which defeats the value of the menu item. Embedding the `cd` makes it a true one-shot resume.

Codex was already a first-class provider in the viewer, but the resume copy action was claude/forgecode-only — adding codex restores parity.

## Behavior matrix

| Provider | cwd known | Copied to clipboard |
|---|---|---|
| claude   | ✅ | `cd '/abs/path' && claude --resume <id>` |
| claude   | ❌ | `claude --resume <id>` (toast: "Resume command copied (working directory unknown)") |
| codex    | ✅ | `cd '/abs/path' && codex resume <id>` |
| codex    | ❌ | `codex resume <id>` (no-cwd toast) |
| forgecode | ✅ | `cd '/abs/path' && forge conversation resume <id>` |
| others   |   | menu item not shown (unchanged) |

## Files changed

- `src/utils/providers.ts` — flip `codex.supportsResumeCommand`; add `codex` branch + optional `cwd` parameter + path quoting in `getResumeCommand`
- `src/components/SessionItem/hooks/useSessionEditing.ts` — resolve `projectCwd` from the store, pass it through, pick the toast key by whether cwd was found
- `src/i18n/locales/{en,ja,ko,zh-CN,zh-TW}/session.json` — add `session.copiedResumeCommandNoCwd`
- `src/i18n/types.generated.ts` — regenerated via `pnpm generate:i18n-types`
- `src/test/providers.utils.test.ts` — refresh codex assertion + new cases for cd-prefix, no-cwd, paths-with-spaces, paths-with-apostrophes
- `src/test/useSessionEditing.test.tsx` — update existing forgecode toast expectation to the no-cwd variant; add a happy-path codex test that seeds the store with a matching project and asserts the cd-prefixed command + plain toast

## Test plan

- [x] `pnpm test --run` — 787 tests passed across 57 files
- [x] `pnpm lint` — 0 errors (1 pre-existing warning in unrelated `GlobalSearchModal.tsx`)
- [x] `pnpm exec tsc --noEmit -p tsconfig.app.json` — clean
- [x] `pnpm i18n:validate` — passes after the new key was added
- [ ] Manual smoke: right-click a claude session, paste in a fresh shell — runs in the right cwd
- [ ] Manual smoke: right-click a codex session, paste — `codex resume <id>` runs in the right cwd
- [ ] Manual smoke: in a state where the project list is empty, the no-cwd toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume commands can include a working-directory prefix for more accurate session resumption.
  * Codex provider now supports resume commands.

* **Improvements**
  * Success toast message varies when the working directory is unknown to clarify results.

* **Localization**
  * Added localized messages for the unknown-working-directory toast (EN, JA, KO, ZH-CN, ZH-TW).

* **Tests**
  * Expanded tests covering resume-command generation, safety, and cwd handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->