### PR TITLE
feat(provider): add CodeBuddy Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The unified history viewer for AI coding assistants.**
 
-Browse, search, and analyze conversations from **Claude Code**, **Gemini CLI**, **Antigravity**, **Codex CLI**, **Cline**, **Cursor**, **Aider**, **OpenCode**, and **ForgeCode** — as a desktop app or headless server. 100% offline.
+Browse, search, and analyze conversations from **Claude Code**, **Gemini CLI**, **Antigravity**, **Codex CLI**, **Cline**, **Cursor**, **Aider**, **OpenCode**, **ForgeCode**, and **CodeBuddy Code** — as a desktop app or headless server. 100% offline.
 
 [![Version](https://img.shields.io/github/v/release/jhlee0409/claude-code-history-viewer?label=Version&color=blue)](https://github.com/jhlee0409/claude-code-history-viewer/releases)
 [![Stars](https://img.shields.io/github/stars/jhlee0409/claude-code-history-viewer?style=flat&color=yellow)](https://github.com/jhlee0409/claude-code-history-viewer/stargazers)
@@ -63,7 +63,7 @@ See [Server Mode](#server-mode-webui) for Docker, VPS, and systemd setup.
 
 AI coding assistants generate thousands of conversation messages, but none of them provide a way to look back at your history across tools. CCHV solves this.
 
-**Nine assistants. One viewer.** Switch between Claude Code, Gemini CLI, Antigravity, Codex CLI, Cline, Cursor, Aider, OpenCode, and ForgeCode sessions seamlessly — compare token usage, search across providers, and analyze your workflow in a single interface.
+**Ten assistants. One viewer.** Switch between Claude Code, Gemini CLI, Antigravity, Codex CLI, Cline, Cursor, Aider, OpenCode, ForgeCode, and CodeBuddy Code sessions seamlessly — compare token usage, search across providers, and analyze your workflow in a single interface.
 
 | Provider | Data Location | What You Get |
 |----------|--------------|--------------|
@@ -76,6 +76,7 @@ AI coding assistants generate thousands of conversation messages, but none of th
 | **Aider** | Project directories | Chat history and edit logs |
 | **OpenCode** | `~/.local/share/opencode/` | Conversation sessions and tool results |
 | **ForgeCode** | `~/.forge/.forge.db` | Conversation history from SQLite database |
+| **CodeBuddy Code** | `~/.codebuddy/projects/` | Conversation history with tool calls (Claude Code fork format) |
 
 No vendor lock-in. No cloud dependency. Your local conversation files, beautifully rendered.
 
@@ -101,7 +102,7 @@ Antigravity note: the viewer resolves the Antigravity root as `~/.gemini/antigra
 
 | Feature | Description |
 |---------|-------------|
-| **Multi-Provider Support** | Unified viewer for **Claude Code**, **Gemini CLI**, **Antigravity**, **Codex CLI**, **Cline**, **Cursor**, **Aider**, **OpenCode**, and **ForgeCode** — filter by provider, compare across tools |
+| **Multi-Provider Support** | Unified viewer for **Claude Code**, **Gemini CLI**, **Antigravity**, **Codex CLI**, **Cline**, **Cursor**, **Aider**, **OpenCode**, **ForgeCode**, and **CodeBuddy Code** — filter by provider, compare across tools |
 | **Conversation Browser** | Navigate conversations by project/session with worktree grouping |
 | **Global Search** | Search across all conversations from all providers instantly |
 | **Analytics Dashboard** | Dual-mode token stats (billing vs conversation), cost breakdown, and provider distribution charts |
@@ -334,7 +335,7 @@ GET /health
 ## Usage
 
 1. Launch the app
-2. It automatically scans for conversation data from all supported providers (Claude Code, Gemini CLI, Codex CLI, Cline, Cursor, Aider, OpenCode, ForgeCode)
+2. It automatically scans for conversation data from all supported providers (Claude Code, Gemini CLI, Codex CLI, Cline, Cursor, Aider, OpenCode, ForgeCode, CodeBuddy Code)
 3. Browse projects in the left sidebar — filter by provider using the tab bar
 4. Click a session to view messages
 5. Use tabs to switch between Messages, Analytics, Token Stats, Recent Edits, and Session Board

--- a/src-tauri/src/commands/archive.rs
+++ b/src-tauri/src/commands/archive.rs
@@ -622,7 +622,7 @@ pub async fn list_archives() -> Result<ArchiveManifest, String> {
 /// * `name` - Human-readable name for the archive
 /// * `description` - Optional description
 /// * `session_file_paths` - Absolute paths to the JSONL session files to archive
-/// * `source_provider` - Provider identifier (e.g. "claude", "codex", "opencode")
+/// * `source_provider` - Provider identifier (e.g. "claude", "codex", "opencode", "codebuddy")
 /// * `source_project_path` - Filesystem path of the originating project
 /// * `source_project_name` - Display name of the originating project
 /// * `include_subagents` - Whether to also copy subagent JSONL files

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -39,6 +39,7 @@ pub async fn scan_all_projects(
             "cursor".to_string(),
             "aider".to_string(),
             "antigravity".to_string(),
+            "codebuddy".to_string(),
         ]
     });
 
@@ -169,6 +170,16 @@ pub async fn scan_all_projects(
         }
     }
 
+    // CodeBuddy
+    if providers_to_scan.iter().any(|p| p == "codebuddy") {
+        match providers::codebuddy::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("CodeBuddy scan failed: {e}");
+            }
+        }
+    }
+
     // WSL scanning (Claude only — other providers' load_sessions/load_messages
     // use native base paths internally, so WSL projects would be visible but
     // not loadable. Extending other providers requires base-path-aware loaders.)
@@ -249,6 +260,7 @@ pub async fn load_provider_sessions(
         "cursor" => providers::cursor::load_sessions(&project_path, exclude),
         "aider" => providers::aider::load_sessions(&project_path, exclude),
         "antigravity" => providers::antigravity::load_sessions(&project_path, exclude),
+        "codebuddy" => providers::codebuddy::load_sessions(&project_path, exclude),
         _ => Err(format!("Unknown provider: {provider}")),
     }
 }
@@ -278,6 +290,7 @@ pub async fn load_provider_messages(
         "cursor" => providers::cursor::load_messages(&session_path)?,
         "aider" => providers::aider::load_messages(&session_path)?,
         "antigravity" => providers::antigravity::load_messages(&session_path)?,
+        "codebuddy" => providers::codebuddy::load_messages(&session_path)?,
         _ => return Err(format!("Unknown provider: {provider}")),
     };
 
@@ -313,6 +326,7 @@ pub async fn search_all_providers(
             "cursor".to_string(),
             "aider".to_string(),
             "antigravity".to_string(),
+            "codebuddy".to_string(),
         ]
     });
 
@@ -451,6 +465,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Antigravity search failed: {e}");
+            }
+        }
+    }
+
+    // CodeBuddy
+    if providers_to_search.iter().any(|p| p == "codebuddy") {
+        match providers::codebuddy::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("CodeBuddy search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -41,13 +41,14 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     let home = home_raw.canonicalize().unwrap_or_else(|_| home_raw.clone());
     let home = strip_windows_prefix(&home);
 
-    let allowed: [PathBuf; 6] = [
+    let allowed: [PathBuf; 7] = [
         home.join(".claude").join("projects"),
         home.join(".codex").join("sessions"),
         home.join(".gemini"),
         home.join(".local").join("share").join("opencode"),
         home.join(".cline").join("tasks"),
         home.join(".cursor"),
+        home.join(".codebuddy").join("projects"),
     ];
 
     let canonical = if path.exists() {

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -264,7 +264,7 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::OpenCode
     } else if is_antigravity_path(project_path) {
         StatsProvider::Antigravity
-    } else if project_path.contains(".codebuddy") {
+    } else if is_codebuddy_path(project_path) {
         StatsProvider::Codebuddy
     } else {
         StatsProvider::Claude
@@ -285,8 +285,9 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
         return StatsProvider::ForgeCode;
     }
 
-    // CodeBuddy: path contains .codebuddy
-    if session_path.contains(".codebuddy") {
+    // CodeBuddy: path is anchored under ~/.codebuddy/projects (not just substring
+    // match, which would misclassify paths like "/work/foo.codebuddy-test").
+    if is_codebuddy_path(session_path) {
         return StatsProvider::Codebuddy;
     }
 
@@ -311,6 +312,23 @@ fn is_antigravity_path(path: &str) -> bool {
     crate::commands::antigravity::resolve_antigravity_root()
         .map(|root| Path::new(path).starts_with(root.as_path()))
         .unwrap_or(false)
+}
+
+/// Whether `path` lies under `~/.codebuddy/projects/`. Anchored detection avoids
+/// false positives from arbitrary substrings (e.g. `/work/foo.codebuddy-test`).
+fn is_codebuddy_path(path: &str) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    is_codebuddy_path_under(path, &home)
+}
+
+/// Implementation of [`is_codebuddy_path`] parameterized by the home dir,
+/// so tests can drive the anchored check with a fixed home and not depend
+/// on whether the CI runner has a HOME env at all.
+fn is_codebuddy_path_under(path: &str, home: &Path) -> bool {
+    let root = home.join(".codebuddy").join("projects");
+    Path::new(path).starts_with(root)
 }
 
 /// Parse a line using simd-json (requires mutable slice)
@@ -5548,5 +5566,49 @@ mod tests {
         assert_eq!(stats.total_cache_creation_tokens, 28644);
         assert_eq!(stats.total_cache_read_tokens, 14732);
         assert_eq!(stats.total_tokens, 6 + 222 + 28644 + 14732);
+    }
+
+    /// `CodeBuddy` provider detection must be anchored under
+    /// `~/.codebuddy/projects`, not a substring match. Otherwise paths like
+    /// `/work/foo.codebuddy-test/...` get routed to `CodeBuddy` loaders that
+    /// then return empty / error, breaking stats for the actual provider.
+    /// Uses an injected home so the assertion is meaningful regardless of
+    /// the runner's environment.
+    #[test]
+    fn is_codebuddy_path_rejects_substring_lookalikes() {
+        let home = Path::new("/test-home/user");
+        // Substring-style matches that the OLD `path.contains(".codebuddy")`
+        // logic would have accepted — all must be rejected by the anchored
+        // version.
+        assert!(
+            !is_codebuddy_path_under("/work/foo.codebuddy-test/projects/abc.jsonl", home),
+            "name suffix lookalike must not match"
+        );
+        assert!(
+            !is_codebuddy_path_under("/Users/dev/notes/.codebuddy-clone/data.jsonl", home),
+            "hidden-dir lookalike must not match"
+        );
+        assert!(
+            !is_codebuddy_path_under("/tmp/sample.codebuddy.jsonl", home),
+            "filename containing the substring must not match"
+        );
+    }
+
+    /// Real-shaped `CodeBuddy` paths must still be detected. Mirrors the
+    /// runtime layout: `~/.codebuddy/projects/<project>/<session>.jsonl`.
+    /// Uses an injected home so the test does not silently skip on runners
+    /// without `$HOME` and does not depend on the actual user's filesystem.
+    #[test]
+    fn is_codebuddy_path_accepts_real_layout() {
+        let home = Path::new("/test-home/user");
+        let real = home
+            .join(".codebuddy")
+            .join("projects")
+            .join("my-project")
+            .join("session-1.jsonl");
+        assert!(
+            is_codebuddy_path_under(real.to_string_lossy().as_ref(), home),
+            "anchored detection must accept ~/.codebuddy/projects/.../*.jsonl"
+        );
     }
 }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -21,6 +21,7 @@ use walkdir::WalkDir;
 enum StatsProvider {
     #[default]
     Claude,
+    Codebuddy,
     Codex,
     ForgeCode,
     OpenCode,
@@ -56,6 +57,7 @@ fn parse_stats_mode(stats_mode: Option<String>) -> StatsMode {
 fn stats_provider_id(provider: StatsProvider) -> &'static str {
     match provider {
         StatsProvider::Claude => "claude",
+        StatsProvider::Codebuddy => "codebuddy",
         StatsProvider::Codex => "codex",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
@@ -209,6 +211,7 @@ fn should_include_stats_message(message: &ClaudeMessage, mode: StatsMode) -> boo
 fn all_stats_providers() -> HashSet<StatsProvider> {
     [
         StatsProvider::Claude,
+        StatsProvider::Codebuddy,
         StatsProvider::Codex,
         StatsProvider::ForgeCode,
         StatsProvider::OpenCode,
@@ -229,6 +232,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
         .into_iter()
         .filter_map(|provider| match provider.as_str() {
             "claude" => Some(StatsProvider::Claude),
+            "codebuddy" => Some(StatsProvider::Codebuddy),
             "codex" => Some(StatsProvider::Codex),
             "forgecode" => Some(StatsProvider::ForgeCode),
             "opencode" => Some(StatsProvider::OpenCode),
@@ -260,6 +264,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::OpenCode
     } else if is_antigravity_path(project_path) {
         StatsProvider::Antigravity
+    } else if project_path.contains(".codebuddy") {
+        StatsProvider::Codebuddy
     } else {
         StatsProvider::Claude
     }
@@ -277,6 +283,11 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
 
     if session_path.starts_with("forgecode://") || session_path.starts_with("forgecode-db://") {
         return StatsProvider::ForgeCode;
+    }
+
+    // CodeBuddy: path contains .codebuddy
+    if session_path.contains(".codebuddy") {
+        return StatsProvider::Codebuddy;
     }
 
     let is_rollout = PathBuf::from(session_path)
@@ -966,6 +977,7 @@ fn collect_provider_global_file_stats(
     }
 
     let projects = match provider {
+        StatsProvider::Codebuddy => providers::codebuddy::scan_projects().unwrap_or_default(),
         StatsProvider::Codex => providers::codex::scan_projects().unwrap_or_default(),
         StatsProvider::ForgeCode => providers::forgecode::scan_projects().unwrap_or_default(),
         StatsProvider::OpenCode => providers::opencode::scan_projects().unwrap_or_default(),
@@ -974,6 +986,7 @@ fn collect_provider_global_file_stats(
     };
 
     let provider_tag = match provider {
+        StatsProvider::Codebuddy => "codebuddy",
         StatsProvider::Codex => "codex",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
@@ -989,6 +1002,7 @@ fn collect_provider_global_file_stats(
         project_keys.insert(format!("{provider_tag}:{}", project.path));
 
         let sessions = match provider {
+            StatsProvider::Codebuddy => providers::codebuddy::load_sessions(&project.path, false),
             StatsProvider::Codex => providers::codex::load_sessions(&project.path, false),
             StatsProvider::ForgeCode => providers::forgecode::load_sessions(&project.path, false),
             StatsProvider::OpenCode => providers::opencode::load_sessions(&project.path, false),
@@ -1009,6 +1023,7 @@ fn collect_provider_global_file_stats(
         .par_iter()
         .filter_map(|(project_name, file_path)| {
             let messages = match provider {
+                StatsProvider::Codebuddy => providers::codebuddy::load_messages(file_path),
                 StatsProvider::Codex => providers::codex::load_messages(file_path),
                 StatsProvider::ForgeCode => providers::forgecode::load_messages(file_path),
                 StatsProvider::OpenCode => providers::opencode::load_messages(file_path),
@@ -1580,6 +1595,18 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
             .and_then(|n| n.to_str())
             .unwrap_or("Unknown")
             .to_string(),
+        StatsProvider::Codebuddy => {
+            if let Ok(projects) = providers::codebuddy::scan_projects() {
+                if let Some(project) = projects.into_iter().find(|p| p.path == project_path) {
+                    return project.name;
+                }
+            }
+            PathBuf::from(project_path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("Unknown")
+                .to_string()
+        }
         StatsProvider::Codex => {
             let cwd = project_path
                 .strip_prefix("codex://")
@@ -1646,6 +1673,19 @@ fn resolve_provider_project_name_from_session(
             let project_path = format!("opencode://{project_part}");
             resolve_provider_project_name(provider, &project_path)
         }
+        StatsProvider::Codebuddy => {
+            if let Ok(projects) = providers::codebuddy::scan_projects() {
+                for project in projects {
+                    if let Ok(sessions) = providers::codebuddy::load_sessions(&project.path, false)
+                    {
+                        if sessions.iter().any(|s| s.file_path == session_path) {
+                            return project.name;
+                        }
+                    }
+                }
+            }
+            "codebuddy".to_string()
+        }
         StatsProvider::Codex => {
             if let Ok(projects) = providers::codex::scan_projects() {
                 for project in projects {
@@ -1669,6 +1709,7 @@ fn load_provider_sessions_for_stats(
     project_path: &str,
 ) -> Result<Vec<crate::models::ClaudeSession>, String> {
     match provider {
+        StatsProvider::Codebuddy => providers::codebuddy::load_sessions(project_path, false),
         StatsProvider::Codex => providers::codex::load_sessions(project_path, false),
         StatsProvider::ForgeCode => providers::forgecode::load_sessions(project_path, false),
         StatsProvider::OpenCode => providers::opencode::load_sessions(project_path, false),
@@ -1685,6 +1726,7 @@ fn load_provider_messages_for_stats(
     session: &crate::models::ClaudeSession,
 ) -> Result<Vec<ClaudeMessage>, String> {
     match provider {
+        StatsProvider::Codebuddy => providers::codebuddy::load_messages(&session.file_path),
         StatsProvider::Codex => providers::codex::load_messages(&session.file_path),
         StatsProvider::ForgeCode => providers::forgecode::load_messages(&session.file_path),
         StatsProvider::OpenCode => providers::opencode::load_messages(&session.file_path),
@@ -2429,6 +2471,7 @@ pub async fn get_session_token_stats(
         }
 
         let messages = match provider {
+            StatsProvider::Codebuddy => providers::codebuddy::load_messages(&session_path)?,
             StatsProvider::Codex => providers::codex::load_messages(&session_path)?,
             StatsProvider::ForgeCode => providers::forgecode::load_messages(&session_path)?,
             StatsProvider::OpenCode => providers::opencode::load_messages(&session_path)?,
@@ -3270,6 +3313,13 @@ pub async fn get_global_stats_summary(
         .par_iter()
         .filter_map(|path| process_session_file_for_global_stats(path, mode, s_ref, e_ref))
         .collect();
+
+    if providers_to_include.contains(&StatsProvider::Codebuddy) {
+        let (codebuddy_stats, codebuddy_projects) =
+            collect_provider_global_file_stats(StatsProvider::Codebuddy, mode, s_ref, e_ref);
+        project_names.extend(codebuddy_projects);
+        file_stats.extend(codebuddy_stats);
+    }
 
     if providers_to_include.contains(&StatsProvider::Codex) {
         let (codex_stats, codex_projects) =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -542,6 +542,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(codebuddy_base) = providers::codebuddy::get_base_path() {
+        let codebuddy_projects = PathBuf::from(codebuddy_base);
+        if codebuddy_projects.is_dir() {
+            paths.push(codebuddy_projects);
+        }
+    }
+
     let mut seen = HashSet::new();
     paths
         .into_iter()

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -34,11 +34,20 @@ pub fn get_base_path() -> Option<String> {
     }
 }
 
-/// Scan `CodeBuddy` projects
+/// Scan `CodeBuddy` projects under the user's `~/.codebuddy/projects` root.
+///
+/// Thin wrapper over [`scan_projects_in`] that resolves the production root
+/// from `dirs::home_dir()`. Tests should call `scan_projects_in` directly with
+/// a tempdir so the assertion runs against the real production code path
+/// instead of a copy of the loop logic.
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     let base_path = get_base_path().ok_or("CodeBuddy projects path not found")?;
-    let base = Path::new(&base_path);
+    scan_projects_in(Path::new(&base_path))
+}
 
+/// Implementation of [`scan_projects`] parameterized by the projects root.
+/// Extracted so tests can pass an isolated tempdir.
+pub fn scan_projects_in(base: &Path) -> Result<Vec<ClaudeProject>, String> {
     let mut projects = Vec::new();
 
     for entry in WalkDir::new(base)
@@ -62,6 +71,15 @@ pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
             .filter_map(Result::ok)
             .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
         {
+            // Skip symlinked .jsonl entries: they could leak file counts and
+            // mtimes from outside the project root into the sidebar summary.
+            // Mirrors the symlink check in `load_sessions`.
+            if std::fs::symlink_metadata(jsonl_entry.path())
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+            {
+                continue;
+            }
             session_count += 1;
             if let Ok(metadata) = jsonl_entry.metadata() {
                 message_count += (metadata.len() / 500) as usize;
@@ -450,9 +468,9 @@ fn convert_function_call(
         "input": input,
     });
 
-    let content = Some(Value::Array(vec![tool_use.clone()]));
+    let content = Some(Value::Array(vec![tool_use]));
 
-    let mut msg = build_provider_message(
+    build_provider_message(
         PROVIDER_ID,
         uuid,
         session_id,
@@ -461,9 +479,7 @@ fn convert_function_call(
         Some("assistant"),
         content,
         None,
-    );
-    msg.tool_use = Some(tool_use);
-    msg
+    )
 }
 
 /// Convert a `"function_call_result"` entry to a Claude-native `tool_result`
@@ -736,7 +752,10 @@ mod tests {
         assert_eq!(tool_use["name"], "Bash");
         // Critical: input must be an OBJECT, not a string
         let input = &tool_use["input"];
-        assert!(input.is_object(), "input must be parsed object, got: {input:?}");
+        assert!(
+            input.is_object(),
+            "input must be parsed object, got: {input:?}"
+        );
         assert_eq!(input["command"], "ls -la");
         assert_eq!(input["description"], "list files");
     }
@@ -777,7 +796,8 @@ mod tests {
         });
 
         let mut counter = 0u64;
-        let msg = convert_function_call_result(&raw, "session-1", "2026-05-29T00:00:00Z", &mut counter);
+        let msg =
+            convert_function_call_result(&raw, "session-1", "2026-05-29T00:00:00Z", &mut counter);
 
         // Should be a "user" type message (Claude-native shape)
         assert_eq!(msg.message_type, "user");
@@ -884,6 +904,83 @@ mod tests {
         assert!(
             result.is_err(),
             "path outside codebuddy root must error, got: {result:?}"
+        );
+    }
+
+    /// Regression for the `function_call` -> `tool_use` conversion. Earlier
+    /// revisions wrote the `tool_use` entry to BOTH `msg.content[]` and the
+    /// top-level `msg.tool_use` field. That double-write doubled tool usage
+    /// counts in `track_tool_usage` and pushed success rate to 50%. Native
+    /// Claude JSONL only carries the entry inside `message.content[]`; the
+    /// top-level `tool_use` field stays `None` and downstream code (`load.rs`)
+    /// extracts from content as needed. This test pins that contract.
+    #[test]
+    fn function_call_does_not_double_write_tool_use() {
+        let raw = json!({
+            "type": "function_call",
+            "id": "fc-1",
+            "callId": "toolu_abc",
+            "name": "Bash",
+            "arguments": "{\"command\":\"ls\"}",
+            "timestamp": 1779785490404_i64,
+        });
+        let mut counter = 0u64;
+        let msg = convert_function_call(&raw, "session-1", "2026-05-29T00:00:00Z", &mut counter);
+
+        // Content array MUST carry the tool_use entry (so the UI renders it
+        // and `load.rs` extracts it on demand).
+        let content = msg.content.expect("content present");
+        let arr = content.as_array().expect("content is array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["type"], "tool_use");
+
+        // Top-level tool_use MUST stay None — duplicating the entry there
+        // re-introduces the stats double-counting bug.
+        assert!(
+            msg.tool_use.is_none(),
+            "top-level msg.tool_use must remain None to avoid stats double-count, got: {:?}",
+            msg.tool_use
+        );
+    }
+
+    /// Regression for `scan_projects` symlink handling. A symlinked `.jsonl`
+    /// inside a project directory used to be counted in the sidebar summary
+    /// (file count + mtime), leaking metadata about external files. The fix
+    /// skips entries whose `symlink_metadata().file_type().is_symlink()` is
+    /// true — same guard used by `load_sessions`.
+    ///
+    /// Calls the real `scan_projects_in` so any future change to the filter
+    /// chain is exercised by this test (no hand-rolled walkdir copy here).
+    #[cfg(unix)]
+    #[test]
+    fn scan_projects_skips_symlinked_jsonl() {
+        use std::os::unix::fs::symlink;
+
+        // Isolated projects root: `<tmp>/projects/<project>/`.
+        // `scan_projects_in` walks the dir we hand it as the projects root,
+        // so we point it at `<tmp>/projects` directly.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let projects_root = tmp.path().join("projects");
+        std::fs::create_dir(&projects_root).expect("create projects root");
+        let project_dir = projects_root.join("test-project");
+        std::fs::create_dir(&project_dir).expect("create project");
+
+        // One regular .jsonl file
+        let real = project_dir.join("real.jsonl");
+        std::fs::write(&real, b"{}\n").expect("write real");
+
+        // One .jsonl symlink pointing outside the project root entirely
+        let target = tmp.path().join("outside.jsonl");
+        std::fs::write(&target, b"{}\n").expect("write target");
+        let linked = project_dir.join("linked.jsonl");
+        symlink(&target, &linked).expect("create symlink");
+
+        // Drive the real production function with the tempdir root.
+        let projects = scan_projects_in(&projects_root).expect("scan ok");
+        assert_eq!(projects.len(), 1, "exactly one project should be reported");
+        assert_eq!(
+            projects[0].session_count, 1,
+            "symlinked .jsonl must not be counted; only the regular file should"
         );
     }
 }

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -1,10 +1,14 @@
 use super::ProviderInfo;
 use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
-use crate::utils::{build_provider_message, find_line_ranges, search_json_value_case_insensitive};
+use crate::utils::{
+    build_provider_message, decode_with_filesystem_check, find_line_ranges,
+    search_json_value_case_insensitive,
+};
 use chrono::{DateTime, Utc};
 use memmap2::Mmap;
 use serde_json::Value;
 use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 use walkdir::WalkDir;
 
@@ -59,10 +63,14 @@ pub fn scan_projects_in(base: &Path) -> Result<Vec<ClaudeProject>, String> {
     {
         let project_dir = entry.path();
 
-        // Count JSONL files
+        // Count JSONL files. While scanning, also opportunistically capture
+        // the first session file path so we can recover the project's real
+        // working directory from its `cwd` field (CodeBuddy's directory
+        // encoding is lossy when project names contain hyphens).
         let mut session_count = 0usize;
         let mut message_count = 0usize;
         let mut last_modified_ts = 0u64;
+        let mut sample_session_paths: Vec<std::path::PathBuf> = Vec::new();
 
         for jsonl_entry in WalkDir::new(project_dir)
             .min_depth(1)
@@ -81,6 +89,9 @@ pub fn scan_projects_in(base: &Path) -> Result<Vec<ClaudeProject>, String> {
                 continue;
             }
             session_count += 1;
+            if sample_session_paths.len() < 3 {
+                sample_session_paths.push(jsonl_entry.path().to_path_buf());
+            }
             if let Ok(metadata) = jsonl_entry.metadata() {
                 message_count += (metadata.len() / 500) as usize;
                 if let Ok(modified) = metadata.modified() {
@@ -100,7 +111,37 @@ pub fn scan_projects_in(base: &Path) -> Result<Vec<ClaudeProject>, String> {
             .and_then(|n| n.to_str())
             .unwrap_or("Unknown");
 
-        let display_name = dir_name.rsplit('-').next().unwrap_or(dir_name).to_string();
+        // Resolve the project's real path so we can show a faithful display
+        // name. CodeBuddy stores projects under names like
+        // `Users-rassyan-WebstormProjects-claude-code-history-viewer` — the
+        // path separator `/` is replaced by `-` without escaping, so a
+        // naive `rsplit('-').next()` would truncate hyphenated project
+        // names (`claude-code-history-viewer` -> `viewer`).
+        //
+        // Resolution order:
+        //   1. Read `cwd` from a session jsonl (CodeBuddy writes the real
+        //      absolute path on every message line) — 100% accurate.
+        //   2. Fall back to filesystem-existence-based decoding (same
+        //      strategy Claude Code uses in `utils::decode_project_path`).
+        //   3. Last resort: keep the existing rsplit('-') behavior so this
+        //      change cannot regress projects that previously displayed
+        //      correctly.
+        let resolved_path = read_cwd_from_jsonls(&sample_session_paths)
+            .or_else(|| decode_with_filesystem_check(dir_name));
+
+        let (display_name, actual_path) = match resolved_path {
+            Some(real_path) => {
+                let leaf = Path::new(&real_path)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| dir_name.to_string());
+                (leaf, real_path)
+            }
+            None => (
+                dir_name.rsplit('-').next().unwrap_or(dir_name).to_string(),
+                project_dir.to_string_lossy().to_string(),
+            ),
+        };
 
         #[allow(clippy::cast_possible_wrap)]
         let last_modified = if last_modified_ts > 0 {
@@ -113,8 +154,12 @@ pub fn scan_projects_in(base: &Path) -> Result<Vec<ClaudeProject>, String> {
 
         projects.push(ClaudeProject {
             name: display_name,
+            // `path` remains the on-disk storage path used to look up
+            // sessions later; `actual_path` is the user-facing real working
+            // directory (when we could recover it) so downstream features
+            // like git-info detection see the correct repo location.
             path: project_dir.to_string_lossy().to_string(),
-            actual_path: project_dir.to_string_lossy().to_string(),
+            actual_path,
             session_count,
             message_count,
             last_modified,
@@ -127,6 +172,39 @@ pub fn scan_projects_in(base: &Path) -> Result<Vec<ClaudeProject>, String> {
 
     projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(projects)
+}
+
+/// Try to extract the real working directory of a `CodeBuddy` project by
+/// reading the `cwd` field from the head of one of its session jsonl files.
+///
+/// `CodeBuddy` writes the real absolute path on every `type:"message"` line,
+/// so the first non-empty `cwd` we can parse is authoritative. We scan only
+/// the first few lines of at most 3 candidate files to keep this cheap
+/// during project listing.
+fn read_cwd_from_jsonls(candidates: &[std::path::PathBuf]) -> Option<String> {
+    const MAX_LINES_PER_FILE: usize = 10;
+
+    for path in candidates {
+        let Ok(file) = File::open(path) else { continue };
+        let reader = BufReader::new(file);
+        for line in reader.lines().take(MAX_LINES_PER_FILE).map_while(Result::ok) {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+                continue;
+            };
+            if let Some(cwd) = value.get("cwd").and_then(|v| v.as_str()) {
+                let cwd_trimmed = cwd.trim();
+                if !cwd_trimmed.is_empty() && Path::new(cwd_trimmed).is_absolute() {
+                    return Some(cwd_trimmed.to_string());
+                }
+            }
+        }
+    }
+
+    None
 }
 
 /// Load sessions for a `CodeBuddy` project
@@ -651,9 +729,13 @@ fn extract_session_info(file_path: &Path) -> Option<ClaudeSession> {
                 }
             }
             "topic" => {
-                if summary.is_none() {
-                    if let Some(topic) = val.get("topic").and_then(|v| v.as_str()) {
-                        summary = Some(topic.to_string());
+                // Last-wins: CodeBuddy may emit multiple `topic` entries as
+                // the conversation evolves. The latest one is the current
+                // session title, so always overwrite (ignoring empty strings).
+                if let Some(topic) = val.get("topic").and_then(|v| v.as_str()) {
+                    let trimmed = topic.trim();
+                    if !trimmed.is_empty() {
+                        summary = Some(trimmed.to_string());
                     }
                 }
             }
@@ -724,6 +806,18 @@ fn extract_session_info(file_path: &Path) -> Option<ClaudeSession> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::fmt::Write as _;
+
+    /// Serialize a slice of JSON values into a newline-delimited body for
+    /// writing a synthetic .jsonl test fixture. Equivalent to
+    /// `lines.iter().map(|v| format!("{v}\n")).collect::<String>()` but
+    /// satisfies `clippy::format_collect`.
+    fn join_jsonl(lines: &[serde_json::Value]) -> String {
+        lines.iter().fold(String::new(), |mut acc, v| {
+            let _ = writeln!(acc, "{v}");
+            acc
+        })
+    }
 
     /// `function_call.arguments` is a JSON string in `CodeBuddy`. Verify we
     /// parse it into a real object so frontend renderers can read individual
@@ -981,6 +1075,160 @@ mod tests {
         assert_eq!(
             projects[0].session_count, 1,
             "symlinked .jsonl must not be counted; only the regular file should"
+        );
+    }
+
+    /// `CodeBuddy` emits a `type:"topic"` entry every time the conversation's
+    /// running title updates. Earlier revisions kept only the FIRST topic
+    /// (because of an `if summary.is_none()` guard), which caused sessions
+    /// that started on one topic and pivoted to another to keep showing the
+    /// stale original title. Pin the last-wins contract.
+    #[test]
+    fn extract_session_info_uses_last_topic() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let projects_root = tmp.path().join("projects");
+        std::fs::create_dir(&projects_root).expect("create projects root");
+        let project_dir = projects_root.join("Users-foo-bar");
+        std::fs::create_dir(&project_dir).expect("create project");
+        let session_path = project_dir.join("session.jsonl");
+
+        // Two topics + a real message so the session passes the
+        // `message_count > 0` gate.
+        let lines = [
+            json!({"type": "topic", "topic": "Initial Topic", "timestamp": 1_700_000_000_000i64}),
+            json!({"type": "message", "role": "user", "sessionId": "s1",
+                    "timestamp": 1_700_000_001_000i64,
+                    "content": [{"type": "input_text", "text": "hello"}]}),
+            json!({"type": "topic", "topic": "Updated Topic", "timestamp": 1_700_000_002_000i64}),
+        ];
+        let body = join_jsonl(&lines);
+        std::fs::write(&session_path, body).expect("write session");
+
+        let session = extract_session_info(&session_path).expect("session parsed");
+        assert_eq!(
+            session.summary.as_deref(),
+            Some("Updated Topic"),
+            "later topic must override earlier one"
+        );
+    }
+
+    /// Defensive: a later `topic` entry whose value is empty/whitespace must
+    /// NOT clobber a previously-valid title. Otherwise a single accidental
+    /// empty topic write would erase the session label entirely.
+    #[test]
+    fn extract_session_info_ignores_empty_topic() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let projects_root = tmp.path().join("projects");
+        std::fs::create_dir(&projects_root).expect("create projects root");
+        let project_dir = projects_root.join("Users-foo-bar");
+        std::fs::create_dir(&project_dir).expect("create project");
+        let session_path = project_dir.join("session.jsonl");
+
+        let lines = [
+            json!({"type": "topic", "topic": "Real Topic", "timestamp": 1_700_000_000_000i64}),
+            json!({"type": "message", "role": "user", "sessionId": "s1",
+                    "timestamp": 1_700_000_001_000i64,
+                    "content": [{"type": "input_text", "text": "hello"}]}),
+            json!({"type": "topic", "topic": "   ", "timestamp": 1_700_000_002_000i64}),
+        ];
+        let body = join_jsonl(&lines);
+        std::fs::write(&session_path, body).expect("write session");
+
+        let session = extract_session_info(&session_path).expect("session parsed");
+        assert_eq!(
+            session.summary.as_deref(),
+            Some("Real Topic"),
+            "whitespace-only topic must not overwrite the prior valid one"
+        );
+    }
+
+    /// `scan_projects_in` must derive the display name from each session
+    /// file's `cwd` field rather than splitting the lossy directory name on
+    /// `-`. Without this, hyphenated project names like
+    /// `claude-code-history-viewer` get truncated to just `viewer`.
+    #[test]
+    fn scan_projects_uses_cwd_for_display_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let projects_root = tmp.path().join("projects");
+        std::fs::create_dir(&projects_root).expect("create projects root");
+
+        // Mimic CodeBuddy's lossy encoding: '/' -> '-', no escaping.
+        let project_dir = projects_root.join("Users-rassyan-WebstormProjects-claude-code-history-viewer");
+        std::fs::create_dir(&project_dir).expect("create project");
+
+        let session = project_dir.join("s.jsonl");
+        let line = json!({
+            "type": "message",
+            "role": "user",
+            "sessionId": "s1",
+            "timestamp": 1_700_000_000_000i64,
+            "cwd": "/Users/rassyan/WebstormProjects/claude-code-history-viewer",
+            "content": [{"type": "input_text", "text": "hi"}],
+        });
+        std::fs::write(&session, format!("{line}\n")).expect("write");
+
+        let projects = scan_projects_in(&projects_root).expect("scan ok");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(
+            projects[0].name, "claude-code-history-viewer",
+            "display name must keep the full hyphenated project leaf"
+        );
+        assert_eq!(
+            projects[0].actual_path, "/Users/rassyan/WebstormProjects/claude-code-history-viewer",
+            "actual_path must be the real cwd, not the lossy storage path"
+        );
+    }
+
+    /// If a project's sessions have no `cwd` (older format, corrupted, etc.)
+    /// the resolver must fall back to filesystem-existence-based decoding so
+    /// hyphenated leaves still survive. We build a real nested tempdir layout
+    /// so the filesystem check has something to recognize.
+    ///
+    /// Note: we canonicalize the tempdir path because on macOS `/var` is a
+    /// symlink to `/private/var`. `decode_with_filesystem_check` uses
+    /// `symlink_metadata` and refuses to recurse through symlinks (a
+    /// reasonable security stance), so without canonicalization the encoded
+    /// path starting with `var-folders-...` would never match the real
+    /// `/var -> /private/var` symlink.
+    #[test]
+    fn scan_projects_falls_back_to_fs_decoding_when_cwd_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let canonical_tmp = std::fs::canonicalize(tmp.path())
+            .expect("canonicalize tempdir");
+
+        let projects_root = canonical_tmp.join("projects");
+        std::fs::create_dir(&projects_root).expect("create projects root");
+
+        // Build a real on-disk path `<tmp>/work/hyphenated-leaf` so
+        // `decode_with_filesystem_check` can walk and recognize it.
+        let real_parent = canonical_tmp.join("work");
+        let real_leaf = real_parent.join("hyphenated-leaf");
+        std::fs::create_dir_all(&real_leaf).expect("create real layout");
+
+        // Build the matching CodeBuddy-style lossy encoding. We strip the
+        // leading `/` and join with `-`, mirroring how CodeBuddy actually
+        // names project directories on disk.
+        let real_leaf_str = real_leaf.to_string_lossy().to_string();
+        let encoded = real_leaf_str.trim_start_matches('/').replace('/', "-");
+        let project_dir = projects_root.join(&encoded);
+        std::fs::create_dir(&project_dir).expect("create project");
+
+        // Session without any `cwd` field — forces fallback path.
+        let session = project_dir.join("s.jsonl");
+        let line = json!({
+            "type": "message",
+            "role": "user",
+            "sessionId": "s1",
+            "timestamp": 1_700_000_000_000i64,
+            "content": [{"type": "input_text", "text": "hi"}],
+        });
+        std::fs::write(&session, format!("{line}\n")).expect("write");
+
+        let projects = scan_projects_in(&projects_root).expect("scan ok");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(
+            projects[0].name, "hyphenated-leaf",
+            "fs-decoding fallback must preserve the hyphenated leaf"
         );
     }
 }

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -187,7 +187,11 @@ fn read_cwd_from_jsonls(candidates: &[std::path::PathBuf]) -> Option<String> {
     for path in candidates {
         let Ok(file) = File::open(path) else { continue };
         let reader = BufReader::new(file);
-        for line in reader.lines().take(MAX_LINES_PER_FILE).map_while(Result::ok) {
+        for line in reader
+            .lines()
+            .take(MAX_LINES_PER_FILE)
+            .map_while(Result::ok)
+        {
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;
@@ -1153,7 +1157,8 @@ mod tests {
         std::fs::create_dir(&projects_root).expect("create projects root");
 
         // Mimic CodeBuddy's lossy encoding: '/' -> '-', no escaping.
-        let project_dir = projects_root.join("Users-rassyan-WebstormProjects-claude-code-history-viewer");
+        let project_dir =
+            projects_root.join("Users-rassyan-WebstormProjects-claude-code-history-viewer");
         std::fs::create_dir(&project_dir).expect("create project");
 
         let session = project_dir.join("s.jsonl");
@@ -1193,8 +1198,7 @@ mod tests {
     #[test]
     fn scan_projects_falls_back_to_fs_decoding_when_cwd_missing() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let canonical_tmp = std::fs::canonicalize(tmp.path())
-            .expect("canonicalize tempdir");
+        let canonical_tmp = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
 
         let projects_root = canonical_tmp.join("projects");
         std::fs::create_dir(&projects_root).expect("create projects root");

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -1,0 +1,889 @@
+use super::ProviderInfo;
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::utils::{build_provider_message, find_line_ranges, search_json_value_case_insensitive};
+use chrono::{DateTime, Utc};
+use memmap2::Mmap;
+use serde_json::Value;
+use std::fs::File;
+use std::path::Path;
+use walkdir::WalkDir;
+
+const PROVIDER_ID: &str = "codebuddy";
+
+/// Detect `CodeBuddy Code` installation
+pub fn detect() -> Option<ProviderInfo> {
+    let base_path = get_base_path()?;
+    let projects_path = Path::new(&base_path);
+
+    Some(ProviderInfo {
+        id: PROVIDER_ID.to_string(),
+        display_name: "CodeBuddy Code".to_string(),
+        base_path: base_path.clone(),
+        is_available: projects_path.exists() && projects_path.is_dir(),
+    })
+}
+
+/// Get the `CodeBuddy` projects base path (`~/.codebuddy/projects`)
+pub fn get_base_path() -> Option<String> {
+    let home = dirs::home_dir()?;
+    let projects_path = home.join(".codebuddy").join("projects");
+    if projects_path.exists() && projects_path.is_dir() {
+        Some(projects_path.to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
+/// Scan `CodeBuddy` projects
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let base_path = get_base_path().ok_or("CodeBuddy projects path not found")?;
+    let base = Path::new(&base_path);
+
+    let mut projects = Vec::new();
+
+    for entry in WalkDir::new(base)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_dir())
+    {
+        let project_dir = entry.path();
+
+        // Count JSONL files
+        let mut session_count = 0usize;
+        let mut message_count = 0usize;
+        let mut last_modified_ts = 0u64;
+
+        for jsonl_entry in WalkDir::new(project_dir)
+            .min_depth(1)
+            .max_depth(1)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
+        {
+            session_count += 1;
+            if let Ok(metadata) = jsonl_entry.metadata() {
+                message_count += (metadata.len() / 500) as usize;
+                if let Ok(modified) = metadata.modified() {
+                    if let Ok(dur) = modified.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                        last_modified_ts = last_modified_ts.max(dur.as_secs());
+                    }
+                }
+            }
+        }
+
+        if session_count == 0 {
+            continue;
+        }
+
+        let dir_name = project_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Unknown");
+
+        let display_name = dir_name.rsplit('-').next().unwrap_or(dir_name).to_string();
+
+        #[allow(clippy::cast_possible_wrap)]
+        let last_modified = if last_modified_ts > 0 {
+            DateTime::from_timestamp(last_modified_ts as i64, 0)
+                .unwrap_or_else(Utc::now)
+                .to_rfc3339()
+        } else {
+            Utc::now().to_rfc3339()
+        };
+
+        projects.push(ClaudeProject {
+            name: display_name,
+            path: project_dir.to_string_lossy().to_string(),
+            actual_path: project_dir.to_string_lossy().to_string(),
+            session_count,
+            message_count,
+            last_modified,
+            git_info: None,
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: None,
+            custom_directory_label: None,
+        });
+    }
+
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+/// Load sessions for a `CodeBuddy` project
+pub fn load_sessions(
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    if project_path.trim().is_empty() {
+        return Err("project_path is required".to_string());
+    }
+
+    let project_dir = Path::new(project_path);
+    if !project_dir.exists() || !project_dir.is_dir() {
+        return Ok(vec![]);
+    }
+
+    // Defense-in-depth: confine traversal to ~/.codebuddy/projects/<project>.
+    // Reject paths outside this root (path traversal) and reject the project
+    // dir itself if it is a symlink (potential symlink attack).
+    validate_session_path(project_dir)?;
+    if std::fs::symlink_metadata(project_dir)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return Err(format!(
+            "Project path must not be a symlink: {}",
+            project_dir.display()
+        ));
+    }
+
+    let mut sessions = Vec::new();
+
+    for entry in WalkDir::new(project_dir)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
+    {
+        let file_path = entry.path();
+        // Skip symlinked .jsonl files — they could point outside the
+        // project root we just validated.
+        if std::fs::symlink_metadata(file_path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        if let Some(session) = extract_session_info(file_path) {
+            sessions.push(session);
+        }
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+/// Load messages from a `CodeBuddy` session file
+#[allow(unsafe_code)]
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let path = Path::new(session_path);
+    if !path.exists() {
+        return Err(format!("Session file not found: {session_path}"));
+    }
+
+    validate_session_path(path)?;
+
+    let file = File::open(path).map_err(|e| e.to_string())?;
+    // SAFETY: File is read-only and we only read from the mapping
+    let mmap = unsafe { Mmap::map(&file) }.map_err(|e| e.to_string())?;
+    let ranges = find_line_ranges(&mmap);
+
+    let mut messages = Vec::new();
+    let mut session_id = String::new();
+    let mut msg_counter = 0u64;
+
+    for &(start, end) in &ranges {
+        let line = &mmap[start..end];
+        let mut buf = line.to_vec();
+        let val: Value = match simd_json::from_slice(&mut buf) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let line_type = val.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let timestamp = convert_timestamp(&val);
+
+        if session_id.is_empty() {
+            if let Some(sid) = val.get("sessionId").and_then(|v| v.as_str()) {
+                session_id = sid.to_string();
+            }
+        }
+
+        match line_type {
+            "message" => {
+                if let Some(msg) = convert_message(&val, &session_id, &timestamp, &mut msg_counter)
+                {
+                    messages.push(msg);
+                }
+            }
+            "function_call" => {
+                messages.push(convert_function_call(
+                    &val,
+                    &session_id,
+                    &timestamp,
+                    &mut msg_counter,
+                ));
+            }
+            "function_call_result" => {
+                messages.push(convert_function_call_result(
+                    &val,
+                    &session_id,
+                    &timestamp,
+                    &mut msg_counter,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(messages)
+}
+
+/// Search `CodeBuddy` sessions for a query string
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let base_path = get_base_path().ok_or("CodeBuddy not found")?;
+    let base = Path::new(&base_path);
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for entry in WalkDir::new(base)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
+    {
+        if results.len() >= limit {
+            break;
+        }
+
+        if let Ok(messages) = load_messages(&entry.path().to_string_lossy()) {
+            for msg in messages {
+                if results.len() >= limit {
+                    return Ok(results);
+                }
+                if let Some(content) = &msg.content {
+                    if search_json_value_case_insensitive(content, &query_lower) {
+                        results.push(msg);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/// Validate that a session path is within `~/.codebuddy/projects`
+fn validate_session_path(path: &Path) -> Result<(), String> {
+    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let allowed = home.join(".codebuddy").join("projects");
+
+    let canonical = if path.exists() {
+        path.canonicalize()
+            .map_err(|e| format!("Path canonicalization error: {e}"))?
+    } else {
+        path.to_path_buf()
+    };
+
+    let canonical_allowed = if allowed.exists() {
+        allowed
+            .canonicalize()
+            .map_err(|e| format!("Path canonicalization error: {e}"))?
+    } else {
+        allowed
+    };
+
+    if canonical.starts_with(&canonical_allowed) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Session path is outside CodeBuddy projects directory: {}",
+            path.display()
+        ))
+    }
+}
+
+/// Convert a numeric or string timestamp to ISO 8601 string.
+///
+/// `CodeBuddy` uses Unix milliseconds (numeric), while Claude uses ISO 8601 strings.
+fn convert_timestamp(val: &Value) -> String {
+    match val.get("timestamp") {
+        Some(Value::Number(n)) => {
+            if let Some(ms) = n.as_i64() {
+                DateTime::from_timestamp_millis(ms)
+                    .unwrap_or_else(Utc::now)
+                    .to_rfc3339()
+            } else {
+                Utc::now().to_rfc3339()
+            }
+        }
+        Some(Value::String(s)) => s.clone(),
+        _ => Utc::now().to_rfc3339(),
+    }
+}
+
+/// Convert content array: `input_text`/`output_text` -> `text`
+fn convert_content_array(content: Option<&Value>) -> Option<Value> {
+    let arr = content?.as_array()?;
+
+    let items: Vec<Value> = arr
+        .iter()
+        .filter_map(|item| {
+            let ctype = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            match ctype {
+                "input_text" | "output_text" | "text" => {
+                    let text = item.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                    Some(serde_json::json!({
+                        "type": "text",
+                        "text": text
+                    }))
+                }
+                "image_blob_ref" => Some(item.clone()),
+                _ => None,
+            }
+        })
+        .collect();
+
+    if items.is_empty() {
+        None
+    } else {
+        Some(Value::Array(items))
+    }
+}
+
+/// Convert a `"message"` type entry to `ClaudeMessage`
+fn convert_message(
+    val: &Value,
+    session_id: &str,
+    timestamp: &str,
+    counter: &mut u64,
+) -> Option<ClaudeMessage> {
+    let role = val.get("role").and_then(|r| r.as_str())?;
+
+    // Skip system-injected messages (providerData.skipRun with XML content)
+    if val
+        .get("providerData")
+        .and_then(|pd| pd.get("skipRun"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        if let Some(content) = val.get("content") {
+            if let Some(arr) = content.as_array() {
+                if let Some(first) = arr.first() {
+                    if let Some(text) = first.get("text").and_then(|t| t.as_str()) {
+                        if text.starts_with("<system-reminder")
+                            || text.starts_with("<command-name>")
+                            || text.starts_with("<local-command-stdout>")
+                        {
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *counter += 1;
+    let uuid = val
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| format!("codebuddy-{counter}"));
+
+    let message_type = match role {
+        "assistant" => "assistant",
+        "system" => "system",
+        _ => "user",
+    };
+
+    let content = convert_content_array(val.get("content"));
+
+    Some(build_provider_message(
+        PROVIDER_ID,
+        uuid,
+        session_id,
+        timestamp.to_string(),
+        message_type,
+        Some(role),
+        content,
+        None,
+    ))
+}
+
+/// Convert a `"function_call"` entry to a Claude-native `tool_use` message.
+///
+/// Output mirrors Claude Code's assistant-with-`tool_use` format:
+///   - top-level type: "assistant"
+///   - content: `[{type:"tool_use", id:<callId>, name, input:<parsed object>}]`
+///
+/// Note `arguments` in `CodeBuddy` JSONL is a JSON-encoded **string** (e.g.
+/// `"{\"command\":\"ls\"}"`), not an object. We parse it so the frontend
+/// renderers (`BashCard`, `GrepCard`, etc.) can read individual params.
+fn convert_function_call(
+    val: &Value,
+    session_id: &str,
+    timestamp: &str,
+    counter: &mut u64,
+) -> ClaudeMessage {
+    *counter += 1;
+    let uuid = val
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| format!("codebuddy-fc-{counter}"));
+
+    let name = val
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown_tool");
+    // Use callId as the tool_use id — that's what frontend pairs results by.
+    let call_id = val.get("callId").and_then(|v| v.as_str()).unwrap_or("");
+
+    // arguments is a JSON-encoded string in CodeBuddy. Parse to object so
+    // BashCard etc. can read input.command, input.pattern, input.file_path.
+    let input = match val.get("arguments") {
+        Some(Value::String(s)) => serde_json::from_str::<Value>(s).unwrap_or(Value::Null),
+        Some(other) => other.clone(),
+        None => Value::Null,
+    };
+
+    let tool_use = serde_json::json!({
+        "type": "tool_use",
+        "id": call_id,
+        "name": name,
+        "input": input,
+    });
+
+    let content = Some(Value::Array(vec![tool_use.clone()]));
+
+    let mut msg = build_provider_message(
+        PROVIDER_ID,
+        uuid,
+        session_id,
+        timestamp.to_string(),
+        "assistant",
+        Some("assistant"),
+        content,
+        None,
+    );
+    msg.tool_use = Some(tool_use);
+    msg
+}
+
+/// Convert a `"function_call_result"` entry to a Claude-native `tool_result`
+/// message.
+///
+/// Output mirrors Claude Code's user-with-`tool_result` format:
+///   - top-level type: "user"
+///   - content: `[{type:"tool_result", tool_use_id:<callId>, content:<text>}]`
+///   - top-level `toolUseResult` field (so the legacy `ToolExecutionResultRouter`
+///     also renders it, matching Claude's UI behavior).
+///
+/// Source field shape: `CodeBuddy` puts result text under `output` (not
+/// `content`) and looks like `{type:"text", text:"..."}` or
+/// `{type:"text", text:"...", title:"..."}`.
+fn convert_function_call_result(
+    val: &Value,
+    session_id: &str,
+    timestamp: &str,
+    counter: &mut u64,
+) -> ClaudeMessage {
+    *counter += 1;
+    let uuid = val
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| format!("codebuddy-fcr-{counter}"));
+
+    let call_id = val.get("callId").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Extract text from `output` (CodeBuddy's actual field). Fall back to
+    // `content`/`message.content` for forward-compat with format changes.
+    let text = val
+        .get("output")
+        .and_then(|o| {
+            o.get("text")
+                .and_then(|t| t.as_str())
+                .map(String::from)
+                .or_else(|| {
+                    // output may itself be a string in some variants
+                    o.as_str().map(String::from)
+                })
+        })
+        .or_else(|| {
+            val.get("content")
+                .and_then(|c| c.as_str())
+                .map(String::from)
+        })
+        .or_else(|| {
+            val.get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_default();
+
+    let is_error = val.get("status").and_then(|s| s.as_str()) == Some("error");
+
+    // Build inline tool_result item — frontend matches by tool_use_id.
+    let mut tool_result_item = serde_json::json!({
+        "type": "tool_result",
+        "tool_use_id": call_id,
+        "content": text,
+    });
+    if is_error {
+        tool_result_item["is_error"] = Value::Bool(true);
+    }
+
+    let content = Some(Value::Array(vec![tool_result_item.clone()]));
+
+    let mut msg = build_provider_message(
+        PROVIDER_ID,
+        uuid,
+        session_id,
+        timestamp.to_string(),
+        "user",
+        Some("user"),
+        content,
+        None,
+    );
+    // Also set the legacy top-level toolUseResult field so the
+    // ToolExecutionResultRouter renders the result block (matches Claude).
+    msg.tool_use_result = Some(tool_result_item);
+    msg
+}
+
+/// Extract session metadata from a JSONL file
+#[allow(unsafe_code)]
+fn extract_session_info(file_path: &Path) -> Option<ClaudeSession> {
+    let file = File::open(file_path).ok()?;
+    // SAFETY: File is read-only
+    let mmap = unsafe { Mmap::map(&file) }.ok()?;
+    let ranges = find_line_ranges(&mmap);
+
+    let mut session_id = String::new();
+    let mut message_count = 0usize;
+    let mut first_time = String::new();
+    let mut last_time = String::new();
+    let mut has_tool_use = false;
+    let mut summary: Option<String> = None;
+    let mut first_user_text: Option<String> = None;
+
+    for &(start, end) in &ranges {
+        let line = &mmap[start..end];
+        let mut buf = line.to_vec();
+        let val: Value = match simd_json::from_slice(&mut buf) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let line_type = val.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let timestamp = convert_timestamp(&val);
+
+        match line_type {
+            "message" => {
+                let role = val.get("role").and_then(|r| r.as_str()).unwrap_or("");
+
+                if val
+                    .get("providerData")
+                    .and_then(|pd| pd.get("skipRun"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+
+                if session_id.is_empty() {
+                    if let Some(sid) = val.get("sessionId").and_then(|v| v.as_str()) {
+                        session_id = sid.to_string();
+                    }
+                }
+
+                message_count += 1;
+
+                if first_time.is_empty() {
+                    first_time.clone_from(&timestamp);
+                }
+                last_time = timestamp;
+
+                if first_user_text.is_none() && role == "user" {
+                    if let Some(content) = val.get("content").and_then(|c| c.as_array()) {
+                        for item in content {
+                            if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                                if !text.starts_with('<') {
+                                    let truncated = if text.chars().count() > 100 {
+                                        format!("{}...", text.chars().take(100).collect::<String>())
+                                    } else {
+                                        text.to_string()
+                                    };
+                                    first_user_text = Some(truncated);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            "function_call" | "function_call_result" => {
+                message_count += 1;
+                has_tool_use = true;
+
+                if first_time.is_empty() {
+                    first_time.clone_from(&timestamp);
+                }
+                last_time = timestamp;
+            }
+            "summary" => {
+                if let Some(s) = val.get("summary").and_then(|v| v.as_str()) {
+                    summary = Some(s.to_string());
+                }
+            }
+            "topic" => {
+                if summary.is_none() {
+                    if let Some(topic) = val.get("topic").and_then(|v| v.as_str()) {
+                        summary = Some(topic.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if message_count == 0 {
+        return None;
+    }
+
+    let file_path_str = file_path.to_string_lossy().to_string();
+    let project_name = file_path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("Unknown")
+        .to_string();
+
+    let last_modified = file_path
+        .metadata()
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .map(|t| {
+            let dt: DateTime<Utc> = t.into();
+            dt.to_rfc3339()
+        })
+        .unwrap_or_else(|| Utc::now().to_rfc3339());
+
+    let final_summary = summary.or(first_user_text);
+
+    Some(ClaudeSession {
+        session_id: file_path_str.clone(),
+        actual_session_id: if session_id.is_empty() {
+            file_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        } else {
+            session_id
+        },
+        file_path: file_path_str,
+        project_name,
+        message_count,
+        first_message_time: if first_time.is_empty() {
+            Utc::now().to_rfc3339()
+        } else {
+            first_time
+        },
+        last_message_time: if last_time.is_empty() {
+            Utc::now().to_rfc3339()
+        } else {
+            last_time
+        },
+        last_modified,
+        has_tool_use,
+        has_errors: false,
+        summary: final_summary,
+        is_renamed: false,
+        provider: Some(PROVIDER_ID.to_string()),
+        storage_type: None,
+        entrypoint: Some("cli".to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// `function_call.arguments` is a JSON string in `CodeBuddy`. Verify we
+    /// parse it into a real object so frontend renderers can read individual
+    /// params (e.g. `BashCard` reads `input.command`).
+    #[test]
+    fn function_call_parses_arguments_string_to_object() {
+        let raw = json!({
+            "type": "function_call",
+            "id": "fc-1",
+            "callId": "toolu_abc",
+            "name": "Bash",
+            "arguments": "{\"command\":\"ls -la\",\"description\":\"list files\"}",
+            "timestamp": 1779785490404_i64,
+        });
+
+        let mut counter = 0u64;
+        let msg = convert_function_call(&raw, "session-1", "2026-05-29T00:00:00Z", &mut counter);
+
+        let content = msg.content.expect("content present");
+        let arr = content.as_array().expect("content is array");
+        assert_eq!(arr.len(), 1);
+        let tool_use = &arr[0];
+
+        assert_eq!(tool_use["type"], "tool_use");
+        assert_eq!(tool_use["id"], "toolu_abc");
+        assert_eq!(tool_use["name"], "Bash");
+        // Critical: input must be an OBJECT, not a string
+        let input = &tool_use["input"];
+        assert!(input.is_object(), "input must be parsed object, got: {input:?}");
+        assert_eq!(input["command"], "ls -la");
+        assert_eq!(input["description"], "list files");
+    }
+
+    /// Even when arguments is malformed JSON, conversion shouldn't panic —
+    /// it should fall back to `Value::Null` so the message still renders.
+    #[test]
+    fn function_call_handles_malformed_arguments_gracefully() {
+        let raw = json!({
+            "type": "function_call",
+            "callId": "toolu_x",
+            "name": "Bash",
+            "arguments": "this is not json",
+        });
+        let mut counter = 0u64;
+        let msg = convert_function_call(&raw, "s", "t", &mut counter);
+        let content = msg.content.unwrap();
+        let tool_use = &content[0];
+        // Either Null or a string — but must NOT panic
+        assert!(tool_use["input"].is_null() || tool_use["input"].is_string());
+    }
+
+    /// `function_call_result.output` is the result text source (NOT `content`).
+    /// Verify we extract it and produce a Claude-native `tool_result` with
+    /// `tool_use_id` matching the original `callId`.
+    #[test]
+    fn function_call_result_extracts_output_field() {
+        let raw = json!({
+            "type": "function_call_result",
+            "id": "fcr-1",
+            "callId": "toolu_abc",
+            "name": "Bash",
+            "status": "completed",
+            "output": {
+                "type": "text",
+                "text": "file1.txt\nfile2.txt\n"
+            },
+        });
+
+        let mut counter = 0u64;
+        let msg = convert_function_call_result(&raw, "session-1", "2026-05-29T00:00:00Z", &mut counter);
+
+        // Should be a "user" type message (Claude-native shape)
+        assert_eq!(msg.message_type, "user");
+
+        let content = msg.content.expect("content present");
+        let arr = content.as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+
+        let tool_result = &arr[0];
+        assert_eq!(tool_result["type"], "tool_result");
+        // Critical: tool_use_id must equal original callId so frontend can pair
+        assert_eq!(tool_result["tool_use_id"], "toolu_abc");
+        // Critical: text from output.text — not from content
+        assert_eq!(tool_result["content"], "file1.txt\nfile2.txt\n");
+        // Status "completed" should NOT set is_error
+        assert!(tool_result.get("is_error").is_none());
+
+        // Top-level toolUseResult also set (so legacy router renders it)
+        assert!(msg.tool_use_result.is_some());
+    }
+
+    /// Error status should mark the result as `is_error: true` so the
+    /// `StatusBadge` shows the red "error" state instead of green "completed".
+    #[test]
+    fn function_call_result_marks_errors() {
+        let raw = json!({
+            "type": "function_call_result",
+            "callId": "toolu_y",
+            "status": "error",
+            "output": { "type": "text", "text": "command not found" },
+        });
+        let mut counter = 0u64;
+        let msg = convert_function_call_result(&raw, "s", "t", &mut counter);
+        let content = msg.content.unwrap();
+        let tool_result = &content[0];
+        assert_eq!(tool_result["is_error"], true);
+    }
+
+    /// `convert_message` must preserve the `system` role rather than coerce it
+    /// into `user`. The previous `if/else` collapsed everything non-assistant
+    /// into "user", which mislabeled system reminders / command output messages
+    /// and broke filtering & visual distinction in the UI.
+    #[test]
+    fn convert_message_preserves_system_role() {
+        let raw = json!({
+            "type": "message",
+            "id": "msg-sys-1",
+            "role": "system",
+            "sessionId": "session-1",
+            "timestamp": 1779785490404_i64,
+            "content": [{"type": "text", "text": "system reminder"}],
+        });
+
+        let mut counter = 0u64;
+        let msg = convert_message(&raw, "session-1", "2026-05-29T00:00:00Z", &mut counter)
+            .expect("system message should not be filtered out");
+
+        assert_eq!(
+            msg.message_type, "system",
+            "system role must produce message_type == \"system\""
+        );
+        assert_eq!(msg.role.as_deref(), Some("system"));
+    }
+
+    /// Sanity check: assistant role still maps to "assistant".
+    #[test]
+    fn convert_message_preserves_assistant_role() {
+        let raw = json!({
+            "type": "message",
+            "id": "msg-a-1",
+            "role": "assistant",
+            "sessionId": "session-1",
+            "timestamp": 1779785490404_i64,
+            "content": [{"type": "output_text", "text": "hi"}],
+        });
+        let mut counter = 0u64;
+        let msg = convert_message(&raw, "session-1", "2026-05-29T00:00:00Z", &mut counter).unwrap();
+        assert_eq!(msg.message_type, "assistant");
+    }
+
+    /// `load_sessions` must reject empty paths up-front. Defense in depth:
+    /// caller code should not pass empty paths, but if it does we want a clear
+    /// error rather than silently scanning whatever `Path::new("")` resolves to.
+    #[test]
+    fn load_sessions_rejects_empty_path() {
+        let result = load_sessions("", false);
+        assert!(result.is_err(), "empty path must error, got: {result:?}");
+        assert!(
+            result.unwrap_err().contains("required"),
+            "error message should mention the missing parameter"
+        );
+    }
+
+    /// `load_sessions` must reject paths outside `~/.codebuddy/projects` to
+    /// prevent path-traversal-style reads of arbitrary directories on disk.
+    #[test]
+    fn load_sessions_rejects_path_outside_codebuddy_root() {
+        // /tmp definitely exists on macOS/Linux and is outside the codebuddy
+        // root. The function checks existence first, so we need a real path.
+        let result = load_sessions("/tmp", false);
+        // Either errors with the "outside" message, or — if /tmp doesn't
+        // canonicalize on this platform — errors with a canonicalize message.
+        // Both are acceptable; what we want to guard against is `Ok(...)`.
+        assert!(
+            result.is_err(),
+            "path outside codebuddy root must error, got: {result:?}"
+        );
+    }
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -4,6 +4,7 @@ pub mod aider;
 pub mod antigravity;
 pub mod claude;
 pub mod cline;
+pub mod codebuddy;
 pub mod codex;
 pub mod cursor;
 pub mod forgecode;
@@ -17,6 +18,7 @@ pub enum ProviderId {
     Aider,
     Claude,
     Cline,
+    Codebuddy,
     Codex,
     Cursor,
     Gemini,
@@ -31,6 +33,7 @@ impl ProviderId {
             Self::Aider => "aider",
             Self::Claude => "claude",
             Self::Cline => "cline",
+            Self::Codebuddy => "codebuddy",
             Self::Codex => "codex",
             Self::Cursor => "cursor",
             Self::Gemini => "gemini",
@@ -45,6 +48,7 @@ impl ProviderId {
             "aider" => Some(Self::Aider),
             "claude" => Some(Self::Claude),
             "cline" => Some(Self::Cline),
+            "codebuddy" => Some(Self::Codebuddy),
             "codex" => Some(Self::Codex),
             "cursor" => Some(Self::Cursor),
             "gemini" => Some(Self::Gemini),
@@ -60,6 +64,7 @@ impl ProviderId {
             Self::Aider => "Aider",
             Self::Claude => "Claude Code",
             Self::Cline => "Cline",
+            Self::Codebuddy => "CodeBuddy Code",
             Self::Codex => "Codex CLI",
             Self::Cursor => "Cursor",
             Self::Gemini => "Gemini CLI",
@@ -108,6 +113,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = antigravity::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = codebuddy::detect() {
         providers.push(info);
     }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -227,7 +227,7 @@ pub fn decode_project_path(session_storage_path: &str) -> String {
 /// 2. Check `/Users/jack` (exists? continue)
 /// 3. Check `/Users/jack/client` (exists? continue)
 /// 4. Check `/Users/jack/client/claude-code-history-viewer` (exists? ✓ return this)
-fn decode_with_filesystem_check(encoded: &str) -> Option<String> {
+pub(crate) fn decode_with_filesystem_check(encoded: &str) -> Option<String> {
     decode_recursive(encoded, "")
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { useAppStore } from "./store/useAppStore";
 import { useAnalytics } from "./hooks/useAnalytics";
 import { useUpdater } from "./hooks/useUpdater";
@@ -280,20 +281,60 @@ function App() {
         setIsViewingGlobalStats(false);
         setAnalyticsCurrentView("messages");
 
-        const currentProject = useAppStore.getState().selectedProject;
-        if (!currentProject || currentProject.name !== session.project_name) {
-          const project = projects.find((p) => p.name === session.project_name);
-          if (project) {
-            await selectProject(project);
+        // Find the project this session belongs to.
+        //
+        // Comparing `project.name === session.project_name` is unreliable
+        // across providers: each provider picks its own way to turn a raw
+        // on-disk directory (e.g. "Users-foo-Projects-bar") into a sidebar
+        // display label, and `session.project_name` is set by the loader,
+        // not by the sidebar. CodeBuddy in particular shortens
+        // `dir_name.rsplit('-').next()` for its sidebar label while the
+        // session loader keeps the encoded form — the two never match,
+        // so the previous equality check failed to switch to the right
+        // project when a session was selected.
+        //
+        // The path prefix is the one signal that's stable everywhere:
+        // a session's `file_path` always lives under its project's `path`.
+        // Match on that first, fall back to the name equality only when
+        // `file_path` is unavailable.
+        //
+        // The prefix match must respect the path-segment boundary so
+        // sibling projects sharing a parent dir don't collide — without
+        // this, `/a/proj` would also match a session under `/a/proj2`.
+        const findProjectForSession = (s: ClaudeSession) => {
+          if (s.file_path) {
+            const fp = s.file_path;
+            const byPath = projects.find((p) => {
+              if (!fp.startsWith(p.path)) return false;
+              if (fp.length === p.path.length) return true;
+              const next = fp.charAt(p.path.length);
+              return next === "/" || next === "\\";
+            });
+            if (byPath) return byPath;
           }
+          return projects.find((p) => p.name === s.project_name);
+        };
+
+        const targetProject = findProjectForSession(session);
+        const currentProject = useAppStore.getState().selectedProject;
+        if (
+          targetProject &&
+          (!currentProject || currentProject.path !== targetProject.path)
+        ) {
+          await selectProject(targetProject);
         }
 
         await selectSession(session);
       } catch (error) {
+        // Per CLAUDE.md "에러 처리": async failures need user-visible
+        // feedback (toast/alert). console.error alone leaves the user
+        // staring at a sidebar that didn't react to their click.
         console.error("Failed to select session:", error);
+        const message = error instanceof Error ? error.message : String(error);
+        toast.error(`${t("session.selectError")}: ${message}`);
       }
     },
-    [projects, selectProject, selectSession, setAnalyticsCurrentView]
+    [projects, selectProject, selectSession, setAnalyticsCurrentView, t]
   );
 
   const handleTokenStatClick = useCallback(

--- a/src/components/ProjectTree/components/ProjectItem.tsx
+++ b/src/components/ProjectTree/components/ProjectItem.tsx
@@ -149,6 +149,7 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
             "px-1.5 py-0.5 text-2xs font-medium rounded-full flex-shrink-0 leading-none",
             providerId === "claude" && "bg-amber-500/15 text-amber-700 dark:text-amber-300",
             providerId === "cline" && "bg-teal-500/15 text-teal-600 dark:text-teal-400",
+            providerId === "codebuddy" && "bg-sky-500/15 text-sky-600 dark:text-sky-400",
             providerId === "codex" && "bg-green-500/15 text-green-600 dark:text-green-400",
             providerId === "cursor" && "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",
             providerId === "gemini" && "bg-purple-500/15 text-purple-600 dark:text-purple-400",

--- a/src/components/ProjectTree/components/ProjectItem.tsx
+++ b/src/components/ProjectTree/components/ProjectItem.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import type { ProjectItemProps } from "../types";
 import { getWorktreeLabel } from "../../../utils/worktreeUtils";
-import { getProviderId, getProviderLabel } from "../../../utils/providers";
+import { getProviderId, getProviderLabel, getProviderBadgeStyle } from "../../../utils/providers";
 
 export const ProjectItem: React.FC<ProjectItemProps> = ({
   project,
@@ -147,15 +147,7 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
         <span
           className={cn(
             "px-1.5 py-0.5 text-2xs font-medium rounded-full flex-shrink-0 leading-none",
-            providerId === "claude" && "bg-amber-500/15 text-amber-700 dark:text-amber-300",
-            providerId === "cline" && "bg-teal-500/15 text-teal-600 dark:text-teal-400",
-            providerId === "codebuddy" && "bg-sky-500/15 text-sky-600 dark:text-sky-400",
-            providerId === "codex" && "bg-green-500/15 text-green-600 dark:text-green-400",
-            providerId === "cursor" && "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",
-            providerId === "gemini" && "bg-purple-500/15 text-purple-600 dark:text-purple-400",
-            providerId === "opencode" && "bg-blue-500/15 text-blue-600 dark:text-blue-400",
-            providerId === "aider" && "bg-rose-500/15 text-rose-600 dark:text-rose-400",
-            providerId === "forgecode" && "bg-orange-500/15 text-orange-700 dark:text-orange-300"
+            getProviderBadgeStyle(providerId)
           )}
         >
           {providerLabel}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -105,6 +105,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       antigravity: 0,
       claude: 0,
       cline: 0,
+      codebuddy: 0,
       codex: 0,
       cursor: 0,
       forgecode: 0,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -120,6 +120,7 @@
   "common.provider.aider": "Aider",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
+  "common.provider.codebuddy": "CodeBuddy Code",
   "common.provider.codex": "Codex CLI",
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -98,6 +98,7 @@
   "session.revealError": "Could not reveal file",
   "session.deleteConfirm": "This will move the session file and all associated data (subagents, tool results) to the trash.",
   "session.deleteError": "Failed to delete session",
+  "session.selectError": "Failed to open session",
   "session.deleteSession": "Delete Session",
   "session.deleteSuccess": "Session deleted",
   "session.deleteTitle": "Delete Session",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -120,6 +120,7 @@
   "common.provider.aider": "Aider",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
+  "common.provider.codebuddy": "CodeBuddy Code",
   "common.provider.codex": "Codex CLI",
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",

--- a/src/i18n/locales/ja/session.json
+++ b/src/i18n/locales/ja/session.json
@@ -98,6 +98,7 @@
   "session.revealError": "ファイルを表示できませんでした",
   "session.deleteConfirm": "セッションファイルと関連するすべてのデータ（サブエージェント、ツール結果）がゴミ箱に移動されます。",
   "session.deleteError": "セッションの削除に失敗しました",
+  "session.selectError": "セッションを開けませんでした",
   "session.deleteSession": "セッションを削除",
   "session.deleteSuccess": "セッションを削除しました",
   "session.deleteTitle": "セッションを削除",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -120,6 +120,7 @@
   "common.provider.aider": "Aider",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
+  "common.provider.codebuddy": "CodeBuddy Code",
   "common.provider.codex": "Codex CLI",
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",

--- a/src/i18n/locales/ko/session.json
+++ b/src/i18n/locales/ko/session.json
@@ -98,6 +98,7 @@
   "session.revealError": "파일을 열 수 없습니다",
   "session.deleteConfirm": "세션 파일과 관련된 모든 데이터(서브에이전트, 도구 결과)가 휴지통으로 이동됩니다.",
   "session.deleteError": "세션 삭제에 실패했습니다",
+  "session.selectError": "세션을 열 수 없습니다",
   "session.deleteSession": "세션 삭제",
   "session.deleteSuccess": "세션이 삭제되었습니다",
   "session.deleteTitle": "세션 삭제",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -120,6 +120,7 @@
   "common.provider.aider": "Aider",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
+  "common.provider.codebuddy": "CodeBuddy Code",
   "common.provider.codex": "Codex CLI",
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",

--- a/src/i18n/locales/zh-CN/session.json
+++ b/src/i18n/locales/zh-CN/session.json
@@ -98,6 +98,7 @@
   "session.revealError": "无法显示文件",
   "session.deleteConfirm": "这将把会话文件及所有相关数据（子代理、工具结果）移至回收站。",
   "session.deleteError": "删除会话失败",
+  "session.selectError": "打开会话失败",
   "session.deleteSession": "删除会话",
   "session.deleteSuccess": "会话已删除",
   "session.deleteTitle": "删除会话",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -120,6 +120,7 @@
   "common.provider.aider": "Aider",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
+  "common.provider.codebuddy": "CodeBuddy Code",
   "common.provider.codex": "Codex CLI",
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",

--- a/src/i18n/locales/zh-TW/session.json
+++ b/src/i18n/locales/zh-TW/session.json
@@ -98,6 +98,7 @@
   "session.revealError": "無法顯示檔案",
   "session.deleteConfirm": "這將把會話檔案及所有相關資料（子代理、工具結果）移至垃圾桶。",
   "session.deleteError": "刪除會話失敗",
+  "session.selectError": "開啟會話失敗",
   "session.deleteSession": "刪除會話",
   "session.deleteSuccess": "會話已刪除",
   "session.deleteTitle": "刪除會話",

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -43,6 +43,7 @@ describe("providers utils", () => {
       "antigravity",
       "claude",
       "cline",
+      "codebuddy",
       "codex",
       "cursor",
       "forgecode",

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "antigravity" | "claude" | "cline" | "codex" | "cursor" | "forgecode" | "gemini" | "opencode";
+export type ProviderId = "aider" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "cursor" | "forgecode" | "gemini" | "opencode";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "antigravity", "claude", "cline", "codex", "cursor", "forgecode", "gemini", "opencode"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "antigravity", "claude", "cline", "codebuddy", "codex", "cursor", "forgecode", "gemini", "opencode"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -11,6 +11,7 @@ const PROVIDER_TRANSLATIONS: Record<
   antigravity: { key: "common.provider.antigravity", fallback: "Antigravity" },
   claude: { key: "common.provider.claude", fallback: "Claude Code" },
   cline: { key: "common.provider.cline", fallback: "Cline" },
+  codebuddy: { key: "common.provider.codebuddy", fallback: "CodeBuddy Code" },
   codex: { key: "common.provider.codex", fallback: "Codex CLI" },
   cursor: { key: "common.provider.cursor", fallback: "Cursor" },
   forgecode: { key: "common.provider.forgecode", fallback: "ForgeCode" },
@@ -51,6 +52,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsArchiveCreation: true,
   },
   cline: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
+  codebuddy: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
     supportsResumeCommand: false,
@@ -111,6 +119,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "aider":
     case "antigravity":
     case "cline":
+    case "codebuddy":
     case "codex":
     case "cursor":
     case "gemini":
@@ -229,6 +238,7 @@ export function supportsArchiveCreation(provider?: ProviderId | string): boolean
 
 export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   claude: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+  codebuddy: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
   codex: "bg-green-500/15 text-green-600 dark:text-green-400",
   cline: "bg-teal-500/15 text-teal-600 dark:text-teal-400",
   cursor: "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",


### PR DESCRIPTION
## Summary

- Add a new provider to support [CodeBuddy Code](https://cnb.cool/codebuddy/codebuddy-code) (a Claude Code fork popular in China) conversation history
- CodeBuddy stores data in `~/.codebuddy/projects/` with a compatible directory layout but a different JSONL message format
- The provider handles all format differences transparently, converting to standard `ClaudeMessage` output

## Motivation

CodeBuddy Code (by Tencent) is a widely-used Claude Code fork in China. Its conversation data shares the same directory structure as Claude (`~/.codebuddy/projects/<project-name>/*.jsonl`) but uses a different JSONL schema:

| Field | Claude | CodeBuddy |
|-------|--------|-----------|
| `timestamp` | ISO 8601 string | Unix milliseconds (number) |
| `type` | `"user"`, `"assistant"`, `"system"` | `"message"` + `role` field |
| content item type | `"text"` | `"input_text"` / `"output_text"` |
| IDs | `uuid` / `parentUuid` | `id` / `parentId` |
| tool calls | `toolUse` / `toolUseResult` | `"function_call"` / `"function_call_result"` types |

Previously, users could add `~/.codebuddy` as a custom Claude path, but sessions would show as empty because the JSONL parser expected string timestamps and failed silently on numeric values.

## Changes

**Backend (Rust):**
- New file: `src-tauri/src/providers/codebuddy.rs` — full provider implementation (detect, scan, load sessions, load messages, search)
- `src-tauri/src/providers/mod.rs` — register `Codebuddy` variant in `ProviderId` enum
- `src-tauri/src/commands/multi_provider.rs` — add codebuddy to scan/load/search dispatch
- `src-tauri/src/lib.rs` — register `~/.codebuddy/projects` in file watcher

**Frontend (TypeScript):**
- `src/types/core/session.ts` — add `"codebuddy"` to `ProviderId` type
- `src/utils/providers.ts` — add provider label, badge style, capabilities
- `src/components/ProjectTree/index.tsx` — add to provider count map
- `src/components/ProjectTree/components/ProjectItem.tsx` — add badge color

## How it works

The provider follows the same pattern as the existing Codex provider:
1. **Detection**: checks if `~/.codebuddy/projects/` exists
2. **Scanning**: walks project directories, counts `.jsonl` files
3. **Session loading**: parses JSONL headers to extract metadata (converts numeric timestamps to RFC 3339)
4. **Message loading**: converts CodeBuddy format to standard `ClaudeMessage` (`input_text`→`text`, `function_call`→`tool_use`, etc.)
5. **Search**: full-text search across all CodeBuddy sessions

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (0 errors)
- [x] `tsc --noEmit` passes (no frontend type errors)
- [x] Manual testing: CodeBuddy projects appear in sidebar with correct session counts
- [x] Manual testing: sessions list displays correctly when expanded
- [x] Manual testing: messages render correctly (user text, assistant text, tool calls)
- [x] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CodeBuddy provider: discover, browse, scan projects, load sessions/messages, and search.

* **Stats & Sync**
  * Included CodeBuddy in global stats and real-time file-watching for live session updates.

* **UI**
  * Added CodeBuddy provider badge and included provider in project counts/filters; improved project resolution when opening sessions.

* **Localization**
  * Added CodeBuddy translations for multiple locales.

* **Tests**
  * Updated provider tests to include CodeBuddy identifier.

* **Bug Fixes**
  * Improved session/path loading safety and handling of symlinked data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Update (2026-05-31, force-pushed `66e3416 → 6a81f25`)

CodeRabbit's second-pass review on this branch surfaced three issues; while addressing them I also tightened the regression tests so they actually exercise the production code paths. All five items are folded into a single commit (`6a81f25`); the original `feat(provider)` commit (`ee779c3`) is unchanged.

**CodeRabbit round-2 findings (all fixed):**

1. `stats.rs::detect_*_provider` used `path.contains(".codebuddy")`, which misclassifies any path that *contains* the substring (e.g. `/work/foo.codebuddy-test/...`). Replaced with a new `is_codebuddy_path` helper that anchors on `~/.codebuddy/projects` via `Path::starts_with`, matching the existing `is_antigravity_path` style.
2. `scan_projects()` walked any `*.jsonl` entry, including symlinks. The existing `load_sessions()` path already blocked symlinks; mirror the same `symlink_metadata().file_type().is_symlink()` skip in `scan_projects()` so file counts and mtimes can't leak from outside the project root.
3. `convert_function_call` wrote the tool-use entry to **both** `msg.content[]` and the top-level `msg.tool_use` field. Native Claude JSONL only carries it in `content[]`, and `stats.rs::track_tool_usage` scans both locations independently — so the duplicate doubled CodeBuddy tool counts and pushed success rate to 50%. Dropped the top-level write; `load.rs` already has a fallback that extracts from `content` when `tool_use` is `None`, so search/edits/load consumers keep working unchanged.

**Test hardening (CLAUDE.md §"높은 응집도" / §"예측 가능성"):**

4. `scan_projects_skips_symlinked_jsonl` originally hand-rolled a copy of the production walkdir + symlink filter loop in the test body — so it would have stayed green even if the real `scan_projects` regressed. Extracted `scan_projects_in(base: &Path)` from `scan_projects()` and rewrote the test to drive `scan_projects_in` with a tempdir, so the assertion now locks in the real code path.
5. `is_codebuddy_path_accepts_real_layout` did `dirs::home_dir()` and silently `return`ed (claiming success) when `$HOME` was unavailable; `is_codebuddy_path_rejects_substring_lookalikes` accidentally passed via the same null-home fallback. Extracted `is_codebuddy_path_under(path, home)` and rewrote both tests to inject a fixed `/test-home/user`, so the assertions are meaningful regardless of the runner's environment.

**New regression tests:**
- `is_codebuddy_path_rejects_substring_lookalikes` (now uses injected home)
- `is_codebuddy_path_accepts_real_layout` (now uses injected home)
- `function_call_does_not_double_write_tool_use`
- `scan_projects_skips_symlinked_jsonl` (now drives `scan_projects_in`)

**Verified:** `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test -- --test-threads=1` (572 unit + 4 integration) all pass.



---

## Update (2026-05-31, force-pushed `6a81f25 → 0949a3a`)

Folded one more issue surfaced by hands-on testing of the new build into the feature commit. The two existing commits now read as:

- `425ac98 feat(provider): add CodeBuddy Code support` — the original feature plus the sidebar handoff fix described below.
- `0949a3a fix(codebuddy): address CodeRabbit round-2 review` — unchanged from the previous round-2 amend.

**Sidebar handoff fix (folded into the feature commit, `App.tsx`):**

Selecting any session in a CodeBuddy project from the sidebar would silently no-op the project switch in `handleSessionSelect`. Root cause: the comparison `project.name === session.project_name` cannot match for CodeBuddy because the sidebar's `project.name` uses `dir_name.rsplit('-').next()` (e.g. `viewer`) while the session loader keeps the encoded form (`Users-rassyan-...-viewer`). The two never line up, so the existing equality fell through and `selectProject` was never called — the user landed on the new session with the previous project's context still active.

Replaced the equality with a `session.file_path.startsWith(project.path)` prefix match (provider-agnostic — works for every provider that lays sessions out under a project directory) and kept the name equality as a fallback for sessions whose `file_path` is unavailable. Also gated `selectProject` on `currentProject?.path !== targetProject.path` so we don't redundantly reload when already on the right project.

This belongs in the feature commit because it's the same naming-mismatch bug the loader's `project_name` already had — fixing the loader without fixing the consumer left the feature half-broken.

**Verified:** `cargo test --lib -- --test-threads=1` (572/572), `pnpm test --run` (794/794), `pnpm lint` baseline unchanged.



---

## Update (2026-06-01, force-pushed `0949a3a → 90f4ee5`)

CodeRabbit's round-3 review (against `0949a3a`) raised two findings on the previously folded sidebar-handoff change — both real, both addressed and folded back into the feature commit:

- `f1bc6f1 feat(provider): add CodeBuddy Code support` — the feature, now with the boundary-aware path matching and the user-visible toast on failure.
- `90f4ee5 fix(codebuddy): address CodeRabbit round-2 review` — unchanged.

**Path-segment boundary in `findProjectForSession` (App.tsx):**

The previous `s.file_path.startsWith(p.path)` predicate would mis-match sibling projects sharing a parent directory: a session under `/a/proj2/...` would be wrongly attributed to a project at `/a/proj`. Replaced with a boundary-aware check — after the prefix matches, the next character must be `/`, `\`, or end-of-string. Handles both POSIX and Windows separators (matches the repo's existing `/[\\\/]/` regex split convention).

**`toast.error` on session-select failure (App.tsx, `session.selectError` key):**

The `handleSessionSelect` catch path previously only called `console.error`, which violates the project guideline that every async failure needs user-visible feedback. Added `toast.error` with a new `session.selectError` key, translated across all 5 locales (en/ja/ko/zh-CN/zh-TW). The console log stays for debugging.

**Verified:** `cargo test --lib -- --test-threads=1` (572/572), `pnpm test --run` (794/794), `pnpm lint` baseline unchanged, `pnpm run i18n:validate` (1786/1786 keys synced).
