### PR TITLE
fix(session): surface backend error when session delete fails

### DIFF
--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -266,8 +266,16 @@ export function useSessionEditing(session: ClaudeSession) {
           setSelectedSession(null);
         }
         toast.success(t("session.deleteSuccess", "Session deleted"));
-      } catch {
-        toast.error(t("session.deleteError", "Failed to delete session"));
+      } catch (error) {
+        const description =
+          error instanceof Error ? error.message : String(error);
+        console.error("[session delete] failed", {
+          sessionId: session.session_id,
+          error,
+        });
+        toast.error(t("session.deleteError", "Failed to delete session"), {
+          description,
+        });
       }
     },
     [providerId, session.file_path, session.session_id, supportsSessionDeletion, t]


### PR DESCRIPTION
## Summary

When session deletion fails, surface the backend error message in the toast description and log it to the developer console with the session id. The previous bare `catch {}` discarded the error, leaving users with only a generic localized toast and nothing to share with maintainers.

Closes #308. Unblocks investigation of #256 and #267 (Windows delete failures whose root cause has been invisible because of this swallowing).

## What changed

`src/components/SessionItem/hooks/useSessionEditing.ts` — delete handler now:
- Captures the caught error.
- `console.error("[session delete] failed", { sessionId, error })` for support.
- Passes the error message into `toast.error(title, { description })`. The localized title stays as-is so existing translations still apply; only the backend reason flows through to the description slot.

## Adjacent swallowing — flagged, not changed

Per the agent brief, similar swallowed-error patterns in the same hook are flagged here for follow-up rather than fixed:

- `useSessionEditing.ts` parameterless `catch {}` at the dynamic-import for `@tauri-apps/plugin-dialog`, the copy-success / copy-failure path, and the "reveal in file manager" failure path.
- Repo-wide `grep -rn '} catch {$'` returns ~20 hits across `ArchiveManager/`, `MessageViewer`, `FolderSelector`, and other components.

These violate the repo's `CLAUDE.md` Code Quality Checklist ("async/await → try/catch + 사용자에게 보이는 피드백. console.error만은 부족") but are out of scope for this single-symptom PR.

## Test plan

- [x] `pnpm tsc --build .` — clean
- [x] `pnpm vitest run src/test/useSessionEditing.test.tsx` — 3 passed (existing clipboard tests unaffected)
- [ ] CI: full lint + tests on PR
- [ ] Manual smoke: delete a `.jsonl` while a process holds it open (or any failure mode) and confirm the toast now shows the underlying reason.

A dedicated unit test for the delete handler's error path would require mocking `@tauri-apps/plugin-dialog`, `@/services/api`, and `@/store/useAppStore`, which exceeds the surface area of this fix. The change is mechanically verifiable; happy to add a fuller integration test in a follow-up if reviewers want it.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages displayed when session deletion fails, providing users with clearer and more informative feedback about what went wrong.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/310)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->