### PR TITLE
fix(antigravity): symlink guards on state and rpc-cache reads (partial #293)

### DIFF
--- a/src-tauri/src/commands/antigravity.rs
+++ b/src-tauri/src/commands/antigravity.rs
@@ -474,13 +474,17 @@ fn parse_token_files(token_file_paths: &[PathBuf]) -> (RpcSessionAggregate, u32,
             .and_then(|ext| ext.to_str())
             .unwrap_or_default()
             .to_ascii_lowercase();
-        // Defense-in-depth: reject symlinked token files. The parent
-        // rpc-cache directory is symlink-guarded upstream, but the files
-        // themselves could still be symlinks pointing outside the root.
-        if let Ok(meta) = std::fs::symlink_metadata(file_path) {
-            if meta.file_type().is_symlink() {
-                continue;
-            }
+        // Defense-in-depth: only read regular files. The parent rpc-cache
+        // directory is symlink-guarded upstream, but the entries within
+        // it could still be symlinks (pointing outside the root) or
+        // non-regular files (FIFOs, devices, …) that could block or
+        // misbehave under `read_to_string`. Match the same guard used
+        // by `load_active_state` / `load_archive_states`.
+        let Ok(meta) = std::fs::symlink_metadata(file_path) else {
+            continue;
+        };
+        if !meta.file_type().is_file() {
+            continue;
         }
         let Ok(content) = std::fs::read_to_string(file_path) else {
             continue;

--- a/src-tauri/src/commands/antigravity.rs
+++ b/src-tauri/src/commands/antigravity.rs
@@ -411,8 +411,13 @@ fn scan_brain_candidates(root: &Path) -> Result<Vec<SessionCandidate>, String> {
         collect_files(&session_dir, &mut file_paths)?;
 
         let pb_path = conversations_dir.join(format!("{session_id}.pb"));
-        if pb_path.exists() {
-            file_paths.push(pb_path);
+        // Defense-in-depth: reject symlinks even though the parent
+        // directory was already symlink-guarded — a symlinked .pb
+        // artifact could point outside the trusted antigravity root.
+        if let Ok(meta) = std::fs::symlink_metadata(&pb_path) {
+            if !meta.file_type().is_symlink() && meta.file_type().is_file() {
+                file_paths.push(pb_path);
+            }
         }
 
         let mut last_modified_ms = 0;
@@ -469,6 +474,14 @@ fn parse_token_files(token_file_paths: &[PathBuf]) -> (RpcSessionAggregate, u32,
             .and_then(|ext| ext.to_str())
             .unwrap_or_default()
             .to_ascii_lowercase();
+        // Defense-in-depth: reject symlinked token files. The parent
+        // rpc-cache directory is symlink-guarded upstream, but the files
+        // themselves could still be symlinks pointing outside the root.
+        if let Ok(meta) = std::fs::symlink_metadata(file_path) {
+            if meta.file_type().is_symlink() {
+                continue;
+            }
+        }
         let Ok(content) = std::fs::read_to_string(file_path) else {
             continue;
         };
@@ -724,7 +737,11 @@ pub fn load_state_file(path: &Path) -> Result<AntigravityState, String> {
 /// 读取活跃状态 `monitor-state.json`
 pub fn load_active_state(root: &Path) -> Option<AntigravityState> {
     let active_path = root.join("monitor-state.json");
-    if !active_path.exists() {
+    // Defense-in-depth: refuse to follow a symlinked monitor-state.json
+    // even though the parent directory is trusted. `symlink_metadata`
+    // also implicitly checks for existence.
+    let meta = std::fs::symlink_metadata(&active_path).ok()?;
+    if meta.file_type().is_symlink() || !meta.file_type().is_file() {
         return None;
     }
     load_state_file(&active_path).ok()
@@ -746,7 +763,17 @@ pub fn load_archive_states(root: &Path) -> Vec<AntigravityState> {
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
         {
-            if let Ok(state) = load_state_file(&entry.path()) {
+            let archive_path = entry.path();
+            // Same defense-in-depth as load_active_state: refuse
+            // symlinked archive files regardless of platform
+            // (DirEntry::file_type follows symlinks on some targets).
+            let Ok(meta) = std::fs::symlink_metadata(&archive_path) else {
+                continue;
+            };
+            if meta.file_type().is_symlink() || !meta.file_type().is_file() {
+                continue;
+            }
+            if let Ok(state) = load_state_file(&archive_path) {
                 named.push((name_str, state));
             }
         }
@@ -1091,6 +1118,48 @@ mod tests {
     fn test_load_antigravity_state_impl_missing_dir() {
         let state = load_antigravity_state_impl(Path::new("/nonexistent/path/xyz")).unwrap();
         assert!(state.sessions.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_load_active_state_rejects_symlink() {
+        let dir = TempDir::new().unwrap();
+        // Real, valid state file lives outside the root we'll scan from.
+        let target = dir.path().join("real-state.json");
+        let state = AntigravityState::default();
+        std::fs::write(&target, serde_json::to_string(&state).unwrap()).unwrap();
+
+        // Inside the scanned root, monitor-state.json is a symlink to it.
+        let root = dir.path().join("scan-root");
+        std::fs::create_dir(&root).unwrap();
+        std::os::unix::fs::symlink(&target, root.join("monitor-state.json")).unwrap();
+
+        // Defense-in-depth: refuse to follow the symlink even though
+        // the link target is valid JSON.
+        assert!(load_active_state(&root).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_load_archive_states_rejects_symlinked_archive() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("real-archive.json");
+        let state = AntigravityState::default();
+        std::fs::write(&target, serde_json::to_string(&state).unwrap()).unwrap();
+
+        let root = dir.path().join("scan-root");
+        std::fs::create_dir(&root).unwrap();
+        std::os::unix::fs::symlink(&target, root.join("monitor-state.archive-2025-06.json"))
+            .unwrap();
+        // A real archive file alongside the symlink should still be picked up.
+        std::fs::write(
+            root.join("monitor-state.archive-2025-07.json"),
+            serde_json::to_string(&state).unwrap(),
+        )
+        .unwrap();
+
+        let archives = load_archive_states(&root);
+        assert_eq!(archives.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Partial fix for #293 — addresses **items 5, 6, 9** from the hardening follow-up checklist (defense-in-depth symlink rejection at the file-read boundary).

**#293 stays open** until the remaining items (see "Deferred" below) land in follow-up PRs.

## Items resolved

### Item 5 — load_active_state / load_archive_states

`commands/antigravity.rs::load_active_state` and `load_archive_states` now call `std::fs::symlink_metadata` before reading the `monitor-state.json` / `monitor-state.archive-*.json` files and refuse to follow symlinks or non-regular files. `DirEntry::file_type` follows symlinks on some platforms, so an explicit `symlink_metadata` keeps behavior portable.

### Item 6 — parse_token_files

The RPC cache aggregation in `parse_token_files` now checks each `token_file_paths` entry before `read_to_string`. Symlinked `usage.jsonl` / `steps.jsonl` (etc.) are skipped — the parent directory is already symlink-guarded upstream, but the files themselves can still be symlinks pointing outside the root.

### Item 9 — pb_path admission

Replaces the bare `pb_path.exists()` check in `build_state_from_token_monitor_sources` with a `symlink_metadata`-based check that rejects symlinks and non-regular files for the `<session_id>.pb` artifact.

## Tests added

Under `#[cfg(unix)]`:

- `test_load_active_state_rejects_symlink` — a symlinked `monitor-state.json` (pointing at a valid serialized `AntigravityState`) is refused; `load_active_state` returns `None`.
- `test_load_archive_states_rejects_symlinked_archive` — a symlinked `monitor-state.archive-2025-06.json` is refused, but a real `monitor-state.archive-2025-07.json` sitting next to it is still picked up — verifying the guard is per-file rather than a directory-wide rejection.

## Deferred to follow-up PRs

These six remain on #293:

- **Item 1** — `antigravity_root_from_path` returning `None` (not falling back to default_root) when the marker is absent. Changing the contract requires auditing every caller.
- **Item 2** — `get_antigravity_project_summary` not accepting `PathBuf::from(root_path)` when item 1 returns `None`. Tied to item 1.
- **Item 3** — Tightening `is_valid_antigravity_session_id` enforcement at every use site (currently confirmed only at HashMap-key sites).
- **Item 4** — `u64 → i64` saturating cast at the frontend boundary.
- **Item 7** — `fs::canonicalize` on `session_path` in `marker_rooted_path` to close the TOCTOU/symlink-bypass class — needs careful thought about how Windows path canonicalization interacts with `\\?\` prefixes.
- **Item 8** — `build_state_from_token_monitor_sources` filesystem-only sessions dropped in the `else` branch. Code-flow fix unrelated to symlink hardening.

## Test plan

- [x] `cargo fmt --check` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry` toolchain limitation; CI handles Rust validation)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: place a symlinked `monitor-state.json` under the antigravity root; confirm it is ignored rather than followed.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added symlink validation so only true regular files are accepted for artifact and token inputs.
  * Hardened state loading to reject symlinked or non-regular active and archived state files.

* **Tests**
  * Added Unix-only tests that verify symlink rejection for active and archived state handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/314)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->