### PR TITLE
fix(antigravity): refuse to guess root when marker is absent (partial #293)

### DIFF
--- a/src-tauri/src/commands/antigravity.rs
+++ b/src-tauri/src/commands/antigravity.rs
@@ -56,6 +56,13 @@ pub fn resolve_antigravity_root() -> Option<PathBuf> {
 
 /// Resolves the antigravity root from an arbitrary path by walking up the directory
 /// tree and looking for the `.token-monitor/rpc-cache/v1` marker.
+///
+/// Returns `None` when no marker is found. Callers used to receive a
+/// `default_root` fallback here, which meant any path that didn't match
+/// the marker was silently accepted as if it lived under the default
+/// antigravity install — that made downstream `path_in_resolved` checks
+/// trivially pass for arbitrary paths. Refuse to guess: missing marker
+/// now means "this is not a recognizable antigravity root".
 pub fn antigravity_root_from_path(path: &str) -> Option<PathBuf> {
     let candidate = PathBuf::from(path);
     let default_root = get_antigravity_root();
@@ -87,7 +94,7 @@ pub fn antigravity_root_from_path(path: &str) -> Option<PathBuf> {
         }
     }
 
-    default_root
+    None
 }
 
 /// Returns the RPC cache root path for a given antigravity root.
@@ -955,10 +962,14 @@ pub async fn get_antigravity_session(
 pub async fn get_antigravity_project_summary(
     root_path: Option<String>,
 ) -> Result<AntigravityProjectSummary, String> {
+    // Resolution order: marker-anchored root from the supplied path,
+    // then the platform-discovered default. The previous middle step
+    // (accept `PathBuf::from(root_path)` directly) weakened the marker
+    // contract — it would admit any supplied path even when the marker
+    // walk failed.
     let root = root_path
         .as_deref()
         .and_then(antigravity_root_from_path)
-        .or_else(|| root_path.as_ref().map(PathBuf::from))
         .or_else(resolve_antigravity_root)
         .ok_or("Cannot determine antigravity root directory")?;
     let state = load_antigravity_state_impl(&root)?;
@@ -1217,6 +1228,39 @@ mod tests {
 
         let archives = load_archive_states(&root);
         assert_eq!(archives.len(), 1);
+    }
+
+    #[test]
+    fn test_antigravity_root_from_path_returns_none_when_marker_absent() {
+        // A temp directory that has none of the antigravity layout
+        // (no `.token-monitor/rpc-cache/v1`) and is outside the default
+        // root must NOT resolve to anything — the function used to fall
+        // back to `default_root` here, silently making the supplied
+        // path look legitimate.
+        let dir = TempDir::new().unwrap();
+        let unrelated_dir = dir.path().join("not-antigravity");
+        std::fs::create_dir(&unrelated_dir).unwrap();
+
+        let resolved = antigravity_root_from_path(&unrelated_dir.to_string_lossy());
+        assert!(
+            resolved.is_none(),
+            "expected None for marker-absent path, got {resolved:?}",
+        );
+    }
+
+    #[test]
+    fn test_antigravity_root_from_path_finds_marker_in_parent() {
+        // Sanity check that the happy path (the supplied path lives
+        // under a directory that has the `.token-monitor/rpc-cache/v1`
+        // marker) still resolves to that root.
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();
+        let nested = root.join("brain").join("sess-x");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let resolved = antigravity_root_from_path(&nested.to_string_lossy()).unwrap();
+        assert_eq!(resolved, root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two more items from the #293 hardening checklist:

- **Item 1** — `antigravity_root_from_path` returns `None` when no `.token-monitor/rpc-cache/v1` marker is found, instead of silently falling back to the default antigravity root.
- **Item 2** — `get_antigravity_project_summary` drops the parallel `PathBuf::from(root_path)` fallback that bypassed the marker contract.

**#293 stays open** until the remaining items land (see "Deferred" below).

## Why

Both changes close the same class of weakness: the previous behavior made downstream `path_in_resolved` checks trivially pass for any path the caller plausibly passed in. The marker-walk function couldn't actually distinguish a real antigravity root from an arbitrary path — it would always return *something*. After this change, an absent marker is treated as "not a recognizable antigravity root" and the caller decides whether to fall through to a platform-discovered default or refuse.

## What changed

- `commands/antigravity.rs::antigravity_root_from_path` — final `default_root` replaced with `None`. Existing callers (`marker_rooted_path` in `providers/antigravity.rs`, `load_antigravity_tool_names`) already pattern-match on `Option` and handle `None` correctly.
- `commands/antigravity.rs::get_antigravity_project_summary` — the middle `.or_else(|| root_path.as_ref().map(PathBuf::from))` is removed from the resolution chain. The chain is now: marker-walk on the supplied path, then `resolve_antigravity_root()`, then error.

## Tests added

- `test_antigravity_root_from_path_returns_none_when_marker_absent` — a marker-free temp directory resolves to `None`.
- `test_antigravity_root_from_path_finds_marker_in_parent` — the happy path (marker on a parent directory) still resolves correctly.

Existing `test_get_antigravity_project_summary_uses_explicit_root_path` already covers the marker-present case for the command itself.

## Deferred to follow-up PRs

These remain on #293:

- **Item 7** — `fs::canonicalize` on `session_path` in `marker_rooted_path` to close the TOCTOU/symlink-bypass class. Windows path canonicalization interacts with `\\?\` prefixes; wants careful thought.
- The upstream `has_rpc_artifact = usage_path.exists() || steps_path.exists()` flag from #314's deferred Copilot review (zero-token session synthesis when all token files are rejected by the new symlink guards).

**Item 4** — `u64 → i64` saturating cast — is a likely stale finding. `grep` for `as i64` / `i64::try_from` in the antigravity module shows only the unrelated `parse_rfc3339_to_ms`; all token fields are `u64` end-to-end. Not addressed here.

## Test plan

- [x] `cargo fmt --check` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry` toolchain limitation; CI handles Rust validation)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: pass a path outside the default root and without a `.token-monitor/rpc-cache/v1` marker to a command that ultimately calls `antigravity_root_from_path` — confirm the project summary falls through to `resolve_antigravity_root()` (or errors) rather than treating the path as legitimate.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced project root identification validation to be more strict. The system now requires proper identification markers to be present, preventing arbitrary paths from being incorrectly recognized as valid project roots.

* **Tests**
  * Added unit tests for project root resolution validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/316)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->