### PR TITLE
fix(webui): register get_session_subagents on Axum router

### DIFF
--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -458,6 +458,12 @@ handler_json!(
 );
 
 handler_json!(
+    get_session_subagents,
+    SessionPathParam,
+    |p: SessionPathParam| async move { commands::session::get_session_subagents(p.session_path).await }
+);
+
+handler_json!(
     search_messages,
     SearchParams,
     |p: SearchParams| async move {

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -460,7 +460,10 @@ handler_json!(
 handler_json!(
     get_session_subagents,
     SessionPathParam,
-    |p: SessionPathParam| async move { commands::session::get_session_subagents(p.session_path).await }
+    |p: SessionPathParam| async move {
+        commands::session::is_safe_session_path(&PathBuf::from(&p.session_path))?;
+        commands::session::get_session_subagents(p.session_path).await
+    }
 );
 
 handler_json!(

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -84,6 +84,7 @@ pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Optio
             "/get_session_message_count",
             post(h::get_session_message_count),
         )
+        .route("/get_session_subagents", post(h::get_session_subagents))
         .route("/search_messages", post(h::search_messages))
         .route("/get_recent_edits", post(h::get_recent_edits))
         .route("/restore_file", post(h::restore_file))


### PR DESCRIPTION
## Summary

Add the missing `/get_session_subagents` POST route to the WebUI Axum router. The command is already registered with the Tauri invoke handler used by the desktop app, but the Axum router that powers `cchv-server --serve` did not have a matching `.route(...)` entry.

Selecting a session in the browser caused the POST to fall through to the SPA fallback, returning HTML — which the frontend kept retrying, producing an infinite refresh loop on session detail load.

Closes #294.

## Diagnosis credit

@bhxch in #294 identified the exact root cause: missing Axum route, frontend's request falling through to SPA fallback and getting interpreted as a 405. Inspection of the codebase confirmed.

## What changed

- `src-tauri/src/server/handlers.rs` — add `get_session_subagents` handler via the existing `handler_json!` macro, accepting `SessionPathParam` (camelCase JSON body) and calling `commands::session::get_session_subagents`.
- `src-tauri/src/server/mod.rs` — register the route at `POST /get_session_subagents`.

The shape of the request body and the response is identical to the Tauri command — desktop behavior is unchanged.

## Test plan

- [x] `cargo fmt --check` clean (locally)
- [ ] `cargo clippy -- -D warnings` — could not run locally because `tauri-runtime-wry` fails to compile against the current macOS toolchain (documented limitation). **Relying on CI for Rust validation.**
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: run `cchv-server --serve`, select a session in the browser, confirm no infinite refresh and subagent data renders.

## Follow-up (not in this PR)

This is one drift case in what is likely a broader pattern — Tauri invoke handler and Axum router can fall out of sync silently when only one side is updated. A sweep / audit of every command registered in `lib.rs::generate_handler!` against the routes in `server/mod.rs` is worth doing as a follow-up; flagging here rather than scoping into this fix.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new POST API endpoint to retrieve session subagent information. This provides programmatic access to subagent data associated with sessions, improving visibility for session management and enabling integration with external tools via standard REST calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/311)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->