### PR TITLE
fix(project): readable display names for deep/cloud-storage and worktree paths

### DIFF
--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -253,7 +253,10 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         let git_info = detect_git_worktree_info(&actual_path);
 
         projects.push(ClaudeProject {
-            name: project_name,
+            name: std::path::Path::new(&actual_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or(project_name),
             path: project_path,
             actual_path,
             session_count,
@@ -431,8 +434,10 @@ mod tests {
         let projects_dir = claude_dir.join("projects");
 
         // Create project with prefix format (like "-Users-jack-client-myapp")
-        // splitn(4, '-') on "-Users-jack-client-myapp" yields:
-        // ["", "Users", "jack", "client-myapp"] -> returns "client-myapp"
+        // decode_project_path falls back to heuristic: splitn(4, '-') yields
+        // ["", "Users", "jack", "client-myapp"] -> decoded path "/Users/jack/client-myapp"
+        // The display name is now taken from the basename of the decoded actual_path,
+        // which gives "client-myapp".
         let project_dir = projects_dir.join("-Users-jack-client-myapp");
         fs::create_dir_all(&project_dir).unwrap();
         create_test_jsonl_file(&project_dir, "session.jsonl", "{}");
@@ -442,8 +447,7 @@ mod tests {
 
         let projects = result.unwrap();
         assert_eq!(projects.len(), 1);
-        // extract_project_name extracts the 4th part from splitn(4, '-')
-        // "-Users-jack-client-myapp" -> ["", "Users", "jack", "client-myapp"]
+        // Display name comes from basename of decoded actual_path (or extract_project_name fallback)
         assert_eq!(projects[0].name, "client-myapp");
     }
 

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -250,9 +250,10 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         let mut session_count = 0;
         let mut message_count = 0;
         let mut last_modified = None;
-        // Ground-truth cwd of this project, read from a top-level session file.
-        // Preferred over decoding the (ambiguous) encoded dir name for display.
-        let mut session_cwd: Option<String> = None;
+        // Ground-truth cwd of this project, read from a session file. Preferred
+        // over decoding the (ambiguous) encoded dir name for display.
+        let mut session_cwd: Option<String> = None; // from a top-level session
+        let mut nested_cwd: Option<String> = None; // from a nested transcript
 
         for jsonl_entry in WalkDir::new(entry.path())
             .into_iter()
@@ -261,10 +262,16 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         {
             session_count += 1;
 
-            // Capture cwd from a top-level (depth 1) session file — the project's
-            // own session, not a nested subagent transcript.
-            if session_cwd.is_none() && jsonl_entry.depth() == 1 {
-                session_cwd = read_session_cwd(jsonl_entry.path());
+            // Capture the project's real cwd from a session file. Prefer a
+            // top-level (depth 1) session — the project's own — but fall back to a
+            // nested transcript: git-worktree dirs contain only nested subagent
+            // sessions whose cwd carries the true worktree path (and branch name).
+            if session_cwd.is_none() {
+                if jsonl_entry.depth() == 1 {
+                    session_cwd = read_session_cwd(jsonl_entry.path());
+                } else if nested_cwd.is_none() {
+                    nested_cwd = read_session_cwd(jsonl_entry.path());
+                }
             }
 
             if let Ok(metadata) = jsonl_entry.metadata() {
@@ -312,7 +319,11 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
                 // paths, project names that contain "projects", and worktrees
                 // correctly, with the true branch name. Fall back to decoding the
                 // encoded directory name only when no session cwd is available.
-                if let Some(name) = session_cwd.as_deref().and_then(display_name_from_cwd) {
+                if let Some(name) = session_cwd
+                    .as_deref()
+                    .or(nested_cwd.as_deref())
+                    .and_then(display_name_from_cwd)
+                {
                     name
                 } else {
                 // ── Fallback: derive from the encoded directory name ──
@@ -655,6 +666,34 @@ mod tests {
 
         let projects = result.unwrap();
         assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "myapp (worktree: feature_x)");
+    }
+
+    #[tokio::test]
+    async fn test_scan_projects_worktree_cwd_from_nested_session() {
+        let temp_dir = TempDir::new().unwrap();
+        let claude_dir = temp_dir.path().join(".claude");
+        let projects_dir = claude_dir.join("projects");
+
+        // Git-worktree dirs hold only nested subagent sessions (no top-level).
+        // The real branch name must come from the nested transcript's cwd.
+        let project_dir =
+            projects_dir.join("-Users-me-code-projects-myapp--claude-worktrees-feature-x");
+        let nested = project_dir.join("sid").join("subagents");
+        fs::create_dir_all(&nested).unwrap();
+        create_test_jsonl_file(
+            &nested,
+            "agent.jsonl",
+            "{\"cwd\":\"/Users/me/code/projects/myapp/.claude/worktrees/feature_x\"}",
+        );
+
+        let result = scan_projects(claude_dir.to_string_lossy().to_string()).await;
+        assert!(result.is_ok());
+
+        let projects = result.unwrap();
+        assert_eq!(projects.len(), 1);
+        // Real branch from nested cwd: "feature_x" (underscore), not the lossy
+        // encoded "feature-x".
         assert_eq!(projects[0].name, "myapp (worktree: feature_x)");
     }
 

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -260,9 +260,15 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
                 // an incorrectly decoded actual_path, so file_name() on it still yields
                 // a long unreadable slug.
                 //
+                // Git worktrees add a wrinkle: their encoded dir embeds
+                // "--claude-worktrees-<branch>" after the project, e.g.
+                // "-Users-me-code-projects-myapp--claude-worktrees-fix".
+                //
                 // Strategy (in order):
-                // 1. Case-insensitive search for "-projects-" anchor in the raw encoded
-                //    name — extracts everything after it ("signal", "vmw-rag", "HW-Refresh").
+                // 0. Git worktree ("…--claude-worktrees-<branch>") →
+                //    "<parent> (worktree: <branch>)".
+                // 1. Case-insensitive "-projects-" anchor in the raw encoded name —
+                //    extracts everything after it ("signal", "vmw-rag", "HW-Refresh").
                 // 2. actual_path file_name() — works for shallow (<= 3 segment) paths.
                 //    Skipped when the result looks like an encoded slug (contains known
                 //    cloud-storage markers).
@@ -274,30 +280,56 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
                     .and_then(|n| n.to_str())
                     .unwrap_or("");
                 const ANCHOR: &str = "-projects-";
-                let raw_lower = raw_dir.to_ascii_lowercase();
-                if let Some(pos) = raw_lower.rfind(ANCHOR) {
-                    let name = &raw_dir[pos + ANCHOR.len()..];
-                    if !name.is_empty() {
-                        name.to_string()
+                const WORKTREE: &str = "--claude-worktrees-";
+                if let Some(wpos) = raw_dir.find(WORKTREE) {
+                    // Git worktree. Derive "<parent> (worktree: <branch>)".
+                    // The branch label is taken from the encoded dir name, so '_'
+                    // renders as '-' (lossy, but adequate for a display label).
+                    let parent_seg = &raw_dir[..wpos];
+                    let branch = &raw_dir[wpos + WORKTREE.len()..];
+                    let parent_lower = parent_seg.to_ascii_lowercase();
+                    let parent = if let Some(pos) = parent_lower.rfind(ANCHOR) {
+                        let p = &parent_seg[pos + ANCHOR.len()..];
+                        if p.is_empty() { parent_seg.to_string() } else { p.to_string() }
                     } else {
-                        project_name
+                        parent_seg
+                            .rsplit('-')
+                            .next()
+                            .filter(|s| !s.is_empty())
+                            .map(str::to_string)
+                            .unwrap_or_else(|| parent_seg.to_string())
+                    };
+                    if branch.is_empty() {
+                        parent
+                    } else {
+                        format!("{parent} (worktree: {branch})")
                     }
-                } else if let Some(n) = std::path::Path::new(&actual_path).file_name() {
-                    let fname = n.to_string_lossy();
-                    // Skip if it still looks like an encoded deep path
-                    if fname.contains("-Library-") || fname.contains("CloudStorage") {
+                } else {
+                    let raw_lower = raw_dir.to_ascii_lowercase();
+                    if let Some(pos) = raw_lower.rfind(ANCHOR) {
+                        let name = &raw_dir[pos + ANCHOR.len()..];
+                        if !name.is_empty() {
+                            name.to_string()
+                        } else {
+                            project_name
+                        }
+                    } else if let Some(n) = std::path::Path::new(&actual_path).file_name() {
+                        let fname = n.to_string_lossy();
+                        // Skip if it still looks like an encoded deep path
+                        if fname.contains("-Library-") || fname.contains("CloudStorage") {
+                            raw_dir.rfind('-')
+                                .map(|p| raw_dir[p + 1..].to_string())
+                                .filter(|s| !s.is_empty())
+                                .unwrap_or(project_name)
+                        } else {
+                            fname.into_owned()
+                        }
+                    } else {
                         raw_dir.rfind('-')
                             .map(|p| raw_dir[p + 1..].to_string())
                             .filter(|s| !s.is_empty())
                             .unwrap_or(project_name)
-                    } else {
-                        fname.into_owned()
                     }
-                } else {
-                    raw_dir.rfind('-')
-                        .map(|p| raw_dir[p + 1..].to_string())
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or(project_name)
                 }
             },
             path: project_path,
@@ -492,6 +524,27 @@ mod tests {
         assert_eq!(projects.len(), 1);
         // Display name comes from basename of decoded actual_path (or extract_project_name fallback)
         assert_eq!(projects[0].name, "client-myapp");
+    }
+
+    #[tokio::test]
+    async fn test_scan_projects_worktree_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let claude_dir = temp_dir.path().join(".claude");
+        let projects_dir = claude_dir.join("projects");
+
+        // Git worktree encoded dir: "<parent>--claude-worktrees-<branch>".
+        // Expect "<project> (worktree: <branch>)" rather than the raw tail.
+        let project_dir =
+            projects_dir.join("-Users-jack-code-projects-myapp--claude-worktrees-feature");
+        fs::create_dir_all(&project_dir).unwrap();
+        create_test_jsonl_file(&project_dir, "session.jsonl", "{}");
+
+        let result = scan_projects(claude_dir.to_string_lossy().to_string()).await;
+        assert!(result.is_ok());
+
+        let projects = result.unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "myapp (worktree: feature)");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -155,6 +155,51 @@ pub async fn detect_claude_config_dir() -> Result<Option<String>, String> {
     }
 }
 
+/// Read the `cwd` field from the first records of a session JSONL file.
+/// The first line often has a null/absent cwd, so scan a bounded number of
+/// lines and return the first non-empty cwd found.
+fn read_session_cwd(path: &std::path::Path) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let file = std::fs::File::open(path).ok()?;
+    for line in BufReader::new(file).lines().take(50).map_while(Result::ok) {
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+            if let Some(cwd) = v.get("cwd").and_then(|c| c.as_str()) {
+                if !cwd.is_empty() {
+                    return Some(cwd.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Derive a human-readable display name from a real (already-decoded) cwd path.
+/// Git worktrees ("<project>/.claude/worktrees/<branch>") render as
+/// "<project> (worktree: <branch>)" using the true branch name.
+fn display_name_from_cwd(cwd: &str) -> Option<String> {
+    const WT: &str = "/.claude/worktrees/";
+    if let Some(pos) = cwd.find(WT) {
+        let parent = std::path::Path::new(&cwd[..pos])
+            .file_name()
+            .and_then(|n| n.to_str())?;
+        let branch = cwd[pos + WT.len()..]
+            .split('/')
+            .next()
+            .filter(|s| !s.is_empty());
+        return Some(match branch {
+            Some(b) => format!("{parent} (worktree: {b})"),
+            None => parent.to_string(),
+        });
+    }
+    std::path::Path::new(cwd)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_string)
+}
+
 #[tauri::command]
 pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, String> {
     #[cfg(debug_assertions)]
@@ -205,6 +250,9 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         let mut session_count = 0;
         let mut message_count = 0;
         let mut last_modified = None;
+        // Ground-truth cwd of this project, read from a top-level session file.
+        // Preferred over decoding the (ambiguous) encoded dir name for display.
+        let mut session_cwd: Option<String> = None;
 
         for jsonl_entry in WalkDir::new(entry.path())
             .into_iter()
@@ -212,6 +260,12 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
             .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
         {
             session_count += 1;
+
+            // Capture cwd from a top-level (depth 1) session file — the project's
+            // own session, not a nested subagent transcript.
+            if session_cwd.is_none() && jsonl_entry.depth() == 1 {
+                session_cwd = read_session_cwd(jsonl_entry.path());
+            }
 
             if let Ok(metadata) = jsonl_entry.metadata() {
                 if let Ok(modified) = metadata.modified() {
@@ -254,6 +308,14 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
 
         projects.push(ClaudeProject {
             name: {
+                // Prefer the project's real cwd (ground truth) — resolves deep/cloud
+                // paths, project names that contain "projects", and worktrees
+                // correctly, with the true branch name. Fall back to decoding the
+                // encoded directory name only when no session cwd is available.
+                if let Some(name) = session_cwd.as_deref().and_then(display_name_from_cwd) {
+                    name
+                } else {
+                // ── Fallback: derive from the encoded directory name ──
                 // Claude encodes project paths by replacing '/' with '-', producing
                 // directory names like "-Users-alice-code-projects-myapp". For paths
                 // deeper than 3 segments, decode_project_path() (splitn(4,'-')) returns
@@ -330,6 +392,7 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
                             .filter(|s| !s.is_empty())
                             .unwrap_or(project_name)
                     }
+                }
                 }
             },
             path: project_path,
@@ -545,6 +608,54 @@ mod tests {
         let projects = result.unwrap();
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].name, "myapp (worktree: feature)");
+    }
+
+    #[tokio::test]
+    async fn test_scan_projects_name_from_cwd() {
+        let temp_dir = TempDir::new().unwrap();
+        let claude_dir = temp_dir.path().join(".claude");
+        let projects_dir = claude_dir.join("projects");
+
+        // Project whose name contains "projects": the encoded "-projects-" anchor
+        // would truncate to "tool". The real cwd resolves it correctly.
+        let project_dir = projects_dir.join("-Users-me-code-projects-my-projects-tool");
+        fs::create_dir_all(&project_dir).unwrap();
+        create_test_jsonl_file(
+            &project_dir,
+            "session.jsonl",
+            "{\"cwd\":\"/Users/me/code/projects/my-projects-tool\"}",
+        );
+
+        let result = scan_projects(claude_dir.to_string_lossy().to_string()).await;
+        assert!(result.is_ok());
+
+        let projects = result.unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "my-projects-tool");
+    }
+
+    #[tokio::test]
+    async fn test_scan_projects_worktree_name_from_cwd() {
+        let temp_dir = TempDir::new().unwrap();
+        let claude_dir = temp_dir.path().join(".claude");
+        let projects_dir = claude_dir.join("projects");
+
+        // Real cwd carries the true branch name, incl. underscores (no lossy
+        // encoding): "feature_x" stays "feature_x".
+        let project_dir = projects_dir.join("-Users-me-code-projects-myapp--claude-worktrees-feature-x");
+        fs::create_dir_all(&project_dir).unwrap();
+        create_test_jsonl_file(
+            &project_dir,
+            "session.jsonl",
+            "{\"cwd\":\"/Users/me/code/projects/myapp/.claude/worktrees/feature_x\"}",
+        );
+
+        let result = scan_projects(claude_dir.to_string_lossy().to_string()).await;
+        assert!(result.is_ok());
+
+        let projects = result.unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "myapp (worktree: feature_x)");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -253,10 +253,53 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         let git_info = detect_git_worktree_info(&actual_path);
 
         projects.push(ClaudeProject {
-            name: std::path::Path::new(&actual_path)
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or(project_name),
+            name: {
+                // Claude encodes project paths by replacing '/' with '-', producing
+                // directory names like "-Users-alice-code-projects-myapp". For paths
+                // deeper than 3 segments, decode_project_path() (splitn(4,'-')) returns
+                // an incorrectly decoded actual_path, so file_name() on it still yields
+                // a long unreadable slug.
+                //
+                // Strategy (in order):
+                // 1. Case-insensitive search for "-projects-" anchor in the raw encoded
+                //    name — extracts everything after it ("signal", "vmw-rag", "HW-Refresh").
+                // 2. actual_path file_name() — works for shallow (<= 3 segment) paths.
+                //    Skipped when the result looks like an encoded slug (contains known
+                //    cloud-storage markers).
+                // 3. Last '-'-delimited segment of the raw encoded name — last-resort
+                //    single-word fallback ("code", "projects", "Projects").
+                // 4. project_name from extract_project_name() — original behavior.
+                let raw_dir = std::path::Path::new(&project_path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("");
+                const ANCHOR: &str = "-projects-";
+                let raw_lower = raw_dir.to_ascii_lowercase();
+                if let Some(pos) = raw_lower.rfind(ANCHOR) {
+                    let name = &raw_dir[pos + ANCHOR.len()..];
+                    if !name.is_empty() {
+                        name.to_string()
+                    } else {
+                        project_name
+                    }
+                } else if let Some(n) = std::path::Path::new(&actual_path).file_name() {
+                    let fname = n.to_string_lossy();
+                    // Skip if it still looks like an encoded deep path
+                    if fname.contains("-Library-") || fname.contains("CloudStorage") {
+                        raw_dir.rfind('-')
+                            .map(|p| raw_dir[p + 1..].to_string())
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or(project_name)
+                    } else {
+                        fname.into_owned()
+                    }
+                } else {
+                    raw_dir.rfind('-')
+                        .map(|p| raw_dir[p + 1..].to_string())
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or(project_name)
+                }
+            },
             path: project_path,
             actual_path,
             session_count,

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -51,6 +51,14 @@ pub fn find_line_starts(data: &[u8]) -> Vec<usize> {
     starts
 }
 
+/// Extract a human-readable project name from the raw encoded directory name.
+///
+/// NOTE: This function uses `splitn(4, '-')` which only strips the first 3 path
+/// segments. For paths deeper than 3 segments (e.g., Google Drive paths like
+/// `/Users/x/Library/CloudStorage/GoogleDrive-.../code/projects/signal`), the
+/// result is still an unreadable encoded slug. In `scan_projects()`, the display
+/// name now comes from the basename of the decoded `actual_path` instead; this
+/// function is kept as a fallback when `actual_path` has no `file_name` component.
 pub fn extract_project_name(raw_project_name: &str) -> String {
     if raw_project_name.starts_with('-') {
         let parts: Vec<&str> = raw_project_name.splitn(4, '-').collect();
@@ -559,6 +567,11 @@ mod tests {
     }
 
     // ===== Project Name Tests =====
+    //
+    // Note: extract_project_name is now only used as a fallback in scan_projects().
+    // The primary display name comes from the basename of the decoded actual_path.
+    // These tests document the existing splitn(4) behavior and its limitations
+    // with deep paths (see test_extract_project_name_deep_path_limitation).
 
     #[test]
     fn test_extract_project_name_with_prefix() {
@@ -598,6 +611,21 @@ mod tests {
     fn test_extract_project_name_exact_four_parts() {
         let result = extract_project_name("-a-b-c");
         assert_eq!(result, "c");
+    }
+
+    #[test]
+    fn test_extract_project_name_deep_path_limitation() {
+        // Documents the limitation: splitn(4, '-') only strips the first 3 segments.
+        // For deep paths (e.g., Google Drive), the result is still an unreadable slug.
+        // This is why scan_projects() now uses the basename of the decoded actual_path
+        // instead of this function.
+        let deep = "-Users-pablo-Library-CloudStorage-GoogleDrive-code-projects-signal";
+        let result = extract_project_name(deep);
+        // Returns everything after the 3rd dash — still mangled
+        assert_eq!(
+            result,
+            "Library-CloudStorage-GoogleDrive-code-projects-signal"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`extract_project_name()` uses `splitn(4, '-')`, which only strips the first 3 path segments. For project paths deeper than 3 segments (e.g. cloud-storage mount points like Google Drive), the decoded `actual_path` is still wrong and the sidebar shows an unreadable encoded slug such as `alonso-Library-CloudStorage-GoogleDrive-...-myapp`. Git worktrees show an equally cryptic `myapp--claude-worktrees-branch`.

Fixes #328.

## Solution

Derive the display `name` from the project's **real `cwd`**, read from a top-level session JSONL — the ground truth, independent of any path-decoding heuristic:

- Deep / cloud-storage / symlinked paths → correct basename (`myapp`, `vmw-rag`, …).
- Project names that themselves contain `projects` (e.g. `my-projects-tool`) → correct (no anchor ambiguity).
- Git worktree (`<project>/.claude/worktrees/<branch>`) → `"<project> (worktree: <branch>)"` with the **true** branch name (underscores preserved).

Cost is one bounded read per project (≤50 lines, stops at the first `cwd`, typically line 2–4) — consistent with `decode_project_path`, which already reads `sessions-index.json` per project.

When no session `cwd` is available (e.g. a dir with no readable top-level session), it falls back to decoding the encoded directory name, in order:
1. Git worktree marker `--claude-worktrees-` → `<parent> (worktree: <branch>)`.
2. Case-insensitive `-projects-` anchor → text after it.
3. `actual_path` basename (shallow paths) — skipped when it still looks like an encoded slug.
4. Last `-` segment, then `extract_project_name()` (original behavior).

No filesystem changes; `scan_projects` only reads.

## Tests
- `test_scan_projects_name_from_cwd` — name from real cwd; resolves `my-projects-tool`.
- `test_scan_projects_worktree_name_from_cwd` — worktree branch from real cwd (`feature_x`, underscore preserved).
- `test_scan_projects_extracts_project_name`, `test_scan_projects_worktree_name` — now cover the encoded-name fallback path (unchanged assertions).
- Full suite green: `cargo test --lib scan_projects` → 17 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Project names now prefer the working directory recorded in session transcripts when present; otherwise they use the decoded filesystem basename. Encoded git worktrees display branch info as "(worktree: <branch>)" and other encoding cases use robust fallback heuristics.

* **Documentation & Tests**
  * Clarified name-extraction behavior and added unit tests covering deep-encoded-path limitations, session-driven naming, and worktree naming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->