### PR TITLE
Improve project labels for long local paths

### DIFF
--- a/src/components/ProjectTree/components/ProjectItem.tsx
+++ b/src/components/ProjectTree/components/ProjectItem.tsx
@@ -5,7 +5,16 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import type { ProjectItemProps } from "../types";
 import { getWorktreeLabel } from "../../../utils/worktreeUtils";
-import { getProviderId, getProviderLabel, getProviderBadgeStyle } from "../../../utils/providers";
+import {
+  getProviderBadgeStyle,
+  getProviderId,
+  getProviderLabel,
+} from "../../../utils/providers";
+import {
+  getCompactParentPath,
+  getPathLeaf,
+  isAbsolutePath,
+} from "../../../utils/pathUtils";
 
 export const ProjectItem: React.FC<ProjectItemProps> = ({
   project,
@@ -24,12 +33,7 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
   const isWorktree = variant === "worktree";
   const isGrouped = isMain || isWorktree;
   const isExpandable = project.session_count > 0;
-
-  const displayName = isMain
-    ? t("project.main", "main")
-    : isWorktree
-      ? getWorktreeLabel(project.actual_path)
-      : project.name;
+  const actualPath = project.actual_path || project.path || project.name;
 
   const providerId = getProviderId(project.provider);
   const baseProviderLabel = getProviderLabel(
@@ -39,6 +43,22 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
   const providerLabel = project.custom_directory_label
     ? `${baseProviderLabel} (${project.custom_directory_label})`
     : baseProviderLabel;
+  const shouldShowParentPath = !isGrouped && isAbsolutePath(actualPath);
+  const parentPath = shouldShowParentPath ? getCompactParentPath(actualPath) : "";
+  const shouldPreferPathLeaf =
+    providerId === "claude" ||
+    project.name === project.path ||
+    project.name === actualPath ||
+    isAbsolutePath(project.name) ||
+    project.name.startsWith("-");
+
+  const displayName = isMain
+    ? t("project.main", "main")
+    : isWorktree
+      ? getWorktreeLabel(project.actual_path)
+      : shouldPreferPathLeaf
+        ? getPathLeaf(actualPath) || project.name
+        : project.name;
 
   return (
     <button
@@ -123,23 +143,32 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
 
       {/* Project Name */}
       <span
-        className={cn(
-          "whitespace-nowrap flex-1 transition-colors",
-          isGrouped ? "text-xs" : "text-sm",
-          isExpanded
-            ? isWorktree
-              ? "text-emerald-600 dark:text-emerald-400 font-medium"
-              : isGrouped
-                ? "text-accent font-medium"
-                : "text-accent font-semibold"
-            : isGrouped
-              ? "text-muted-foreground"
-              : "text-sidebar-foreground/80",
-          !isGrouped && "duration-300"
-        )}
-        title={project.actual_path}
+        className="min-w-0 flex-1"
+        title={actualPath}
       >
-        {displayName}
+        <span
+          className={cn(
+            "block truncate transition-colors",
+            isGrouped ? "text-xs" : "text-sm",
+            isExpanded
+              ? isWorktree
+                ? "text-emerald-600 dark:text-emerald-400 font-medium"
+                : isGrouped
+                  ? "text-accent font-medium"
+                  : "text-accent font-semibold"
+              : isGrouped
+                ? "text-muted-foreground"
+                : "text-sidebar-foreground/80",
+            !isGrouped && "duration-300"
+          )}
+        >
+          {displayName}
+        </span>
+        {parentPath && (
+          <span className="mt-0.5 block truncate text-2xs text-muted-foreground/70">
+            {parentPath}
+          </span>
+        )}
       </span>
 
       {/* Provider Badge */}

--- a/src/test/pathUtils.test.ts
+++ b/src/test/pathUtils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCompactParentPath,
+  getDisplayPathParts,
+  getPathLeaf,
+} from "../utils/pathUtils";
+
+describe("path display utilities", () => {
+  it("returns the leaf segment for a deep Unix path", () => {
+    expect(getPathLeaf("/Users/alex/Projects/GitHub/acme/my-repo")).toBe(
+      "my-repo"
+    );
+  });
+
+  it("returns the leaf segment for a Windows path", () => {
+    expect(getPathLeaf("C:\\Users\\alex\\Projects\\acme\\my-repo")).toBe(
+      "my-repo"
+    );
+  });
+
+  it("compacts macOS home-directory parents with a tilde", () => {
+    expect(getCompactParentPath("/Users/alex/Projects/GitHub/acme/my-repo")).toBe(
+      "... / Projects / GitHub / acme"
+    );
+  });
+
+  it("compacts Linux home-directory parents with a tilde", () => {
+    expect(getCompactParentPath("/home/alex/code/acme/my-repo")).toBe(
+      "~ / code / acme"
+    );
+  });
+
+  it("compacts Windows home-directory parents with a tilde", () => {
+    expect(getDisplayPathParts("C:\\Users\\alex\\Projects\\acme\\my-repo")).toEqual([
+      "~",
+      "Projects",
+      "acme",
+      "my-repo",
+    ]);
+    expect(getDisplayPathParts("C:/Users/alex/Projects/acme/my-repo")).toEqual([
+      "~",
+      "Projects",
+      "acme",
+      "my-repo",
+    ]);
+    expect(getDisplayPathParts("/C:/Users/alex/Projects/acme/my-repo")).toEqual([
+      "~",
+      "Projects",
+      "acme",
+      "my-repo",
+    ]);
+  });
+
+  it("strips Windows drive letters from compact display paths", () => {
+    expect(getDisplayPathParts("D:\\work\\acme\\my-repo")).toEqual([
+      "work",
+      "acme",
+      "my-repo",
+    ]);
+    expect(getCompactParentPath("D:\\work\\acme\\my-repo")).toBe("work / acme");
+  });
+
+  it("normalizes iCloud Drive's internal folder name", () => {
+    const path =
+      "/Users/alex/Library/Mobile Documents/com~apple~CloudDocs/Research/OB/my-repo";
+
+    expect(getDisplayPathParts(path)).toEqual([
+      "iCloud Drive",
+      "Research",
+      "OB",
+      "my-repo",
+    ]);
+    expect(getCompactParentPath(path)).toBe("iCloud Drive / Research / OB");
+  });
+});

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -14,7 +14,7 @@ export function isAbsolutePath(path: string): boolean {
 }
 
 /**
- * Detect home directory from paths (infer from /Users/xxx, /home/xxx, or C:\Users\xxx patterns)
+ * Detect home directory from paths (infer from /Users/xxx, /home/xxx, or Windows Users paths)
  */
 export function detectHomeDir(paths: string[]): string | null {
   for (const path of paths) {
@@ -26,8 +26,8 @@ export function detectHomeDir(paths: string[]): string | null {
     const linuxMatch = path.match(/^(\/home\/[^/]+)/);
     if (linuxMatch?.[1]) return linuxMatch[1];
 
-    // Windows: C:\Users\username\... (case-insensitive)
-    const windowsMatch = path.match(/^([A-Za-z]:\\Users\\[^\\]+)/i);
+    // Windows: C:\Users\username\... or C:/Users/username/... (case-insensitive)
+    const windowsMatch = path.match(/^(\/?[A-Za-z]:[\\/]Users[\\/][^\\/]+)/i);
     if (windowsMatch?.[1]) return windowsMatch[1];
   }
   return null;
@@ -50,4 +50,55 @@ export function formatDisplayPath(path: string, homeDir: string | null): string 
 export function formatPathWithTilde(path: string, allPaths?: string[]): string {
   const homeDir = allPaths ? detectHomeDir(allPaths) : detectHomeDir([path]);
   return formatDisplayPath(path, homeDir);
+}
+
+/**
+ * Split a local filesystem path into non-empty parts.
+ */
+export function splitPathParts(path: string): string[] {
+  return path.split(/[\\/]+/).filter(Boolean);
+}
+
+/**
+ * Return the final folder/file name from a path-like string.
+ */
+export function getPathLeaf(path: string): string {
+  const parts = splitPathParts(path);
+  return parts.length > 0 ? (parts[parts.length - 1] ?? path) : path;
+}
+
+/**
+ * Return user-facing path parts for compact sidebar display.
+ */
+export function getDisplayPathParts(path: string): string[] {
+  const normalized = path.replace(/\\/g, "/");
+  const iCloudMarker = "/Library/Mobile Documents/com~apple~CloudDocs";
+  const iCloudIndex = normalized.indexOf(iCloudMarker);
+
+  if (iCloudIndex >= 0) {
+    const afterICloud = normalized.slice(iCloudIndex + iCloudMarker.length);
+    return ["iCloud Drive", ...splitPathParts(afterICloud)];
+  }
+
+  const normalizedHomeDir = detectHomeDir([path])?.replace(/\\+/g, "/");
+  if (normalizedHomeDir && normalized.startsWith(normalizedHomeDir)) {
+    const relativePath = normalized.slice(normalizedHomeDir.length);
+    return relativePath ? ["~", ...splitPathParts(relativePath)] : ["~"];
+  }
+
+  const withoutDrivePrefix = normalized.replace(/^[A-Za-z]:(?=\/|$)/, "");
+  return splitPathParts(withoutDrivePrefix);
+}
+
+/**
+ * Return a short parent path suitable for secondary text under a leaf label.
+ */
+export function getCompactParentPath(path: string, maxParts = 3): string {
+  const parts = getDisplayPathParts(path);
+  if (parts.length <= 1) return "";
+
+  const parentParts = parts.slice(0, -1);
+  const visibleParent = parentParts.slice(-maxParts).join(" / ");
+  const prefix = parentParts.length > maxParts ? "... / " : "";
+  return `${prefix}${visibleParent}`;
 }


### PR DESCRIPTION
First off, thank you for building and maintaining this project. It has been genuinely useful for reviewing local Claude Code conversations, especially across a lot of project folders.

This PR improves the sidebar project labels when projects come from long local paths:

- show the leaf folder name as the primary project label
- show a compact parent path as secondary text so similar folder names are still distinguishable
- normalize iCloud Drive's internal macOS folder segment to `iCloud Drive`
- keep the full path available in the row title tooltip

This should make deeply nested projects easier to scan without losing the full path context.

Checks run:

- `npx pnpm@10.13.1 exec lint-staged`
- `npx pnpm@10.13.1 exec vitest run src/test/pathUtils.test.ts src/components/ProjectTree/components/__tests__/TreeSemantics.test.tsx`
- `npx pnpm@10.13.1 build`

Refs #328.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project items now use a single canonical path for the title and visible name.
  * Long project names truncate more cleanly, and non-grouped items can show a secondary compact parent-directory line.
  * Paths are displayed with improved readability, including tilde (~) for home directories and clearer iCloud Drive presentation.

* **Refactor**
  * Improved project-name rendering structure to enhance truncation behavior and consistent tooltips.

* **Tests**
  * Added cross-platform coverage for path display utilities, including Windows drives, deep paths, and iCloud Drive edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->