### PR TITLE
fix(navigator): multi-pass scroll to correct TOC click landing position

### DIFF
--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -574,18 +574,37 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
       );
 
       if (index !== -1) {
-        // Scroll with a slight delay to ensure rendering is stable, using 'start' alignment
-        // We use a timeout to let the virtualizer settle if it just loaded
-        setTimeout(() => {
+        // Multi-pass scroll to correct for height-estimate inaccuracy (#269).
+        // `estimateMessageHeight` returns a fixed bucket per message type, but
+        // real heights vary by 5-10x with code blocks, tool results, etc.
+        // A single scrollToIndex on a far-off target lands at the estimate-based
+        // offset and misses once the rows in between render and measure their
+        // real heights. Re-issuing scrollToIndex after each render pass lets
+        // TanStack Virtual recompute against the now-measured totals and
+        // converge on the target.
+        const initialPass = setTimeout(() => {
+          virtualizer.scrollToIndex(index, { align: "start" });
+        }, 50);
+
+        const correctionPass = setTimeout(() => {
+          virtualizer.scrollToIndex(index, { align: "start" });
+        }, 200);
+
+        const finalPass = setTimeout(() => {
           virtualizer.scrollToIndex(index, { align: "start", behavior: "smooth" });
-        }, 100);
+        }, 450);
 
         // Auto-clear the target after a few seconds so the highlight fades
-        const timer = setTimeout(() => {
+        const clearTimer = setTimeout(() => {
           clearTargetMessage();
         }, 3000);
 
-        return () => clearTimeout(timer);
+        return () => {
+          clearTimeout(initialPass);
+          clearTimeout(correctionPass);
+          clearTimeout(finalPass);
+          clearTimeout(clearTimer);
+        };
       }
     }
   }, [targetMessageUuid, scrollElementReady, flattenedMessages, virtualizer, clearTargetMessage]);


### PR DESCRIPTION
## Summary

Closes #269.

Clicking a navigator (TOC) entry to jump to a far-off message landed at the wrong offset because TanStack Virtual only had estimated heights for the rows in between. The user's report (\"jump position is not accurate\") triggers most reliably after applying the navigator's user-only filter and clicking a deeply-nested entry.

## Root cause

\`estimateMessageHeight\` returns a fixed bucket per message type:

| Type | Estimate |
|---|---|
| assistant | 180 |
| user | 120 |
| toolResult | 200 |
| agentTaskGroup | 150 + 40·N |
| summary | 80 |
| progress | 60 |

Real rendered heights span 50–5000px depending on code blocks, tool results, generated content. A single \`scrollToIndex\` on a distant target lands at the estimate-based offset and misses by however much the in-between rows under-/over-estimated, since the virtualiser only measures rows once they actually render.

## Fix

Re-issue \`scrollToIndex\` in three passes inside the existing deep-link effect:

| Pass | Delay | Behaviour |
|---|---|---|
| 1 | 50ms | instant — coarse landing using estimates |
| 2 | 200ms | instant — corrected after first render+measure |
| 3 | 450ms | smooth — final polish on the now-accurate offset |

All four timers (the three passes plus the existing \`clearTargetMessage\` timer) are cleaned up in the effect's teardown so a quick navigator click chain doesn't leak handlers.

## Test plan

- [x] \`pnpm tsc --build .\` ✅
- [x] \`pnpm vitest run\` ✅ 782 tests
- [x] \`pnpm lint\` ✅ 0 errors
- [ ] Manual: open a session with 100+ mixed messages → toggle the navigator user-only filter → click a user entry near the bottom → verify the message is properly aligned to the top of the viewport
- [ ] Manual: click successive navigator entries quickly — no stale handlers / scroll jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved accuracy when navigating to specific messages via deep links. The message viewer now reliably scrolls to the target message position with enhanced precision and extended highlight duration for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->