### PR TITLE
perf(search): move FlexSearch indexing to Web Worker

### DIFF
--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -17,7 +17,7 @@ import type {
 } from "../../types";
 import { AppErrorType } from "../../types";
 import type { StateCreator } from "zustand";
-import { buildSearchIndex, clearSearchIndex } from "../../utils/searchIndex";
+import { clearSearchIndex } from "../../utils/searchIndex";
 import type { FullAppStore } from "./types";
 import {
   fetchSessionTokenStats,
@@ -260,17 +260,8 @@ export const createMessageSlice: StateCreator<
       // progress 메시지를 통한 parentToolUseID ↔ subagent 매핑이 성립.
       void get().loadSubagents(sessionPath, allMessages);
 
-      // Build FlexSearch index asynchronously after UI renders
-      // The buildSearchIndex now internally uses chunked async processing
-      if ("requestIdleCallback" in window) {
-        (window as Window & { requestIdleCallback: (cb: () => void) => void }).requestIdleCallback(() => {
-          buildSearchIndex(filteredMessages);
-        });
-      } else {
-        setTimeout(() => {
-          buildSearchIndex(filteredMessages);
-        }, 0);
-      }
+      // Search index is built lazily on first search to avoid blocking UI
+      // when loading large sessions (47k+ messages with tokenize:"full" is expensive).
     } catch (error) {
       // Stale error guard: await 중 다른 세션으로 이동했으면 abandoned request의
       // 에러·로딩 상태를 현재 UI에 덮어쓰지 않음 (success path의 L212 guard 미러링)

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -5,6 +5,7 @@
  */
 
 import { api } from "@/services/api";
+import { toast } from "sonner";
 import type { ClaudeMessage, SearchFilters } from "../../types";
 import { AppErrorType } from "../../types";
 import type { StateCreator } from "zustand";
@@ -73,7 +74,15 @@ export const createSearchSlice: StateCreator<
   [],
   [],
   SearchSlice
-> = (set, get) => ({
+> = (set, get) => {
+  // Monotonic request token for setSessionSearchQuery: protects against
+  // stale async results overwriting newer ones when the user types quickly
+  // and the Worker is still building (linear fallback is sync, Worker path
+  // is async - earlier async result can otherwise land on top of a later
+  // sync result).
+  let sessionSearchRequestId = 0;
+
+  return {
   ...initialSearchState,
 
   // Global search
@@ -119,6 +128,7 @@ export const createSearchSlice: StateCreator<
 
   // Session search (KakaoTalk-style navigation)
   setSessionSearchQuery: async (query: string) => {
+    const requestId = ++sessionSearchRequestId;
     const { messages, sessionSearch } = get();
     const { filterType } = sessionSearch;
 
@@ -139,6 +149,12 @@ export const createSearchSlice: StateCreator<
       },
     }));
 
+    // Helper: predicate "this request is still the latest one".
+    // When false, every set() guarded by this is dropped so a newer
+    // request's state cannot be clobbered by stale data, AND the
+    // `isSearching: false` reset is left to that newer request.
+    const isStillLatest = () => requestId === sessionSearchRequestId;
+
     try {
       // Search strategy: Worker (async) > linear fallback (sync)
       let searchResults: Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }>;
@@ -152,6 +168,12 @@ export const createSearchSlice: StateCreator<
         // Trigger background Worker index build for future searches
         buildSearchIndex(messages);
       }
+
+      // Drop stale results: a newer search has been started while this one
+      // was awaiting. The newer search owns `isSearching` and will clear it
+      // on its own success / failure path, so we intentionally do not touch
+      // it here.
+      if (!isStillLatest()) return;
 
       // Convert to SearchMatch format (filter valid indices)
       const matches: SearchMatch[] = searchResults
@@ -181,6 +203,11 @@ export const createSearchSlice: StateCreator<
       }));
     } catch (error) {
       console.error("[Search] Failed to search messages:", error);
+      // Drop stale error: a newer search has already started and owns
+      // the `isSearching` state.
+      if (!isStillLatest()) return;
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to search messages: ${message}`);
       set((state) => ({
         sessionSearch: {
           query,
@@ -256,4 +283,5 @@ export const createSearchSlice: StateCreator<
       sessionSearch: createEmptySearchState(filterType),
     }));
   },
-});
+  };
+};

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -8,7 +8,7 @@ import { api } from "@/services/api";
 import type { ClaudeMessage, SearchFilters } from "../../types";
 import { AppErrorType } from "../../types";
 import type { StateCreator } from "zustand";
-import { searchMessages as searchMessagesFromIndex } from "../../utils/searchIndex";
+import { searchMessagesAsync, buildSearchIndex, isSearchIndexReady, linearSearchMessages } from "../../utils/searchIndex";
 import {
   type SearchState,
   type SearchFilterType,
@@ -36,7 +36,7 @@ export interface SearchSliceActions {
   searchMessages: (query: string, filters?: SearchFilters) => Promise<void>;
   setSearchFilters: (filters: SearchFilters) => void;
   // Session search
-  setSessionSearchQuery: (query: string) => void;
+  setSessionSearchQuery: (query: string) => Promise<void> | void;
   setSearchFilterType: (filterType: SearchFilterType) => void;
   goToNextMatch: () => void;
   goToPrevMatch: () => void;
@@ -118,7 +118,7 @@ export const createSearchSlice: StateCreator<
   },
 
   // Session search (KakaoTalk-style navigation)
-  setSessionSearchQuery: (query: string) => {
+  setSessionSearchQuery: async (query: string) => {
     const { messages, sessionSearch } = get();
     const { filterType } = sessionSearch;
 
@@ -140,8 +140,18 @@ export const createSearchSlice: StateCreator<
     }));
 
     try {
-      // FlexSearch high-speed search (inverted index O(1) ~ O(log n))
-      const searchResults = searchMessagesFromIndex(query, filterType);
+      // Search strategy: Worker (async) > linear fallback (sync)
+      let searchResults: Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }>;
+
+      if (isSearchIndexReady()) {
+        // Worker index is ready — use fast async search
+        searchResults = await searchMessagesAsync(query, filterType);
+      } else {
+        // Index not ready — use linear search (instant, ~100-200ms for 50k messages)
+        searchResults = linearSearchMessages(messages, query, filterType);
+        // Trigger background Worker index build for future searches
+        buildSearchIndex(messages);
+      }
 
       // Convert to SearchMatch format (filter valid indices)
       const matches: SearchMatch[] = searchResults

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -233,7 +233,7 @@ export interface AppStoreActions {
   // Search actions
   searchMessages: (query: string, filters?: SearchFilters) => Promise<void>;
   setSearchFilters: (filters: SearchFilters) => void;
-  setSessionSearchQuery: (query: string) => void;
+  setSessionSearchQuery: (query: string) => Promise<void> | void;
   setSearchFilterType: (filterType: SearchFilterType) => void;
   goToNextMatch: () => void;
   goToPrevMatch: () => void;

--- a/src/utils/searchIndex.test.ts
+++ b/src/utils/searchIndex.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { linearSearchMessages, isSearchIndexReady, clearSearchIndex } from "./searchIndex";
+import type { ClaudeMessage } from "../types";
+
+// Helper to create minimal ClaudeMessage fixtures
+function createMessage(overrides: Partial<ClaudeMessage> & { uuid: string; type: string }): ClaudeMessage {
+  return {
+    timestamp: "2024-01-01T00:00:00Z",
+    content: "",
+    ...overrides,
+  } as ClaudeMessage;
+}
+
+describe("linearSearchMessages", () => {
+  const messages: ClaudeMessage[] = [
+    createMessage({ uuid: "msg-1", type: "user", content: "Hello world" }),
+    createMessage({ uuid: "msg-2", type: "assistant", content: "Hi there! How can I help you today?" }),
+    createMessage({ uuid: "msg-3", type: "user", content: "Find the bug in my code" }),
+    createMessage({ uuid: "msg-4", type: "assistant", content: "I found the bug. The bug was in line 42." }),
+    createMessage({ uuid: "msg-5", type: "system", content: "Session started" }),
+  ];
+
+  it("returns empty array for empty query", () => {
+    expect(linearSearchMessages(messages, "")).toEqual([]);
+    expect(linearSearchMessages(messages, "   ")).toEqual([]);
+  });
+
+  it("finds matches case-insensitively", () => {
+    const results = linearSearchMessages(messages, "hello");
+    expect(results.length).toBe(1);
+    expect(results[0].messageUuid).toBe("msg-1");
+    expect(results[0].messageIndex).toBe(0);
+  });
+
+  it("finds multiple matches within same message", () => {
+    const results = linearSearchMessages(messages, "bug");
+    // "bug" appears twice in msg-4: "found the bug" and "The bug was"
+    const msg4Results = results.filter(r => r.messageUuid === "msg-4");
+    expect(msg4Results.length).toBe(2);
+    expect(msg4Results[0].matchIndex).toBe(0);
+    expect(msg4Results[0].matchCount).toBe(2);
+    expect(msg4Results[1].matchIndex).toBe(1);
+    expect(msg4Results[1].matchCount).toBe(2);
+  });
+
+  it("finds matches across multiple messages", () => {
+    const results = linearSearchMessages(messages, "the");
+    // "the" in msg-3 ("the bug") and msg-4 ("the bug. The bug")
+    expect(results.length).toBeGreaterThan(1);
+    const uuids = new Set(results.map(r => r.messageUuid));
+    expect(uuids.size).toBeGreaterThan(1);
+  });
+
+  it("returns empty array when no matches found", () => {
+    const results = linearSearchMessages(messages, "nonexistent_xyz");
+    expect(results.length).toBe(0);
+  });
+
+  it("handles empty messages array", () => {
+    const results = linearSearchMessages([], "hello");
+    expect(results.length).toBe(0);
+  });
+
+  it("searches array content fields", () => {
+    const msgWithArray = createMessage({
+      uuid: "msg-array",
+      type: "assistant",
+      content: [{ type: "text", text: "function calculateTotal()" }],
+    });
+    const results = linearSearchMessages([msgWithArray], "calculateTotal");
+    expect(results.length).toBe(1);
+    expect(results[0].messageUuid).toBe("msg-array");
+  });
+
+  it("searches toolUseResult content", () => {
+    const msgWithTool = createMessage({
+      uuid: "msg-tool",
+      type: "user",
+      content: "",
+      toolUseResult: { content: "Error: file not found", stdout: "" },
+    });
+    const results = linearSearchMessages([msgWithTool], "file not found");
+    expect(results.length).toBe(1);
+    expect(results[0].messageUuid).toBe("msg-tool");
+  });
+
+  it("supports toolId filter type", () => {
+    const msgWithToolUse = createMessage({
+      uuid: "msg-tid",
+      type: "assistant",
+      content: [{ type: "tool_use", id: "toolu_abc123", name: "read_file" }],
+    });
+    const results = linearSearchMessages([msgWithToolUse], "toolu_abc123", "toolId");
+    expect(results.length).toBe(1);
+    expect(results[0].messageUuid).toBe("msg-tid");
+  });
+});
+
+describe("isSearchIndexReady / clearSearchIndex", () => {
+  beforeEach(() => {
+    clearSearchIndex();
+  });
+
+  it("returns false before any build", () => {
+    expect(isSearchIndexReady()).toBe(false);
+  });
+
+  it("returns false after clear", () => {
+    clearSearchIndex();
+    expect(isSearchIndexReady()).toBe(false);
+  });
+});

--- a/src/utils/searchIndex.test.ts
+++ b/src/utils/searchIndex.test.ts
@@ -35,12 +35,13 @@ describe("linearSearchMessages", () => {
   it("finds multiple matches within same message", () => {
     const results = linearSearchMessages(messages, "bug");
     // "bug" appears twice in msg-4: "found the bug" and "The bug was"
+    // Sorted newest-first with descending matchIndex, so matchIndex 1 comes first
     const msg4Results = results.filter(r => r.messageUuid === "msg-4");
     expect(msg4Results.length).toBe(2);
-    expect(msg4Results[0].matchIndex).toBe(0);
-    expect(msg4Results[0].matchCount).toBe(2);
-    expect(msg4Results[1].matchIndex).toBe(1);
+    expect(msg4Results[1].matchIndex).toBe(0);
     expect(msg4Results[1].matchCount).toBe(2);
+    expect(msg4Results[0].matchIndex).toBe(1);
+    expect(msg4Results[0].matchCount).toBe(2);
   });
 
   it("finds matches across multiple messages", () => {
@@ -93,6 +94,41 @@ describe("linearSearchMessages", () => {
     const results = linearSearchMessages([msgWithToolUse], "toolu_abc123", "toolId");
     expect(results.length).toBe(1);
     expect(results[0].messageUuid).toBe("msg-tid");
+  });
+
+  it("returns results newest-first (descending messageIndex)", () => {
+    // msg-1 (oldest, index 0) has "hello", msg-4 (newest, index 3) has "bug"
+    // Searching for "bug" should return msg-4 before msg-1
+    const results = linearSearchMessages(messages, "bug");
+    expect(results.length).toBe(3); // msg-3 has 1, msg-4 has 2 = 3 total
+    // The result at index 0 should be from msg-4 (latest message with matches)
+    expect(results[0].messageUuid).toBe("msg-4");
+    // Results should be in descending messageIndex order
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].messageIndex).toBeLessThanOrEqual(results[i - 1].messageIndex);
+    }
+  });
+
+  it("finds mid-word substrings that FlexSearch forward tokenize would miss", () => {
+    // FlexSearch "forward" tokenize only matches at word boundaries.
+    // Searching for "orld" in "Hello world" — "forward" misses it because
+    // "world" tokenizes to ["w","wo","wor","worl","world"].  "orld" starts
+    // with "o", not "w", so it's not a prefix of any "world" token.
+    // The linear fallback (indexOf) correctly finds it as a substring.
+    const msg = createMessage({
+      uuid: "msg-mid",
+      type: "user",
+      content: "Hello world and a big debugging session",
+    });
+    const resultsMidWord = linearSearchMessages([msg], "orld");
+    expect(resultsMidWord.length).toBe(1);
+    expect(resultsMidWord[0].messageUuid).toBe("msg-mid");
+
+    // Also verify "bug" embedded in "debugging" is found (forward tokenize
+    // would miss this because "debugging" tokens don't include "bug").
+    const resultsEmbedded = linearSearchMessages([msg], "bug");
+    expect(resultsEmbedded.length).toBe(1);
+    expect(resultsEmbedded[0].messageUuid).toBe("msg-mid");
   });
 });
 

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -258,9 +258,25 @@ const extractUuidFromResult = (item: string | EnrichedResult): string => {
 };
 
 // FlexSearch Document 인덱스 생성 헬퍼
+//
+// Tokenize mode: "forward" (prefix-only indexing).
+//
+// Why not "full":
+//   "full" creates every substring of every word (O(n²) tokens), which
+//   pegs the CPU at 100% for large sessions (47k+ messages, ~20s freeze).
+//   "forward" creates only prefix substrings (O(n) tokens), keeping index
+//   construction well under a second even for our largest sessions.
+//
+// Tradeoff — recall gap:
+//   forward tokenize only matches queries that appear at a word boundary.
+//   Searching for "bug" will NOT match "debugging" (no token starts with "bug").
+//   With "full", it would.  For chat history search this is an acceptable
+//   tradeoff — the common case (whole-word / prefix search) is fast and
+//   accurate, and the linear fallback (linearSearchMessages) provides full
+//   substring recall during the brief window before the index is ready.
 const createFlexSearchIndex = (): FlexSearchDocumentIndex => {
   return new FlexSearch.Document({
-    tokenize: "forward", // 전방 매칭 (O(n) 인덱싱, "full"은 O(n²)로 대량 메시지에서 CPU 폭주)
+    tokenize: "forward",
     cache: 100, // 최근 100개 쿼리 캐시
     document: {
       id: "uuid",
@@ -444,12 +460,12 @@ class MessageSearchIndex {
     });
 
     // 완전 역순 정렬: 아래에서 위로 탐색 (최신 메시지의 마지막 매치부터)
-    allMatches.sort((a, b) => {
-      if (a.messageIndex !== b.messageIndex) {
-        return b.messageIndex - a.messageIndex; // 최신 메시지 우선
-      }
-      return b.matchIndex - a.matchIndex; // 메시지 내에서도 마지막 매치부터
-    });
+  allMatches.sort((a, b) => {
+    if (a.messageIndex !== b.messageIndex) {
+      return b.messageIndex - a.messageIndex; // newest messages first
+    }
+    return b.matchIndex - a.matchIndex; // last match within a message first
+  });
 
     return allMatches;
   }
@@ -619,8 +635,17 @@ export const isSearchIndexReady = (): boolean => {
 
 /**
  * Linear search fallback — scans all messages with String.includes.
- * Used when FlexSearch index is not yet built. O(n) but non-blocking
- * (runs synchronously in a single pass, typically 50-200ms for 50k messages).
+ * Used when FlexSearch index is not yet built (pre-index stage).
+ *
+ * Returns results in newest-first order (descending messageIndex, then
+ * descending matchIndex), matching the FlexSearch path so navigation is
+ * consistent regardless of which code path is active.
+ *
+ * Performance: O(n) single pass, typically 50-200ms for 50k messages.
+ * Recall: substring match (indexOf) — finds queries even mid-word, which
+ * means the first search after session load may return more results than
+ * subsequent searches through the FlexSearch "forward" index.  This gap
+ * is a conscious tradeoff; see createFlexSearchIndex above.
  */
 export const linearSearchMessages = (
   messages: ClaudeMessage[],
@@ -662,6 +687,9 @@ export const linearSearchMessages = (
       }
     }
   }
+
+  // Sort newest-first to match FlexSearch result order for consistent navigation
+  results.sort((a, b) => b.messageIndex - a.messageIndex || b.matchIndex - a.matchIndex);
 
   return results;
 };

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -1,9 +1,11 @@
 import FlexSearch from "flexsearch";
+import type { Document as FlexSearchDocument } from "flexsearch";
 import type { ClaudeMessage } from "../types";
 import type { SearchFilterType } from "../store/useAppStore";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type FlexSearchDocumentIndex = any;
+// FlexSearch document shape used by this module's content / toolId indexes
+type SearchDoc = { uuid: string; messageIndex: number; text: string };
+type FlexSearchDocumentIndex = FlexSearchDocument<SearchDoc>;
 
 // Type guards for safe type checking
 const isRecord = (value: unknown): value is Record<string, unknown> => {
@@ -400,7 +402,9 @@ class MessageSearchIndex {
 
     // 매치된 메시지 UUID 수집
     const matchedUuids = new Set<string>();
-    results.forEach((fieldResult: { field: string; result: (string | EnrichedResult)[] }) => {
+    // FlexSearch's enriched result type is complex; cast to the shape we actually consume.
+    const enrichedResults = results as unknown as Array<{ field: string; result: (string | EnrichedResult)[] }>;
+    enrichedResults.forEach((fieldResult) => {
       if (fieldResult.result) {
         fieldResult.result.forEach((item: string | EnrichedResult) => {
           const uuid = extractUuidFromResult(item);
@@ -471,8 +475,37 @@ type SearchResult = { messageUuid: string; messageIndex: number; matchIndex: num
 
 let worker: Worker | null = null;
 let workerReady = false;
+// In-flight build guard: prevents repeated index rebuilds when the user
+// types continuously. Same messages reference is a no-op while a build
+// is in flight or already ready.
+let workerBuildInFlight = false;
+let lastBuildMessagesRef: ClaudeMessage[] | null = null;
 const pendingSearchCallbacks = new Map<number, (results: SearchResult[]) => void>();
+const pendingSearchTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
+const SEARCH_TIMEOUT_MS = 5000;
 let searchIdCounter = 0;
+
+// Internal: clear a pending search (cancel its timeout + delete its callback).
+function resolveAndCleanupSearch(id: number, results: SearchResult[]): void {
+  const callback = pendingSearchCallbacks.get(id);
+  if (!callback) return;
+  pendingSearchCallbacks.delete(id);
+  const timer = pendingSearchTimeouts.get(id);
+  if (timer != null) {
+    clearTimeout(timer);
+    pendingSearchTimeouts.delete(id);
+  }
+  callback(results);
+}
+
+// Internal: resolve every pending search with [] - used when the worker
+// errors out or is cleared, so callbacks don't leak and the UI is unstuck.
+function resolveAllPendingSearches(): void {
+  const ids = Array.from(pendingSearchCallbacks.keys());
+  for (const id of ids) {
+    resolveAndCleanupSearch(id, []);
+  }
+}
 
 function getWorker(): Worker | null {
   if (worker) return worker;
@@ -482,16 +515,23 @@ function getWorker(): Worker | null {
       const msg = event.data;
       if (msg.type === "build-complete") {
         workerReady = true;
+        workerBuildInFlight = false;
         if (import.meta.env.DEV) {
           console.log(`[SearchIndex Worker] Index built for ${msg.count} messages`);
         }
       } else if (msg.type === "search-result") {
-        const callback = pendingSearchCallbacks.get(msg.id);
-        if (callback) {
-          pendingSearchCallbacks.delete(msg.id);
-          callback(msg.results);
-        }
+        resolveAndCleanupSearch(msg.id, msg.results);
       }
+    };
+    // Resolve all pending searches on worker crash/error so the UI never
+    // gets stuck in a "searching..." state.
+    worker.onerror = (event) => {
+      if (import.meta.env.DEV) {
+        console.error("[SearchIndex Worker] Worker error:", event);
+      }
+      workerReady = false;
+      workerBuildInFlight = false;
+      resolveAllPendingSearches();
     };
     return worker;
   } catch {
@@ -504,7 +544,13 @@ function getWorker(): Worker | null {
 export const buildSearchIndex = (messages: ClaudeMessage[]): void => {
   const w = getWorker();
   if (w) {
+    // De-dup: skip if the same messages reference is already building or built.
+    if (lastBuildMessagesRef === messages && (workerBuildInFlight || workerReady)) {
+      return;
+    }
     workerReady = false;
+    workerBuildInFlight = true;
+    lastBuildMessagesRef = messages;
     // Send minimal message data to worker (avoid transferring unnecessary fields)
     const minimalMessages = messages.map(m => ({
       uuid: m.uuid,
@@ -529,6 +575,15 @@ export const searchMessagesAsync = (
     return new Promise((resolve) => {
       const id = ++searchIdCounter;
       pendingSearchCallbacks.set(id, resolve);
+      // 5s safety timeout so the promise never stays pending if the worker
+      // drops the message or the search hangs.
+      const timer = setTimeout(() => {
+        if (import.meta.env.DEV) {
+          console.warn(`[SearchIndex Worker] Search ${id} timed out after ${SEARCH_TIMEOUT_MS}ms`);
+        }
+        resolveAndCleanupSearch(id, []);
+      }, SEARCH_TIMEOUT_MS);
+      pendingSearchTimeouts.set(id, timer);
       w.postMessage({ type: "search", id, query, filterType });
     });
   }
@@ -547,6 +602,10 @@ export const searchMessages = (
 export const clearSearchIndex = (): void => {
   messageSearchIndex.clear();
   workerReady = false;
+  workerBuildInFlight = false;
+  lastBuildMessagesRef = null;
+  // Also resolve pending searches so callbacks don't linger past the clear.
+  resolveAllPendingSearches();
   const w = getWorker();
   if (w) {
     w.postMessage({ type: "clear" });

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -258,7 +258,7 @@ const extractUuidFromResult = (item: string | EnrichedResult): string => {
 // FlexSearch Document 인덱스 생성 헬퍼
 const createFlexSearchIndex = (): FlexSearchDocumentIndex => {
   return new FlexSearch.Document({
-    tokenize: "full", // 전체 substring 매칭 지원 (단어 중간도 검색)
+    tokenize: "forward", // 전방 매칭 (O(n) 인덱싱, "full"은 O(n²)로 대량 메시지에서 CPU 폭주)
     cache: 100, // 최근 100개 쿼리 캐시
     document: {
       id: "uuid",
@@ -281,8 +281,18 @@ class MessageSearchIndex {
     this.toolIdIndex = createFlexSearchIndex();
   }
 
+  // 인덱스가 구축 완료되었는지 확인
+  isReady(): boolean {
+    return this.isBuilt;
+  }
+
   // 인덱스 구축 (메시지 로드 시 1회 호출) - 청크 단위 비동기 처리
   build(messages: ClaudeMessage[]): void {
+    // Skip if already built with same messages or currently building
+    if (this.messages === messages && (this.isBuilt || this.messages.length > 0)) {
+      return;
+    }
+
     // 기존 인덱스 클리어
     this.clear();
 
@@ -295,13 +305,15 @@ class MessageSearchIndex {
 
   // 비동기 청크 인덱싱 (메인 스레드 차단 방지)
   private buildAsync(messages: ClaudeMessage[]): void {
-    const CHUNK_SIZE = 20; // 한 번에 처리할 메시지 수
+    const CHUNK_SIZE = 50; // 한 번에 처리할 메시지 수 (forward tokenize 기준 ~10ms/chunk)
+    const YIELD_INTERVAL_MS = 50; // chunk 간 최소 대기 시간 (UI 반응성 확보)
     let currentIndex = 0;
 
-    const processChunk = () => {
+    const processChunk = (deadline?: IdleDeadline) => {
+      const timeLimit = deadline ? () => deadline.timeRemaining() > 2 : () => true;
       const endIndex = Math.min(currentIndex + CHUNK_SIZE, messages.length);
 
-      for (let i = currentIndex; i < endIndex; i++) {
+      for (let i = currentIndex; i < endIndex && timeLimit(); i++) {
         const message = messages[i];
         if (!message) continue;
 
@@ -326,13 +338,16 @@ class MessageSearchIndex {
         }
 
         this.messageMap.set(message.uuid, i);
+        currentIndex = i + 1;
       }
 
-      currentIndex = endIndex;
-
       if (currentIndex < messages.length) {
-        // 다음 청크를 다음 프레임에 처리
-        setTimeout(processChunk, 0);
+        // 다음 청크를 idle callback으로 예약 (UI 반응성 우선)
+        if ("requestIdleCallback" in window) {
+          (window as Window & { requestIdleCallback: (cb: IdleRequestCallback, opts?: { timeout: number }) => number }).requestIdleCallback(processChunk, { timeout: 2000 });
+        } else {
+          setTimeout(processChunk, YIELD_INTERVAL_MS);
+        }
       } else {
         // 완료
         this.isBuilt = true;
@@ -342,8 +357,12 @@ class MessageSearchIndex {
       }
     };
 
-    // 첫 청크 시작
-    processChunk();
+    // 첫 청크를 idle callback으로 시작
+    if ("requestIdleCallback" in window) {
+      (window as Window & { requestIdleCallback: (cb: IdleRequestCallback, opts?: { timeout: number }) => number }).requestIdleCallback(processChunk, { timeout: 2000 });
+    } else {
+      setTimeout(processChunk, YIELD_INTERVAL_MS);
+    }
   }
 
   // 메시지 내 모든 매치 위치 찾기
@@ -441,21 +460,148 @@ class MessageSearchIndex {
   }
 }
 
-// 싱글톤 인스턴스
+// 싱글톤 인스턴스 (kept as fallback for non-worker environments)
 export const messageSearchIndex = new MessageSearchIndex();
+
+// ============================================================================
+// Web Worker-based Search Index
+// ============================================================================
+
+type SearchResult = { messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number };
+
+let worker: Worker | null = null;
+let workerReady = false;
+const pendingSearchCallbacks = new Map<number, (results: SearchResult[]) => void>();
+let searchIdCounter = 0;
+
+function getWorker(): Worker | null {
+  if (worker) return worker;
+  try {
+    worker = new Worker(new URL("./searchWorker.ts", import.meta.url), { type: "module" });
+    worker.onmessage = (event) => {
+      const msg = event.data;
+      if (msg.type === "build-complete") {
+        workerReady = true;
+        if (import.meta.env.DEV) {
+          console.log(`[SearchIndex Worker] Index built for ${msg.count} messages`);
+        }
+      } else if (msg.type === "search-result") {
+        const callback = pendingSearchCallbacks.get(msg.id);
+        if (callback) {
+          pendingSearchCallbacks.delete(msg.id);
+          callback(msg.results);
+        }
+      }
+    };
+    return worker;
+  } catch {
+    // Worker creation failed (e.g., in test environment)
+    return null;
+  }
+}
 
 // 편의 함수들
 export const buildSearchIndex = (messages: ClaudeMessage[]): void => {
-  messageSearchIndex.build(messages);
+  const w = getWorker();
+  if (w) {
+    workerReady = false;
+    // Send minimal message data to worker (avoid transferring unnecessary fields)
+    const minimalMessages = messages.map(m => ({
+      uuid: m.uuid,
+      type: m.type,
+      content: m.content,
+      toolUse: (m as Record<string, unknown>).toolUse,
+      toolUseResult: (m as Record<string, unknown>).toolUseResult,
+    }));
+    w.postMessage({ type: "build", messages: minimalMessages });
+  } else {
+    // Fallback to main thread (shouldn't happen in browser)
+    messageSearchIndex.build(messages);
+  }
+};
+
+export const searchMessagesAsync = (
+  query: string,
+  filterType: SearchFilterType = "content"
+): Promise<SearchResult[]> => {
+  const w = getWorker();
+  if (w && workerReady) {
+    return new Promise((resolve) => {
+      const id = ++searchIdCounter;
+      pendingSearchCallbacks.set(id, resolve);
+      w.postMessage({ type: "search", id, query, filterType });
+    });
+  }
+  // Worker not ready — resolve immediately with empty (caller uses linear fallback)
+  return Promise.resolve([]);
 };
 
 export const searchMessages = (
   query: string,
   filterType: SearchFilterType = "content"
-): Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }> => {
+): SearchResult[] => {
+  // Synchronous search: only works if main-thread index is built (legacy fallback)
   return messageSearchIndex.search(query, filterType);
 };
 
 export const clearSearchIndex = (): void => {
   messageSearchIndex.clear();
+  workerReady = false;
+  const w = getWorker();
+  if (w) {
+    w.postMessage({ type: "clear" });
+  }
+};
+
+export const isSearchIndexReady = (): boolean => {
+  return workerReady || messageSearchIndex.isReady();
+};
+
+/**
+ * Linear search fallback — scans all messages with String.includes.
+ * Used when FlexSearch index is not yet built. O(n) but non-blocking
+ * (runs synchronously in a single pass, typically 50-200ms for 50k messages).
+ */
+export const linearSearchMessages = (
+  messages: ClaudeMessage[],
+  query: string,
+  filterType: SearchFilterType = "content"
+): SearchResult[] => {
+  if (!query.trim()) return [];
+  const lowerQuery = query.toLowerCase();
+
+  const results: SearchResult[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (!message) continue;
+
+    const text = filterType === "toolId"
+      ? extractToolIds(message)
+      : extractSearchableText(message);
+
+    if (!text) continue;
+    const lowerText = text.toLowerCase();
+
+    // Count all occurrences
+    let count = 0;
+    let pos = 0;
+    while ((pos = lowerText.indexOf(lowerQuery, pos)) !== -1) {
+      count++;
+      pos += lowerQuery.length;
+    }
+
+    if (count > 0) {
+      for (let matchIdx = 0; matchIdx < count; matchIdx++) {
+        results.push({
+          messageUuid: message.uuid,
+          messageIndex: i,
+          matchIndex: matchIdx,
+          matchCount: count,
+        });
+      }
+    }
+  }
+
+  return results;
 };

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -556,8 +556,8 @@ export const buildSearchIndex = (messages: ClaudeMessage[]): void => {
       uuid: m.uuid,
       type: m.type,
       content: m.content,
-      toolUse: (m as Record<string, unknown>).toolUse,
-      toolUseResult: (m as Record<string, unknown>).toolUseResult,
+      toolUse: (m as unknown as Record<string, unknown>).toolUse,
+      toolUseResult: (m as unknown as Record<string, unknown>).toolUseResult,
     }));
     w.postMessage({ type: "build", messages: minimalMessages });
   } else {
@@ -606,9 +606,10 @@ export const clearSearchIndex = (): void => {
   lastBuildMessagesRef = null;
   // Also resolve pending searches so callbacks don't linger past the clear.
   resolveAllPendingSearches();
-  const w = getWorker();
-  if (w) {
-    w.postMessage({ type: "clear" });
+  // Only send clear to worker if it already exists — avoids eagerly
+  // spinning up the worker on every selectSession.
+  if (worker) {
+    worker.postMessage({ type: "clear" });
   }
 };
 

--- a/src/utils/searchWorker.ts
+++ b/src/utils/searchWorker.ts
@@ -1,0 +1,261 @@
+/**
+ * Search Index Web Worker
+ *
+ * Runs FlexSearch indexing and search operations off the main thread
+ * to prevent UI blocking when handling large message sets (47k+).
+ */
+
+import FlexSearch from "flexsearch";
+
+// ============================================================================
+// Types (duplicated here since workers can't import from main thread modules)
+// ============================================================================
+
+interface ClaudeMessageMinimal {
+  uuid: string;
+  type: string;
+  content: unknown;
+  toolUse?: unknown;
+  toolUseResult?: unknown;
+}
+
+type SearchFilterType = "content" | "toolId";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type FlexSearchDocumentIndex = any;
+
+// ============================================================================
+// Worker Message Protocol
+// ============================================================================
+
+interface BuildMessage {
+  type: "build";
+  messages: ClaudeMessageMinimal[];
+}
+
+interface SearchMessage {
+  type: "search";
+  id: number;
+  query: string;
+  filterType: SearchFilterType;
+}
+
+interface ClearMessage {
+  type: "clear";
+}
+
+type IncomingMessage = BuildMessage | SearchMessage | ClearMessage;
+
+interface BuildCompleteResponse {
+  type: "build-complete";
+  count: number;
+}
+
+interface SearchResultResponse {
+  type: "search-result";
+  id: number;
+  results: Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _OutgoingMessage = BuildCompleteResponse | SearchResultResponse;
+
+// ============================================================================
+// Text Extraction (same logic as main thread searchIndex.ts)
+// ============================================================================
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const hasStringProperty = (obj: Record<string, unknown>, key: string): boolean => {
+  return key in obj && typeof obj[key] === "string";
+};
+
+const MAX_TEXT_LENGTH = 10000;
+
+const extractSearchableText = (message: ClaudeMessageMinimal): string => {
+  const parts: string[] = [];
+  try {
+    if (message.content) {
+      if (typeof message.content === "string") {
+        parts.push(message.content);
+      } else if (Array.isArray(message.content)) {
+        for (const item of message.content) {
+          if (typeof item === "string") {
+            parts.push(item);
+          } else if (isRecord(item)) {
+            if (item.type === "image") continue;
+            if (hasStringProperty(item, "text")) parts.push((item.text as string).slice(0, MAX_TEXT_LENGTH));
+            if (hasStringProperty(item, "thinking")) parts.push((item.thinking as string).slice(0, MAX_TEXT_LENGTH));
+            if (item.type === "tool_use" && hasStringProperty(item, "name")) parts.push(item.name as string);
+            if (item.type === "tool_result" && hasStringProperty(item, "content")) parts.push(item.content as string);
+            if (item.type === "server_tool_use" && hasStringProperty(item, "name")) parts.push(item.name as string);
+          }
+        }
+      }
+    }
+    if (message.type === "assistant" && isRecord(message.toolUse) && hasStringProperty(message.toolUse, "name")) {
+      parts.push(message.toolUse.name as string);
+    }
+    const MAX_CONTENT_LENGTH = 5000;
+    if ((message.type === "user" || message.type === "assistant") && message.toolUseResult) {
+      const result = message.toolUseResult;
+      if (typeof result === "string") {
+        parts.push(result.slice(0, MAX_CONTENT_LENGTH));
+      } else if (isRecord(result)) {
+        if (hasStringProperty(result, "stdout")) parts.push((result.stdout as string).slice(0, MAX_CONTENT_LENGTH));
+        if (hasStringProperty(result, "stderr")) parts.push((result.stderr as string).slice(0, MAX_CONTENT_LENGTH));
+        if (hasStringProperty(result, "content")) parts.push((result.content as string).slice(0, MAX_CONTENT_LENGTH));
+      }
+    }
+  } catch {
+    // ignore extraction errors
+  }
+  return parts.join(" ");
+};
+
+const extractToolIds = (message: ClaudeMessageMinimal): string => {
+  const ids: string[] = [];
+  try {
+    if (Array.isArray(message.content)) {
+      for (const item of message.content) {
+        if (isRecord(item)) {
+          if (item.type === "tool_use" && hasStringProperty(item, "id")) ids.push(item.id as string);
+          if (item.type === "tool_result" && hasStringProperty(item, "tool_use_id")) ids.push(item.tool_use_id as string);
+        }
+      }
+    }
+    if (message.type === "assistant" && isRecord(message.toolUse) && hasStringProperty(message.toolUse, "id")) {
+      ids.push(message.toolUse.id as string);
+    }
+  } catch {
+    // ignore
+  }
+  return ids.join(" ");
+};
+
+// ============================================================================
+// FlexSearch Index
+// ============================================================================
+
+const createFlexSearchIndex = (): FlexSearchDocumentIndex => {
+  return new FlexSearch.Document({
+    tokenize: "forward",
+    cache: 100,
+    document: {
+      id: "uuid",
+      index: ["text"],
+      store: ["uuid", "messageIndex"],
+    },
+  });
+};
+
+let contentIndex: FlexSearchDocumentIndex = createFlexSearchIndex();
+let toolIdIndex: FlexSearchDocumentIndex = createFlexSearchIndex();
+const messageMap = new Map<string, number>();
+let messages: ClaudeMessageMinimal[] = [];
+let isBuilt = false;
+
+function clearIndex() {
+  contentIndex = createFlexSearchIndex();
+  toolIdIndex = createFlexSearchIndex();
+  messageMap.clear();
+  messages = [];
+  isBuilt = false;
+}
+
+function buildIndex(msgs: ClaudeMessageMinimal[]) {
+  clearIndex();
+  messages = msgs;
+
+  for (let i = 0; i < msgs.length; i++) {
+    const message = msgs[i];
+    if (!message) continue;
+
+    const text = extractSearchableText(message);
+    if (text.trim()) {
+      contentIndex.add({ uuid: message.uuid, messageIndex: i, text: text.toLowerCase() });
+    }
+
+    const toolIds = extractToolIds(message);
+    if (toolIds.trim()) {
+      toolIdIndex.add({ uuid: message.uuid, messageIndex: i, text: toolIds.toLowerCase() });
+    }
+
+    messageMap.set(message.uuid, i);
+  }
+
+  isBuilt = true;
+}
+
+function searchIndex(
+  query: string,
+  filterType: SearchFilterType
+): Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }> {
+  if (!isBuilt || !query.trim()) return [];
+
+  const lowerQuery = query.toLowerCase();
+  const index = filterType === "toolId" ? toolIdIndex : contentIndex;
+
+  const results = index.search(lowerQuery, { limit: 1000, enrich: true });
+  const matchedUuids = new Set<string>();
+  results.forEach((fieldResult: { result: Array<string | { id: string }> }) => {
+    if (fieldResult.result) {
+      fieldResult.result.forEach((item: string | { id: string }) => {
+        matchedUuids.add(typeof item === "string" ? item : item.id);
+      });
+    }
+  });
+
+  const allMatches: Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }> = [];
+  matchedUuids.forEach((uuid) => {
+    const messageIndex = messageMap.get(uuid);
+    if (messageIndex === undefined) return;
+    const message = messages[messageIndex];
+    if (!message) return;
+
+    const text = filterType === "toolId" ? extractToolIds(message) : extractSearchableText(message);
+    const lowerText = text.toLowerCase();
+    let count = 0;
+    let pos = 0;
+    while ((pos = lowerText.indexOf(lowerQuery, pos)) !== -1) {
+      count++;
+      pos += lowerQuery.length;
+    }
+
+    for (let matchIdx = 0; matchIdx < count; matchIdx++) {
+      allMatches.push({ messageUuid: uuid, messageIndex, matchIndex: matchIdx, matchCount: count });
+    }
+  });
+
+  allMatches.sort((a, b) => a.messageIndex - b.messageIndex || a.matchIndex - b.matchIndex);
+  return allMatches;
+}
+
+// ============================================================================
+// Worker Message Handler
+// ============================================================================
+
+self.onmessage = (event: MessageEvent<IncomingMessage>) => {
+  const msg = event.data;
+
+  switch (msg.type) {
+    case "build": {
+      buildIndex(msg.messages);
+      const response: BuildCompleteResponse = { type: "build-complete", count: msg.messages.length };
+      self.postMessage(response);
+      break;
+    }
+    case "search": {
+      const results = searchIndex(msg.query, msg.filterType);
+      const response: SearchResultResponse = { type: "search-result", id: msg.id, results };
+      self.postMessage(response);
+      break;
+    }
+    case "clear": {
+      clearIndex();
+      break;
+    }
+  }
+};

--- a/src/utils/searchWorker.ts
+++ b/src/utils/searchWorker.ts
@@ -138,6 +138,13 @@ const extractToolIds = (message: ClaudeMessageMinimal): string => {
 
 // ============================================================================
 // FlexSearch Index
+//
+// Tokenize: "forward" (prefix-only, O(n) indexing).
+// "full" would create every substring (O(n²)) and freeze the UI on
+// large sessions.  The tradeoff is that forward tokenize only matches
+// queries at word boundaries — "bug" won't match "debugging".
+// The main-thread linear fallback provides full substring recall during
+// the brief window before this worker index is ready.
 // ============================================================================
 
 const createFlexSearchIndex = (): FlexSearchDocumentIndex => {

--- a/src/utils/searchWorker.ts
+++ b/src/utils/searchWorker.ts
@@ -6,6 +6,7 @@
  */
 
 import FlexSearch from "flexsearch";
+import type { Document as FlexSearchDocument } from "flexsearch";
 
 // ============================================================================
 // Types (duplicated here since workers can't import from main thread modules)
@@ -21,8 +22,9 @@ interface ClaudeMessageMinimal {
 
 type SearchFilterType = "content" | "toolId";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type FlexSearchDocumentIndex = any;
+// FlexSearch document shape used by this worker's content / toolId indexes
+type SearchDoc = { uuid: string; messageIndex: number; text: string };
+type FlexSearchDocumentIndex = FlexSearchDocument<SearchDoc>;
 
 // ============================================================================
 // Worker Message Protocol
@@ -200,7 +202,9 @@ function searchIndex(
 
   const results = index.search(lowerQuery, { limit: 1000, enrich: true });
   const matchedUuids = new Set<string>();
-  results.forEach((fieldResult: { result: Array<string | { id: string }> }) => {
+  // FlexSearch's enriched result type is complex; cast to the shape we actually consume.
+  const enrichedResults = results as unknown as Array<{ result: Array<string | { id: string }> }>;
+  enrichedResults.forEach((fieldResult) => {
     if (fieldResult.result) {
       fieldResult.result.forEach((item: string | { id: string }) => {
         matchedUuids.add(typeof item === "string" ? item : item.id);

--- a/src/utils/searchWorker.ts
+++ b/src/utils/searchWorker.ts
@@ -59,8 +59,7 @@ interface SearchResultResponse {
   results: Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _OutgoingMessage = BuildCompleteResponse | SearchResultResponse;
+type OutgoingMessage = BuildCompleteResponse | SearchResultResponse;
 
 // ============================================================================
 // Text Extraction (same logic as main thread searchIndex.ts)
@@ -233,7 +232,7 @@ function searchIndex(
     }
   });
 
-  allMatches.sort((a, b) => a.messageIndex - b.messageIndex || a.matchIndex - b.matchIndex);
+  allMatches.sort((a, b) => b.messageIndex - a.messageIndex || b.matchIndex - a.matchIndex);
   return allMatches;
 }
 
@@ -248,13 +247,13 @@ self.onmessage = (event: MessageEvent<IncomingMessage>) => {
     case "build": {
       buildIndex(msg.messages);
       const response: BuildCompleteResponse = { type: "build-complete", count: msg.messages.length };
-      self.postMessage(response);
+      self.postMessage(response satisfies OutgoingMessage);
       break;
     }
     case "search": {
       const results = searchIndex(msg.query, msg.filterType);
       const response: SearchResultResponse = { type: "search-result", id: msg.id, results };
-      self.postMessage(response);
+      self.postMessage(response satisfies OutgoingMessage);
       break;
     }
     case "clear": {


### PR DESCRIPTION
  ## Summary
  - Fixed: CPU pegged at 100% when loading/searching sessions with 47k+ messages
  - Root cause: FlexSearch `tokenize:"full"` index build on main thread via chunked setTimeout
  - Fix: moved indexing to a Web Worker; first search uses linear fallback; Worker index used once ready

  ## Changes
  - New `searchWorker.ts` — dedicated Worker for FlexSearch build + search
  - `searchIndex.ts` — Worker communication layer + linear search fallback
  - `searchSlice.ts` — async search with fallback strategy
  - `messageSlice.ts` — removed eager index build on session load
  - New `searchIndex.test.ts` — unit tests for linear search

  ## Test plan
  - [x] Open 47k message session — no CPU spike on load
  - [x] Search works immediately (linear fallback)
  - [x] After Worker completes, subsequent searches use index
  - [x] `vitest run` — 11 tests pass
  - [x] ESLint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search indexing now builds lazily and uses a background worker when available to reduce startup/UI blocking.
  * Immediate fallback via a fast linear scan provides instant results while background indexing builds.
  * Forward-prefix matching and refined match counting improve relevance and per-message match accuracy.
  * Search operations are now readiness-aware with guards to prevent stale results and surface errors as user notifications.

* **Tests**
  * Expanded tests for linear search behavior, indexing readiness, and clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Update (2026-05-31, force-pushed `b3a2f30 → 5f3fea5`)

CodeRabbit's review on this branch surfaced six findings (three inline, three outside-diff). Two rounds of fixes have been folded into the existing commit chain; this is a description-only update reflecting the latest force-push.

**Round 1 (`8788ba8`, addresses three inline findings on `searchIndex.ts` / `searchWorker.ts`):**

1. `searchMessagesAsync` had no failure path. If `search-result` never came back (worker crash, dropped postMessage), the promise stayed pending forever and `pendingSearchCallbacks` leaked. Added `worker.onerror` to resolve all pending searches with `[]`, plus a 5s per-search safety timeout. Centralized cleanup in `resolveAndCleanupSearch` so the timer and callback are always released together.
2. Index build was repeatedly restarted on consecutive keystrokes — every search input went through the `else` branch in `searchSlice` and triggered another `postMessage(build)`, wasting ~3s per duplicate build. Added a `workerBuildInFlight` flag plus `lastBuildMessagesRef` so the same messages reference is a no-op while a build is in flight or already ready.
3. `searchWorker.ts` and `searchIndex.ts` used `type X = any` with `eslint-disable` comments. Replaced with `FlexSearch.Document<SearchDoc>` typing, using `as unknown as` casts only where FlexSearch's enriched search result types don't directly match the consumed shape (per CLAUDE.md guidance on `any` replacement).

**Round 2 (`5f3fea5`, replaces `b3a2f30` — addresses two outside-diff findings on `searchSlice.ts` plus a readability follow-up):**

4. **Race condition** in `setSessionSearchQuery`: with the index still building, earlier searches go through the sync linear path and set state immediately, while later searches go through the async Worker path. Their late resolve would overwrite the more recent linear result. Added a monotonic request token (`sessionSearchRequestId`) captured at call entry; after each `await`, drop the result if the token no longer matches the latest request. The same guard runs on the catch path so a stale failure can't wipe a newer successful search.
5. **User feedback on failure**: the catch block previously only called `console.error`, leaving the user with no indication that search had failed. Per CLAUDE.md §"에러 처리", user-visible feedback (toast/alert) is required on async errors. Imported `sonner` toast and emit `toast.error` with the error message.
6. **Readability follow-up**: lifted the `requestId !== sessionSearchRequestId` check into a small `isStillLatest()` predicate, and documented on the early-return that we are intentionally NOT clearing `isSearching` here — the newer in-flight request owns that state and will reset it on its own success / failure path. Without that comment the bare `return` reads like a forgotten state reset rather than a deliberate handoff (CLAUDE.md §"예측 가능성" / §"가독성").

**Verified:** `searchIndex.test.ts` 11/11 pass; `pnpm lint` and `tsc` match baseline (no new errors or warnings introduced).
