### PR TITLE
fix(stats): aggregate token_distribution.reasoning in global summary (#292 item 1)

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -3343,6 +3343,7 @@ pub async fn get_global_stats_summary(
         summary.token_distribution.output += stats.token_distribution.output;
         summary.token_distribution.cache_creation += stats.token_distribution.cache_creation;
         summary.token_distribution.cache_read += stats.token_distribution.cache_read;
+        summary.token_distribution.reasoning += stats.token_distribution.reasoning;
 
         // Aggregate tool usage
         for (name, (usage, success)) in stats.tool_usage {
@@ -4943,6 +4944,78 @@ mod tests {
         assert_eq!(summary.total_projects, 1);
         assert_eq!(summary.total_sessions, 1);
         assert_eq!(summary.total_tokens, 22);
+    }
+
+    #[tokio::test]
+    #[serial]
+    /// Verify global summary accumulates `token_distribution.reasoning` from
+    /// providers that emit reasoning tokens (Antigravity). Pre-fix, the
+    /// aggregation loop dropped reasoning even though every other distribution
+    /// field was carried through — leaving the UI's reasoning breakdown at 0
+    /// no matter how many reasoning tokens the underlying sessions reported.
+    async fn test_global_summary_aggregates_reasoning_tokens() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let home = temp_dir.path();
+
+        // Override HOME so resolve_antigravity_root() points at our fixture.
+        // env::set_var is process-global → this test must be `#[serial]` so
+        // it cannot race with other HOME-touching tests.
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home);
+
+        let antigravity_root = home.join(".gemini").join("antigravity");
+        let rpc_session = antigravity_root
+            .join(".token-monitor")
+            .join("rpc-cache")
+            .join("v1")
+            .join("session-reasoning");
+        fs::create_dir_all(&rpc_session).expect("failed to create rpc-cache session dir");
+
+        let usage_record = json!({
+            "recordType": "usage",
+            "sessionId": "session-reasoning",
+            "sequence": 0,
+            "model": "claude-sonnet-4-6",
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0,
+            "reasoningTokens": 1234,
+            "totalTokens": 1384,
+            "raw": {
+                "chatModel": {
+                    "chatStartMetadata": { "createdAt": "2026-05-14T10:00:00Z" }
+                }
+            }
+        });
+        fs::write(rpc_session.join("usage.jsonl"), format!("{usage_record}\n"))
+            .expect("failed to write antigravity usage file");
+
+        // claude_path is required but the Claude projects subtree is empty —
+        // we are only exercising the Antigravity branch of the global summary.
+        let summary = get_global_stats_summary(
+            home.to_string_lossy().to_string(),
+            Some(vec!["antigravity".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+        )
+        .await
+        .expect("failed to get global summary");
+
+        assert_eq!(
+            summary.token_distribution.reasoning, 1234,
+            "reasoning tokens must reach the global summary, not get dropped during aggregation"
+        );
+        // Sanity: the rest of the distribution still aggregates correctly.
+        assert_eq!(summary.token_distribution.input, 100);
+        assert_eq!(summary.token_distribution.output, 50);
+
+        if let Some(value) = original_home {
+            std::env::set_var("HOME", value);
+        } else {
+            std::env::remove_var("HOME");
+        }
     }
 
     /// Write a temporary `ForgeCode` database used by stats tests.


### PR DESCRIPTION
Closes #292 (last remaining item — #313 / #317 / #318 / #320 already shipped the other six items).

## Summary

`get_global_stats_summary` aggregates each `SessionFileStats.token_distribution.{input, output, cache_creation, cache_read}` into the global `summary.token_distribution`, but the **reasoning** field was missing from that loop — so even though `collect_provider_global_file_stats` populates `stats.token_distribution.reasoning` for Antigravity sessions, the global summary kept reporting **0 reasoning tokens** to the UI.

Add the missing `summary.token_distribution.reasoning += stats.token_distribution.reasoning;` line. No type changes; the field already exists on `TokenDistribution`.

## Why this is the minimal fix

I went into this expecting the [agent brief on #292 item 1](https://github.com/jhlee0409/claude-code-history-viewer/issues/292) — that the fix would require bumping `dedup_token_totals`'s 5-tuple return type to a 6-tuple across all 7+ callers, or wiring a separate reasoning extraction path through every caller. After tracing the data flow, that's only needed if we wanted reasoning to flow through Claude / Codex / OpenCode / ForgeCode aggregations too — and those providers don't track reasoning in `TokenUsage` (it has no `reasoning_tokens` field), so even with a 6-tuple they'd contribute 0.

The actual gap was a single missing accumulation line in the **global** loop. The per-project Antigravity branch (`get_provider_project_stats_summary`'s `if provider == Antigravity` block) and the per-file Antigravity branch (top of `collect_provider_global_file_stats`) already accumulate `reasoning` correctly. Only the global summary's outer aggregation was dropping it.

`total_tokens` stays consistent because it's `summary.total_tokens += stats.total_tokens`, and each per-file `stats.total_tokens` already includes reasoning at the source (the Antigravity branch sums it in at line ~895 inside `collect_provider_global_file_stats`).

## Test added

`test_global_summary_aggregates_reasoning_tokens` (serial, `#[tokio::test]`):

- Overrides `HOME` to a `TempDir` so `resolve_antigravity_root` points at the fixture
- Drops a single `usage.jsonl` with `reasoningTokens: 1234` into `<HOME>/.gemini/antigravity/.token-monitor/rpc-cache/v1/session-reasoning/`
- Calls `get_global_stats_summary` with `providers = ["antigravity"]`, `billing_total` mode
- Asserts `summary.token_distribution.reasoning == 1234`
- Sanity-asserts `input == 100`, `output == 50` so a regression in either the new line or the surrounding aggregation is visible

Test is `#[serial]` because `env::set_var("HOME")` is process-global. Matches the existing HOME-using pattern in this module.

## Test plan

- [x] `cargo fmt` clean
- [ ] `cargo clippy -- -D warnings` — could not run locally (`tauri-runtime-wry-2.10.1` + local rustc compile error, independent of this diff; CI handles Rust validation)
- [ ] CI: Lint + Test Suite (test must run with `--test-threads=1` to satisfy the HOME guard — repo already enforces this in `CLAUDE.md` § Release Process)
- [ ] Manual smoke (post-merge / pre-v1.13.0): in the global analytics dashboard with at least one Antigravity session that reports reasoning tokens, confirm the **reasoning** chip in the token-distribution breakdown shows a non-zero value instead of 0.

> *This was authored by Claude during a /loop session.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global statistics now track and display reasoning token distribution data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/323)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->