### PR TITLE
fix(antigravity): include filesystem-only brain sessions + tighten id validation (partial #293)

### DIFF
--- a/src-tauri/src/commands/antigravity.rs
+++ b/src-tauri/src/commands/antigravity.rs
@@ -406,6 +406,13 @@ fn scan_brain_candidates(root: &Path) -> Result<Vec<SessionCandidate>, String> {
         }
 
         let session_id = entry.file_name().to_string_lossy().to_string();
+        // Defense-in-depth: refuse any brain-dir name that wouldn't be
+        // safe to embed in a file path (e.g. `..`, `foo/bar`, control
+        // chars). The entry filename is read straight from disk so the
+        // allowlist guards against an attacker-placed directory.
+        if !is_valid_antigravity_session_id(&session_id) {
+            continue;
+        }
         let session_dir = entry.path();
         let mut file_paths = Vec::new();
         collect_files(&session_dir, &mut file_paths)?;
@@ -644,22 +651,21 @@ fn build_state_from_token_monitor_sources(root: &Path) -> Result<AntigravityStat
             )
         };
 
-        let persisted = if has_rpc_artifact {
-            build_session_state(
-                &candidate.session_id,
-                &candidate.session_dir,
-                &rpc_dir,
-                &candidate.label_hint,
-                &token_file_paths,
-                effective_last_modified,
-                source,
-                SessionLifecycleStatus::Active,
-            )
-        } else {
-            // brain/ session without rpc-cache data — skip; rpc cache scan will find it
-            // if it later has real data files
-            continue;
-        };
+        // Synthesize a session from whichever source is available.
+        // Previously the no-rpc-artifact branch skipped the candidate
+        // entirely, relying on the rpc-cache scan below to pick it up
+        // later — but that scan only walks the rpc-cache directory, so
+        // brain/-only sessions never reached the synthesized state.
+        let persisted = build_session_state(
+            &candidate.session_id,
+            &candidate.session_dir,
+            &rpc_dir,
+            &candidate.label_hint,
+            &token_file_paths,
+            effective_last_modified,
+            source,
+            SessionLifecycleStatus::Active,
+        );
         seen_ids.insert(candidate.session_id.clone());
         sessions.insert(candidate.session_id, persisted);
     }
@@ -676,6 +682,12 @@ fn build_state_from_token_monitor_sources(root: &Path) -> Result<AntigravityStat
                 continue;
             }
             let session_id = entry.file_name().to_string_lossy().to_string();
+            // Same allowlist applied to brain/ candidates: a directory
+            // dropped into rpc-cache must look like a session id before
+            // we trust it as a path component or HashMap key.
+            if !is_valid_antigravity_session_id(&session_id) {
+                continue;
+            }
             if seen_ids.contains(&session_id) {
                 continue;
             }
@@ -1194,6 +1206,50 @@ mod tests {
 
         let archives = load_archive_states(&root);
         assert_eq!(archives.len(), 1);
+    }
+
+    #[test]
+    fn test_build_state_includes_filesystem_only_brain_session() {
+        // Regression: a brain/ candidate that has token-bearing files
+        // but no rpc-cache directory was previously dropped on the
+        // floor. It should be synthesized from the filesystem source.
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();
+        let session_dir = root.join("brain").join("sess-fs");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        // Drop a minimal text-bearing file so the candidate is admitted.
+        std::fs::write(session_dir.join("task.md"), "# Test session\n").unwrap();
+
+        let state = build_state_from_token_monitor_sources(root).unwrap();
+        assert!(state.sessions.contains_key("sess-fs"));
+        let session = state.sessions.get("sess-fs").unwrap();
+        assert_eq!(session.latest.source, "filesystem");
+    }
+
+    #[test]
+    fn test_scan_brain_candidates_rejects_invalid_session_id() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        let brain_dir = root.join("brain");
+        std::fs::create_dir_all(&brain_dir).unwrap();
+        // Names outside the [A-Za-z0-9_-]+ allowlist must be ignored
+        // even when they hold token-bearing files.
+        for bad in ["..weird", "has space", "has.dot", "has:colon"] {
+            let s = brain_dir.join(bad);
+            std::fs::create_dir_all(&s).unwrap();
+            std::fs::write(s.join("task.md"), "# bad\n").unwrap();
+        }
+        // Sanity: a well-formed name in the same directory is still picked up.
+        let good = brain_dir.join("good-session-1");
+        std::fs::create_dir_all(&good).unwrap();
+        std::fs::write(good.join("task.md"), "# good\n").unwrap();
+
+        let candidates = scan_brain_candidates(root).unwrap();
+        let ids: Vec<&str> = candidates.iter().map(|c| c.session_id.as_str()).collect();
+        assert_eq!(ids, vec!["good-session-1"]);
     }
 
     #[test]

--- a/src-tauri/src/commands/antigravity.rs
+++ b/src-tauri/src/commands/antigravity.rs
@@ -656,10 +656,21 @@ fn build_state_from_token_monitor_sources(root: &Path) -> Result<AntigravityStat
         // entirely, relying on the rpc-cache scan below to pick it up
         // later — but that scan only walks the rpc-cache directory, so
         // brain/-only sessions never reached the synthesized state.
