### PR TITLE
fix(wsl): always persist excludedDistros to prevent TypeError on toggle

### DIFF
--- a/src-tauri/src/models/metadata.rs
+++ b/src-tauri/src/models/metadata.rs
@@ -213,7 +213,7 @@ pub struct WslSettings {
     #[serde(default)]
     pub enabled: bool,
     /// List of WSL distro names to exclude from scanning
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub excluded_distros: Vec<String>,
 }
 

--- a/src/components/SettingsManager/sections/WslSection.tsx
+++ b/src/components/SettingsManager/sections/WslSection.tsx
@@ -38,9 +38,10 @@ function WslSectionInner({ isExpanded, onToggle }: WslSectionProps) {
   const { t } = useTranslation();
   const { userMetadata, setWslEnabled, toggleWslDistro } = useAppStore();
 
-  const wslSettings = userMetadata?.settings?.wsl ?? {
+  const wslSettings = {
     enabled: false,
-    excludedDistros: [],
+    excludedDistros: [] as string[],
+    ...userMetadata?.settings?.wsl,
   };
 
   const [distros, setDistros] = useState<WslDistro[]>([]);

--- a/src/store/slices/metadataSlice.ts
+++ b/src/store/slices/metadataSlice.ts
@@ -302,13 +302,13 @@ export const createMetadataSlice: StateCreator<
 
   setWslEnabled: async (enabled: boolean) => {
     const current = get().userMetadata?.settings ?? {};
-    const wsl: WslSettings = current.wsl ?? { enabled: false, excludedDistros: [] };
+    const wsl: WslSettings = { enabled: false, excludedDistros: [], ...current.wsl };
     await get().updateUserSettings({ wsl: { ...wsl, enabled } });
   },
 
   toggleWslDistro: async (distroName: string) => {
     const current = get().userMetadata?.settings ?? {};
-    const wsl: WslSettings = current.wsl ?? { enabled: false, excludedDistros: [] };
+    const wsl: WslSettings = { enabled: false, excludedDistros: [], ...current.wsl };
     const excluded = wsl.excludedDistros.includes(distroName)
       ? wsl.excludedDistros.filter((d: string) => d !== distroName)
       : [...wsl.excludedDistros, distroName];


### PR DESCRIPTION
## Summary

When clicking Settings Manager while WSL History Scanning is set, "An unexpected error occurred" with a `TypeError` (Issue #341). Fixed by ensuring that either: both `enabled` and `excludedDistros` are present, or both are absent, under `settings.wsl` in `user-data.json`.

## Problem

Toggling the WSL enable switch caused a `TypeError` because `excludedDistros` was missing from `user-data.json`. The root cause was `skip_serializing_if = "Vec::is_empty"` on the Rust `WslSettings.excluded_distros` field — an empty list was silently omitted from JSON. On the next read, the TypeScript side received `{ enabled: true }` (a partial object), and the `??` fallback didn't fire since the object wasn't `null`/`undefined`, leaving `excludedDistros` as undefined.

## Changes

- `src-tauri/src/models/metadata.rs` — removed `skip_serializing_if = "Vec::is_empty"` from `excluded_distros` so `"excludedDistros": []` is always written to JSON.
- `src/store/slices/metadataSlice.ts` — replaced `current.wsl ??` defaults with `{ ...defaults, ...current.wsl }` to fill in missing fields from a partial object, not just a fully absent one.
- `src/components/SettingsManager/sections/WslSection.tsx` — same spread-with-defaults fix for backward compat with JSON files written before this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WSL settings initialization to ensure default values are consistently applied and properly serialized, preventing potential issues with missing or undefined settings fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->