### PR TITLE
fix(antigravity): date-filter most_used_tools in per-project stats (#292 item 2)

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1214,6 +1214,27 @@ fn track_tool_usage(message: &ClaudeMessage, tool_usage: &mut HashMap<String, (u
     }
 }
 
+/// Track tool usage across a slice of Antigravity messages while honoring
+/// the active date filter. Per-project token totals filter by record
+/// timestamp; this mirrors that behavior at the message level so the tool
+/// breakdown does not drift from the token totals.
+fn track_antigravity_tool_usage(
+    messages: &[ClaudeMessage],
+    s_limit: Option<&DateTime<Utc>>,
+    e_limit: Option<&DateTime<Utc>>,
+    tool_usage_map: &mut HashMap<String, (u32, u32)>,
+) {
+    let has_date_filter = s_limit.is_some() || e_limit.is_some();
+    for message in messages {
+        if has_date_filter
+            && !is_within_date_limits(parse_timestamp_utc(&message.timestamp), s_limit, e_limit)
+        {
+            continue;
+        }
+        track_tool_usage(message, tool_usage_map);
+    }
+}
+
 /// Extract token usage from a normalized message.
 fn extract_token_usage(message: &ClaudeMessage) -> TokenUsage {
     if let Some(usage) = &message.usage {
@@ -1891,9 +1912,12 @@ fn get_provider_project_stats_summary(
             summary.token_distribution.reasoning += session_stats.total_reasoning_tokens;
 
             if let Ok(messages) = providers::antigravity::load_messages(&session.file_path) {
-                for message in &messages {
-                    track_tool_usage(message, &mut tool_usage_map);
-                }
+                track_antigravity_tool_usage(
+                    &messages,
+                    s_limit.as_ref(),
+                    e_limit.as_ref(),
+                    &mut tool_usage_map,
+                );
             }
 
             let mut timestamps = records
@@ -4661,6 +4685,56 @@ mod tests {
             .find(|daily| daily.date == "2025-01-01")
             .expect("missing jan1 daily stat");
         assert_eq!(jan1.session_count, 2);
+    }
+
+    #[test]
+    /// Verify track_antigravity_tool_usage honors the start_date / end_date window.
+    fn test_track_antigravity_tool_usage_respects_date_filter() {
+        let mk = |timestamp: &str, tool: &str| {
+            let mut msg = make_test_message(Some("antigravity"), "assistant", None);
+            msg.content = Some(json!([
+                { "type": "text", "text": "preamble" },
+                { "type": "tool_use", "id": "t-1", "name": tool, "input": {} }
+            ]));
+            msg.timestamp = timestamp.to_string();
+            msg
+        };
+
+        let messages = vec![
+            mk("2026-01-01T10:00:00Z", "BrowserClick"),
+            mk("2026-01-05T10:00:00Z", "BrowserGetDom"),
+        ];
+
+        // No filter → both tools tracked.
+        let mut all = HashMap::new();
+        track_antigravity_tool_usage(&messages, None, None, &mut all);
+        assert_eq!(all.len(), 2);
+
+        // Window covering only the second message → only its tool is tracked.
+        let s = parse_date_limit(Some("2026-01-03T00:00:00Z".to_string()), "start_date");
+        let e = parse_date_limit(Some("2026-01-31T00:00:00Z".to_string()), "end_date");
+        let mut filtered = HashMap::new();
+        track_antigravity_tool_usage(&messages, s.as_ref(), e.as_ref(), &mut filtered);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered.contains_key("BrowserGetDom"));
+        assert!(!filtered.contains_key("BrowserClick"));
+
+        // Window excluding both messages → empty.
+        let s = parse_date_limit(Some("2026-02-01T00:00:00Z".to_string()), "start_date");
+        let mut none = HashMap::new();
+        track_antigravity_tool_usage(&messages, s.as_ref(), None, &mut none);
+        assert!(none.is_empty());
+
+        // Unparseable timestamp with an active filter is rejected (defensive).
+        let mut bad_msg = make_test_message(Some("antigravity"), "assistant", None);
+        bad_msg.content = Some(json!([
+            { "type": "tool_use", "id": "t-2", "name": "BrowserClick", "input": {} }
+        ]));
+        bad_msg.timestamp = "not-a-timestamp".to_string();
+        let s = parse_date_limit(Some("2020-01-01T00:00:00Z".to_string()), "start_date");
+        let mut rejected = HashMap::new();
+        track_antigravity_tool_usage(&[bad_msg], s.as_ref(), None, &mut rejected);
+        assert!(rejected.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -4688,7 +4688,7 @@ mod tests {
     }
 
     #[test]
-    /// Verify track_antigravity_tool_usage honors the start_date / end_date window.
+    /// Verify `track_antigravity_tool_usage` honors the `start_date` / `end_date` window.
     fn test_track_antigravity_tool_usage_respects_date_filter() {
         let mk = |timestamp: &str, tool: &str| {
             let mut msg = make_test_message(Some("antigravity"), "assistant", None);


### PR DESCRIPTION
## Summary

Resolves **item 2** of #292 — Antigravity tool aggregation now honors the active `start_date` / `end_date` filter on per-project stats, matching how the token totals on the same code path already behave.

## Why

`get_provider_project_stats_summary` iterates `providers::antigravity::load_messages(...)` and feeds every message into `track_tool_usage`, regardless of the active date window. Meanwhile, the token totals computed two lines above (via `build_antigravity_session_token_stats`) already respect `s_limit` / `e_limit`. The tool breakdown therefore drifts from the token totals whenever a date filter is applied.

## What changed

- Extracted the iteration into `track_antigravity_tool_usage(messages, s_limit, e_limit, tool_usage_map)`. The helper gates each message via `is_within_date_limits(parse_timestamp_utc(&message.timestamp), s_limit, e_limit)`, then calls the existing `track_tool_usage`.
- Call site in `get_provider_project_stats_summary` now delegates to the helper.
- Unit test (`test_track_antigravity_tool_usage_respects_date_filter`) covers:
  - no filter → both tools tracked
  - window covering only the later message → only its tool is tracked
  - window excluding all → empty
  - unparseable timestamp + active filter → rejected (defensive, mirrors `is_within_date_limits`'s `None` handling)

## Scope notes

- Tool names for Antigravity sessions are concentrated on the **last** assistant message by `merge_tool_names_into_messages`. The date filter is therefore effectively per-session (in or out), which is exactly what the issue framing accepts: "Tool tracking iterates over messages while token totals iterate over records; aligning the date filter requires picking a single timestamp source." Per-message gating on the message's own timestamp is the consistent choice without restructuring the tool-name merge.
- `#292` stays open. Items 1 (reasoning aggregation), 3 (daily/heatmap `stats_mode`), and 7 (`load_antigravity_usage_records` rpc-cache fallback) are tracked separately.

## Test plan

- [x] `cargo fmt` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry-2.10.1` + local rustc compile error, independent of this diff; CI handles Rust validation)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: open the Antigravity per-project stats view, scope to a narrow date range that excludes the session's last assistant timestamp, confirm `most_used_tools` is now empty rather than carrying tools from outside the window.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tool usage statistics so date filters are properly applied, ensuring tool counts and success metrics match the selected date range.

* **Tests**
  * Added a unit test verifying unfiltered behavior, date-window filtering (including empty windows), and handling of invalid timestamps when a date filter is active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/317)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->