### PR TITLE
fix(forgecode): four minor follow-ups from #295

### DIFF
--- a/src-tauri/src/providers/forgecode.rs
+++ b/src-tauri/src/providers/forgecode.rs
@@ -1641,12 +1641,15 @@ fn parse_conversation_path(session_path: &str) -> Option<(String, String)> {
 }
 
 /// Validate a single `ForgeCode` virtual path component.
+///
+/// IDs sit at the boundary of rename/delete/load routing, so we apply
+/// the standard `^[A-Za-z0-9_-]+$` allowlist used elsewhere for path
+/// components rather than the looser "no slashes / dots" check.
 fn is_valid_virtual_component(value: &str) -> bool {
     !value.is_empty()
-        && value != "."
-        && value != ".."
-        && !value.contains('/')
-        && !value.contains('\\')
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
 /// Quote an `SQLite` identifier for generated `ForgeCode` queries.
@@ -1795,6 +1798,34 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rusqlite::params;
     use tempfile::TempDir;
+
+    /// RAII guard that restores a process-wide env var when dropped.
+    ///
+    /// Use this instead of manual save / set / restore blocks so that the
+    /// original value is put back even if an assertion in the test panics.
+    /// Tests in this module rely on `--test-threads=1` (see project README)
+    /// because env vars are global to the process.
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     /// Create a temporary `ForgeCode` test database.
     fn create_test_db(tmp: &TempDir) -> Connection {
@@ -2181,16 +2212,9 @@ mod tests {
     fn detection_prefers_forge_config_and_checks_artifacts() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join(".forge_history"), "history").unwrap();
-        let original = std::env::var("FORGE_CONFIG").ok();
-        std::env::set_var("FORGE_CONFIG", tmp.path());
+        let _guard = EnvGuard::set("FORGE_CONFIG", tmp.path());
 
         let detected = detect().unwrap();
-
-        if let Some(original) = original {
-            std::env::set_var("FORGE_CONFIG", original);
-        } else {
-            std::env::remove_var("FORGE_CONFIG");
-        }
 
         assert_eq!(detected.id, "forgecode");
         assert_eq!(detected.display_name, "ForgeCode");
@@ -2323,6 +2347,34 @@ mod tests {
         assert_eq!(
             parse_conversation_path("forgecode-db://workspace/ws-1/conversation/conv-1"),
             Some(("ws-1".to_string(), "conv-1".to_string()))
+        );
+    }
+
+    #[test]
+    /// Reject ids that fall outside the `[A-Za-z0-9_-]+` allowlist.
+    fn parse_conversation_path_rejects_non_allowlist_components() {
+        // path separators and traversal — original constraints
+        assert_eq!(parse_conversation_path("forgecode://workspace/.."), None);
+        assert_eq!(parse_conversation_path("forgecode://workspace/."), None);
+        assert_eq!(
+            parse_conversation_path("forgecode://workspace/ws/conversation/../escape"),
+            None
+        );
+        // characters outside the tightened allowlist
+        assert_eq!(
+            parse_conversation_path("forgecode://workspace/ws 1/conversation/conv-1"),
+            None,
+            "spaces are rejected"
+        );
+        assert_eq!(
+            parse_conversation_path("forgecode://workspace/ws.1/conversation/conv-1"),
+            None,
+            "dots are rejected"
+        );
+        assert_eq!(
+            parse_conversation_path("forgecode://workspace/ws-1/conversation/conv:1"),
+            None,
+            "colons are rejected"
         );
     }
 }

--- a/src-tauri/src/providers/forgecode.rs
+++ b/src-tauri/src/providers/forgecode.rs
@@ -1803,16 +1803,20 @@ mod tests {
     ///
     /// Use this instead of manual save / set / restore blocks so that the
     /// original value is put back even if an assertion in the test panics.
-    /// Tests in this module rely on `--test-threads=1` (see project README)
-    /// because env vars are global to the process.
+    /// Tests in this module rely on `--test-threads=1` (see `CLAUDE.md`
+    /// "Phase 1: Quality Gate") because env vars are global to the process.
+    ///
+    /// `original` is stored as `OsString` rather than `String` so that
+    /// non-UTF-8 values (legitimate on macOS / Linux) are restored
+    /// losslessly on drop instead of being silently dropped.
     struct EnvGuard {
         key: &'static str,
-        original: Option<String>,
+        original: Option<std::ffi::OsString>,
     }
 
     impl EnvGuard {
         fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let original = std::env::var(key).ok();
+            let original = std::env::var_os(key);
             std::env::set_var(key, value);
             Self { key, original }
         }

--- a/src/components/ArchiveManager/ArchiveCreateDialog.tsx
+++ b/src/components/ArchiveManager/ArchiveCreateDialog.tsx
@@ -232,7 +232,11 @@ export const ArchiveCreateDialog: React.FC<ArchiveCreateDialogProps> = ({
                   </p>
                 ) : (
                   filteredProjects.map((project) => {
-                    const canArchive = supportsArchiveCreation(project.provider);
+                    // Normalize provider the same way the create path does so
+                    // legacy data without an explicit provider is treated as
+                    // Claude on both the capability check and the label.
+                    const provider = project.provider ?? 'claude';
+                    const canArchive = supportsArchiveCreation(provider);
                     return (
                     <button
                       key={project.path}
@@ -249,7 +253,7 @@ export const ArchiveCreateDialog: React.FC<ArchiveCreateDialogProps> = ({
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium truncate">{project.name}</p>
                         <p className="text-2xs text-muted-foreground truncate">
-                          {canArchive ? project.actual_path : `${project.provider} — ${t('archive.create.unsupportedProvider')}`}
+                          {canArchive ? project.actual_path : `${provider} — ${t('archive.create.unsupportedProvider')}`}
                         </p>
                       </div>
                       {canArchive && (

--- a/src/components/NativeRenameDialog.tsx
+++ b/src/components/NativeRenameDialog.tsx
@@ -41,13 +41,19 @@ export const NativeRenameDialog: React.FC<NativeRenameDialogProps> = ({
   const isForgeCode = provider === "forgecode";
   const usesStandaloneTitlePreview = isOpenCode || isForgeCode;
 
-  // Extract existing title if present
+  // Extract existing title if present. For providers that use a
+  // standalone title (OpenCode, ForgeCode) the saved name *is* the title,
+  // so mirror the parsing path the save side uses — otherwise the input
+  // arrives empty and a blind save would silently reset the title.
   useEffect(() => {
-    if (open) {
+    if (!open) return;
+    if (usesStandaloneTitlePreview) {
+      setTitle(currentName);
+    } else {
       const match = currentName.match(/^\[(.+?)\]/);
       setTitle(match?.[1] ?? "");
     }
-  }, [open, currentName]);
+  }, [open, currentName, usesStandaloneTitlePreview]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary

Closes #296. Four small, independent items from the #295 follow-up checklist:

1. **Stricter virtual-path component validation** in `providers/forgecode.rs::is_valid_virtual_component`. Now enforces `^[A-Za-z0-9_-]+$` instead of the looser "no slashes / dots" check, matching the standard allowlist used elsewhere for path-component IDs.
2. **`FORGE_CONFIG` env restoration via drop guard** in the `forgecode.rs` test module. Replaces manual save / restore with an RAII `EnvGuard` so an intermediate panic no longer leaks the override into other tests in the same process.
3. **Provider fallback consistency in `ArchiveCreateDialog`**. The picker now normalizes `provider = project.provider ?? 'claude'` the same way the archive-creation path does, so legacy data without an explicit provider stops rendering as `undefined` in the picker.
4. **Title prefill for `usesStandaloneTitlePreview` providers** in `NativeRenameDialog`. OpenCode / ForgeCode save the title directly (no `[...]` prefix), so initial state derivation now mirrors the save path and prefills with `currentName` instead of leaving the input empty.

## What changed

- `src-tauri/src/providers/forgecode.rs` — tightened `is_valid_virtual_component`, added `EnvGuard` test helper, replaced the manual env save / restore in `detection_prefers_forge_config_and_checks_artifacts`, added a regression test (`parse_conversation_path_rejects_non_allowlist_components`) covering spaces, dots, colons, and traversal.
- `src/components/ArchiveManager/ArchiveCreateDialog.tsx` — single line normalization at the top of the picker map callback; both `supportsArchiveCreation(...)` and the displayed label now use the normalized value.
- `src/components/NativeRenameDialog.tsx` — branch the prefill effect on `usesStandaloneTitlePreview` and update its dependency list.

## Test plan

- [x] `pnpm tsc --build .` — clean
- [x] `pnpm lint` — 0 errors (1 pre-existing warning in `GlobalSearchModal.tsx`)
- [x] `pnpm vitest run` — 782 passed
- [x] `cargo fmt --check` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally because `tauri-runtime-wry` fails to compile against the current macOS toolchain (documented limitation). **Relying on CI.**
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: open Archive picker on a project without a provider field (legacy data) → label reads "claude — ..." not "undefined — ..."; open Native Rename on a ForgeCode or OpenCode session → input prefilled with the current title rather than empty.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archive creation dialog now defaults missing provider values and correctly reflects provider support.
  * Rename dialog reliably initializes and updates the editable title across provider modes.

* **Tests**
  * Strengthened path-component validation with a stricter character allowlist.
  * Improved test setup/teardown for environment-based detection tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/312)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->