### PR TITLE
fix(antigravity): rpc-cache fallback in load_antigravity_usage_records (#292 item 7)

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1389,10 +1389,9 @@ fn calculate_session_active_minutes(timestamps: &mut [DateTime<Utc>]) -> u32 {
 fn load_antigravity_usage_records(
     session_path: &str,
 ) -> Result<Vec<AntigravityUsageRecord>, String> {
-    let usage_path = PathBuf::from(session_path).join("usage.jsonl");
-    if !usage_path.exists() {
+    let Some(usage_path) = providers::antigravity::resolve_usage_jsonl_path(session_path) else {
         return Ok(vec![]);
-    }
+    };
 
     let content = fs::read_to_string(&usage_path)
         .map_err(|e| format!("Failed to read {}: {}", usage_path.display(), e))?;
@@ -4749,6 +4748,79 @@ mod tests {
             .find(|entry| entry.hour == 16 && entry.day == 2)
             .expect("missing activity heatmap entry");
         assert_eq!(heatmap.tokens_used, 930);
+    }
+
+    #[test]
+    /// `load_antigravity_usage_records` mirrors the rpc-cache fallback used by
+    /// `providers::antigravity::load_messages` so a brain/-only session whose
+    /// `usage.jsonl` lives in the rpc-cache contributes records (and therefore
+    /// tokens) to per-session / project / global stats.
+    fn test_load_antigravity_usage_records_falls_back_to_rpc_cache() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let root = temp_dir.path();
+        let rpc_v1 = root
+            .join(".token-monitor")
+            .join("rpc-cache")
+            .join("v1")
+            .join("session-brain-only");
+        fs::create_dir_all(&rpc_v1).expect("failed to create rpc-cache session dir");
+
+        // Brain/-only session — no in-place usage.jsonl.
+        let brain_dir = root.join("brain").join("session-brain-only");
+        fs::create_dir_all(&brain_dir).expect("failed to create brain dir");
+
+        // The rpc-cache carries the actual usage record.
+        let usage_record = json!({
+            "recordType": "usage",
+            "sessionId": "session-brain-only",
+            "sequence": 0,
+            "model": "claude-sonnet-4-6",
+            "inputTokens": 1000,
+            "outputTokens": 200,
+            "cacheReadTokens": 600,
+            "cacheWriteTokens": 100,
+            "reasoningTokens": 50,
+            "totalTokens": 1950,
+            "raw": {
+                "chatModel": {
+                    "chatStartMetadata": {
+                        "createdAt": "2026-04-14T16:28:44Z"
+                    }
+                }
+            }
+        });
+        fs::write(rpc_v1.join("usage.jsonl"), format!("{usage_record}\n"))
+            .expect("failed to write rpc-cache usage file");
+
+        let records = load_antigravity_usage_records(&brain_dir.to_string_lossy())
+            .expect("expected fallback to surface rpc-cache records");
+
+        assert_eq!(
+            records.len(),
+            1,
+            "fallback should surface the rpc-cache record"
+        );
+        let record = &records[0];
+        assert_eq!(record.input_tokens, 1000);
+        assert_eq!(record.output_tokens, 200);
+        assert_eq!(record.total_tokens, 1950);
+    }
+
+    #[test]
+    /// When neither in-session nor rpc-cache `usage.jsonl` exists, the helper
+    /// returns `Ok(vec![])` (legacy behaviour preserved).
+    fn test_load_antigravity_usage_records_returns_empty_when_missing() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let root = temp_dir.path();
+        fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1"))
+            .expect("failed to create rpc-cache root");
+
+        let brain_dir = root.join("brain").join("session-none");
+        fs::create_dir_all(&brain_dir).expect("failed to create brain dir");
+
+        let records = load_antigravity_usage_records(&brain_dir.to_string_lossy())
+            .expect("expected empty result");
+        assert!(records.is_empty());
     }
 
     #[tokio::test]

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -428,31 +428,39 @@ pub fn load_sessions(path: &str, _exclude_sidechain: bool) -> Result<Vec<ClaudeS
     Ok(sessions)
 }
 
-/// Map each usage record in a session's usage.jsonl to a pair of `ClaudeMessages`.
+/// Resolve the `usage.jsonl` path for an Antigravity session, mirroring
+/// the lookup used by [`load_messages`]: prefer `<session_path>/usage.jsonl`
+/// and fall back to the rpc-cache location for filesystem-only / brain-only
+/// sessions. Returns `None` when the session path does not resolve to a
+/// recognised Antigravity root, or when neither candidate exists.
+pub(crate) fn resolve_usage_jsonl_path(session_path: &str) -> Option<PathBuf> {
+    let dir = PathBuf::from(session_path);
+    let usage_path = dir.join("usage.jsonl");
+    if usage_path.exists() {
+        return Some(usage_path);
+    }
+
+    let root = marker_rooted_path(session_path)?;
+    let session_id = dir.file_name()?.to_string_lossy().to_string();
+    let rpc_cache = get_antigravity_rpc_cache_root(&root)
+        .join(&session_id)
+        .join("usage.jsonl");
+    if rpc_cache.exists() {
+        Some(rpc_cache)
+    } else {
+        None
+    }
+}
+
+/// Map each usage record in a session's `usage.jsonl` to a pair of `ClaudeMessages`.
 pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
