### PR TITLE
fix: handle deep project paths in sidebar width and slug parsing

### DIFF
--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -605,6 +605,15 @@ mod tests {
         assert_eq!(result, "c");
     }
 
+    #[test]
+    fn test_extract_project_name_fallback_when_path_missing() {
+        // Guarantees we hit the splitn(4) fallback when filesystem decoding
+        // fails (deleted project, or path that never existed). Uses a sentinel
+        // prefix unlikely to ever exist on any developer machine.
+        let result = extract_project_name("-__cchv_definitely_missing_12345__-foo-bar-leafname");
+        assert_eq!(result, "bar-leafname");
+    }
+
     /// Helper for deep-path tests: creates a nested directory tree under the
     /// canonical temp dir, encodes it Claude-style, and returns the encoded
     /// slug plus the root for cleanup. Canonicalization is required because

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -628,7 +628,12 @@ mod tests {
             deep = deep.join(s);
         }
         std::fs::create_dir_all(&deep).expect("create deep tmp dir");
-        let encoded = deep.to_string_lossy().replace('/', "-");
+        // Normalize both Unix and Windows separators so the encoded slug
+        // matches Claude's leading-dash convention regardless of host OS.
+        let mut encoded = deep.to_string_lossy().replace(['/', '\\'], "-");
+        if !encoded.starts_with('-') {
+            encoded.insert(0, '-');
+        }
         (encoded, root)
     }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -52,16 +52,21 @@ pub fn find_line_starts(data: &[u8]) -> Vec<usize> {
 }
 
 pub fn extract_project_name(raw_project_name: &str) -> String {
-    if raw_project_name.starts_with('-') {
+    if let Some(stripped) = raw_project_name.strip_prefix('-') {
+        // Prefer filesystem-checked decoding — handles arbitrarily deep paths
+        // and project names containing hyphens (e.g. ~/Projects/{Host}/{Org}/{Repo}).
+        if let Some(decoded) = decode_with_filesystem_check(stripped) {
+            if let Some(leaf) = Path::new(&decoded).file_name() {
+                return leaf.to_string_lossy().to_string();
+            }
+        }
+        // Fallback: original heuristic for paths no longer on disk.
         let parts: Vec<&str> = raw_project_name.splitn(4, '-').collect();
         if parts.len() == 4 {
-            parts[3].to_string()
-        } else {
-            raw_project_name.to_string()
+            return parts[3].to_string();
         }
-    } else {
-        raw_project_name.to_string()
     }
+    raw_project_name.to_string()
 }
 
 /// Estimate message count from file size (more accurate calculation)
@@ -598,6 +603,57 @@ mod tests {
     fn test_extract_project_name_exact_four_parts() {
         let result = extract_project_name("-a-b-c");
         assert_eq!(result, "c");
+    }
+
+    /// Helper for deep-path tests: creates a nested directory tree under the
+    /// canonical temp dir, encodes it Claude-style, and returns the encoded
+    /// slug plus the root for cleanup. Canonicalization is required because
+    /// the decoder rejects symlinked path components (macOS `/var` →
+    /// `/private/var`).
+    fn make_encoded_path(root_name: &str, segments: &[&str]) -> (String, std::path::PathBuf) {
+        let root = std::fs::canonicalize(std::env::temp_dir())
+            .expect("canonicalize temp dir")
+            .join(root_name);
+        let mut deep = root.clone();
+        for s in segments {
+            deep = deep.join(s);
+        }
+        std::fs::create_dir_all(&deep).expect("create deep tmp dir");
+        let encoded = deep.to_string_lossy().replace('/', "-");
+        (encoded, root)
+    }
+
+    #[test]
+    fn test_extract_project_name_deep_path() {
+        // Paths deeper than 3 segments (e.g. ~/Projects/{Host}/{Org}/{Repo})
+        // must return just the leaf, not the encoded suffix.
+        let (encoded, root) = make_encoded_path(
+            "cchv_extract_deep_test",
+            &["Projects", "GitHub", "org", "repo"],
+        );
+        let result = extract_project_name(&encoded);
+        std::fs::remove_dir_all(&root).ok();
+        assert_eq!(result, "repo");
+    }
+
+    #[test]
+    fn test_extract_project_name_with_hyphens_in_segments() {
+        // Real-world example: a deep path where directory names themselves
+        // contain hyphens. The encoded slug is ambiguous (every hyphen could
+        // be a separator OR part of a name), so this can only resolve
+        // correctly via filesystem existence checks.
+        let (encoded, root) = make_encoded_path(
+            "cchv_extract_hyphens_test",
+            &[
+                "Projects",
+                "internal.github.acme.com",
+                "dumb-department-name",
+                "dummy-app-microservice-apple",
+            ],
+        );
+        let result = extract_project_name(&encoded);
+        std::fs::remove_dir_all(&root).ok();
+        assert_eq!(result, "dummy-app-microservice-apple");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,7 +229,7 @@ function App() {
   } = useResizablePanel({
     defaultWidth: 256,
     minWidth: 200,
-    maxWidth: 480,
+    maxWidth: 800,
     storageKey: "sidebar-width",
   });
 


### PR DESCRIPTION
## Summary

Two small, related fixes for users with deeply nested project paths.

- **`src/App.tsx`**: raise `useResizablePanel` `maxWidth` from `480` to `800` so the left sidebar can stretch wide enough to show long project names. Default (256) and min (200) unchanged; existing persisted widths in localStorage stay valid.
- **`src-tauri/src/utils.rs`**: `extract_project_name` now delegates to the existing `decode_with_filesystem_check` helper before falling back to the original `splitn(4, '-')` heuristic. The heuristic returns `parts[3]` verbatim for slugs with more than 3 hyphens, so a project at `~/Projects/GitHub/org/repo` would render as `"Projects-GitHub-org-repo"` in the sidebar. The filesystem-checked decoder disambiguates correctly, including project names that themselves contain hyphens (e.g. `dumb-department-name`).

Both fixes preserve existing behavior for shallow paths and for projects whose directories no longer exist on disk (the heuristic remains as fallback). All existing `extract_project_name` tests continue to pass; three new tests cover the deep-path success cases and the heuristic-fallback case explicitly.

Closes #327
Closes #328

## Test plan

- [x] `cargo test -- --test-threads=1` — full suite passes (incl. 3 new tests: `test_extract_project_name_deep_path`, `test_extract_project_name_with_hyphens_in_segments` (validates the realistic case `~/Projects/internal.github.acme.com/dumb-department-name/dummy-app-microservice-apple` → `dummy-app-microservice-apple`), and `test_extract_project_name_fallback_when_path_missing` (makes the heuristic-fallback branch coverage explicit instead of relying on dev-filesystem state))
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `pnpm tsc --build .` — clean
- [x] `pnpm vitest run` — 785 tests pass
- [x] `pnpm lint` — clean (1 pre-existing warning unrelated to this change)
- [x] `pnpm run i18n:validate` — all keys synced across en/ko/ja/zh-CN/zh-TW
- [x] Manual: dragged sidebar to ~800px in `just dev`, confirmed long project names render correctly

## Notes

This PR intentionally does NOT include two related improvements that surfaced during investigation, in order to keep the diff focused:

- The resize handle in `ProjectTree/index.tsx:972` is `w-3` and transparent until hover, making it hard to discover.
- `ProjectItem.tsx` renders the project name with `whitespace-nowrap` and no `truncate` — long names overflow invisibly even after the ceiling raise if a user keeps the sidebar narrow.

Happy to file follow-ups if you'd like to address either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable project-name extraction for dash-prefixed encoded paths, returning only the leaf name and falling back to the prior heuristic when needed.

* **Style**
  * Increased sidebar maximum resize width from 480 to 800 pixels for greater layout flexibility.

* **Tests**
  * Added unit tests (including helper) covering fallback, deep-path, and hyphen-containing segment cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/329)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->