### PR TITLE
fix(antigravity): partial stats correctness — 3 of 7 items from #292

### DIFF
--- a/src-tauri/src/commands/antigravity.rs
+++ b/src-tauri/src/commands/antigravity.rs
@@ -771,7 +771,9 @@ pub fn merge_states(
         }
     }
 
-    // Active overrides archives
+    // Active overrides archives; preserve its last_poll_at so the
+    // frontend can show when the monitor last refreshed.
+    let last_poll_at = active.as_ref().and_then(|a| a.last_poll_at);
     if let Some(active_state) = active {
         for (id, session) in active_state.sessions {
             merged.insert(id, session);
@@ -779,7 +781,7 @@ pub fn merge_states(
     }
 
     AntigravityState {
-        last_poll_at: None,
+        last_poll_at,
         sessions: merged,
     }
 }
@@ -996,6 +998,34 @@ mod tests {
     fn test_merge_states_empty() {
         let merged = merge_states(vec![], None);
         assert!(merged.sessions.is_empty());
+        assert!(merged.last_poll_at.is_none());
+    }
+
+    #[test]
+    fn test_merge_states_preserves_active_last_poll_at() {
+        let archive = AntigravityState {
+            last_poll_at: None,
+            sessions: HashMap::new(),
+        };
+        let active = AntigravityState {
+            last_poll_at: Some(1_700_000_002_000),
+            sessions: HashMap::new(),
+        };
+
+        let merged = merge_states(vec![archive], Some(active));
+        assert_eq!(merged.last_poll_at, Some(1_700_000_002_000));
+    }
+
+    #[test]
+    fn test_merge_states_no_active_drops_archive_last_poll_at() {
+        // Archive states intentionally don't carry their own poll time,
+        // so a merge without an active state results in `None`.
+        let archive = AntigravityState {
+            last_poll_at: Some(1_700_000_000_000),
+            sessions: HashMap::new(),
+        };
+        let merged = merge_states(vec![archive], None);
+        assert!(merged.last_poll_at.is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -142,16 +142,18 @@ fn antigravity_chat_token_breakdown(value: &serde_json::Value) -> Option<(u64, u
         return None;
     }
 
-    let chat_tokens = token_breakdown["groups"]
-        .as_array()
-        .map(|groups| {
-            groups
-                .iter()
-                .filter(|group| group["type"].as_str() == Some("TOKEN_TYPE_CHAT_MESSAGES"))
-                .map(|group| group["numTokens"].as_u64().unwrap_or(0))
-                .sum::<u64>()
-        })
-        .unwrap_or(0)
+    // When the `groups` array is missing entirely (e.g. estimatedTokensUsed
+    // was provided without a breakdown), return None so the caller falls
+    // back to the full input/cache totals rather than scaling everything
+    // to zero. An explicit empty `groups` array, or one without any
+    // TOKEN_TYPE_CHAT_MESSAGES entries, is still a legitimate "0 chat
+    // tokens" result and keeps the existing behavior.
+    let groups = token_breakdown["groups"].as_array()?;
+    let chat_tokens = groups
+        .iter()
+        .filter(|group| group["type"].as_str() == Some("TOKEN_TYPE_CHAT_MESSAGES"))
+        .map(|group| group["numTokens"].as_u64().unwrap_or(0))
+        .sum::<u64>()
         .min(total_tokens);
 
     Some((chat_tokens, total_tokens))
@@ -832,7 +834,10 @@ fn collect_provider_global_file_stats(
     let mut project_keys = HashSet::new();
 
     if provider == StatsProvider::Antigravity {
-        let Ok(root) = crate::commands::antigravity::get_antigravity_root()
+        // Use the resolver that honors the external-state override so an
+        // external Antigravity root contributes to the global summary
+        // (the bare get_antigravity_root only returns the default path).
+        let Ok(root) = crate::commands::antigravity::resolve_antigravity_root()
             .ok_or_else(|| "Cannot determine antigravity root directory".to_string())
         else {
             return (Vec::new(), project_keys);


### PR DESCRIPTION
## Summary

Partial fix for #292 — addresses 3 of the 7 items on the Antigravity stats correctness checklist. Each fix is small, isolated, and independently verifiable.

**#292 stays open** until the remaining four items (see "Deferred" below) land in follow-up PRs.

## Items resolved

### External root excluded from global stats (item 4)

`collect_provider_global_file_stats` in `commands/stats.rs` was calling `get_antigravity_root()` directly. Now uses `resolve_antigravity_root()` so an external Antigravity state directory (the override path) contributes to the global summary, matching the behavior already in place elsewhere.

### `groups` missing → input/cache zeroed (item 5)

`antigravity_chat_token_breakdown` returned `Some((0, total))` when `tokenBreakdown.groups` was absent entirely, which made the caller scale all conversation-mode input/cache totals to zero. It now returns `None` in that case so the caller's existing `.unwrap_or((input_tokens, cache_creation_tokens, cache_read_tokens))` falls through to the full totals — equivalent to the non-detail path.

An explicit empty `groups` array, or one without any `TOKEN_TYPE_CHAT_MESSAGES` entries, is still a legitimate "0 chat tokens" result and keeps the prior behavior.

### `last_poll_at` lost in merge_states (item 6)

`commands/antigravity.rs::merge_states` was hardcoding `last_poll_at: None` in the merged result, dropping the active state's polling timestamp before the frontend could see it. Now extracts the active state's `last_poll_at` before consuming it and threads it through to the merged result. Adds two regression tests:

- merging archive(s) + active preserves the active state's `last_poll_at`.
- merging archive(s) only returns `None` (archive states intentionally don't carry their own poll time — encoded in the test as documentation of the contract).

## Deferred to follow-up PRs

These four are NOT addressed here. They need wider refactors that I want to size and review separately:

- **Item 1** — Reasoning aggregation in the Codex/ForgeCode-style global summary block. The per-message path uses `dedup_token_totals_msg` which returns a 5-tuple without reasoning; adding reasoning requires touching the dedup signature or extracting reasoning separately, with implications across every caller.
- **Item 2** — Antigravity `most_used_tools` ignoring the active `start_date`/`end_date` filter. Tool tracking iterates over messages while token totals iterate over records; aligning the date filter requires picking a single timestamp source.
- **Item 3** — Daily / heatmap aggregations in the Antigravity per-project stats path using raw `record.total_tokens` instead of the mode-aware totals.
- **Item 7** — `load_antigravity_usage_records` rpc-cache fallback. Mirrors the fallback in `providers::antigravity::load_messages` and requires making `marker_rooted_path` pub or duplicating the path-walk logic.

## Test plan

- [x] `cargo fmt --check` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry` toolchain limitation; CI handles Rust validation)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: trigger global stats with an external Antigravity root configured, verify it now contributes; record without `tokenBreakdown.groups` no longer zeros conversation-mode input/cache; `last_poll_at` surfaces in the merged state payload.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state merging to preserve poll timing information when active states are present
  * Corrected chat token breakdown parsing to handle missing data elements gracefully
  * Enhanced global statistics collection to respect external configuration overrides

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/313)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->