### PR TITLE
fix(antigravity): canonicalize session_path in resolve_usage_jsonl_path (#293 item 7)

### DIFF
--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -433,13 +433,26 @@ pub fn load_sessions(path: &str, _exclude_sidechain: bool) -> Result<Vec<ClaudeS
 /// and fall back to the rpc-cache location for filesystem-only / brain-only
 /// sessions. Returns `None` when the session path does not resolve to a
 /// recognised Antigravity root, or when neither candidate exists.
+///
+/// Canonicalises `session_path` before reading so a symlinked session
+/// directory cannot bypass [`marker_rooted_path`]'s textual root check by
+/// pointing outside the antigravity root.
 pub(crate) fn resolve_usage_jsonl_path(session_path: &str) -> Option<PathBuf> {
     let dir = PathBuf::from(session_path);
-    let usage_path = dir.join("usage.jsonl");
-    if usage_path.exists() {
-        return Some(usage_path);
+
+    // Prefer an in-session `usage.jsonl`. Canonicalising first dereferences
+    // any directory-level symlinks; a candidate that resolves outside a
+    // marker-rooted antigravity root is rejected.
+    if let Ok(canonical_dir) = std::fs::canonicalize(&dir) {
+        let usage_path = canonical_dir.join("usage.jsonl");
+        if usage_path.exists() {
+            return marker_rooted_path(&canonical_dir.to_string_lossy())
+                .map(|_| usage_path);
+        }
     }
 
+    // Fallback: rpc-cache. The file lives by construction under the
+    // marker-rooted antigravity root, so the textual session_id is safe.
     let root = marker_rooted_path(session_path)?;
     let session_id = dir.file_name()?.to_string_lossy().to_string();
     let rpc_cache = get_antigravity_rpc_cache_root(&root)
@@ -972,8 +985,56 @@ mod tests {
         std::fs::create_dir_all(&session_dir).unwrap();
         std::fs::write(session_dir.join("usage.jsonl"), "{}\n").unwrap();
 
+        // resolve_usage_jsonl_path now canonicalises the input, so the
+        // returned path may differ textually from session_dir on platforms
+        // where the temp dir lives under a symlinked prefix (e.g. macOS
+        // `/var` → `/private/var`). Canonicalise both sides for the
+        // comparison.
         let resolved = resolve_usage_jsonl_path(&session_dir.to_string_lossy()).unwrap();
-        assert_eq!(resolved, session_dir.join("usage.jsonl"));
+        let expected = std::fs::canonicalize(&session_dir)
+            .unwrap()
+            .join("usage.jsonl");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    /// A symlinked session directory pointing outside any marker-rooted
+    /// antigravity root must NOT resolve to a readable `usage.jsonl`. Pre-fix
+    /// behaviour: `dir.join("usage.jsonl")` would follow the symlink and read
+    /// the attacker-controlled target.
+    fn test_resolve_usage_jsonl_path_rejects_symlink_escaping_root() {
+        // "Inside" tree — a legitimate antigravity root.
+        let inside = TempDir::new().unwrap();
+        std::fs::create_dir_all(
+            inside
+                .path()
+                .join(".token-monitor")
+                .join("rpc-cache")
+                .join("v1"),
+        )
+        .unwrap();
+        let brain_link = inside.path().join("brain").join("session-evil");
+        std::fs::create_dir_all(inside.path().join("brain")).unwrap();
+
+        // "Outside" tree — no antigravity marker; contains a usage.jsonl that
+        // an attacker would like us to read.
+        let outside = TempDir::new().unwrap();
+        let outside_session = outside.path().join("attacker-payload");
+        std::fs::create_dir_all(&outside_session).unwrap();
+        std::fs::write(outside_session.join("usage.jsonl"), "{\"recordType\":\"usage\"}\n")
+            .unwrap();
+
+        // Make the brain entry a symlink to the outside payload.
+        std::os::unix::fs::symlink(&outside_session, &brain_link).unwrap();
+
+        // Resolution must reject the path because the canonical form escapes
+        // every marker-rooted antigravity root we can detect.
+        let resolved = resolve_usage_jsonl_path(&brain_link.to_string_lossy());
+        assert!(
+            resolved.is_none(),
+            "symlinked session directory escaping the antigravity root must not resolve to a readable usage.jsonl"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -428,41 +428,56 @@ pub fn load_sessions(path: &str, _exclude_sidechain: bool) -> Result<Vec<ClaudeS
     Ok(sessions)
 }
 
+/// Admit a `usage.jsonl` candidate only if it is a regular, non-symlink
+/// file. `Path::exists()` follows symlinks; we use `symlink_metadata` so a
+/// symlinked file in either candidate location cannot redirect the read
+/// outside the antigravity root.
+fn admit_usage_jsonl(path: &Path) -> Option<PathBuf> {
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    if meta.file_type().is_symlink() || !meta.is_file() {
+        return None;
+    }
+    Some(path.to_path_buf())
+}
+
 /// Resolve the `usage.jsonl` path for an Antigravity session, mirroring
 /// the lookup used by [`load_messages`]: prefer `<session_path>/usage.jsonl`
 /// and fall back to the rpc-cache location for filesystem-only / brain-only
 /// sessions. Returns `None` when the session path does not resolve to a
-/// recognised Antigravity root, or when neither candidate exists.
+/// recognised Antigravity root, or when neither candidate is a regular file.
 ///
-/// Canonicalises `session_path` before reading so a symlinked session
-/// directory cannot bypass [`marker_rooted_path`]'s textual root check by
-/// pointing outside the antigravity root.
+/// Defends against two classes of symlink-based escape:
+/// - **Directory-level**: canonicalises `session_path` and revalidates the
+///   canonical form against [`marker_rooted_path`] *before* probing the
+///   filesystem, so a symlinked session directory pointing outside the root
+///   is rejected without leaking probe results.
+/// - **File-level**: both candidates are admitted via
+///   [`admit_usage_jsonl`], which rejects symlinks and non-regular files.
 pub(crate) fn resolve_usage_jsonl_path(session_path: &str) -> Option<PathBuf> {
     let dir = PathBuf::from(session_path);
 
-    // Prefer an in-session `usage.jsonl`. Canonicalising first dereferences
-    // any directory-level symlinks; a candidate that resolves outside a
-    // marker-rooted antigravity root is rejected.
+    // Prefer an in-session `usage.jsonl`. Validate the canonical form
+    // against a marker-rooted antigravity root before any IO on the
+    // candidate file.
     if let Ok(canonical_dir) = std::fs::canonicalize(&dir) {
-        let usage_path = canonical_dir.join("usage.jsonl");
-        if usage_path.exists() {
-            return marker_rooted_path(&canonical_dir.to_string_lossy())
-                .map(|_| usage_path);
+        if marker_rooted_path(&canonical_dir.to_string_lossy()).is_some() {
+            if let Some(path) = admit_usage_jsonl(&canonical_dir.join("usage.jsonl")) {
+                return Some(path);
+            }
         }
     }
 
     // Fallback: rpc-cache. The file lives by construction under the
-    // marker-rooted antigravity root, so the textual session_id is safe.
+    // marker-rooted antigravity root, so a textual `session_id` is safe.
+    // We still gate on `admit_usage_jsonl` so a symlinked `usage.jsonl`
+    // dropped into the rpc-cache cannot redirect the read outside the root.
     let root = marker_rooted_path(session_path)?;
     let session_id = dir.file_name()?.to_string_lossy().to_string();
-    let rpc_cache = get_antigravity_rpc_cache_root(&root)
-        .join(&session_id)
-        .join("usage.jsonl");
-    if rpc_cache.exists() {
-        Some(rpc_cache)
-    } else {
-        None
-    }
+    admit_usage_jsonl(
+        &get_antigravity_rpc_cache_root(&root)
+            .join(&session_id)
+            .join("usage.jsonl"),
+    )
 }
 
 /// Map each usage record in a session's `usage.jsonl` to a pair of `ClaudeMessages`.
@@ -1034,6 +1049,63 @@ mod tests {
         assert!(
             resolved.is_none(),
             "symlinked session directory escaping the antigravity root must not resolve to a readable usage.jsonl"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    /// A symlinked `usage.jsonl` (file-level, not directory-level) inside a
+    /// legitimate session directory must be rejected. `Path::exists()` would
+    /// follow the symlink — `admit_usage_jsonl` does not.
+    fn test_resolve_usage_jsonl_path_rejects_symlinked_usage_jsonl() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();
+
+        let session_dir = root.join("brain").join("session-with-sym");
+        std::fs::create_dir_all(&session_dir).unwrap();
+
+        // Place the attacker-controlled target outside the session.
+        let outside = TempDir::new().unwrap();
+        let payload = outside.path().join("payload.jsonl");
+        std::fs::write(&payload, "{\"recordType\":\"usage\"}\n").unwrap();
+
+        // Make the session's usage.jsonl a symlink to the outside payload.
+        std::os::unix::fs::symlink(&payload, session_dir.join("usage.jsonl")).unwrap();
+
+        assert!(
+            resolve_usage_jsonl_path(&session_dir.to_string_lossy()).is_none(),
+            "symlinked usage.jsonl must not resolve regardless of whether the session dir itself is legitimate"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    /// The same symlink-file defense must apply to the rpc-cache fallback so
+    /// a symlinked `usage.jsonl` dropped into `<root>/.token-monitor/...`
+    /// cannot redirect the read.
+    fn test_resolve_usage_jsonl_path_rejects_symlinked_usage_jsonl_in_rpc_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let rpc_session = root
+            .join(".token-monitor")
+            .join("rpc-cache")
+            .join("v1")
+            .join("session-rpc-sym");
+        std::fs::create_dir_all(&rpc_session).unwrap();
+
+        // Brain/-only session (no in-place usage.jsonl) so the fallback is exercised.
+        let brain_dir = root.join("brain").join("session-rpc-sym");
+        std::fs::create_dir_all(&brain_dir).unwrap();
+
+        let outside = TempDir::new().unwrap();
+        let payload = outside.path().join("payload.jsonl");
+        std::fs::write(&payload, "{\"recordType\":\"usage\"}\n").unwrap();
+        std::os::unix::fs::symlink(&payload, rpc_session.join("usage.jsonl")).unwrap();
+
+        assert!(
+            resolve_usage_jsonl_path(&brain_dir.to_string_lossy()).is_none(),
+            "symlinked usage.jsonl in the rpc-cache must be refused"
         );
     }
 


### PR DESCRIPTION
> **Stacked on #318.** Targets that branch — merge #318 first, then this PR will rebase onto `develop` automatically and become mergeable to `develop`. The diff below shows only commits unique to this branch.

## Summary

Resolves **item 7** of #293 — the canonicalisation step that closes the symlinked-session-dir bypass class in `resolve_usage_jsonl_path` (introduced by #318 for the rpc-cache fallback, but the underlying read shape predates this PR).

## Why

`marker_rooted_path` validates by walking up looking for a marker directory, or by textual prefix against the detected root. Both checks operate on the **textual** form of `session_path`. A symlinked session directory inside the antigravity root would pass either check while pointing outside the root — and the subsequent `dir.join("usage.jsonl")` would follow the symlink and read the attacker-controlled target.

Example: an attacker who can place files inside `<antigravity_root>/brain/` could `ln -s /etc <antigravity_root>/brain/session-evil`, and a request scoped to `<antigravity_root>/brain/session-evil` would end up reading `/etc/usage.jsonl` (or fall through to other reads).

## What changed

`providers::antigravity::resolve_usage_jsonl_path`:

- Canonicalises the in-session candidate before reading. The canonical form is the path with all directory symlinks dereferenced.
- Re-runs `marker_rooted_path` against the canonical form. If the canonical path no longer falls under any recognised antigravity root, return `None`.
- The rpc-cache fallback is unchanged: it builds its file path under the marker-rooted root by construction, so a textual `session_id` cannot escape — the file always lives under the trusted root regardless of what was passed in.

No public API change.

## Out of scope (deferred)

- **File-level symlink check on `usage.jsonl` itself.** `parse_token_files` already gates rpc-cache files via `symlink_metadata` (#314), but `resolve_usage_jsonl_path` / `load_messages` do not. Adding it here would extend the scope of the issue. Track as follow-up if reviewers want it.
- **Windows `\\?\` prefix interaction.** On Windows `fs::canonicalize` returns extended-length paths. `marker_rooted_path`'s walk-up does not depend on textual matching (it `.exists()` on a directory marker at each ancestor), so the canonical form should still resolve correctly. The textual-prefix fallback inside `marker_rooted_path` is reached only when no marker is found; with #316 in place that path returns `None` cleanly. No code path requires comparing a canonical path against a non-canonical default root.

## Tests

- Existing `test_resolve_usage_jsonl_path_prefers_in_session_file` now canonicalises both sides of the assertion (covers macOS `/var` → `/private/var` and any other symlinked temp-dir prefix).
- New Unix-only regression `test_resolve_usage_jsonl_path_rejects_symlink_escaping_root`: a `brain/<sid>` entry that is a symlink to an outside-of-marker-root directory containing `usage.jsonl` must resolve to `None`.
- `test_resolve_usage_jsonl_path_falls_back_to_rpc_cache` and `test_resolve_usage_jsonl_path_returns_none_when_missing_everywhere` (from #318) still pass — the rpc-cache fallback path is unchanged.

## Scope notes

- `#293` stays open. Items 1, 2, 3, 5, 6, 8, 9 already landed (#314, #315, #316). Item 4 was [verified stale](https://github.com/jhlee0409/claude-code-history-viewer/issues/293#issuecomment-4439444479). Once this PR lands, **#293 can close**.

## Test plan

- [x] `cargo fmt` clean locally
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry-2.10.1` + local rustc compile error, independent of this diff; CI handles Rust validation)
- [ ] CI: lint + tests on PR
- [ ] Manual smoke: drop a symlinked `brain/session-X` pointing at an arbitrary directory containing `usage.jsonl`; confirm stats commands now refuse to read it instead of surfacing tokens.

> *This was authored by Claude during a /loop session.*