+        //
+        // The storage_dir becomes the session's user-facing file_path
+        // (used by "Reveal in Finder" etc.). Point it at the actual
+        // data location: rpc_dir when token files come from rpc-cache,
+        // session_dir for filesystem-only sessions whose rpc_dir does
+        // not exist on disk.
+        let storage_dir = if has_rpc_artifact {
+            rpc_dir.clone()
+        } else {
+            candidate.session_dir.clone()
+        };
         let persisted = build_session_state(
             &candidate.session_id,
             &candidate.session_dir,
-            &rpc_dir,
+            &storage_dir,
             &candidate.label_hint,
             &token_file_paths,
             effective_last_modified,
@@ -1226,6 +1237,13 @@ mod tests {
         assert!(state.sessions.contains_key("sess-fs"));
         let session = state.sessions.get("sess-fs").unwrap();
         assert_eq!(session.latest.source, "filesystem");
+        // file_path must point at the on-disk brain/ directory, not
+        // the (non-existent) rpc-cache sibling. UI "Reveal in Finder"
+        // and similar actions depend on this being a real path.
+        assert_eq!(
+            session.latest.file_path,
+            session_dir.to_string_lossy().to_string()
+        );
     }
 
     #[test]
@@ -1236,8 +1254,10 @@ mod tests {
         let brain_dir = root.join("brain");
         std::fs::create_dir_all(&brain_dir).unwrap();
         // Names outside the [A-Za-z0-9_-]+ allowlist must be ignored
-        // even when they hold token-bearing files.
-        for bad in ["..weird", "has space", "has.dot", "has:colon"] {
+        // even when they hold token-bearing files. Stick to characters
+        // that are legal on every supported filesystem (Windows
+        // disallows `:`, `/`, etc.) so the test runs cross-platform.
+        for bad in ["..weird", "has space", "has.dot", "has+plus"] {
             let s = brain_dir.join(bad);
             std::fs::create_dir_all(&s).unwrap();
             std::fs::write(s.join("task.md"), "# bad\n").unwrap();


### PR DESCRIPTION
## Summary

Two more items from the #293 hardening checklist:

- **Item 8** — `build_state_from_token_monitor_sources` no longer drops brain/-only sessions on the floor.
- **Item 3** — apply `is_valid_antigravity_session_id` at the two on-disk directory-name read sites before they become path components.

**#293 stays open** until the remaining items land — see "Deferred" below.

## Items resolved

### Item 8 — brain-only sessions were dropped

`build_state_from_token_monitor_sources` synthesized a session only when the candidate had a corresponding rpc-cache directory (the `if has_rpc_artifact` branch). The `else` branch built `token_file_paths` from the filesystem source and then `continue`d, so brain/-only sessions never reached the synthesized state. The follow-up rpc-cache scan does not pick them up either — it only walks the rpc-cache directory.

Call `build_session_state` unconditionally now and let the existing source discriminator (`"rpc-artifact"` vs `"filesystem"`) record whether tokens were read from rpc artifacts or the filesystem `task.md` / `implementation_plan.md` files.

### Item 3 — `is_valid_antigravity_session_id` at every use site

Apply the existing `^[A-Za-z0-9_-]+$` allowlist before treating an on-disk directory name as a path component:

1. `scan_brain_candidates` — `entry.file_name()` becomes `<conversations_dir>/{session_id}.pb`.
2. The rpc-cache iteration in `build_state_from_token_monitor_sources` — `entry.file_name()` becomes `<session_dir>/usage.jsonl` / `steps.jsonl`.

Both sites read from disk, so an attacker-placed directory with `..`, slashes, or control characters could previously have slipped into a `join`.

## Tests added

- `test_build_state_includes_filesystem_only_brain_session` — drop a brain/-only candidate with a `task.md` and assert the synthesized state includes it with `source = "filesystem"`.
- `test_scan_brain_candidates_rejects_invalid_session_id` — create four brain/ directories with names outside the allowlist (`..weird`, `has space`, `has.dot`, `has:colon`) plus one valid sibling; assert only the valid sibling survives.

## Deferred to follow-up PRs

These four remain on #293:

- **Item 1** — `antigravity_root_from_path` returning `None` when the marker is absent. Changing the contract requires auditing every caller.
- **Item 2** — `get_antigravity_project_summary` not accepting `PathBuf::from(root_path)` when item 1 returns `None`. Tied to item 1.
- **Item 4** — `u64 → i64` saturating cast at the frontend boundary. **Likely stale finding** — `grep` for `as i64` / `i64::try_from` in the antigravity module returns only one match (`parse_rfc3339_to_ms`, unrelated to token totals). All token fields are `u64` end-to-end. Flagging here rather than silently dropping; revisit when a concrete cast site surfaces.
- **Item 7** — `fs::canonicalize` on `session_path` in `marker_rooted_path` to close the TOCTOU/symlink-bypass class. Windows path canonicalization interacts with `\\?\` prefixes; wants careful thought.

Plus the upstream `has_rpc_artifact = usage_path.exists() || steps_path.exists()` flag from #314's deferred Copilot review (zero-token session synthesis when all token files are rejected by symlink guards).

## Test plan

- [x] `cargo fmt --check` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry` toolchain limitation; CI handles Rust validation)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: place a `brain/<session>/task.md` without any rpc-cache for that session id; confirm the session appears in the project summary. Place a `brain/has space/` directory; confirm it is silently ignored.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session directory names are validated to prevent unsafe/invalid entries.
  * Sessions lacking cache artifacts are now synthesized from filesystem data with correct source and file path handling.
  * Consistent validation applied across all session sources to avoid malformed entries.

* **Tests**
  * Added regression tests for directory-name validation.
  * Added tests verifying filesystem-only session synthesis and metadata correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/315)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->