-    let dir = std::path::PathBuf::from(session_path);
-    let session_id = dir
+    let session_id = PathBuf::from(session_path)
         .file_name()
         .map(|f| f.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let root = match marker_rooted_path(session_path) {
-        Some(root) => root,
-        None => return Ok(vec![]),
-    };
-
-    let usage_path = dir.join("usage.jsonl");
-    let usage_path = if usage_path.exists() {
-        usage_path
-    } else {
-        let rpc_cache = get_antigravity_rpc_cache_root(&root)
-            .join(&session_id)
-            .join("usage.jsonl");
-        if rpc_cache.exists() {
-            rpc_cache
-        } else {
-            return Ok(vec![]);
-        }
+    let Some(usage_path) = resolve_usage_jsonl_path(session_path) else {
+        return Ok(vec![]);
     };
 
     let content = std::fs::read_to_string(&usage_path)
@@ -951,5 +959,59 @@ mod tests {
         results.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         results.truncate(max_results);
         results
+    }
+
+    #[test]
+    /// Direct `<session_path>/usage.jsonl` is returned when it exists.
+    fn test_resolve_usage_jsonl_path_prefers_in_session_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();
+
+        let session_dir = root.join("brain").join("session-direct");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("usage.jsonl"), "{}\n").unwrap();
+
+        let resolved = resolve_usage_jsonl_path(&session_dir.to_string_lossy()).unwrap();
+        assert_eq!(resolved, session_dir.join("usage.jsonl"));
+    }
+
+    #[test]
+    /// When `<session_path>/usage.jsonl` is absent, fall back to the rpc-cache
+    /// location — matching what `load_messages` already does for brain/-only
+    /// sessions.
+    fn test_resolve_usage_jsonl_path_falls_back_to_rpc_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let rpc_v1 = root.join(".token-monitor").join("rpc-cache").join("v1");
+        std::fs::create_dir_all(&rpc_v1).unwrap();
+
+        // Brain/-only session with no in-place usage.jsonl.
+        let session_id = "session-fallback";
+        let brain_dir = root.join("brain").join(session_id);
+        std::fs::create_dir_all(&brain_dir).unwrap();
+
+        // The same session has token data in the rpc-cache.
+        let cached_session = rpc_v1.join(session_id);
+        std::fs::create_dir_all(&cached_session).unwrap();
+        let cached_usage = cached_session.join("usage.jsonl");
+        std::fs::write(&cached_usage, "{}\n").unwrap();
+
+        let resolved = resolve_usage_jsonl_path(&brain_dir.to_string_lossy()).unwrap();
+        assert_eq!(resolved, cached_usage);
+    }
+
+    #[test]
+    /// Returns `None` when neither the in-session nor the rpc-cache file
+    /// exists — callers should treat this as "no records".
+    fn test_resolve_usage_jsonl_path_returns_none_when_missing_everywhere() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();
+
+        let brain_dir = root.join("brain").join("session-empty");
+        std::fs::create_dir_all(&brain_dir).unwrap();
+
+        assert!(resolve_usage_jsonl_path(&brain_dir.to_string_lossy()).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Resolves **item 7** of #292 — `load_antigravity_usage_records` in `commands/stats.rs` now mirrors the rpc-cache fallback already used by `providers::antigravity::load_messages`, so brain/-only sessions contribute records (and therefore tokens) to per-session / project / global stats instead of silently zeroing out.

## Why

`providers::antigravity::load_messages(session_path)` resolves the session's token data via a two-step lookup:

1. `<session_path>/usage.jsonl` (filesystem source)
2. `<root>/.token-monitor/rpc-cache/v1/<session_id>/usage.jsonl` (rpc-cache fallback)

`load_antigravity_usage_records` only ever did step 1. For a session whose `file_path` points at a brain/-only directory (no in-place `usage.jsonl`), `load_messages` would surface the conversation while the stats pipeline saw `Ok(vec![])` and treated it as 0 tokens.

## What changed

- **`providers::antigravity::resolve_usage_jsonl_path(session_path) -> Option<PathBuf>`** — `pub(crate)` helper that captures the two-step lookup. `load_messages` now delegates to it.
- **`commands::stats::load_antigravity_usage_records`** — calls the same helper instead of inlining `PathBuf::from(session_path).join("usage.jsonl")`.

No public API change. Direct-`usage.jsonl` behaviour is unchanged; only the fallback path is newly available to the stats helper.

## Tests added

- `resolve_usage_jsonl_path` (in `providers::antigravity::tests`):
  - prefers `<session_path>/usage.jsonl` when present
  - falls back to the rpc-cache `usage.jsonl` for brain/-only sessions
  - returns `None` when neither candidate exists
- `load_antigravity_usage_records` (in `commands::stats::tests`):
  - brain/-only session resolves via the rpc-cache (parses real record fields)
  - missing-everywhere still returns `Ok(vec![])`

## Scope notes

- `#292` stays open. Items 1 (reasoning aggregation), 2 (date filter on `most_used_tools`, in flight as #317), and 3 (daily/heatmap `stats_mode`) are tracked separately.
- Symlink hardening on the rpc-cache fallback (canonicalize / `symlink_metadata`) is covered by **#293 item 7** — explicitly deferred so the surface area of this PR stays small.

## Test plan

- [x] `cargo fmt` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry-2.10.1` + local rustc compile error, independent of this diff; CI handles Rust validation)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: configure an Antigravity session whose `file_path` points at a brain/-only directory; verify it now contributes non-zero tokens to per-project / global stats.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session usage record resolution with enhanced fallback handling to ensure records load correctly across different session configurations
  * Added unit tests covering usage record resolution including edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/318)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->