### PR TITLE
fix(wsl): guard against missing excludedDistros in partial settings

### DIFF
--- a/src/components/SettingsManager/sections/WslSection.tsx
+++ b/src/components/SettingsManager/sections/WslSection.tsx
@@ -38,9 +38,10 @@ function WslSectionInner({ isExpanded, onToggle }: WslSectionProps) {
   const { t } = useTranslation();
   const { userMetadata, setWslEnabled, toggleWslDistro } = useAppStore();
 
-  const wslSettings = userMetadata?.settings?.wsl ?? {
-    enabled: false,
-    excludedDistros: [],
+  const rawWsl = userMetadata?.settings?.wsl;
+  const wslSettings = {
+    enabled: rawWsl?.enabled ?? false,
+    excludedDistros: rawWsl?.excludedDistros ?? [],
   };
 
   const [distros, setDistros] = useState<WslDistro[]>([]);

--- a/src/store/slices/metadataSlice.ts
+++ b/src/store/slices/metadataSlice.ts
@@ -302,13 +302,21 @@ export const createMetadataSlice: StateCreator<
 
   setWslEnabled: async (enabled: boolean) => {
     const current = get().userMetadata?.settings ?? {};
-    const wsl: WslSettings = current.wsl ?? { enabled: false, excludedDistros: [] };
+    const rawWsl = current.wsl;
+    const wsl: WslSettings = {
+      enabled: rawWsl?.enabled ?? false,
+      excludedDistros: rawWsl?.excludedDistros ?? [],
+    };
     await get().updateUserSettings({ wsl: { ...wsl, enabled } });
   },
 
   toggleWslDistro: async (distroName: string) => {
     const current = get().userMetadata?.settings ?? {};
-    const wsl: WslSettings = current.wsl ?? { enabled: false, excludedDistros: [] };
+    const rawWsl = current.wsl;
+    const wsl: WslSettings = {
+      enabled: rawWsl?.enabled ?? false,
+      excludedDistros: rawWsl?.excludedDistros ?? [],
+    };
     const excluded = wsl.excludedDistros.includes(distroName)
       ? wsl.excludedDistros.filter((d: string) => d !== distroName)
       : [...wsl.excludedDistros, distroName];

--- a/src/test/metadataSlice.test.ts
+++ b/src/test/metadataSlice.test.ts
@@ -441,6 +441,91 @@ describe("metadataSlice", () => {
   });
 
   // ==========================================================================
+  // WSL Handler Tests
+  // ==========================================================================
+
+  describe("setWslEnabled / toggleWslDistro with partial settings", () => {
+    // Regression for #305: when persisted wsl settings exist but omit
+    // excludedDistros (e.g. legacy data), handlers must not throw.
+
+    const seedPartialWsl = async (
+      useStore: ReturnType<typeof createTestStore>,
+      // intentionally missing excludedDistros to simulate the legacy shape
+      wsl: { enabled?: boolean; excludedDistros?: string[] }
+    ) => {
+      const metadata: UserMetadata = {
+        version: 1,
+        sessions: {},
+        projects: {},
+        settings: { wsl: wsl as unknown as UserMetadata["settings"]["wsl"] },
+      };
+      mockInvoke.mockResolvedValueOnce(metadata);
+      await useStore.getState().loadMetadata();
+    };
+
+    it("setWslEnabled handles wsl object missing excludedDistros", async () => {
+      const useStore = createTestStore();
+      await seedPartialWsl(useStore, { enabled: true });
+
+      mockInvoke.mockResolvedValueOnce({
+        version: 1,
+        sessions: {},
+        projects: {},
+        settings: { wsl: { enabled: false, excludedDistros: [] } },
+      });
+
+      await expect(
+        useStore.getState().setWslEnabled(false)
+      ).resolves.not.toThrow();
+
+      expect(mockInvoke).toHaveBeenLastCalledWith("update_user_settings", {
+        settings: { wsl: { enabled: false, excludedDistros: [] } },
+      });
+    });
+
+    it("toggleWslDistro handles wsl object missing excludedDistros", async () => {
+      const useStore = createTestStore();
+      await seedPartialWsl(useStore, { enabled: true });
+
+      mockInvoke.mockResolvedValueOnce({
+        version: 1,
+        sessions: {},
+        projects: {},
+        settings: { wsl: { enabled: true, excludedDistros: ["Ubuntu"] } },
+      });
+
+      await expect(
+        useStore.getState().toggleWslDistro("Ubuntu")
+      ).resolves.not.toThrow();
+
+      expect(mockInvoke).toHaveBeenLastCalledWith("update_user_settings", {
+        settings: { wsl: { enabled: true, excludedDistros: ["Ubuntu"] } },
+      });
+    });
+
+    it("toggleWslDistro round-trips for fully formed wsl object", async () => {
+      const useStore = createTestStore();
+      await seedPartialWsl(useStore, {
+        enabled: true,
+        excludedDistros: ["Ubuntu"],
+      });
+
+      mockInvoke.mockResolvedValueOnce({
+        version: 1,
+        sessions: {},
+        projects: {},
+        settings: { wsl: { enabled: true, excludedDistros: [] } },
+      });
+
+      await useStore.getState().toggleWslDistro("Ubuntu");
+
+      expect(mockInvoke).toHaveBeenLastCalledWith("update_user_settings", {
+        settings: { wsl: { enabled: true, excludedDistros: [] } },
+      });
+    });
+  });
+
+  // ==========================================================================
   // getSessionDisplayName Tests
   // ==========================================================================
 

--- a/src/test/metadataSlice.test.ts
+++ b/src/test/metadataSlice.test.ts
@@ -474,9 +474,7 @@ describe("metadataSlice", () => {
         settings: { wsl: { enabled: false, excludedDistros: [] } },
       });
 
-      await expect(
-        useStore.getState().setWslEnabled(false)
-      ).resolves.not.toThrow();
+      await useStore.getState().setWslEnabled(false);
 
       expect(mockInvoke).toHaveBeenLastCalledWith("update_user_settings", {
         settings: { wsl: { enabled: false, excludedDistros: [] } },
@@ -494,9 +492,7 @@ describe("metadataSlice", () => {
         settings: { wsl: { enabled: true, excludedDistros: ["Ubuntu"] } },
       });
 
-      await expect(
-        useStore.getState().toggleWslDistro("Ubuntu")
-      ).resolves.not.toThrow();
+      await useStore.getState().toggleWslDistro("Ubuntu");
 
       expect(mockInvoke).toHaveBeenLastCalledWith("update_user_settings", {
         settings: { wsl: { enabled: true, excludedDistros: ["Ubuntu"] } },


### PR DESCRIPTION
## Summary

- Normalize `wsl` settings on read in `WslSection` and in `metadataSlice` handlers so a partial persisted object (e.g. `{ enabled: true }` with no `excludedDistros`) no longer crashes the settings UI on render.
- Adds three regression tests on the metadata slice covering the partial-object case plus a round-trip for fully formed input.

Closes #305.

## Background

When `userMetadata.settings.wsl` exists but omits `excludedDistros`, the existing `??`-fallback (`userMetadata?.settings?.wsl ?? { enabled: false, excludedDistros: [] }`) does **not** fire, so `wslSettings.excludedDistros.includes(...)` inside `distros.map(...)` throws:

```
TypeError: Cannot read properties of undefined (reading 'includes')
```

Reported on Windows / Edge WebView2 after enabling the WSL toggle (#305).

The same shape was reachable in `setWslEnabled` / `toggleWslDistro` for the same legacy data, so both call sites were tightened with the same per-field defaulting.

## Test plan

- [x] `pnpm tsc --build .` — clean
- [x] `pnpm lint` — 0 errors (1 pre-existing warning in `GlobalSearchModal.tsx`, unrelated)
- [x] `pnpm vitest run` — 785 passed (incl. 3 new WSL regression cases)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke (Windows): enable WSL section with legacy data, confirm no toast / crash

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of WSL settings so the app gracefully accepts incomplete or legacy configurations without errors and preserves expected values when toggling or updating settings.
* **Tests**
  * Added tests covering WSL settings edge cases to ensure stability and correct round-tripping of legacy/partial configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/309)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->