### PR TITLE
fix(wsl): WSL chat history ignored in project list and global search for Claude-only user

### DIFF
--- a/src/components/modals/globalSearch/GlobalSearchModal.tsx
+++ b/src/components/modals/globalSearch/GlobalSearchModal.tsx
@@ -48,7 +48,7 @@ export const GlobalSearchModal = ({
     const resultsContainerRef = useRef<HTMLDivElement>(null);
     const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const { claudePath, projects, selectProject, selectSession, sessions, getSessionDisplayName, activeProviders, navigateToMessage, clearTargetMessage } =
+    const { claudePath, projects, selectProject, selectSession, sessions, getSessionDisplayName, activeProviders, navigateToMessage, clearTargetMessage, userMetadata } =
         useAppStore();
     const [selectedProjectPath, setSelectedProjectPath] = useState<string>("all");
 
@@ -113,10 +113,12 @@ export const GlobalSearchModal = ({
                     filters.messageType = messageTypeFilter;
                 }
                 const hasNonClaudeProviders = hasNonDefaultProvider(activeProviders);
+                const wslEnabled = userMetadata?.settings?.wsl?.enabled ?? false;
+                const wslExcludedDistros = userMetadata?.settings?.wsl?.excludedDistros ?? [];
                 const searchResults = await api<GlobalSearchResult[]>(
-                    hasNonClaudeProviders ? "search_all_providers" : "search_messages",
-                    hasNonClaudeProviders
-                        ? { claudePath, query: trimmedQuery, activeProviders, filters, limit: MAX_RESULTS }
+                    (hasNonClaudeProviders || wslEnabled) ? "search_all_providers" : "search_messages",
+                    (hasNonClaudeProviders || wslEnabled)
+                        ? { claudePath, query: trimmedQuery, activeProviders, filters, limit: MAX_RESULTS, wslEnabled, wslExcludedDistros }
                         : { claudePath, query: trimmedQuery, filters, limit: MAX_RESULTS },
                 );
                 setResults(searchResults);
@@ -129,7 +131,7 @@ export const GlobalSearchModal = ({
                 setIsSearching(false);
             }
         },
-        [claudePath, activeProviders, selectedProjectPath, messageTypeFilter],
+        [claudePath, activeProviders, selectedProjectPath, messageTypeFilter, userMetadata],
     );
 
     // Handle input change with debounce

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -232,12 +232,13 @@ export const createProjectSlice: StateCreator<
     try {
       const start = performance.now();
       const settings = get().userMetadata?.settings;
-      const projects = (hasNonClaudeProviders || hasCustomPaths)
+      const wslEnabled = settings?.wsl?.enabled ?? false;
+      const projects = (hasNonClaudeProviders || hasCustomPaths || wslEnabled)
         ? await api<ClaudeProject[]>("scan_all_projects", {
             ...(claudePath && { claudePath }),
             activeProviders: scanProviders,
             customClaudePaths: hasCustomPaths ? customClaudePaths : undefined,
-            wslEnabled: settings?.wsl?.enabled ?? false,
+            wslEnabled,
             wslExcludedDistros: settings?.wsl?.excludedDistros ?? [],
           })
         : await api<ClaudeProject[]>("scan_projects", {

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -91,14 +91,15 @@ export const createSearchSlice: StateCreator<
       const customClaudePaths = get().userMetadata?.settings?.customClaudePaths;
       const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
       const settings = get().userMetadata?.settings;
-      const results = (hasNonClaudeProviders || hasCustomPaths)
+      const wslEnabled = settings?.wsl?.enabled ?? false;
+      const results = (hasNonClaudeProviders || hasCustomPaths || wslEnabled)
         ? await api<ClaudeMessage[]>("search_all_providers", {
             claudePath,
             query,
             activeProviders,
             filters,
             customClaudePaths: hasCustomPaths ? customClaudePaths : undefined,
-            wslEnabled: settings?.wsl?.enabled ?? false,
+            wslEnabled,
             wslExcludedDistros: settings?.wsl?.excludedDistros ?? [],
           })
         : await api<ClaudeMessage[]>("search_messages", {

--- a/src/test/wslBranching.test.ts
+++ b/src/test/wslBranching.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests: WSL branch routing in scanProjects and searchMessages
+ *
+ * Verifies that scan_all_projects / search_all_providers are called
+ * (instead of the WSL-unaware fallbacks) whenever wslEnabled is true,
+ * even when no other providers or custom paths are configured.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { create } from "zustand";
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: vi.fn(),
+}));
+
+vi.mock("@/services/api", () => ({
+  api: mockApi,
+}));
+
+import { createProjectSlice } from "../store/slices/projectSlice";
+import { createSearchSlice } from "../store/slices/searchSlice";
+import { createMetadataSlice } from "../store/slices/metadataSlice";
+import { createSettingsSlice } from "../store/slices/settingsSlice";
+import { createProviderSlice } from "../store/slices/providerSlice";
+import type { AppStore } from "../store/useAppStore";
+
+// Minimal store: only the slices to read via get().
+// Remaining fields required by AppStore are stubbed with vi.fn() / defaults.
+function createTestStore() {
+  return create<AppStore>()((...args) => ({
+    ...createProjectSlice(...args),
+    ...createSearchSlice(...args),
+    ...createMetadataSlice(...args),
+    ...createSettingsSlice(...args),
+    ...createProviderSlice(...args),
+
+    messages: [],
+    isLoadingMessages: false,
+    hasMoreMessages: false,
+    currentPage: 0,
+    messageError: null,
+    loadMessages: vi.fn(),
+    loadMoreMessages: vi.fn(),
+    clearMessages: vi.fn(),
+    setTargetMessage: vi.fn(),
+    targetMessage: null,
+    clearTargetMessage: vi.fn(),
+    navigateToMessage: vi.fn(),
+    analyticsData: null,
+    isLoadingAnalytics: false,
+    analyticsError: null,
+    loadAnalytics: vi.fn(),
+    globalStats: null,
+    isLoadingGlobalStats: false,
+    globalStatsError: null,
+    loadGlobalStats: vi.fn(),
+    captureMode: false,
+    setCaptureMode: vi.fn(),
+    boards: [],
+    isLoadingBoards: false,
+    boardError: null,
+    loadBoards: vi.fn(),
+    createBoard: vi.fn(),
+    updateBoard: vi.fn(),
+    deleteBoard: vi.fn(),
+    filters: {},
+    setFilters: vi.fn(),
+    resetFilters: vi.fn(),
+    currentRoute: null,
+    navigate: vi.fn(),
+    goBack: vi.fn(),
+    watchedPaths: [],
+    startWatcher: vi.fn(),
+    stopWatcher: vi.fn(),
+    navigator: null,
+    initNavigator: vi.fn(),
+    archiveSession: vi.fn(),
+    archivedSessions: [],
+    isLoadingArchive: false,
+    archiveError: null,
+    loadArchivedSessions: vi.fn(),
+    sessionPicker: null,
+    openSessionPicker: vi.fn(),
+    closeSessionPicker: vi.fn(),
+  } as unknown as AppStore));
+}
+
+function seedStore(
+  store: ReturnType<typeof createTestStore>,
+  wslEnabled: boolean,
+  excludedDistros: string[] = []
+) {
+  store.setState({
+    claudePath: "/home/user/.claude",
+    userMetadata: {
+      version: 1,
+      sessions: {},
+      projects: {},
+      settings: { wsl: { enabled: wslEnabled, excludedDistros } },
+    },
+    activeProviders: ["claude"],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApi.mockResolvedValue([]);
+});
+
+describe("scanProjects — WSL branch routing", () => {
+  it("calls scan_all_projects when wslEnabled is true (even with no other providers)", async () => {
+    const store = createTestStore();
+    seedStore(store, true);
+
+    await store.getState().scanProjects();
+
+    expect(mockApi).toHaveBeenCalledWith(
+      "scan_all_projects",
+      expect.objectContaining({ wslEnabled: true })
+    );
+  });
+
+  it("passes wslExcludedDistros through to scan_all_projects", async () => {
+    const store = createTestStore();
+    seedStore(store, true, ["Debian"]);
+
+    await store.getState().scanProjects();
+
+    expect(mockApi).toHaveBeenCalledWith(
+      "scan_all_projects",
+      expect.objectContaining({ wslExcludedDistros: ["Debian"] })
+    );
+  });
+
+  it("falls back to scan_projects when wslEnabled is false and no other providers", async () => {
+    const store = createTestStore();
+    seedStore(store, false);
+
+    await store.getState().scanProjects();
+
+    expect(mockApi).toHaveBeenCalledWith("scan_projects", expect.anything());
+    expect(mockApi).not.toHaveBeenCalledWith("scan_all_projects", expect.anything());
+  });
+});
+
+describe("searchMessages — WSL branch routing", () => {
+  it("calls search_all_providers when wslEnabled is true", async () => {
+    const store = createTestStore();
+    seedStore(store, true);
+
+    await store.getState().searchMessages("hello");
+
+    expect(mockApi).toHaveBeenCalledWith(
+      "search_all_providers",
+      expect.objectContaining({ wslEnabled: true, query: "hello" })
+    );
+  });
+
+  it("falls back to search_messages when wslEnabled is false and no other providers", async () => {
+    const store = createTestStore();
+    seedStore(store, false);
+
+    await store.getState().searchMessages("hello");
+
+    expect(mockApi).toHaveBeenCalledWith(
+      "search_messages",
+      expect.objectContaining({ query: "hello" })
+    );
+    expect(mockApi).not.toHaveBeenCalledWith("search_all_providers", expect.anything());
+  });
+});


### PR DESCRIPTION
## Summary

Fix WSL chat history being invisible in both the project list and global search for users who only have Claude installed (no other providers, no custom paths).

## Problem

`scanProjects`, `searchMessages` (store), and `GlobalSearchModal` all shared the same branching condition to decide which backend command to call:
```ts
hasNonClaudeProviders || hasCustomPaths
```
When neither was true — the common case for a typical Claude-only user — the code fell through to `scan_projects` / `search_messages`, which have no WSL awareness at all. `wslEnabled` and `wslExcludedDistros` were already being read from settings and passed as arguments, but only ever reached the backend when the condition happened to be true for an unrelated reason.

## Changes

- `src/store/slices/projectSlice.ts` — added `|| wslEnabled` to the `scan_all_projects` branch condition in `scanProjects`
- `src/store/slices/searchSlice.ts` — same fix for the `search_all_providers` branch in `searchMessages`
- `src/components/modals/globalSearch/GlobalSearchModal.tsx` — same fix in the modal's own inline search call, which bypasses the store entirely; also threads `wslEnabled` and `wslExcludedDistros` through to the API call

## Test Plan

Added `src/test/wslBranching.test.ts` with 5 unit tests covering both `scanProjects` and `searchMessages`:

- `scan_all_projects` is called (not `scan_projects`) when `wslEnabled: true` with only Claude present
- `wslExcludedDistros` is forwarded correctly to `scan_all_projects`
- `scan_projects` is called when `wslEnabled`: false with only Claude present (no regression)
- `search_all_providers` is called (not `search_messages`) when `wslEnabled: true`
- `search_messages` is called when `wslEnabled`: false (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search and project scanning now respect WSL configuration settings, with support for excluding specific distros from operations when WSL is enabled.

* **Tests**
  * Added test coverage for WSL-aware branching logic in search and project scanning operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->