### PR TITLE
fix(session): use in-app delete confirmation

### DIFF
--- a/src/components/SessionItem/SessionItem.tsx
+++ b/src/components/SessionItem/SessionItem.tsx
@@ -5,6 +5,7 @@ import { useSessionEditing } from "./hooks/useSessionEditing";
 import { SessionHeader } from "./components/SessionHeader";
 import { SessionNameEditor } from "./components/SessionNameEditor";
 import { SessionContextMenu } from "./components/SessionContextMenu";
+import { SessionDeleteDialog } from "./components/SessionDeleteDialog";
 import { SessionMeta } from "./components/SessionMeta";
 import type { SessionItemProps } from "./types";
 import type { Boundary } from "@/utils/contextMenu";
@@ -142,6 +143,16 @@ export const SessionItem: React.FC<SessionItemProps> = ({
         currentName={editing.localSummary || ""}
         provider={editing.providerId}
         onSuccess={editing.handleNativeRenameSuccess}
+      />
+
+      <SessionDeleteDialog
+        open={editing.isDeleteDialogOpen}
+        onOpenChange={editing.setIsDeleteDialogOpen}
+        title={editing.deleteDialogTitle}
+        description={editing.deleteDialogDescription}
+        filePath={session.file_path}
+        isDeleting={editing.isDeletingSession}
+        onConfirm={editing.handleConfirmDeleteSession}
       />
     </div>
   );

--- a/src/components/SessionItem/components/SessionDeleteDialog.tsx
+++ b/src/components/SessionItem/components/SessionDeleteDialog.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Loader2, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui";
+
+interface SessionDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  filePath: string;
+  isDeleting: boolean;
+  onConfirm: () => void | Promise<void>;
+}
+
+export const SessionDeleteDialog: React.FC<SessionDeleteDialogProps> = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  filePath,
+  isDeleting,
+  onConfirm,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-md"
+        showCloseButton={!isDeleting}
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-destructive">
+            <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-destructive/10 text-destructive">
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            </span>
+            {title}
+          </DialogTitle>
+          <DialogDescription className="text-sm leading-relaxed">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2">
+          <p className="text-xs font-medium text-destructive">
+            {t("session.deleteTarget", "Session file")}
+          </p>
+          <p className="mt-1 break-all text-xs text-muted-foreground">
+            {filePath}
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isDeleting}
+          >
+            {t("common.cancel", "Cancel")}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isDeleting}
+          >
+            {isDeleting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            {t("session.deleteSession", "Delete Session")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -7,7 +7,6 @@ import {
 } from "@/hooks/useSessionMetadata";
 import { useAppStore } from "@/store/useAppStore";
 import { api } from "@/services/api";
-import { isTauri } from "@/utils/platform";
 import { isAbsolutePath } from "@/utils/pathUtils";
 import {
   getResumeCommand,
@@ -43,27 +42,14 @@ function legacyCopy(text: string): void {
   }
 }
 
-async function confirmSessionDelete(
-  message: string,
-  title: string,
-): Promise<boolean> {
-  if (isTauri()) {
-    const { ask } = await import("@tauri-apps/plugin-dialog");
-    return ask(message, {
-      title,
-      kind: "warning",
-    });
-  }
-
-  return window.confirm(`${title}\n\n${message}`);
-}
-
 export function useSessionEditing(session: ClaudeSession) {
   const { t } = useTranslation();
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState("");
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
   const [isNativeRenameOpen, setIsNativeRenameOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeletingSession, setIsDeletingSession] = useState(false);
   const [localSummary, setLocalSummary] = useState(session.summary);
   const inputRef = useRef<HTMLInputElement>(null);
   const ignoreBlurRef = useRef<boolean>(false);
@@ -76,6 +62,17 @@ export function useSessionEditing(session: ClaudeSession) {
   const isArchivedCodexSession =
     providerId === "codex" &&
     /(?:^|[\\/])archived_sessions(?:[\\/]|$)/.test(session.file_path);
+  const deleteDialogTitle = t("session.deleteTitle", "Delete Session");
+  const deleteDialogDescription =
+    providerId === "forgecode"
+      ? t(
+          "session.deleteConfirmForgeCode",
+          "This will permanently delete the ForgeCode conversation from the Forge database."
+        )
+      : t(
+          "session.deleteConfirm",
+          "This will move the session file and associated data (subagents, tool results) to your system Trash."
+        );
 
   // Sync localSummary when session.summary prop changes
   useEffect(() => {
@@ -264,50 +261,59 @@ export function useSessionEditing(session: ClaudeSession) {
   );
 
   const handleDeleteSession = useCallback(
-    async (e: React.MouseEvent) => {
+    (e: React.MouseEvent) => {
       e.stopPropagation();
       setIsContextMenuOpen(false);
       if (!session.file_path || !supportsSessionDeletion) {
         toast.error(t("session.deleteError", "Failed to delete session"));
         return;
       }
-      try {
-        const deleteConfirmMessage =
-          providerId === "forgecode"
-            ? t(
-                "session.deleteConfirmForgeCode",
-                "This will permanently delete the ForgeCode conversation from the Forge database."
-              )
-            : t(
-                "session.deleteConfirm",
-                "This will move the session file and associated data (subagents, tool results) to your system Trash."
-              );
-        const confirmed = await confirmSessionDelete(
-          deleteConfirmMessage,
-          t("session.deleteTitle", "Delete Session"),
-        );
-        if (!confirmed) return;
-        await api("delete_session", { filePath: session.file_path });
-        const { sessions, setSessions, selectedSession, setSelectedSession } =
-          useAppStore.getState();
-        setSessions(sessions.filter((s) => s.session_id !== session.session_id));
-        if (selectedSession?.session_id === session.session_id) {
-          setSelectedSession(null);
-        }
-        toast.success(t("session.deleteSuccess", "Session deleted"));
-      } catch (error) {
-        const description =
-          error instanceof Error ? error.message : String(error);
-        console.error("[session delete] failed", {
-          sessionId: session.session_id,
-          error,
-        });
-        toast.error(t("session.deleteError", "Failed to delete session"), {
-          description,
-        });
-      }
+      setIsDeleteDialogOpen(true);
     },
-    [providerId, session.file_path, session.session_id, supportsSessionDeletion, t]
+    [session.file_path, supportsSessionDeletion, t]
+  );
+
+  const handleConfirmDeleteSession = useCallback(async () => {
+    if (!session.file_path || !supportsSessionDeletion) {
+      setIsDeleteDialogOpen(false);
+      toast.error(t("session.deleteError", "Failed to delete session"));
+      return;
+    }
+
+    setIsDeletingSession(true);
+    try {
+      await api("delete_session", { filePath: session.file_path });
+      const { sessions, setSessions, selectedSession, setSelectedSession } =
+        useAppStore.getState();
+      setSessions(sessions.filter((s) => s.session_id !== session.session_id));
+      if (selectedSession?.session_id === session.session_id) {
+        setSelectedSession(null);
+      }
+      setIsDeleteDialogOpen(false);
+      toast.success(t("session.deleteSuccess", "Session deleted"));
+    } catch (error) {
+      const description =
+        error instanceof Error ? error.message : String(error);
+      console.error("[session delete] failed", {
+        sessionId: session.session_id,
+        error,
+      });
+      toast.error(t("session.deleteError", "Failed to delete session"), {
+        description,
+      });
+    } finally {
+      setIsDeletingSession(false);
+    }
+  }, [session.file_path, session.session_id, supportsSessionDeletion, t]);
+
+  const handleDeleteDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (isDeletingSession) {
+        return;
+      }
+      setIsDeleteDialogOpen(open);
+    },
+    [isDeletingSession]
   );
 
   const handleNativeRenameClick = useCallback(
@@ -349,6 +355,8 @@ export function useSessionEditing(session: ClaudeSession) {
     editValue,
     isContextMenuOpen,
     isNativeRenameOpen,
+    isDeleteDialogOpen,
+    isDeletingSession,
     localSummary,
     displayName,
     hasCustomName,
@@ -360,6 +368,8 @@ export function useSessionEditing(session: ClaudeSession) {
     supportsSessionDeletion,
     supportsRevealInFinder,
     isArchivedCodexSession,
+    deleteDialogTitle,
+    deleteDialogDescription,
     inputRef,
     ignoreBlurRef,
 
@@ -367,6 +377,7 @@ export function useSessionEditing(session: ClaudeSession) {
     setEditValue,
     setIsContextMenuOpen,
     setIsNativeRenameOpen,
+    setIsDeleteDialogOpen: handleDeleteDialogOpenChange,
     saveCustomName,
     cancelEditing,
     resetCustomName,
@@ -378,6 +389,7 @@ export function useSessionEditing(session: ClaudeSession) {
     handleCopyFilePath,
     handleRevealInFinder,
     handleDeleteSession,
+    handleConfirmDeleteSession,
     handleNativeRenameClick,
     handleNativeRenameSuccess,
   };

--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -282,7 +282,7 @@ export function useSessionEditing(session: ClaudeSession) {
 
     setIsDeletingSession(true);
     try {
-      await api("delete_session", { filePath: session.file_path });
+      await api("delete_session", { file_path: session.file_path });
       const { sessions, setSessions, selectedSession, setSelectedSession } =
         useAppStore.getState();
       setSessions(sessions.filter((s) => s.session_id !== session.session_id));

--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -7,6 +7,7 @@ import {
 } from "@/hooks/useSessionMetadata";
 import { useAppStore } from "@/store/useAppStore";
 import { api } from "@/services/api";
+import { isTauri } from "@/utils/platform";
 import { isAbsolutePath } from "@/utils/pathUtils";
 import {
   getResumeCommand,
@@ -40,6 +41,21 @@ function legacyCopy(text: string): void {
   } finally {
     document.removeEventListener("copy", handleCopy);
   }
+}
+
+async function confirmSessionDelete(
+  message: string,
+  title: string,
+): Promise<boolean> {
+  if (isTauri()) {
+    const { ask } = await import("@tauri-apps/plugin-dialog");
+    return ask(message, {
+      title,
+      kind: "warning",
+    });
+  }
+
+  return window.confirm(`${title}\n\n${message}`);
 }
 
 export function useSessionEditing(session: ClaudeSession) {
@@ -256,7 +272,6 @@ export function useSessionEditing(session: ClaudeSession) {
         return;
       }
       try {
-        const { ask } = await import("@tauri-apps/plugin-dialog");
         const deleteConfirmMessage =
           providerId === "forgecode"
             ? t(
@@ -267,10 +282,10 @@ export function useSessionEditing(session: ClaudeSession) {
                 "session.deleteConfirm",
                 "This will move the session file and associated data (subagents, tool results) to your system Trash."
               );
-        const confirmed = await ask(deleteConfirmMessage, {
-          title: t("session.deleteTitle", "Delete Session"),
-          kind: "warning",
-        });
+        const confirmed = await confirmSessionDelete(
+          deleteConfirmMessage,
+          t("session.deleteTitle", "Delete Session"),
+        );
         if (!confirmed) return;
         await api("delete_session", { filePath: session.file_path });
         const { sessions, setSessions, selectedSession, setSelectedSession } =

--- a/src/test/SessionDeleteDialog.test.tsx
+++ b/src/test/SessionDeleteDialog.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SessionDeleteDialog } from "@/components/SessionItem/components/SessionDeleteDialog";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (_key: string, fallback?: string) => fallback ?? "",
+    }),
+  };
+});
+
+describe("SessionDeleteDialog", () => {
+  it("renders an in-app confirmation dialog with cancel and delete actions", () => {
+    const onOpenChange = vi.fn();
+    const onConfirm = vi.fn();
+
+    render(
+      <SessionDeleteDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title="Delete Session"
+        description="This will move the session file to your system Trash."
+        filePath="/tmp/session.jsonl"
+        isDeleting={false}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Delete Session" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("This will move the session file to your system Trash.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("/tmp/session.jsonl")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Session" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -28,12 +28,6 @@ vi.mock("@/services/api", () => ({
   api: vi.fn(),
 }));
 
-vi.mock("@tauri-apps/plugin-dialog", () => ({
-  ask: vi.fn(() => {
-    throw new Error("Tauri dialog should not be used in WebUI tests");
-  }),
-}));
-
 vi.mock("@/hooks/useSessionMetadata", () => ({
   useSessionDisplayName: () => "Session title",
   useSessionMetadata: () => ({
@@ -77,10 +71,6 @@ describe("useSessionEditing clipboard actions", () => {
       },
     });
     Object.defineProperty(document, "execCommand", {
-      configurable: true,
-      value: vi.fn(),
-    });
-    Object.defineProperty(window, "confirm", {
       configurable: true,
       value: vi.fn(),
     });
@@ -241,45 +231,8 @@ describe("useSessionEditing clipboard actions", () => {
     expect(toast.error).toHaveBeenCalledWith("Copy failed");
   });
 
-  it("confirms before deleting a session in WebUI mode", async () => {
-    const otherSession: ClaudeSession = {
-      ...session,
-      session_id: "other-session-id",
-      actual_session_id: "other-actual-session-id",
-      file_path: "/tmp/other-session.jsonl",
-    };
-    const confirm = vi.fn().mockReturnValue(true);
-    Object.defineProperty(window, "confirm", {
-      configurable: true,
-      value: confirm,
-    });
-    vi.mocked(api).mockResolvedValue(undefined);
-    useAppStore.setState({
-      sessions: [session, otherSession],
-      selectedSession: session,
-    });
-
-    const { result } = renderHook(() => useSessionEditing(session));
-
-    await act(async () => {
-      await result.current.handleDeleteSession({
-        stopPropagation: vi.fn(),
-      } as unknown as React.MouseEvent);
-    });
-
-    expect(confirm).toHaveBeenCalledWith(
-      expect.stringContaining("Delete Session"),
-    );
-    expect(api).toHaveBeenCalledWith("delete_session", {
-      filePath: session.file_path,
-    });
-    expect(useAppStore.getState().sessions).toEqual([otherSession]);
-    expect(useAppStore.getState().selectedSession).toBeNull();
-    expect(toast.success).toHaveBeenCalledWith("Session deleted");
-  });
-
-  it("does not delete when the WebUI confirmation is cancelled", async () => {
-    const confirm = vi.fn().mockReturnValue(false);
+  it("opens the in-app confirmation dialog before deleting a session", () => {
+    const confirm = vi.fn();
     Object.defineProperty(window, "confirm", {
       configurable: true,
       value: confirm,
@@ -291,13 +244,77 @@ describe("useSessionEditing clipboard actions", () => {
 
     const { result } = renderHook(() => useSessionEditing(session));
 
-    await act(async () => {
-      await result.current.handleDeleteSession({
+    act(() => {
+      result.current.handleDeleteSession({
         stopPropagation: vi.fn(),
       } as unknown as React.MouseEvent);
     });
 
-    expect(confirm).toHaveBeenCalled();
+    expect(result.current.isDeleteDialogOpen).toBe(true);
+    expect(result.current.deleteDialogTitle).toBe("Delete Session");
+    expect(result.current.deleteDialogDescription).toContain("Trash");
+    expect(confirm).not.toHaveBeenCalled();
+    expect(api).not.toHaveBeenCalled();
+    expect(useAppStore.getState().sessions).toEqual([session]);
+    expect(useAppStore.getState().selectedSession).toEqual(session);
+  });
+
+  it("deletes a session after the in-app confirmation is accepted", async () => {
+    const otherSession: ClaudeSession = {
+      ...session,
+      session_id: "other-session-id",
+      actual_session_id: "other-actual-session-id",
+      file_path: "/tmp/other-session.jsonl",
+    };
+    vi.mocked(api).mockResolvedValue(undefined);
+    useAppStore.setState({
+      sessions: [session, otherSession],
+      selectedSession: session,
+    });
+
+    const { result } = renderHook(() => useSessionEditing(session));
+
+    act(() => {
+      result.current.handleDeleteSession({
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(result.current.isDeleteDialogOpen).toBe(true);
+
+    await act(async () => {
+      await result.current.handleConfirmDeleteSession();
+    });
+
+    expect(api).toHaveBeenCalledWith("delete_session", {
+      filePath: session.file_path,
+    });
+    expect(result.current.isDeleteDialogOpen).toBe(false);
+    expect(result.current.isDeletingSession).toBe(false);
+    expect(useAppStore.getState().sessions).toEqual([otherSession]);
+    expect(useAppStore.getState().selectedSession).toBeNull();
+    expect(toast.success).toHaveBeenCalledWith("Session deleted");
+  });
+
+  it("does not delete when the in-app confirmation dialog is cancelled", () => {
+    useAppStore.setState({
+      sessions: [session],
+      selectedSession: session,
+    });
+
+    const { result } = renderHook(() => useSessionEditing(session));
+
+    act(() => {
+      result.current.handleDeleteSession({
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    act(() => {
+      result.current.setIsDeleteDialogOpen(false);
+    });
+
+    expect(result.current.isDeleteDialogOpen).toBe(false);
     expect(api).not.toHaveBeenCalled();
     expect(useAppStore.getState().sessions).toEqual([session]);
     expect(useAppStore.getState().selectedSession).toEqual(session);

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { useSessionEditing } from "@/components/SessionItem/hooks/useSessionEditing";
+import { api } from "@/services/api";
 import { useAppStore } from "@/store/useAppStore";
 import type { ClaudeProject, ClaudeSession } from "@/types";
 
@@ -21,6 +22,16 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock("@/services/api", () => ({
+  api: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  ask: vi.fn(() => {
+    throw new Error("Tauri dialog should not be used in WebUI tests");
+  }),
 }));
 
 vi.mock("@/hooks/useSessionMetadata", () => ({
@@ -52,7 +63,13 @@ const session: ClaudeSession & { provider: string; is_renamed: boolean } = {
 describe("useSessionEditing clipboard actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAppStore.setState({ projects: [] });
+    vi.mocked(api).mockReset();
+    useAppStore.setState({
+      projects: [],
+      selectedProject: null,
+      selectedSession: null,
+      sessions: [],
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {
@@ -60,6 +77,10 @@ describe("useSessionEditing clipboard actions", () => {
       },
     });
     Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(window, "confirm", {
       configurable: true,
       value: vi.fn(),
     });
@@ -218,5 +239,67 @@ describe("useSessionEditing clipboard actions", () => {
     expect(execCommand).toHaveBeenCalledWith("copy");
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith("Copy failed");
+  });
+
+  it("confirms before deleting a session in WebUI mode", async () => {
+    const otherSession: ClaudeSession = {
+      ...session,
+      session_id: "other-session-id",
+      actual_session_id: "other-actual-session-id",
+      file_path: "/tmp/other-session.jsonl",
+    };
+    const confirm = vi.fn().mockReturnValue(true);
+    Object.defineProperty(window, "confirm", {
+      configurable: true,
+      value: confirm,
+    });
+    vi.mocked(api).mockResolvedValue(undefined);
+    useAppStore.setState({
+      sessions: [session, otherSession],
+      selectedSession: session,
+    });
+
+    const { result } = renderHook(() => useSessionEditing(session));
+
+    await act(async () => {
+      await result.current.handleDeleteSession({
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.stringContaining("Delete Session"),
+    );
+    expect(api).toHaveBeenCalledWith("delete_session", {
+      filePath: session.file_path,
+    });
+    expect(useAppStore.getState().sessions).toEqual([otherSession]);
+    expect(useAppStore.getState().selectedSession).toBeNull();
+    expect(toast.success).toHaveBeenCalledWith("Session deleted");
+  });
+
+  it("does not delete when the WebUI confirmation is cancelled", async () => {
+    const confirm = vi.fn().mockReturnValue(false);
+    Object.defineProperty(window, "confirm", {
+      configurable: true,
+      value: confirm,
+    });
+    useAppStore.setState({
+      sessions: [session],
+      selectedSession: session,
+    });
+
+    const { result } = renderHook(() => useSessionEditing(session));
+
+    await act(async () => {
+      await result.current.handleDeleteSession({
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(confirm).toHaveBeenCalled();
+    expect(api).not.toHaveBeenCalled();
+    expect(useAppStore.getState().sessions).toEqual([session]);
+    expect(useAppStore.getState().selectedSession).toEqual(session);
   });
 });

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -287,7 +287,7 @@ describe("useSessionEditing clipboard actions", () => {
     });
 
     expect(api).toHaveBeenCalledWith("delete_session", {
-      filePath: session.file_path,
+      file_path: session.file_path,
     });
     expect(result.current.isDeleteDialogOpen).toBe(false);
     expect(result.current.isDeletingSession).toBe(false);


### PR DESCRIPTION
## Summary
- Replace the WebUI browser confirmation prompt with an in-app session delete dialog that matches the existing site UI.
- Keep deletion behind an explicit double-check: menu actions only open the dialog, and the API call runs only after the destructive confirmation button is clicked.
- Remove the unconditional Tauri dialog call from the delete flow so WebUI no longer crashes on missing `invoke`.
- Add regression coverage for opening/cancelling/confirming deletion and for the new dialog component.

## Root cause
The session delete flow imported `@tauri-apps/plugin-dialog` and called `ask()` unconditionally. In WebUI/browser mode the dialog plugin tries to call Tauri `invoke`, which is unavailable, so deletion failed before the confirmation could complete.

## User impact
WebUI users now get a styled confirmation dialog instead of a browser prompt, and session deletion works without the `Cannot read properties of undefined (reading invoke)` error.

## Validation
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec eslint src/components/SessionItem/SessionItem.tsx src/components/SessionItem/components/SessionDeleteDialog.tsx src/components/SessionItem/hooks/useSessionEditing.ts src/test/useSessionEditing.test.tsx src/test/SessionDeleteDialog.test.tsx`
- `corepack pnpm exec vitest run src/test/useSessionEditing.test.tsx src/test/SessionDeleteDialog.test.tsx`
- `corepack pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated session deletion confirmation dialog with provider-specific title/description and clear destructive delete action.
* **Bug Fixes**
  * Improved the deletion flow to use a two-step confirmation; the dialog can’t be dismissed while deletion is in progress, and canceling prevents deletion.
* **Tests**
  * Expanded coverage to assert the deletion API call, dialog open/close behavior, selection reset after deletion, and success feedback.
  * Added unit tests for the delete dialog’s rendering and cancel/confirm interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->