### PR TITLE
fix(ui): use OverlayScrollbars initialized event instead of polling

### DIFF
--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -336,40 +336,22 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollElementReady]);
 
-  // Wait for OverlayScrollbars to initialize
+  // OverlayScrollbars initialized callback (stable ref to avoid re-bindingclear)
+  const handleScrollbarsInitialized = useCallback(() => {
+    if (import.meta.env.DEV) {
+      console.log(`[MessageViewer] scrollElementReady via initialized event`);
+    }
+    setScrollElementReady(true);
+  }, []);
+
+  // Fallback: if OverlayScrollbars already initialized before event binding (e.g. fast mount)
   useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let attempts = 0;
-    const maxAttempts = 50; // 최대 50번 시도 (약 500ms)
-    const checkInterval = 10; // 10ms 간격
-    const startTime = import.meta.env.DEV ? performance.now() : 0;
-
-    const checkScrollElement = () => {
+    if (!scrollElementReady) {
       const element = scrollContainerRef.current?.osInstance()?.elements().viewport;
-      if (element && !scrollElementReady) {
-        if (import.meta.env.DEV) {
-          console.log(`[MessageViewer] scrollElementReady after ${attempts} attempts, ${(performance.now() - startTime).toFixed(1)}ms`);
-        }
+      if (element) {
         setScrollElementReady(true);
-        return;
       }
-
-      attempts++;
-      if (attempts < maxAttempts) {
-        timeoutId = setTimeout(checkScrollElement, checkInterval);
-      } else if (import.meta.env.DEV) {
-        console.warn(`[MessageViewer] scrollElement not ready after ${maxAttempts} attempts (${maxAttempts * checkInterval}ms)`);
-      }
-    };
-
-    // Check immediately
-    checkScrollElement();
-
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-    };
+    }
   }, [scrollElementReady, selectedSession?.session_id]);
 
   // Virtual scrolling
@@ -938,6 +920,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
           options={{
             scrollbars: { theme: "os-theme-custom", autoHide: "leave", autoHideDelay: 400 },
           }}
+          events={{ initialized: handleScrollbarsInitialized }}
         >
         {/* 디버깅 정보 */}
         {import.meta.env.DEV && (


### PR DESCRIPTION
  ## Summary
  - Fixed: message list not rendering for sessions with 47k+ messages
  - Root cause: OverlayScrollbars polling init (50×10ms = 500ms) times out before initialization completes under heavy React computation load
  - Fix: replaced polling with native `events.initialized` callback

  ## Test plan
  - [x] Open session with 47k+ messages — messages now render correctly
  - [x] Normal sessions still work as before
  - [x] ESLint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized message viewer scrollbar initialization by switching from polling-based detection to event-driven detection, improving performance and responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhlee0409/claude-code-history-viewer/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->