### PR TITLE
fix(webui-server): accept sessions under a symlinked ~/.claude allowlist root (#355)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -98,6 +98,9 @@ jobs:
           cache-on-failure: true
 
 
+      - name: Create dist placeholder for rust-embed
+        run: mkdir -p dist && touch dist/index.html
+
       - name: Run tests with nextest
         working-directory: src-tauri
         run: cargo nextest run --profile ci --retries 2

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -102,6 +102,13 @@ jobs:
         working-directory: src-tauri
         run: cargo nextest run --profile ci --retries 2
 
+      # webui-server gates extra command surface (incl. is_safe_session_path),
+      # which the default run does not compile. Exercise it explicitly so those
+      # paths get real test coverage (e.g. the #355 symlinked-root regression).
+      - name: Run tests with nextest (webui-server feature)
+        working-directory: src-tauri
+        run: cargo nextest run --profile ci --retries 2 --features webui-server
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -51,6 +51,21 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
         home.join(".codebuddy").join("projects"),
     ];
 
+    // Canonicalize each allowlist entry so the comparison below is like-for-like
+    // with the canonicalized candidate. Without this, a symlinked provider root
+    // (e.g. `~/.claude -> ~/.claude-store`, common in container / persistent-volume
+    // setups) makes the candidate resolve to the symlink target while the literal
+    // allowlist entry does not — so `starts_with` fails and valid sessions are
+    // wrongly rejected (#355). Entries that do not exist fall back to the literal
+    // path, preserving the confinement guarantee for unused provider roots.
+    let allowed: Vec<PathBuf> = allowed
+        .into_iter()
+        .map(|d| {
+            let resolved = d.canonicalize().unwrap_or(d);
+            strip_windows_prefix(&resolved)
+        })
+        .collect();
+
     let canonical = if path.exists() {
         path.canonicalize()
             .map_err(|e| format!("Path canonicalization error: {e}"))?
@@ -66,5 +81,71 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
         Ok(())
     } else {
         Err("Session path not in allowed provider directories".to_string())
+    }
+}
+
+#[cfg(all(test, feature = "webui-server", unix))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::os::unix::fs::symlink;
+
+    /// Run `body` with `$HOME` temporarily pointed at `home`, restoring it after.
+    /// Serialized because `is_safe_session_path` resolves the home dir from the
+    /// process environment (other suites also override `HOME`).
+    fn with_home<T>(home: &std::path::Path, body: impl FnOnce() -> T) -> T {
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", home);
+        let out = body();
+        match prev {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        out
+    }
+
+    // Regression test for #355: when `~/.claude` is itself a symlink, the
+    // candidate path canonicalizes to the symlink target, so the allowlist
+    // entries must be canonicalized too or valid sessions are rejected.
+    #[test]
+    #[serial]
+    fn accepts_session_under_symlinked_claude_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path();
+        let store_projects = home.join(".claude-store").join("projects").join("proj");
+        std::fs::create_dir_all(&store_projects).expect("mk store");
+        symlink(home.join(".claude-store"), home.join(".claude")).expect("symlink .claude");
+        let session = store_projects.join("session.jsonl");
+        std::fs::write(&session, b"{}").expect("write session");
+
+        // Access via the symlinked path; canonicalize() resolves it to the store.
+        let via_symlink = home
+            .join(".claude")
+            .join("projects")
+            .join("proj")
+            .join("session.jsonl");
+        let res = with_home(home, || is_safe_session_path(&via_symlink));
+        assert!(
+            res.is_ok(),
+            "session under a symlinked .claude root should be allowed: {res:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn rejects_session_outside_allowlist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path();
+        std::fs::create_dir_all(home.join(".claude").join("projects")).expect("mk claude");
+        let outside = home.join("not-a-provider");
+        std::fs::create_dir_all(&outside).expect("mk outside");
+        let session = outside.join("session.jsonl");
+        std::fs::write(&session, b"{}").expect("write session");
+
+        let res = with_home(home, || is_safe_session_path(&session));
+        assert!(
+            res.is_err(),
+            "a path outside every provider root must be rejected"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`is_safe_session_path` (the WebUI/Axum guard that confines untrusted HTTP-supplied session paths to known provider roots) canonicalized **only the candidate path**, not the allowlist entries. When a provider root is itself a symlink — e.g. `~/.claude -> ~/.claude-store`, common in container / persistent-volume setups — the candidate resolves to the symlink target while the literal allowlist entry does not, so `starts_with` fails and **valid sessions are wrongly rejected**.

Fixes #355.

## Fix

Canonicalize each allowlist entry too, so the comparison is like-for-like with the canonicalized candidate. Entries that don't exist on disk fall back to their literal path, preserving the confinement guarantee for unused provider roots (no widening of what's accepted).

## Tests / CI

- Adds a unix regression test (`accepts_session_under_symlinked_claude_root`) reproducing #355, and an out-of-allowlist rejection test — both `#[serial]` since the guard reads `$HOME` from the process env.
- Adds a CI job that runs the suite with `--features webui-server`, so `is_safe_session_path` (gated behind that feature) is actually compiled and exercised — previously it had **no** CI coverage.

## Notes

- Rebased on top of #353 (CodeBuddy), so the canonicalization applies to all 7 provider roots including `~/.codebuddy`.
- `cargo fmt --check` + `cargo clippy --all-features -D warnings` pass locally (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session paths that involve symlinked provider directories are now properly validated and accepted, improving reliability when allowlisted paths include symlinks.

* **Tests**
  * Added regression tests covering session-path safety behavior for both allowed symlinked roots and rejected non-allowlisted paths.
  * Updated the CI test run to additionally cover webui-server–gated paths, using a placeholder output file before executing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->