### PR TITLE
fix(codex): skip auto-injected <environment_context> when picking session summary (#307)

### DIFF
--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -513,11 +513,18 @@ fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
                             last_time.clone_from(&ts);
                         }
 
-                        // Extract first user message as summary
+                        // Extract first user message as summary, skipping
+                        // auto-injected wrapper blocks (e.g. <environment_context>)
+                        // that codex CLI / Codex Desktop prepend to every session —
+                        // they are system context, not a real user prompt.
                         if summary.is_none() {
                             if let Some(role) = payload.get("role").and_then(|r| r.as_str()) {
                                 if role == "user" {
-                                    summary = extract_text_from_content(payload);
+                                    if let Some(text) = extract_text_from_content(payload) {
+                                        if !is_codex_auto_injected_user_text(&text) {
+                                            summary = Some(text);
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -581,6 +588,16 @@ fn extract_text_from_content(item: &Value) -> Option<String> {
         }
     }
     None
+}
+
+/// Returns true when `text` is an auto-injected wrapper block prepended by
+/// codex CLI / Codex Desktop to every session (currently
+/// `<environment_context>...</environment_context>`). These look like user
+/// messages structurally but contain no real prompt, so they should be
+/// skipped when picking a session summary preview.
+fn is_codex_auto_injected_user_text(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    trimmed.starts_with("<environment_context>")
 }
 
 fn convert_codex_item(
@@ -2291,5 +2308,98 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].session_id, "archived-session");
+    }
+
+    /// Helper: write `lines` as one JSON-per-line into a fresh rollout file
+    /// and run `extract_session_info` against it. Returns the resulting
+    /// `SessionInfo`. Used by the env-context-skip tests below.
+    fn run_extract_session_info_on_lines(lines: Vec<Value>) -> SessionInfo {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let rollout_path = tmp.path().join("rollout-2026-05-13.jsonl");
+        let body = lines
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&rollout_path, format!("{body}\n")).expect("rollout fixture should be written");
+        extract_session_info(&rollout_path).expect("extract_session_info should succeed")
+    }
+
+    fn session_meta_line() -> Value {
+        json!({
+            "timestamp": "2026-05-13T08:00:00Z",
+            "type": "session_meta",
+            "payload": { "id": "sess-env-ctx", "cwd": "/tmp/proj" }
+        })
+    }
+
+    fn user_message_line(timestamp: &str, text: &str) -> Value {
+        json!({
+            "timestamp": timestamp,
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": text }]
+            }
+        })
+    }
+
+    const ENV_CONTEXT_BLOCK: &str = "<environment_context>\n  <cwd>/tmp/proj</cwd>\n  <shell>powershell</shell>\n  <current_date>2026-05-13</current_date>\n  <timezone>Asia/Shanghai</timezone>\n</environment_context>";
+
+    #[test]
+    /// First user message is an auto-injected <environment_context> block;
+    /// second user message is a real prompt — the summary should be the
+    /// real prompt, not the env-context block.
+    fn extract_session_info_skips_environment_context_wrapper() {
+        let info = run_extract_session_info_on_lines(vec![
+            session_meta_line(),
+            user_message_line("2026-05-13T08:00:01Z", ENV_CONTEXT_BLOCK),
+            user_message_line(
+                "2026-05-13T08:00:02Z",
+                "Please review my PR for the Antigravity provider.",
+            ),
+        ]);
+
+        assert_eq!(
+            info.summary.as_deref(),
+            Some("Please review my PR for the Antigravity provider.")
+        );
+        // message_count counts *every* response_item type=message,
+        // including the skipped wrapper, so the count surfaces real
+        // activity volume.
+        assert_eq!(info.message_count, 2);
+    }
+
+    #[test]
+    /// First user message is a real prompt — extractor must not regress
+    /// pre-existing behaviour for sessions without an env-context wrapper.
+    fn extract_session_info_uses_first_real_user_prompt() {
+        let info = run_extract_session_info_on_lines(vec![
+            session_meta_line(),
+            user_message_line("2026-05-13T08:00:01Z", "fix the WSL crash"),
+            user_message_line("2026-05-13T08:00:02Z", "second message"),
+        ]);
+
+        assert_eq!(info.summary.as_deref(), Some("fix the WSL crash"));
+        assert_eq!(info.message_count, 2);
+    }
+
+    #[test]
+    /// Session contains only auto-injected wrapper messages and no real
+    /// prompt — summary stays None, matching legacy empty-session behaviour.
+    fn extract_session_info_env_context_only_yields_no_summary() {
+        let info = run_extract_session_info_on_lines(vec![
+            session_meta_line(),
+            user_message_line("2026-05-13T08:00:01Z", ENV_CONTEXT_BLOCK),
+        ]);
+
+        assert!(
+            info.summary.is_none(),
+            "env-context-only sessions should not produce a misleading summary; got {:?}",
+            info.summary
+        );
+        // The wrapper still counts as a message — only the summary is gated.
+        assert_eq!(info.message_count, 1);
     }
 }

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -2348,7 +2348,7 @@ mod tests {
     const ENV_CONTEXT_BLOCK: &str = "<environment_context>\n  <cwd>/tmp/proj</cwd>\n  <shell>powershell</shell>\n  <current_date>2026-05-13</current_date>\n  <timezone>Asia/Shanghai</timezone>\n</environment_context>";
 
     #[test]
-    /// First user message is an auto-injected <environment_context> block;
+    /// First user message is an auto-injected `<environment_context>` block;
     /// second user message is a real prompt — the summary should be the
     /// real prompt, not the env-context block.
     fn extract_session_info_skips_environment_context_wrapper() {


### PR DESCRIPTION
Closes #307.

## Summary

Codex sessions in the viewer were falling back to UUID-only previews because the auto-injected `<environment_context>...</environment_context>` block — prepended by codex CLI / Codex Desktop to every session — was being picked up as the "first user message" and used as `session.summary`. Either the user saw the env-context noise (visually indistinguishable from no preview) or the UI fell through to the session id for an adjacent reason.

This PR makes `extract_session_info` skip wrapper blocks at summary-extraction time, scanning forward to the first real user prompt. If a session contains only wrappers (no real prompt), `summary` stays `None`, matching legacy empty-session behaviour.

## Acceptance criteria (from the [agent brief](https://github.com/jhlee0409/claude-code-history-viewer/issues/307#issuecomment-4443532383))

- [x] env-context wrapper + real prompt → `summary` = real prompt
- [x] real prompt first (no wrapper) → `summary` unchanged from current behaviour
- [x] env-context-only session → `summary = None`
- [x] `message_count` / `first_message_time` / `last_message_time` still count every `response_item type=message`, including wrappers — the fix is summary-only
- [x] Three new unit tests cover the three cases against synthetic JSONL fixtures
- [x] Existing Codex provider tests untouched

## Out of scope (deferred)

- Other auto-injected artefact patterns (e.g. Claude Code-style `<command-message>` / `<command-name>`, slash-command preambles). The wrapper-skip helper is named `is_codex_auto_injected_user_text` so it can grow incrementally; for this PR it only matches `<environment_context>`.
- Hiding env-context blocks at message-display time. The session viewer should still show the env-context message; only summary selection changes.
- The 200-char truncation length.

## Test plan

- [x] `cargo fmt` clean
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry-2.10.1` + local rustc compile error, independent of this diff; CI handles Rust validation)
- [ ] CI: Lint + Test Suite
- [ ] Manual smoke (post-merge / pre-v1.13.0): with a codex session in `~/.codex/sessions/...`, confirm the session list shows the first real user prompt instead of `<environment_context>` text or the session UUID.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session summary generation now ignores auto-injected environment-context wrappers so summaries reflect the first real user prompt instead of system-inserted content.
  * Improved handling of edge cases where a session contains only auto-injected context—these no-longer produce misleading summaries while keeping message counts accurate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/322)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->