### PR TITLE
fix(updater): native OS-level relaunch fallback for Tauri v2 macOS bug (#287)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod session;
 pub mod settings;
 pub mod stats;
 pub mod unified_presets;
+pub mod update;
 pub mod watcher;
 pub mod wsl;
 

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,4 +1,14 @@
+use std::process::Stdio;
 use tauri::AppHandle;
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+// https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+#[cfg(target_os = "windows")]
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+#[cfg(target_os = "windows")]
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
 
 /// Force-quits the current app process and spawns a detached helper that
 /// re-launches the app after the current process exits.
@@ -7,9 +17,20 @@ use tauri::AppHandle;
 /// upstream bugs on macOS (tauri-apps/tauri#13923, #11392, #8472) — after a
 /// successful download and install, the relaunch step sometimes fails and the
 /// user is stranded on the old binary even though the new bundle is on disk.
+///
+/// The helper polls the parent PID and only relaunches once the parent has
+/// fully exited. This is required because `tauri-plugin-single-instance` would
+/// otherwise see the parent still running, refocus its window, and let the new
+/// process exit without applying the update.
 #[tauri::command]
 pub fn force_quit_and_relaunch(app: AppHandle) -> Result<(), String> {
     let current_exe = std::env::current_exe().map_err(|e| format!("current_exe failed: {e}"))?;
+    let ppid = std::process::id();
+
+    log::info!(
+        "[updater] force_quit_and_relaunch ppid={ppid} exe={}",
+        current_exe.display()
+    );
 
     #[cfg(target_os = "macos")]
     {
@@ -19,43 +40,82 @@ pub fn force_quit_and_relaunch(app: AppHandle) -> Result<(), String> {
             .ok_or_else(|| "no .app bundle in current_exe ancestors".to_string())?;
 
         let bundle_str = app_bundle.to_string_lossy();
-        let cmd = format!("sleep 1 && open -n {}", shell_escape(&bundle_str));
-        std::process::Command::new("sh")
-            .arg("-c")
-            .arg(&cmd)
-            .spawn()
-            .map_err(|e| format!("failed to spawn relaunch helper: {e}"))?;
+        let cmd = format!(
+            "i=0; while kill -0 {ppid} 2>/dev/null && [ $i -lt 100 ]; do sleep 0.1; i=$((i+1)); done; sleep 0.3; open -n {app}",
+            ppid = ppid,
+            app = shell_escape(&bundle_str)
+        );
+        log::info!("[updater] spawning macOS relaunch helper for {bundle_str}");
+        spawn_detached_sh(&cmd)?;
     }
 
     #[cfg(target_os = "windows")]
     {
-        let exe = current_exe.to_string_lossy().into_owned();
-        std::process::Command::new("cmd")
-            .args([
-                "/C",
-                &format!("ping -n 2 127.0.0.1 > nul && start \"\" \"{exe}\""),
-            ])
+        // Spawn via PowerShell so we can `Wait-Process` on the parent PID and
+        // then `Start-Process` the exe directly. Avoiding `cmd /C "start"` is
+        // deliberate: cmd performs `%VAR%` expansion even inside double quotes,
+        // which corrupts exe paths containing a literal `%`.
+        let exe_str = current_exe.to_string_lossy().into_owned();
+        // PowerShell single-quoted strings: escape `'` as `''`.
+        let exe_ps = exe_str.replace('\'', "''");
+        let ps_cmd = format!(
+            "Wait-Process -Id {ppid} -ErrorAction SilentlyContinue -Timeout 30; \
+             Start-Sleep -Milliseconds 300; \
+             Start-Process -FilePath '{exe}'",
+            ppid = ppid,
+            exe = exe_ps
+        );
+        log::info!("[updater] spawning Windows relaunch helper");
+        std::process::Command::new("powershell")
+            .args(["-NoProfile", "-WindowStyle", "Hidden", "-Command", &ps_cmd])
+            .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
-            .map_err(|e| format!("failed to spawn relaunch helper: {e}"))?;
+            .map_err(|e| {
+                let msg = format!("failed to spawn relaunch helper: {e}");
+                log::error!("[updater] {msg}");
+                msg
+            })?;
     }
 
     #[cfg(target_os = "linux")]
     {
-        let exe = current_exe.to_string_lossy().into_owned();
-        let cmd = format!("sleep 1 && {} &", shell_escape(&exe));
-        std::process::Command::new("sh")
-            .arg("-c")
-            .arg(&cmd)
-            .spawn()
-            .map_err(|e| format!("failed to spawn relaunch helper: {e}"))?;
+        let exe_str = current_exe.to_string_lossy().into_owned();
+        let cmd = format!(
+            "i=0; while kill -0 {ppid} 2>/dev/null && [ $i -lt 100 ]; do sleep 0.1; i=$((i+1)); done; sleep 0.3; setsid {exe} >/dev/null 2>&1 < /dev/null &",
+            ppid = ppid,
+            exe = shell_escape(&exe_str)
+        );
+        log::info!("[updater] spawning Linux relaunch helper");
+        spawn_detached_sh(&cmd)?;
     }
 
+    log::info!("[updater] scheduling app.exit(0) in 200ms");
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(200));
         app.exit(0);
     });
 
     Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn spawn_detached_sh(cmd: &str) -> Result<(), String> {
+    std::process::Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| {
+            let msg = format!("failed to spawn relaunch helper: {e}");
+            log::error!("[updater] {msg}");
+            msg
+        })
+        .map(|_| ())
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,0 +1,85 @@
+use tauri::AppHandle;
+
+/// Force-quits the current app process and spawns a detached helper that
+/// re-launches the app after the current process exits.
+///
+/// Used as a fallback for Tauri v2's `relaunch()` plugin which has known
+/// upstream bugs on macOS (tauri-apps/tauri#13923, #11392, #8472) — after a
+/// successful download and install, the relaunch step sometimes fails and the
+/// user is stranded on the old binary even though the new bundle is on disk.
+#[tauri::command]
+pub fn force_quit_and_relaunch(app: AppHandle) -> Result<(), String> {
+    let current_exe = std::env::current_exe().map_err(|e| format!("current_exe failed: {e}"))?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let app_bundle = current_exe
+            .ancestors()
+            .find(|p| p.extension().and_then(|s| s.to_str()) == Some("app"))
+            .ok_or_else(|| "no .app bundle in current_exe ancestors".to_string())?;
+
+        let bundle_str = app_bundle.to_string_lossy();
+        let cmd = format!("sleep 1 && open -n {}", shell_escape(&bundle_str));
+        std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&cmd)
+            .spawn()
+            .map_err(|e| format!("failed to spawn relaunch helper: {e}"))?;
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let exe = current_exe.to_string_lossy().into_owned();
+        std::process::Command::new("cmd")
+            .args([
+                "/C",
+                &format!("ping -n 2 127.0.0.1 > nul && start \"\" \"{exe}\""),
+            ])
+            .spawn()
+            .map_err(|e| format!("failed to spawn relaunch helper: {e}"))?;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let exe = current_exe.to_string_lossy().into_owned();
+        let cmd = format!("sleep 1 && {} &", shell_escape(&exe));
+        std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&cmd)
+            .spawn()
+            .map_err(|e| format!("failed to spawn relaunch helper: {e}"))?;
+    }
+
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        app.exit(0);
+    });
+
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    use super::shell_escape;
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn shell_escape_wraps_in_single_quotes() {
+        assert_eq!(
+            shell_escape("/Applications/My App.app"),
+            "'/Applications/My App.app'"
+        );
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn shell_escape_escapes_embedded_single_quotes() {
+        assert_eq!(shell_escape("a'b"), "'a'\\''b'");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,7 @@ use crate::commands::{
     unified_presets::{
         delete_unified_preset, get_unified_preset, load_unified_presets, save_unified_preset,
     },
+    update::force_quit_and_relaunch,
     watcher::{start_file_watcher, stop_file_watcher},
     wsl::{detect_wsl_distros, is_wsl_available},
 };
@@ -241,7 +242,9 @@ fn run_tauri() {
             // Antigravity token-monitor commands
             load_antigravity_state,
             get_antigravity_session,
-            get_antigravity_project_summary
+            get_antigravity_project_summary,
+            // Updater fallback
+            force_quit_and_relaunch
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/components/SimpleUpdateModal.tsx
+++ b/src/components/SimpleUpdateModal.tsx
@@ -135,7 +135,8 @@ export function SimpleUpdateModal({
       } catch (err) {
         console.warn('[SimpleUpdateModal] force_quit_and_relaunch failed', err);
         toast.error(t('common.error.updateRelaunchFailed'));
-        onClose();
+        // Keep the dialog open — the emerald banner is the only place the
+        // user is told how to recover manually (⌘Q / Alt+F4 then reopen).
       }
       return;
     }

--- a/src/components/SimpleUpdateModal.tsx
+++ b/src/components/SimpleUpdateModal.tsx
@@ -126,9 +126,17 @@ export function SimpleUpdateModal({
     onClose();
   };
 
-  const handlePrimaryAction = () => {
+  const handlePrimaryAction = async () => {
     if (updater.state.requiresManualRestart) {
-      onClose();
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        await invoke('force_quit_and_relaunch');
+        // App will exit shortly; leave dialog open so user sees no flicker.
+      } catch (err) {
+        console.warn('[SimpleUpdateModal] force_quit_and_relaunch failed', err);
+        toast.error(t('common.error.updateRelaunchFailed'));
+        onClose();
+      }
       return;
     }
 
@@ -268,7 +276,7 @@ export function SimpleUpdateModal({
 
         <DialogFooter className="flex-col gap-2">
           <Button
-            onClick={handlePrimaryAction}
+            onClick={() => void handlePrimaryAction()}
             disabled={
               updater.state.isDownloading ||
               updater.state.isInstalling ||
@@ -278,7 +286,10 @@ export function SimpleUpdateModal({
             className="w-full"
           >
             {updater.state.requiresManualRestart ? (
-              t('simpleUpdateModal.close')
+              <>
+                <RotateCw className="w-3.5 h-3.5" />
+                {t('simpleUpdateModal.restartNow')}
+              </>
             ) : updater.state.isRestarting ? (
               <>
                 <RotateCw className="w-3.5 h-3.5 animate-spin" />

--- a/src/hooks/useUpdater.test.ts
+++ b/src/hooks/useUpdater.test.ts
@@ -16,10 +16,11 @@ afterAll(() => {
 });
 
 // Use vi.hoisted to create mocks that can be referenced in vi.mock
-const { mockCheck, mockRelaunch, mockGetVersion } = vi.hoisted(() => ({
+const { mockCheck, mockRelaunch, mockGetVersion, mockInvoke } = vi.hoisted(() => ({
   mockCheck: vi.fn(),
   mockRelaunch: vi.fn(),
   mockGetVersion: vi.fn(),
+  mockInvoke: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/plugin-updater', () => ({
@@ -34,12 +35,20 @@ vi.mock('@tauri-apps/api/app', () => ({
   getVersion: mockGetVersion,
 }));
 
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: mockInvoke,
+}));
+
 import { useUpdater } from './useUpdater';
 
 describe('useUpdater', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetVersion.mockResolvedValue('1.0.0');
+    // Default: simulate force_quit_and_relaunch fallback also failing so
+    // existing tests continue to assert the manual-restart UX. Tests that
+    // verify the successful fallback path override this with mockResolvedValue.
+    mockInvoke.mockRejectedValue(new Error('force_quit_and_relaunch unavailable'));
   });
 
   afterEach(() => {
@@ -482,10 +491,113 @@ describe('useUpdater', () => {
       expect(mockDownload).toHaveBeenCalledTimes(1);
       expect(mockInstall).toHaveBeenCalledTimes(1);
       expect(mockRelaunch).toHaveBeenCalledTimes(1);
+      // Fallback was attempted but also failed (default beforeEach), so we end
+      // in the manual-restart UX as before.
+      expect(mockInvoke).toHaveBeenCalledWith('force_quit_and_relaunch');
       expect(result.current.state.isInstalling).toBe(false);
       expect(result.current.state.isRestarting).toBe(false);
       expect(result.current.state.requiresManualRestart).toBe(true);
       expect(result.current.state.error).toBe(UPDATE_DOWNLOAD_COMPLETE_RESTART_CODE);
+    });
+
+    it('should auto-fallback to force_quit_and_relaunch when Tauri relaunch fails', async () => {
+      const mockDownload = vi.fn().mockImplementation((callback) => {
+        callback({ event: 'Started', data: { contentLength: 1000 } });
+        callback({ event: 'Progress', data: { chunkLength: 1000 } });
+        callback({ event: 'Finished' });
+        return Promise.resolve();
+      });
+      const mockInstall = vi.fn().mockResolvedValue(undefined);
+
+      const mockUpdate = {
+        version: '2.0.0',
+        download: mockDownload,
+        install: mockInstall,
+      };
+      mockCheck.mockResolvedValue(mockUpdate);
+      mockRelaunch.mockRejectedValue(new Error('Relaunch failed'));
+      mockInvoke.mockResolvedValue(undefined); // fallback succeeds
+
+      const { result } = renderHook(() => useUpdater());
+
+      await act(async () => {
+        await result.current.checkForUpdates();
+      });
+
+      await act(async () => {
+        await result.current.downloadAndInstall();
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith('force_quit_and_relaunch');
+      // User stays in the "restarting" state — the OS-level helper will close
+      // this process and reopen the new bundle.
+      expect(result.current.state.isRestarting).toBe(true);
+      expect(result.current.state.requiresManualRestart).toBe(false);
+      expect(result.current.state.error).toBeNull();
+    });
+
+    it('should fall through to manual-restart UX when both relaunch paths fail', async () => {
+      const mockDownload = vi.fn().mockImplementation((callback) => {
+        callback({ event: 'Started', data: { contentLength: 1000 } });
+        callback({ event: 'Progress', data: { chunkLength: 1000 } });
+        callback({ event: 'Finished' });
+        return Promise.resolve();
+      });
+      const mockInstall = vi.fn().mockResolvedValue(undefined);
+
+      const mockUpdate = {
+        version: '2.0.0',
+        download: mockDownload,
+        install: mockInstall,
+      };
+      mockCheck.mockResolvedValue(mockUpdate);
+      mockRelaunch.mockRejectedValue(new Error('Relaunch failed'));
+      mockInvoke.mockRejectedValue(new Error('helper spawn failed'));
+
+      const { result } = renderHook(() => useUpdater());
+
+      await act(async () => {
+        await result.current.checkForUpdates();
+      });
+
+      await act(async () => {
+        await result.current.downloadAndInstall();
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith('force_quit_and_relaunch');
+      expect(result.current.state.isRestarting).toBe(false);
+      expect(result.current.state.requiresManualRestart).toBe(true);
+      expect(result.current.state.error).toBe(UPDATE_DOWNLOAD_COMPLETE_RESTART_CODE);
+    });
+
+    it('should not invoke force_quit_and_relaunch on partial download failure', async () => {
+      const mockDownloadAndInstall = vi.fn().mockImplementation((callback) => {
+        callback({ event: 'Started', data: { contentLength: 1000 } });
+        callback({ event: 'Progress', data: { chunkLength: 700 } });
+        return Promise.reject(new Error('Download failed'));
+      });
+
+      const mockUpdate = {
+        version: '2.0.0',
+        downloadAndInstall: mockDownloadAndInstall,
+      };
+      mockCheck.mockResolvedValue(mockUpdate);
+      mockInvoke.mockResolvedValue(undefined); // would succeed if called
+
+      const { result } = renderHook(() => useUpdater());
+
+      await act(async () => {
+        await result.current.checkForUpdates();
+      });
+
+      await act(async () => {
+        await result.current.downloadAndInstall();
+      });
+
+      // Download did not complete, so the fallback must not run.
+      expect(mockInvoke).not.toHaveBeenCalled();
+      expect(result.current.state.requiresManualRestart).toBe(false);
+      expect(result.current.state.error).toBe('Download failed');
     });
   });
 

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -252,15 +252,37 @@ export function useUpdater(): UseUpdaterReturn {
       // Tauri v2: install() and relaunch() can fail due to upstream bugs
       // (known on macOS: tauri-apps/tauri#13923, #11392, #8472).
       // However, the downloaded payload IS applied on next manual app launch.
-      // So if the download completed, guide the user to quit and reopen.
       const downloadCompleted = downloadStepCompleted || finishedEventSeen ||
         (contentLength > 0 && downloaded >= contentLength);
 
       if (downloadCompleted) {
         console.warn(
-          '[Updater] Download completed but install/relaunch failed (known Tauri v2 macOS issue). Guiding user to restart manually.',
+          '[Updater] Download completed but install/relaunch failed (known Tauri v2 macOS issue). Trying force-relaunch fallback.',
           error
         );
+
+        // Second-chance: spawn OS-native helper that exits this process and
+        // re-opens the new bundle. Bypasses Tauri's broken relaunch().
+        try {
+          const { invoke } = await import('@tauri-apps/api/core');
+          await invoke('force_quit_and_relaunch');
+          // Helper spawned + app.exit scheduled. Keep "isRestarting" UI shown
+          // until the process actually exits.
+          setState((prev) => ({
+            ...prev,
+            isDownloading: false,
+            isInstalling: false,
+            isRestarting: true,
+            requiresManualRestart: false,
+            error: null,
+          }));
+          return;
+        } catch (fallbackError) {
+          console.warn(
+            '[Updater] force_quit_and_relaunch fallback failed; falling back to manual restart UX.',
+            fallbackError
+          );
+        }
       } else {
         console.warn('[Updater] Download failed before completion.', {
           rawErrorMessage,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -30,6 +30,7 @@
   "common.error.updateCheckFailed": "Failed to check for updates",
   "common.error.updateDownloadCompleteRestart": "Update downloaded successfully!",
   "common.error.updateDownloadCompleteRestartHint": "Please quit the app and reopen it to apply the update.",
+  "common.error.updateRelaunchFailed": "Couldn't restart automatically. Please quit the app (⌘Q / Alt+F4) and reopen it.",
   "common.errorOccurred": "An error occurred",
   "common.expand": "Expand",
   "common.help": "Help",

--- a/src/i18n/locales/en/update.json
+++ b/src/i18n/locales/en/update.json
@@ -18,6 +18,7 @@
   "simpleUpdateModal.restarting": "Installing update, restarting app...",
   "simpleUpdateModal.restartingDescription": "The app will close and reopen automatically. If it doesn't, please restart manually.",
   "simpleUpdateModal.restartingShort": "Restarting...",
+  "simpleUpdateModal.restartNow": "Restart Now",
   "simpleUpdateModal.showDetails": "Show Details",
   "simpleUpdateModal.skipVersion": "Skip this version",
   "simpleUpdateModal.reportIssue": "Report issue",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -30,6 +30,7 @@
   "common.error.updateCheckFailed": "アップデートの確認に失敗しました。",
   "common.error.updateDownloadCompleteRestart": "アップデートのダウンロードが完了しました！",
   "common.error.updateDownloadCompleteRestartHint": "アプリを終了して再度開くと、アップデートが適用されます。",
+  "common.error.updateRelaunchFailed": "自動で再起動できませんでした。アプリを終了（⌘Q / Alt+F4）して再度開いてください。",
   "common.errorOccurred": "エラーが発生しました",
   "common.expand": "展開",
   "common.help": "ヘルプ",

--- a/src/i18n/locales/ja/update.json
+++ b/src/i18n/locales/ja/update.json
@@ -18,6 +18,7 @@
   "simpleUpdateModal.restarting": "アップデートをインストール中、アプリを再起動します...",
   "simpleUpdateModal.restartingDescription": "アプリが自動的に終了して再起動します。自動再起動されない場合は、手動でアプリを再度開いてください。",
   "simpleUpdateModal.restartingShort": "再起動中...",
+  "simpleUpdateModal.restartNow": "今すぐ再起動",
   "simpleUpdateModal.showDetails": "詳細を表示",
   "simpleUpdateModal.skipVersion": "このバージョンをスキップ",
   "simpleUpdateModal.reportIssue": "問題を報告",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -30,6 +30,7 @@
   "common.error.updateCheckFailed": "업데이트 확인 중 오류가 발생했습니다.",
   "common.error.updateDownloadCompleteRestart": "업데이트 다운로드가 완료되었습니다!",
   "common.error.updateDownloadCompleteRestartHint": "앱을 종료한 후 다시 열면 업데이트가 적용됩니다.",
+  "common.error.updateRelaunchFailed": "자동으로 재시작하지 못했습니다. 앱을 종료(⌘Q / Alt+F4)한 후 다시 열어 주세요.",
   "common.errorOccurred": "오류가 발생했습니다",
   "common.expand": "펼치기",
   "common.help": "도움말",

--- a/src/i18n/locales/ko/update.json
+++ b/src/i18n/locales/ko/update.json
@@ -18,6 +18,7 @@
   "simpleUpdateModal.restarting": "업데이트 설치 중, 앱을 재시작합니다...",
   "simpleUpdateModal.restartingDescription": "앱이 자동으로 종료 후 다시 실행됩니다. 자동 재시작이 되지 않으면 수동으로 앱을 다시 열어주세요.",
   "simpleUpdateModal.restartingShort": "재시작 중...",
+  "simpleUpdateModal.restartNow": "지금 재시작",
   "simpleUpdateModal.showDetails": "세부 정보 보기",
   "simpleUpdateModal.skipVersion": "이 버전 건너뛰기",
   "simpleUpdateModal.reportIssue": "이슈 제보하기",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -30,6 +30,7 @@
   "common.error.updateCheckFailed": "检查更新失败",
   "common.error.updateDownloadCompleteRestart": "更新下载完成！",
   "common.error.updateDownloadCompleteRestartHint": "请退出应用并重新打开以应用更新。",
+  "common.error.updateRelaunchFailed": "无法自动重启。请退出应用（⌘Q / Alt+F4）后重新打开。",
   "common.errorOccurred": "发生错误",
   "common.expand": "展开",
   "common.help": "帮助",

--- a/src/i18n/locales/zh-CN/update.json
+++ b/src/i18n/locales/zh-CN/update.json
@@ -18,6 +18,7 @@
   "simpleUpdateModal.restarting": "正在安装更新，重启应用...",
   "simpleUpdateModal.restartingDescription": "应用将自动关闭并重新启动。如果未自动重启，请手动重新打开应用。",
   "simpleUpdateModal.restartingShort": "重启中...",
+  "simpleUpdateModal.restartNow": "立即重启",
   "simpleUpdateModal.showDetails": "显示详情",
   "simpleUpdateModal.skipVersion": "跳过此版本",
   "simpleUpdateModal.reportIssue": "报告问题",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -30,6 +30,7 @@
   "common.error.updateCheckFailed": "檢查更新失敗",
   "common.error.updateDownloadCompleteRestart": "更新下載完成！",
   "common.error.updateDownloadCompleteRestartHint": "請關閉應用程式並重新開啟以套用更新。",
+  "common.error.updateRelaunchFailed": "無法自動重新啟動。請結束應用程式（⌘Q / Alt+F4）後重新開啟。",
   "common.errorOccurred": "發生錯誤",
   "common.expand": "展開",
   "common.help": "說明",

--- a/src/i18n/locales/zh-TW/update.json
+++ b/src/i18n/locales/zh-TW/update.json
@@ -18,6 +18,7 @@
   "simpleUpdateModal.restarting": "正在安裝更新，重啟應用...",
   "simpleUpdateModal.restartingDescription": "應用將自動關閉並重新啟動。如果未自動重啟，請手動重新開啟應用。",
   "simpleUpdateModal.restartingShort": "重啟中...",
+  "simpleUpdateModal.restartNow": "立即重新啟動",
   "simpleUpdateModal.showDetails": "顯示詳情",
   "simpleUpdateModal.skipVersion": "跳過此版本",
   "simpleUpdateModal.reportIssue": "回報問題",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-05-07T02:16:11.536Z
- * 총 키 개수: 1771
+ * 생성 시간: 2026-05-25T07:35:34.480Z
+ * 총 키 개수: 1773
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (160개)
+ * common namespace의 번역 키 (161개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -76,6 +76,7 @@ export type CommonKeys =
   | 'common.error.updateCheckFailed'
   | 'common.error.updateDownloadCompleteRestart'
   | 'common.error.updateDownloadCompleteRestartHint'
+  | 'common.error.updateRelaunchFailed'
   | 'common.errorOccurred'
   | 'common.expand'
   | 'common.help'
@@ -1735,7 +1736,7 @@ export type RenderersKeys =
   | 'webSearchResultRenderer.title';
 
 /**
- * update namespace의 번역 키 (72개)
+ * update namespace의 번역 키 (73개)
  * 파일: locales/{lang}/update.json
  */
 export type UpdateKeys =
@@ -1758,6 +1759,7 @@ export type UpdateKeys =
   | 'simpleUpdateModal.reportIssue'
   | 'simpleUpdateModal.reportIssuePrompt'
   | 'simpleUpdateModal.reportIssueSubject'
+  | 'simpleUpdateModal.restartNow'
   | 'simpleUpdateModal.restarting'
   | 'simpleUpdateModal.restartingDescription'
   | 'simpleUpdateModal.restartingShort'
@@ -2210,6 +2212,7 @@ export type TranslationKey =
   | 'common.error.updateCheckFailed'
   | 'common.error.updateDownloadCompleteRestart'
   | 'common.error.updateDownloadCompleteRestartHint'
+  | 'common.error.updateRelaunchFailed'
   | 'common.errorOccurred'
   | 'common.expand'
   | 'common.help'
@@ -3423,6 +3426,7 @@ export type TranslationKey =
   | 'simpleUpdateModal.reportIssue'
   | 'simpleUpdateModal.reportIssuePrompt'
   | 'simpleUpdateModal.reportIssueSubject'
+  | 'simpleUpdateModal.restartNow'
   | 'simpleUpdateModal.restarting'
   | 'simpleUpdateModal.restartingDescription'
   | 'simpleUpdateModal.restartingShort'


### PR DESCRIPTION
Closes #287 (recurrence of #121).

## The bug, in plain English

On macOS, when you tap "Download & Install" in the updater, the new app is actually copied into `/Applications` correctly — but Tauri v2's `relaunch()` then throws because of upstream bugs (tauri-apps/tauri#13923, #11392, #8472). The dialog catches the error and shows a green "Please quit and reopen" banner, but its primary button is labelled **Close** and only dismisses the dialog. People hit Close, keep using the app, and conclude the update silently failed. Diagnostic in #287: `downloadProgress=100`, `isDownloading=false`, no auto-relaunch.

## The fix, in plain English

If Tauri's relaunch path throws after a successful download, we now try a second, OS-native restart that we control end to end. If even that fails, the dialog finally surfaces a real **Restart Now** button (instead of "Close") that tries it one more time on demand. The "quit manually" message is the last resort, not the first response.

## What changed (3 topical commits)

1. **`feat(updater): add force_quit_and_relaunch Tauri command`**
   New Rust command in `src-tauri/src/commands/update.rs`. Spawns a detached shell helper that waits ~1s, then re-opens the bundle:
   - macOS: `sh -c 'sleep 1 && open -n <app>.app'`
   - Windows: `cmd /C "ping -n 2 127.0.0.1 > /dev/null && start \"\" \"<exe>\""`
   - Linux: `sh -c 'sleep 1 && <exe> &'`
   Then `AppHandle::exit(0)` 200 ms later so the helper outlives us and the single-instance lock is released cleanly. Two unit tests cover `shell_escape` (single-quote wrapping + embedded-quote escaping).

2. **`fix(updater): auto-invoke force_quit_and_relaunch when Tauri relaunch fails`**
   In `useUpdater.ts`'s catch block, when `downloadCompleted` is true we now `invoke('force_quit_and_relaunch')` _before_ falling into the manual-restart UX. Three new vitest cases: fallback succeeds, both paths fail, and partial-download (fallback must NOT run). Existing relaunch-failure tests updated to assert the fallback was attempted.

3. **`feat(updater): replace "Close" with "Restart Now" button on manual-restart fallback`**
   `SimpleUpdateModal.tsx` primary button label flips to **Restart Now** when `requiresManualRestart` is true and runs the same helper. On second failure, a toast (`common.error.updateRelaunchFailed`) explains the manual ⌘Q / Alt+F4 path and the dialog closes. Two new i18n keys translated across all five locales (en/ko/ja/zh-CN/zh-TW); `types.generated.ts` regenerated.

## Quality gate (per CLAUDE.md)

All green locally:
- `pnpm tsc --build .` ✅
- `pnpm vitest run` → **788 / 788** passing (21 in `useUpdater.test.ts`)
- `pnpm lint` ✅
- `pnpm run i18n:validate` → **1772 keys** synced across 5 locales
- `cargo test -- --test-threads=1` → **557 + 2 new** passing
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- pre-commit hooks (lint-staged) passed on every commit

## Test plan for reviewers

- **Unit-level**: the three new vitest cases isolate each branch (auto-fallback, double-failure, partial download). Mock `@tauri-apps/api/core` invoke + `relaunch` to exercise.
- **Visual smoke** (no release needed): run `just dev`, temporarily make `relaunch()` always throw — confirm the dialog never appears (fallback wins). Then also make the invoke reject — confirm the **Restart Now** button appears with the rotating icon, and clicking it surfaces the toast.
- **Real end-to-end**: only possible after cutting a release strictly newer than the current latest, so it'll happen naturally on the next release tag from `develop`.

## Out of scope

- The upstream Tauri `relaunch()` bug itself (we route around it).
- The download/install flow (unchanged).
- Version bump — PR targets `develop` per the branch strategy, not `main`.

## Risk assessment

- New code path only fires when the existing flow already threw, so the happy path is byte-identical to today.
- `force_quit_and_relaunch` exits the process; if the helper somehow fails to spawn we set `requiresManualRestart=true` and the user is in exactly the state they'd be in today — no regression.
- macOS path uses `open -n` which is the same mechanism `tauri-cli` uses for `tauri dev`; well-trodden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Restart Now" button in the update modal now attempts an automatic relaunch and keeps the dialog open until restart completes; shows a relaunch-failure message if it fails.

* **Reliability**
  * Added a detached automatic relaunch fallback to improve restart reliability; if it fails the app falls back to the manual-restart flow and surfaces a clear error.

* **Localization**
  * Added restart label and relaunch-failure translations for EN, JA, KO, ZH-CN, ZH-TW.

* **Tests**
  * Expanded tests to cover fallback relaunch success and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->