### PR TITLE
feat(server): consolidated WebUI account auth + read-only + base-path (supersedes #382/#377/#374/#375/#376)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="referrer" content="no-referrer" />
-    <link rel="icon" type="image/png" href="/app-icon.png" />
+    <link rel="icon" type="image/png" href="%BASE_URL%app-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Claude Code History</title>
 
     <!-- PWA -->
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="%BASE_URL%manifest.json" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="theme-color" content="#0a0a12" />
@@ -24,6 +24,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="%BASE_URL%src/main.tsx"></script>
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,13 +1,13 @@
 {
   "name": "Claude Code History Viewer",
   "short_name": "Code History",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#0a0a12",
   "theme_color": "#0a0a12",
   "icons": [
     {
-      "src": "/app-icon.png",
+      "src": "app-icon.png",
       "sizes": "128x128",
       "type": "image/png",
       "purpose": "any maskable"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = []
-webui-server = ["dep:axum", "dep:tower-http", "dep:tower", "dep:tokio", "dep:tokio-stream", "dep:rust-embed", "dep:mime_guess"]
+webui-server = ["dep:axum", "dep:tower-http", "dep:tower", "dep:tokio", "dep:tokio-stream", "dep:rust-embed", "dep:mime_guess", "dep:argon2"]
 
 [build-dependencies]
 tauri-build = { version = "2.6.2", features = [] }
@@ -59,6 +59,7 @@ notify = { version = "7.0", default-features = false, features = ["macos_fsevent
 notify-debouncer-mini = "0.5"
 
 # WebUI server mode (optional)
+argon2 = { version = "0.5", optional = true }
 axum = { version = "0.8", optional = true, features = ["json", "query", "tokio"] }
 tower-http = { version = "0.6", optional = true, features = ["cors", "fs", "trace"] }
 tower = { version = "0.5", optional = true, features = ["util"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -408,6 +408,14 @@ fn run_server(args: &[String]) {
         .unwrap_or_else(|| "0.0.0.0".to_string());
     let dist_dir = crate::cli_args::extract_flag_value(args, "--dist");
     let read_only = args.iter().any(|a| a == "--read-only");
+    let base_path = crate::cli_args::extract_flag_value(args, "--base-path")
+        .map(|value| {
+            server::normalize_base_path(&value).unwrap_or_else(|error| {
+                eprintln!("❌ Invalid --base-path: {error}");
+                std::process::exit(2);
+            })
+        })
+        .unwrap_or_else(|| "/".to_string());
 
     let resolved_auth = resolve_auth(args).unwrap_or_else(|message| {
         eprintln!("{message}");
@@ -455,7 +463,10 @@ fn run_server(args: &[String]) {
                     "⚠ Custom auth token is shorter than {MIN_CUSTOM_TOKEN_LENGTH} characters; use a strong random token for network access."
                 );
             }
-            eprintln!("   Open in browser: http://{display_addr}");
+            eprintln!(
+                "   Open in browser: http://{display_addr}{}",
+                server_base_href(&base_path)
+            );
 
             match source {
                 AuthTokenSource::Generated => {
@@ -493,7 +504,10 @@ fn run_server(args: &[String]) {
                     "⚠ Secure cookies are disabled. Add {SECURE_COOKIES_FLAG} when using HTTPS reverse proxy."
                 );
             }
-            eprintln!("   Open in browser: http://{display_addr}");
+            eprintln!(
+                "   Open in browser: http://{display_addr}{}",
+                server_base_href(&base_path)
+            );
         }
         AuthStartup::Disabled => {
             eprintln!("🔓 Authentication disabled (--no-auth)");
@@ -503,7 +517,10 @@ fn run_server(args: &[String]) {
                 );
                 eprintln!("  Anyone on your network can read your conversation history without authentication.");
             }
-            eprintln!("   Open in browser: http://{display_addr}");
+            eprintln!(
+                "   Open in browser: http://{display_addr}{}",
+                server_base_href(&base_path)
+            );
         }
     }
     if read_only {
@@ -515,8 +532,17 @@ fn run_server(args: &[String]) {
         // Start background file watcher (sends events to broadcast channel)
         let _watcher_handle = start_server_file_watcher(&state);
 
-        server::start(state, &host, port, dist_dir.as_deref()).await;
+        server::start(state, &host, port, dist_dir.as_deref(), &base_path).await;
     });
+}
+
+#[cfg(feature = "webui-server")]
+fn server_base_href(base_path: &str) -> String {
+    if base_path == "/" {
+        "/".to_string()
+    } else {
+        format!("{base_path}/")
+    }
 }
 
 /// Detect the machine's LAN IP address by connecting a UDP socket to an

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,24 @@ pub mod wsl;
 #[cfg(feature = "webui-server")]
 pub mod server;
 
+#[cfg(feature = "webui-server")]
+const ALLOW_UNSAFE_NO_AUTH_FLAG: &str = "--allow-unsafe-no-auth";
+
+#[cfg(feature = "webui-server")]
+const MIN_CUSTOM_TOKEN_LENGTH: usize = 32;
+
+#[cfg(feature = "webui-server")]
+const AUTH_USER_FLAG: &str = "--auth-user";
+
+#[cfg(feature = "webui-server")]
+const AUTH_PASSWORD_HASH_FLAG: &str = "--auth-password-hash";
+
+#[cfg(feature = "webui-server")]
+const SECURE_COOKIES_FLAG: &str = "--secure-cookies";
+
+#[cfg(feature = "webui-server")]
+const PRINT_PASSWORD_HASH_FLAG: &str = "--print-password-hash";
+
 #[cfg(test)]
 pub mod test_utils;
 
@@ -338,6 +356,10 @@ fn configure_linux_ime_environment() {
 #[cfg(not(target_os = "linux"))]
 fn configure_linux_ime_environment() {}
 
+// Pure helper used by the Linux IME setup above and exercised by unit tests;
+// gated to where it is referenced so non-Linux release builds do not see it as
+// dead code under `-D warnings`.
+#[cfg(any(target_os = "linux", test))]
 fn linux_ime_environment_updates(
     gtk_im_module: Option<&str>,
     xmodifiers: Option<&str>,
@@ -370,6 +392,15 @@ fn linux_ime_environment_updates(
 fn run_server(args: &[String]) {
     use std::sync::Arc;
 
+    match maybe_print_password_hash(args) {
+        Ok(true) => return,
+        Ok(false) => {}
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(2);
+        }
+    }
+
     let port = crate::cli_args::extract_flag_value(args, "--port")
         .and_then(|v| v.parse::<u16>().ok())
         .unwrap_or(3727);
@@ -377,9 +408,23 @@ fn run_server(args: &[String]) {
         .unwrap_or_else(|| "0.0.0.0".to_string());
     let dist_dir = crate::cli_args::extract_flag_value(args, "--dist");
 
-    // Auth token: --token <value> | --no-auth | auto-generated uuid v4
-    let auth_token_info = resolve_auth_token(args);
-    let auth_token = auth_token_info.as_ref().map(|(token, _)| token.clone());
+    let resolved_auth = resolve_auth(args).unwrap_or_else(|message| {
+        eprintln!("{message}");
+        std::process::exit(2);
+    });
+    let allow_unsafe_no_auth = args.iter().any(|a| a == ALLOW_UNSAFE_NO_AUTH_FLAG);
+
+    if let Err(message) =
+        validate_auth_startup_options(&host, resolved_auth.auth.is_enabled(), allow_unsafe_no_auth)
+    {
+        eprintln!("{message}");
+        std::process::exit(2);
+    }
+
+    if let Err(message) = validate_account_cookie_security(&host, &resolved_auth.startup) {
+        eprintln!("{message}");
+        std::process::exit(2);
+    }
 
     let metadata = Arc::new(MetadataState::default());
     let (event_tx, _rx) =
@@ -388,7 +433,7 @@ fn run_server(args: &[String]) {
     let state = Arc::new(server::state::AppState {
         metadata,
         start_time: std::time::Instant::now(),
-        auth_token: auth_token.clone(),
+        auth: resolved_auth.auth.clone(),
         event_tx,
     });
 
@@ -399,31 +444,65 @@ fn run_server(args: &[String]) {
         host.clone()
     };
     let display_addr = format!("{display_host}:{port}");
-    if let Some((token, source)) = auth_token_info {
-        let preview: String = token.chars().take(8).collect();
-        eprintln!("🔑 Auth token enabled: {preview}...");
-        eprintln!("   Open in browser: http://{display_addr}");
+    match &resolved_auth.startup {
+        AuthStartup::Token { token, source } => {
+            let preview: String = token.chars().take(8).collect();
+            eprintln!("🔑 Auth token enabled: {preview}...");
+            if is_weak_custom_token(token, *source) {
+                eprintln!(
+                    "⚠ Custom auth token is shorter than {MIN_CUSTOM_TOKEN_LENGTH} characters; use a strong random token for network access."
+                );
+            }
+            eprintln!("   Open in browser: http://{display_addr}");
 
-        match source {
-            AuthTokenSource::Generated => {
-                if let Some(path) = write_generated_token_file(&token) {
-                    eprintln!("   Generated token saved to: {}", path.to_string_lossy());
-                    eprintln!("   First login: append '?token=<token-from-file>' to the URL");
-                } else {
-                    eprintln!("⚠ Failed to persist generated token. Re-run with --token <value>.");
+            match source {
+                AuthTokenSource::Generated => {
+                    if let Some(path) = write_generated_token_file(token) {
+                        eprintln!("   Generated token saved to: {}", path.to_string_lossy());
+                        eprintln!("   First login: append '?token=<token-from-file>' to the URL");
+                    } else {
+                        eprintln!(
+                            "⚠ Failed to persist generated token. Re-run with --token <value>."
+                        );
+                    }
+                }
+                AuthTokenSource::Cli | AuthTokenSource::Env => {
+                    eprintln!("   First login: append '?token=<your-token>' to the URL");
                 }
             }
-            AuthTokenSource::Cli | AuthTokenSource::Env => {
-                eprintln!("   First login: append '?token=<your-token>' to the URL");
+        }
+        AuthStartup::Account {
+            username,
+            source,
+            secure_cookies,
+        } => {
+            eprintln!("🔐 Account auth enabled for user: {username}");
+            eprintln!(
+                "   Credentials source: {}",
+                match source {
+                    AccountAuthSource::Cli => "CLI flags",
+                    AccountAuthSource::Env => "environment variables",
+                }
+            );
+            if *secure_cookies {
+                eprintln!("   Secure cookies enabled; serve behind HTTPS.");
+            } else if !is_loopback_bind_host(&host) {
+                eprintln!(
+                    "⚠ Secure cookies are disabled. Add {SECURE_COOKIES_FLAG} when using HTTPS reverse proxy."
+                );
             }
+            eprintln!("   Open in browser: http://{display_addr}");
         }
-    } else {
-        eprintln!("🔓 Authentication disabled (--no-auth)");
-        if host == "0.0.0.0" {
-            eprintln!("⚠ WARNING: --no-auth with 0.0.0.0 exposes your data to the entire network!");
-            eprintln!("  Anyone on your network can read your conversation history without authentication.");
+        AuthStartup::Disabled => {
+            eprintln!("🔓 Authentication disabled (--no-auth)");
+            if !is_loopback_bind_host(&host) {
+                eprintln!(
+                    "⚠ WARNING: --no-auth on a non-loopback host exposes your data to the network!"
+                );
+                eprintln!("  Anyone on your network can read your conversation history without authentication.");
+            }
+            eprintln!("   Open in browser: http://{display_addr}");
         }
-        eprintln!("   Open in browser: http://{display_addr}");
     }
 
     let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
@@ -452,6 +531,283 @@ enum AuthTokenSource {
     Cli,
     Env,
     Generated,
+}
+
+#[cfg(feature = "webui-server")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AccountAuthSource {
+    Cli,
+    Env,
+}
+
+#[cfg(feature = "webui-server")]
+struct ResolvedAuth {
+    auth: server::auth::AuthState,
+    startup: AuthStartup,
+}
+
+#[cfg(feature = "webui-server")]
+enum AuthStartup {
+    Disabled,
+    Token {
+        token: String,
+        source: AuthTokenSource,
+    },
+    Account {
+        username: String,
+        source: AccountAuthSource,
+        secure_cookies: bool,
+    },
+}
+
+#[cfg(feature = "webui-server")]
+fn resolve_auth(args: &[String]) -> Result<ResolvedAuth, String> {
+    if args.iter().any(|a| a == "--no-auth") {
+        return Ok(ResolvedAuth {
+            auth: server::auth::AuthState::Disabled,
+            startup: AuthStartup::Disabled,
+        });
+    }
+
+    let secure_cookies = secure_cookies_enabled(args);
+    if let Some(account) = resolve_account_auth(args, secure_cookies)? {
+        return Ok(account);
+    }
+
+    let Some((token, source)) = resolve_auth_token(args) else {
+        return Ok(ResolvedAuth {
+            auth: server::auth::AuthState::Disabled,
+            startup: AuthStartup::Disabled,
+        });
+    };
+
+    Ok(ResolvedAuth {
+        auth: server::auth::AuthState::Token {
+            token: token.clone(),
+            secure_cookies,
+        },
+        startup: AuthStartup::Token { token, source },
+    })
+}
+
+#[cfg(feature = "webui-server")]
+fn resolve_account_auth(
+    args: &[String],
+    secure_cookies: bool,
+) -> Result<Option<ResolvedAuth>, String> {
+    let username_from_cli = require_non_empty_flag(args, AUTH_USER_FLAG)?;
+    let hash_from_cli = require_non_empty_flag(args, AUTH_PASSWORD_HASH_FLAG)?;
+    let username_from_env = non_empty_env("CCHV_AUTH_USERNAME");
+    let hash_from_env = non_empty_env("CCHV_AUTH_PASSWORD_HASH");
+
+    let username = username_from_cli
+        .clone()
+        .or(username_from_env)
+        .unwrap_or_default();
+    let password_hash = hash_from_cli.clone().or(hash_from_env).unwrap_or_default();
+
+    if username.is_empty() && password_hash.is_empty() {
+        return Ok(None);
+    }
+    if username.is_empty() {
+        return Err(
+            "Account auth is missing a username. Set --auth-user or CCHV_AUTH_USERNAME."
+                .to_string(),
+        );
+    }
+    if password_hash.is_empty() {
+        return Err(
+            "Account auth is missing a password hash. Set --auth-password-hash or CCHV_AUTH_PASSWORD_HASH."
+                .to_string(),
+        );
+    }
+    if !server::auth::password_hash_is_valid(&password_hash) {
+        return Err("Account auth password hash must be a valid Argon2 PHC string.".to_string());
+    }
+
+    let source = if username_from_cli.is_some() || hash_from_cli.is_some() {
+        AccountAuthSource::Cli
+    } else {
+        AccountAuthSource::Env
+    };
+
+    Ok(Some(ResolvedAuth {
+        auth: server::auth::AuthState::Account(std::sync::Arc::new(
+            server::auth::AccountAuth::new(username.clone(), password_hash, secure_cookies),
+        )),
+        startup: AuthStartup::Account {
+            username,
+            source,
+            secure_cookies,
+        },
+    }))
+}
+
+#[cfg(feature = "webui-server")]
+fn require_non_empty_flag(args: &[String], flag: &str) -> Result<Option<String>, String> {
+    if let Some(value) = crate::cli_args::extract_flag_value(args, flag) {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(format!("{flag} must not be empty"));
+        }
+        return Ok(Some(trimmed.to_string()));
+    }
+    if crate::cli_args::has_explicit_empty_flag(args, flag) {
+        return Err(format!("{flag} must not be empty"));
+    }
+    Ok(None)
+}
+
+#[cfg(feature = "webui-server")]
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(feature = "webui-server")]
+fn secure_cookies_enabled(args: &[String]) -> bool {
+    args.iter().any(|a| a == SECURE_COOKIES_FLAG)
+        || non_empty_env("CCHV_SECURE_COOKIES")
+            .map(|value| {
+                matches!(
+                    value.to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+}
+
+#[cfg(feature = "webui-server")]
+fn maybe_print_password_hash(args: &[String]) -> Result<bool, String> {
+    let requested = args
+        .iter()
+        .any(|arg| arg == PRINT_PASSWORD_HASH_FLAG || arg.starts_with("--print-password-hash="));
+    if !requested {
+        return Ok(false);
+    }
+
+    let password = crate::cli_args::extract_flag_value(args, PRINT_PASSWORD_HASH_FLAG)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| non_empty_env("CCHV_AUTH_PASSWORD"))
+        .ok_or_else(|| {
+            format!(
+                "Set {PRINT_PASSWORD_HASH_FLAG} <password> or CCHV_AUTH_PASSWORD before generating a password hash."
+            )
+        })?;
+
+    let hash = server::auth::hash_password_argon2id(&password)?;
+    println!("{hash}");
+    Ok(true)
+}
+
+#[cfg(feature = "webui-server")]
+fn validate_auth_startup_options(
+    host: &str,
+    auth_enabled: bool,
+    allow_unsafe_no_auth: bool,
+) -> Result<(), String> {
+    if auth_enabled || is_loopback_bind_host(host) || allow_unsafe_no_auth {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Refusing to start with --no-auth on non-loopback host '{host}'. \
+Use --host 127.0.0.1 for local-only access, enable token auth, or add \
+{ALLOW_UNSAFE_NO_AUTH_FLAG} if you intentionally want unauthenticated network access."
+    ))
+}
+
+/// Account auth issues a multi-day session bearer cookie. On a non-loopback bind
+/// without secure cookies (i.e. plain HTTP), that cookie travels in cleartext and can
+/// be sniffed and replayed to hijack the session. Refuse to start in that case rather
+/// than only warning — mirroring the `--no-auth` guard. Loopback binds (local-only) and
+/// `--secure-cookies` (HTTPS / TLS-terminating reverse proxy) are allowed.
+#[cfg(feature = "webui-server")]
+fn validate_account_cookie_security(host: &str, startup: &AuthStartup) -> Result<(), String> {
+    if let AuthStartup::Account {
+        secure_cookies: false,
+        ..
+    } = startup
+    {
+        if !is_loopback_bind_host(host) {
+            return Err(format!(
+                "Refusing to start account auth on non-loopback host '{host}' without secure cookies. \
+The session cookie would be sent in cleartext and could be hijacked. \
+Add {SECURE_COOKIES_FLAG} when serving over HTTPS (e.g. behind a TLS reverse proxy), \
+or use --host 127.0.0.1 for local-only access."
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(test, feature = "webui-server"))]
+mod auth_startup_tests {
+    use super::*;
+
+    fn account(secure_cookies: bool) -> AuthStartup {
+        AuthStartup::Account {
+            username: "admin".to_string(),
+            source: AccountAuthSource::Cli,
+            secure_cookies,
+        }
+    }
+
+    #[test]
+    fn account_insecure_cookies_refused_on_non_loopback() {
+        assert!(validate_account_cookie_security("0.0.0.0", &account(false)).is_err());
+        assert!(validate_account_cookie_security("192.168.1.10", &account(false)).is_err());
+    }
+
+    #[test]
+    fn account_insecure_cookies_allowed_on_loopback() {
+        assert!(validate_account_cookie_security("127.0.0.1", &account(false)).is_ok());
+        assert!(validate_account_cookie_security("localhost", &account(false)).is_ok());
+    }
+
+    #[test]
+    fn account_secure_cookies_allowed_anywhere() {
+        assert!(validate_account_cookie_security("0.0.0.0", &account(true)).is_ok());
+    }
+
+    #[test]
+    fn non_account_modes_are_unaffected() {
+        assert!(validate_account_cookie_security("0.0.0.0", &AuthStartup::Disabled).is_ok());
+        assert!(validate_account_cookie_security(
+            "0.0.0.0",
+            &AuthStartup::Token {
+                token: "x".to_string(),
+                source: AuthTokenSource::Cli,
+            },
+        )
+        .is_ok());
+    }
+}
+
+#[cfg(feature = "webui-server")]
+fn is_loopback_bind_host(host: &str) -> bool {
+    let normalized = host
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .trim_end_matches('.');
+
+    if normalized.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    normalized
+        .parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
+#[cfg(feature = "webui-server")]
+fn is_weak_custom_token(token: &str, source: AuthTokenSource) -> bool {
+    !matches!(source, AuthTokenSource::Generated) && token.chars().count() < MIN_CUSTOM_TOKEN_LENGTH
 }
 
 /// Resolve the authentication token from CLI arguments or environment.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -719,9 +719,17 @@ fn maybe_print_password_hash(args: &[String]) -> Result<bool, String> {
         return Ok(false);
     }
 
-    let password = crate::cli_args::extract_flag_value(args, PRINT_PASSWORD_HASH_FLAG)
+    let cli_value = crate::cli_args::extract_flag_value(args, PRINT_PASSWORD_HASH_FLAG)
         .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+        .filter(|value| !value.is_empty());
+    if cli_value.is_some() {
+        eprintln!(
+            "⚠ Passing the password on the command line exposes it in your shell history and process list. \
+Prefer: CCHV_AUTH_PASSWORD=<password> {PRINT_PASSWORD_HASH_FLAG}"
+        );
+    }
+
+    let password = cli_value
         .or_else(|| non_empty_env("CCHV_AUTH_PASSWORD"))
         .ok_or_else(|| {
             format!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -407,6 +407,7 @@ fn run_server(args: &[String]) {
     let host = crate::cli_args::extract_flag_value(args, "--host")
         .unwrap_or_else(|| "0.0.0.0".to_string());
     let dist_dir = crate::cli_args::extract_flag_value(args, "--dist");
+    let read_only = args.iter().any(|a| a == "--read-only");
 
     let resolved_auth = resolve_auth(args).unwrap_or_else(|message| {
         eprintln!("{message}");
@@ -434,6 +435,7 @@ fn run_server(args: &[String]) {
         metadata,
         start_time: std::time::Instant::now(),
         auth: resolved_auth.auth.clone(),
+        read_only,
         event_tx,
     });
 
@@ -503,6 +505,9 @@ fn run_server(args: &[String]) {
             }
             eprintln!("   Open in browser: http://{display_addr}");
         }
+    }
+    if read_only {
+        eprintln!("🔒 Read-only mode enabled: mutating API endpoints will return 403");
     }
 
     let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");

--- a/src-tauri/src/server/auth.rs
+++ b/src-tauri/src/server/auth.rs
@@ -249,10 +249,13 @@ impl AccountAuth {
 
     fn check_rate_limit(&self, key: &str) -> Result<(), AuthFailure> {
         let now = Instant::now();
+        // Recover from a poisoned lock instead of failing: this runs on the critical
+        // path of every login, so treating poison as a hard error would permanently
+        // brick authentication for the operator after any panic-while-locked.
         let mut attempts = self
             .attempts
             .lock()
-            .map_err(|_| AuthFailure::InvalidCredentials)?;
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let attempt = attempts.entry(key.to_string()).or_default();
 
         if let Some(until) = attempt.locked_until {
@@ -276,15 +279,17 @@ impl AccountAuth {
 
     fn record_failure(&self, key: &str) {
         let now = Instant::now();
-        if let Ok(mut attempts) = self.attempts.lock() {
-            let attempt = attempts.entry(key.to_string()).or_default();
-            if attempt.first_failure.is_none() {
-                attempt.first_failure = Some(now);
-            }
-            attempt.failures = attempt.failures.saturating_add(1);
-            if attempt.failures >= MAX_LOGIN_FAILURES {
-                attempt.locked_until = Some(now + LOGIN_LOCKOUT);
-            }
+        let mut attempts = self
+            .attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let attempt = attempts.entry(key.to_string()).or_default();
+        if attempt.first_failure.is_none() {
+            attempt.first_failure = Some(now);
+        }
+        attempt.failures = attempt.failures.saturating_add(1);
+        if attempt.failures >= MAX_LOGIN_FAILURES {
+            attempt.locked_until = Some(now + LOGIN_LOCKOUT);
         }
     }
 
@@ -637,5 +642,30 @@ mod tests {
             "sessions map must stay bounded, got {}",
             sessions.len()
         );
+    }
+
+    #[test]
+    fn account_locks_out_after_max_failures() {
+        let auth = AccountAuth::new("admin".to_string(), test_hash(), false);
+        let wrong = AuthLoginRequest {
+            token: None,
+            username: Some("admin".to_string()),
+            password: Some("wrong".to_string()),
+        };
+        for _ in 0..MAX_LOGIN_FAILURES {
+            assert_eq!(
+                auth.login(&wrong).unwrap_err(),
+                AuthFailure::InvalidCredentials
+            );
+        }
+        // Once the threshold is hit the account bucket is locked, so even the correct
+        // password is rate-limited — the accepted residual (a correct-username flood
+        // can lock out the operator; per-IP limiting is deliberately out of scope here).
+        let good = AuthLoginRequest {
+            token: None,
+            username: Some("admin".to_string()),
+            password: Some("correct horse battery staple".to_string()),
+        };
+        assert_eq!(auth.login(&good).unwrap_err(), AuthFailure::RateLimited);
     }
 }

--- a/src-tauri/src/server/auth.rs
+++ b/src-tauri/src/server/auth.rs
@@ -1,0 +1,641 @@
+//! `WebUI` authentication primitives.
+
+use argon2::password_hash::SaltString;
+use argon2::{Algorithm, Argon2, Params, PasswordHash, PasswordHasher, PasswordVerifier, Version};
+use axum::http::{header, HeaderMap, Method, Request, StatusCode};
+use axum::response::{AppendHeaders, IntoResponse, Response};
+use base64::Engine;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+pub const LEGACY_AUTH_COOKIE_NAME: &str = "cchv_auth";
+pub const SESSION_COOKIE_NAME: &str = "cchv_session";
+pub const CSRF_COOKIE_NAME: &str = "cchv_csrf";
+const COOKIE_MAX_AGE_SECONDS: u64 = 60 * 60 * 24 * 7;
+const SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 12);
+const SESSION_ABSOLUTE_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 7);
+const LOGIN_WINDOW: Duration = Duration::from_secs(60 * 15);
+const LOGIN_LOCKOUT: Duration = Duration::from_secs(60 * 10);
+const MAX_LOGIN_FAILURES: u32 = 5;
+/// Hard cap on concurrently tracked sessions; least-recently-seen are evicted
+/// past this so a long-running server cannot accumulate sessions without bound.
+const MAX_SESSIONS: usize = 256;
+/// Fixed rate-limit buckets. There is exactly one valid account, so failed logins
+/// are tracked under just these two keys — never under attacker-supplied usernames —
+/// which bounds the attempts map and isolates unknown-user spam from the real account.
+const ACCOUNT_BUCKET: &str = "account";
+const UNKNOWN_BUCKET: &str = "_unknown";
+
+#[derive(Clone)]
+pub enum AuthState {
+    Disabled,
+    Token { token: String, secure_cookies: bool },
+    Account(Arc<AccountAuth>),
+}
+
+#[derive(Clone)]
+pub struct AccountAuth {
+    username: String,
+    password_hash: String,
+    secure_cookies: bool,
+    sessions: Arc<Mutex<HashMap<String, SessionRecord>>>,
+    attempts: Arc<Mutex<HashMap<String, LoginAttempt>>>,
+}
+
+#[derive(Clone)]
+struct SessionRecord {
+    csrf_token: String,
+    created_at: Instant,
+    last_seen: Instant,
+}
+
+#[derive(Default)]
+struct LoginAttempt {
+    first_failure: Option<Instant>,
+    failures: u32,
+    locked_until: Option<Instant>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthLoginRequest {
+    pub token: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum LoginOutcome {
+    Disabled,
+    Token {
+        token: String,
+    },
+    Account {
+        session_id: String,
+        csrf_token: String,
+    },
+}
+
+pub enum AuthenticatedRequest {
+    None,
+    Token,
+    Account { csrf_token: String },
+}
+
+impl AuthState {
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+
+    pub fn secure_cookies(&self) -> bool {
+        match self {
+            Self::Disabled => false,
+            Self::Token { secure_cookies, .. } => *secure_cookies,
+            Self::Account(account) => account.secure_cookies,
+        }
+    }
+
+    pub fn login(&self, payload: &AuthLoginRequest) -> Result<LoginOutcome, AuthFailure> {
+        match self {
+            Self::Disabled => Ok(LoginOutcome::Disabled),
+            Self::Token { token, .. } => {
+                let Some(candidate) = payload.token.as_deref().map(str::trim) else {
+                    return Err(AuthFailure::InvalidCredentials);
+                };
+                if constant_time_eq(candidate.as_bytes(), token.as_bytes()) {
+                    Ok(LoginOutcome::Token {
+                        token: candidate.to_string(),
+                    })
+                } else {
+                    Err(AuthFailure::InvalidCredentials)
+                }
+            }
+            Self::Account(account) => account.login(payload),
+        }
+    }
+
+    pub fn authenticate<B>(&self, request: &Request<B>) -> AuthenticatedRequest {
+        match self {
+            Self::Disabled => AuthenticatedRequest::None,
+            Self::Token { token, .. } => {
+                if bearer_token_matches(request.headers(), token)
+                    || cookie_token(request.headers(), LEGACY_AUTH_COOKIE_NAME).is_some_and(
+                        |candidate| constant_time_eq(candidate.as_bytes(), token.as_bytes()),
+                    )
+                    || allow_query_token(request)
+                        .and_then(|candidate| {
+                            constant_time_eq(candidate.as_bytes(), token.as_bytes()).then_some(())
+                        })
+                        .is_some()
+                {
+                    AuthenticatedRequest::Token
+                } else {
+                    AuthenticatedRequest::None
+                }
+            }
+            Self::Account(account) => account
+                .authenticate_session(request.headers())
+                .map(|csrf_token| AuthenticatedRequest::Account { csrf_token })
+                .unwrap_or(AuthenticatedRequest::None),
+        }
+    }
+
+    pub fn logout(&self, headers: &HeaderMap) {
+        if let Self::Account(account) = self {
+            if let Some(session_id) = cookie_token(headers, SESSION_COOKIE_NAME) {
+                account.remove_session(&session_id);
+            }
+        }
+    }
+}
+
+impl AccountAuth {
+    pub fn new(username: String, password_hash: String, secure_cookies: bool) -> Self {
+        Self {
+            username,
+            password_hash,
+            secure_cookies,
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+            attempts: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn login(&self, payload: &AuthLoginRequest) -> Result<LoginOutcome, AuthFailure> {
+        let username = payload.username.as_deref().unwrap_or("").trim();
+        let password = payload.password.as_deref().unwrap_or("");
+
+        // Decide the rate-limit bucket from whether the username matched — never from
+        // attacker-supplied text. With a single valid account this caps the attempts
+        // map at two keys (real account vs shared "_unknown"), so a username-rotating
+        // attacker cannot exhaust memory and unknown-user spam cannot lock out the real
+        // account. `user_ok` is a constant-time compare and is computed unconditionally.
+        let user_ok = constant_time_eq(username.as_bytes(), self.username.as_bytes());
+        let attempt_key = if user_ok {
+            ACCOUNT_BUCKET
+        } else {
+            UNKNOWN_BUCKET
+        };
+
+        self.check_rate_limit(attempt_key)?;
+
+        // Always run Argon2 regardless of `user_ok` so total response time does not
+        // depend on whether the username exists (no enumeration timing oracle).
+        let password_ok = verify_argon2id_password(password, &self.password_hash);
+        if !(user_ok && password_ok) {
+            self.record_failure(attempt_key);
+            return Err(AuthFailure::InvalidCredentials);
+        }
+
+        self.clear_attempts(attempt_key);
+        let session_id = random_token();
+        let csrf_token = random_token();
+        let now = Instant::now();
+        let record = SessionRecord {
+            csrf_token: csrf_token.clone(),
+            created_at: now,
+            last_seen: now,
+        };
+
+        if let Ok(mut sessions) = self.sessions.lock() {
+            // Drop expired sessions, then enforce the hard cap with least-recently-seen
+            // eviction so the map stays bounded on a long-running server.
+            sessions.retain(|_, r| {
+                now.duration_since(r.created_at) <= SESSION_ABSOLUTE_TIMEOUT
+                    && now.duration_since(r.last_seen) <= SESSION_IDLE_TIMEOUT
+            });
+            while sessions.len() >= MAX_SESSIONS {
+                let Some(oldest) = sessions
+                    .iter()
+                    .min_by_key(|(_, r)| r.last_seen)
+                    .map(|(k, _)| k.clone())
+                else {
+                    break;
+                };
+                sessions.remove(&oldest);
+            }
+            sessions.insert(session_id.clone(), record);
+        }
+
+        Ok(LoginOutcome::Account {
+            session_id,
+            csrf_token,
+        })
+    }
+
+    fn authenticate_session(&self, headers: &HeaderMap) -> Option<String> {
+        let session_id = cookie_token(headers, SESSION_COOKIE_NAME)?;
+        let now = Instant::now();
+        let mut sessions = self.sessions.lock().ok()?;
+        let record = sessions.get_mut(&session_id)?;
+
+        if now.duration_since(record.created_at) > SESSION_ABSOLUTE_TIMEOUT
+            || now.duration_since(record.last_seen) > SESSION_IDLE_TIMEOUT
+        {
+            sessions.remove(&session_id);
+            return None;
+        }
+
+        record.last_seen = now;
+        Some(record.csrf_token.clone())
+    }
+
+    fn remove_session(&self, session_id: &str) {
+        if let Ok(mut sessions) = self.sessions.lock() {
+            sessions.remove(session_id);
+        }
+    }
+
+    fn check_rate_limit(&self, key: &str) -> Result<(), AuthFailure> {
+        let now = Instant::now();
+        let mut attempts = self
+            .attempts
+            .lock()
+            .map_err(|_| AuthFailure::InvalidCredentials)?;
+        let attempt = attempts.entry(key.to_string()).or_default();
+
+        if let Some(until) = attempt.locked_until {
+            if until > now {
+                return Err(AuthFailure::RateLimited);
+            }
+            attempt.locked_until = None;
+            attempt.failures = 0;
+            attempt.first_failure = None;
+        }
+
+        if let Some(first) = attempt.first_failure {
+            if now.duration_since(first) > LOGIN_WINDOW {
+                attempt.failures = 0;
+                attempt.first_failure = None;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn record_failure(&self, key: &str) {
+        let now = Instant::now();
+        if let Ok(mut attempts) = self.attempts.lock() {
+            let attempt = attempts.entry(key.to_string()).or_default();
+            if attempt.first_failure.is_none() {
+                attempt.first_failure = Some(now);
+            }
+            attempt.failures = attempt.failures.saturating_add(1);
+            if attempt.failures >= MAX_LOGIN_FAILURES {
+                attempt.locked_until = Some(now + LOGIN_LOCKOUT);
+            }
+        }
+    }
+
+    fn clear_attempts(&self, key: &str) {
+        if let Ok(mut attempts) = self.attempts.lock() {
+            attempts.remove(key);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthFailure {
+    InvalidCredentials,
+    RateLimited,
+    CsrfRequired,
+}
+
+pub fn csrf_valid<B>(request: &Request<B>, csrf_token: &str) -> bool {
+    if request.method() == Method::GET || request.method() == Method::HEAD {
+        return true;
+    }
+
+    request
+        .headers()
+        .get("x-csrf-token")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|candidate| constant_time_eq(candidate.as_bytes(), csrf_token.as_bytes()))
+}
+
+pub fn auth_error_response(failure: AuthFailure) -> Response {
+    match failure {
+        AuthFailure::InvalidCredentials => StatusCode::UNAUTHORIZED.into_response(),
+        AuthFailure::RateLimited => (
+            StatusCode::TOO_MANY_REQUESTS,
+            axum::Json(serde_json::json!({
+                "error": "Too many login attempts. Try again later."
+            })),
+        )
+            .into_response(),
+        AuthFailure::CsrfRequired => StatusCode::FORBIDDEN.into_response(),
+    }
+}
+
+pub fn login_response(outcome: LoginOutcome, secure: bool) -> Response {
+    match outcome {
+        LoginOutcome::Disabled => clear_auth_cookies_response(secure),
+        LoginOutcome::Token { token } => token_cookie_response(&token, secure),
+        LoginOutcome::Account {
+            session_id,
+            csrf_token,
+        } => session_cookie_response(&session_id, &csrf_token, secure),
+    }
+}
+
+pub fn clear_auth_cookies_response(secure: bool) -> Response {
+    let secure = secure_attribute(secure);
+    (
+        StatusCode::NO_CONTENT,
+        AppendHeaders([
+            (
+                header::SET_COOKIE,
+                header_value(&format!(
+                    "{LEGACY_AUTH_COOKIE_NAME}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0{secure}"
+                )),
+            ),
+            (
+                header::SET_COOKIE,
+                header_value(&format!(
+                    "{SESSION_COOKIE_NAME}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0{secure}"
+                )),
+            ),
+            (
+                header::SET_COOKIE,
+                header_value(&format!(
+                    "{CSRF_COOKIE_NAME}=; SameSite=Strict; Path=/; Max-Age=0{secure}"
+                )),
+            ),
+        ]),
+    )
+        .into_response()
+}
+
+fn token_cookie_response(token: &str, secure: bool) -> Response {
+    let encoded = urlencoding::encode(token);
+    let secure = secure_attribute(secure);
+    (
+        StatusCode::NO_CONTENT,
+        [(
+            header::SET_COOKIE,
+            header_value(&format!(
+                "{LEGACY_AUTH_COOKIE_NAME}={encoded}; HttpOnly; SameSite=Lax; Path=/; Max-Age={COOKIE_MAX_AGE_SECONDS}{secure}"
+            )),
+        )],
+    )
+        .into_response()
+}
+
+fn session_cookie_response(session_id: &str, csrf_token: &str, secure: bool) -> Response {
+    let session_id = urlencoding::encode(session_id);
+    let csrf_token = urlencoding::encode(csrf_token);
+    let secure = secure_attribute(secure);
+    (
+        StatusCode::NO_CONTENT,
+        AppendHeaders([
+            (
+                header::SET_COOKIE,
+                header_value(&format!(
+                    "{SESSION_COOKIE_NAME}={session_id}; HttpOnly; SameSite=Strict; Path=/; Max-Age={COOKIE_MAX_AGE_SECONDS}{secure}"
+                )),
+            ),
+            (
+                header::SET_COOKIE,
+                header_value(&format!(
+                    "{CSRF_COOKIE_NAME}={csrf_token}; SameSite=Strict; Path=/; Max-Age={COOKIE_MAX_AGE_SECONDS}{secure}"
+                )),
+            ),
+        ]),
+    )
+        .into_response()
+}
+
+fn header_value(value: &str) -> axum::http::HeaderValue {
+    axum::http::HeaderValue::from_str(value).unwrap_or_else(|_| {
+        axum::http::HeaderValue::from_static(
+            "cchv_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0",
+        )
+    })
+}
+
+fn secure_attribute(secure: bool) -> &'static str {
+    if secure {
+        "; Secure"
+    } else {
+        ""
+    }
+}
+
+fn bearer_token_matches(headers: &HeaderMap, expected: &str) -> bool {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|header| header.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|candidate| constant_time_eq(candidate.as_bytes(), expected.as_bytes()))
+}
+
+fn cookie_token(headers: &HeaderMap, name: &str) -> Option<String> {
+    let cookie_header = headers.get(header::COOKIE)?.to_str().ok()?;
+    for part in cookie_header.split(';') {
+        let trimmed = part.trim();
+        if let Some(value) = trimmed.strip_prefix(&format!("{name}=")) {
+            return Some(urlencoding::decode(value).ok()?.into_owned());
+        }
+    }
+    None
+}
+
+fn allow_query_token<B>(request: &Request<B>) -> Option<String> {
+    if request.method() != Method::GET {
+        return None;
+    }
+    if !matches!(request.uri().path(), "/api/events" | "/events") {
+        return None;
+    }
+
+    request.uri().query().and_then(|query| {
+        query.split('&').find_map(|pair| {
+            let token = pair.strip_prefix("token=")?;
+            Some(urlencoding::decode(token).ok()?.into_owned())
+        })
+    })
+}
+
+fn verify_argon2id_password(password: &str, password_hash: &str) -> bool {
+    let Ok(parsed_hash) = PasswordHash::new(password_hash) else {
+        return false;
+    };
+    recommended_argon2id()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok()
+}
+
+pub fn password_hash_is_valid(password_hash: &str) -> bool {
+    PasswordHash::new(password_hash)
+        .map(|hash| hash.algorithm.as_str() == "argon2id")
+        .unwrap_or(false)
+}
+
+pub fn hash_password_argon2id(password: &str) -> Result<String, String> {
+    let salt_seed = uuid::Uuid::new_v4();
+    let salt = SaltString::encode_b64(salt_seed.as_bytes())
+        .map_err(|_| "failed to generate password salt".to_string())?;
+    recommended_argon2id()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|hash| hash.to_string())
+        .map_err(|_| "failed to hash password".to_string())
+}
+
+fn recommended_argon2id() -> Argon2<'static> {
+    let params =
+        Params::new(19 * 1024, 2, 1, None).expect("static Argon2id parameters should be valid");
+    Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+}
+
+fn random_token() -> String {
+    let raw = format!(
+        "{}{}",
+        uuid::Uuid::new_v4().as_simple(),
+        uuid::Uuid::new_v4().as_simple()
+    );
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw.as_bytes())
+}
+
+/// Constant-time byte comparison to prevent timing side-channel attacks on token validation.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+
+    fn test_hash() -> String {
+        hash_password_argon2id("correct horse battery staple").unwrap()
+    }
+
+    #[test]
+    fn account_login_creates_session_and_csrf() {
+        let auth = AccountAuth::new("admin".to_string(), test_hash(), true);
+        let payload = AuthLoginRequest {
+            token: None,
+            username: Some("admin".to_string()),
+            password: Some("correct horse battery staple".to_string()),
+        };
+
+        let outcome = auth.login(&payload).unwrap();
+        let LoginOutcome::Account {
+            session_id,
+            csrf_token,
+        } = outcome
+        else {
+            panic!("expected account login");
+        };
+
+        assert!(session_id.len() > 40);
+        assert!(csrf_token.len() > 40);
+    }
+
+    #[test]
+    fn account_login_rejects_wrong_password() {
+        let auth = AccountAuth::new("admin".to_string(), test_hash(), true);
+        let payload = AuthLoginRequest {
+            token: None,
+            username: Some("admin".to_string()),
+            password: Some("wrong".to_string()),
+        };
+
+        assert_eq!(
+            auth.login(&payload).unwrap_err(),
+            AuthFailure::InvalidCredentials
+        );
+    }
+
+    #[test]
+    fn csrf_header_must_match_session_token() {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/api/save_settings")
+            .header("x-csrf-token", "abc")
+            .body(Body::empty())
+            .unwrap();
+
+        assert!(csrf_valid(&request, "abc"));
+        assert!(!csrf_valid(&request, "def"));
+    }
+
+    fn bad_login(username: &str) -> AuthLoginRequest {
+        AuthLoginRequest {
+            token: None,
+            username: Some(username.to_string()),
+            password: Some("definitely-wrong".to_string()),
+        }
+    }
+
+    #[test]
+    fn unknown_usernames_collapse_to_one_bucket() {
+        // A username-rotating attacker must not be able to grow the attempts map:
+        // every unknown username shares the "_unknown" bucket, so the map stays tiny.
+        let auth = AccountAuth::new("admin".to_string(), test_hash(), false);
+        for i in 0..40 {
+            let _ = auth.login(&bad_login(&format!("intruder{i}")));
+        }
+        let attempts = auth.attempts.lock().unwrap();
+        assert!(
+            attempts.len() <= 2,
+            "unknown usernames must share one bucket, got {} keys",
+            attempts.len()
+        );
+        assert!(attempts.contains_key(UNKNOWN_BUCKET));
+    }
+
+    #[test]
+    fn unknown_username_spam_does_not_lock_real_account() {
+        // Spamming unknown usernames locks only the "_unknown" bucket; the real
+        // account lives in a separate bucket and must remain able to authenticate.
+        let auth = AccountAuth::new("admin".to_string(), test_hash(), false);
+        for _ in 0..(MAX_LOGIN_FAILURES + 2) {
+            let _ = auth.login(&bad_login("intruder"));
+        }
+        let good = AuthLoginRequest {
+            token: None,
+            username: Some("admin".to_string()),
+            password: Some("correct horse battery staple".to_string()),
+        };
+        assert!(
+            auth.login(&good).is_ok(),
+            "unknown-user lockout must not affect the real account"
+        );
+    }
+
+    #[test]
+    fn login_evicts_oldest_session_when_at_capacity() {
+        let auth = AccountAuth::new("admin".to_string(), test_hash(), false);
+        {
+            let mut sessions = auth.sessions.lock().unwrap();
+            let now = Instant::now();
+            for i in 0..MAX_SESSIONS {
+                sessions.insert(
+                    format!("pre-{i}"),
+                    SessionRecord {
+                        csrf_token: "x".to_string(),
+                        created_at: now,
+                        last_seen: now,
+                    },
+                );
+            }
+        }
+        let good = AuthLoginRequest {
+            token: None,
+            username: Some("admin".to_string()),
+            password: Some("correct horse battery staple".to_string()),
+        };
+        auth.login(&good).unwrap();
+        let sessions = auth.sessions.lock().unwrap();
+        assert!(
+            sessions.len() <= MAX_SESSIONS,
+            "sessions map must stay bounded, got {}",
+            sessions.len()
+        );
+    }
+}

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -386,6 +386,14 @@ handler_no_params!(
     commands::metadata::get_metadata_folder_path
 );
 
+pub async fn get_server_config(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Value>, ApiError> {
+    Ok(Json(serde_json::json!({
+        "readOnly": state.read_only,
+    })))
+}
+
 /// Note: scope parameter is accepted for API contract compatibility but not used
 /// by the underlying command (it always reads the global MCP config).
 pub async fn get_mcp_servers(Json(_p): Json<McpScopeParam>) -> Result<Json<Value>, ApiError> {

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -425,6 +425,17 @@ pub fn normalize_base_path(raw: &str) -> Result<String, String> {
         if segment == "." || segment == ".." {
             return Err("base path must not contain '.' or '..' segments".to_string());
         }
+        // Restrict to URL-unreserved characters so the value cannot break out of the
+        // injected `<base href="...">` attribute (defense-in-depth; operator-controlled).
+        if !segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~'))
+        {
+            return Err(
+                "base path segments may only contain letters, digits, '-', '_', '.', '~'"
+                    .to_string(),
+            );
+        }
     }
 
     Ok(without_trailing.to_string())
@@ -659,9 +670,17 @@ pub async fn start(
 ) {
     let router = build_router(state, host, port, dist_dir, base_path);
 
-    let addr: SocketAddr = format!("{host}:{port}")
-        .parse()
-        .expect("Invalid server address");
+    // Resolve via lookup_host so hostnames (e.g. `--host localhost`, which the
+    // loopback guard accepts) work and an unresolvable address exits gracefully
+    // instead of panicking — SocketAddr::parse alone rejects non-IP hosts.
+    let addr: SocketAddr = tokio::net::lookup_host((host, port))
+        .await
+        .ok()
+        .and_then(|mut addrs| addrs.next())
+        .unwrap_or_else(|| {
+            eprintln!("❌ Could not resolve server address '{host}:{port}'");
+            std::process::exit(2);
+        });
 
     if host != "127.0.0.1" {
         eprintln!(
@@ -759,6 +778,18 @@ mod tests {
                 false,
             ))),
             read_only: false,
+            event_tx,
+        })
+    }
+
+    fn test_state_read_only() -> Arc<AppState> {
+        let (event_tx, _rx) =
+            tokio::sync::broadcast::channel::<crate::commands::watcher::FileWatchEvent>(1);
+        Arc::new(AppState {
+            metadata: Arc::new(MetadataState::default()),
+            start_time: std::time::Instant::now(),
+            auth: AuthState::Disabled,
+            read_only: true,
             event_tx,
         })
     }
@@ -1046,8 +1077,9 @@ mod tests {
             .map(|i| start + i)
             .expect("test module marker after build_router");
         let src = &full[start..end];
-        // Matches both inline and multi-line `.route( "<path>", post(` forms.
-        let re = regex::Regex::new(r#"\.route\(\s*"(/[a-z_]+)"\s*,\s*post\("#).unwrap();
+        // Matches both inline and multi-line `.route( "<path>", post(` forms. Charset
+        // is broad (letters/digits/-/_) so a future route can't evade classification.
+        let re = regex::Regex::new(r#"\.route\(\s*"(/[A-Za-z0-9_-]+)"\s*,\s*post\("#).unwrap();
         let registered: HashSet<&str> = re
             .captures_iter(src)
             .map(|c| c.get(1).unwrap().as_str())
@@ -1178,5 +1210,58 @@ mod tests {
             let body = String::from_utf8(body.to_vec()).unwrap();
             assert!(body.contains("<base href=\"/viewer/\" />"));
         }
+    }
+
+    #[tokio::test]
+    async fn read_only_mode_blocks_mutations_over_http() {
+        let app = build_router(test_state_read_only(), "127.0.0.1", 3727, None, "/");
+        // A mutating route is rejected with 403 by the read-only layer.
+        let blocked = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/delete_session")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), StatusCode::FORBIDDEN);
+        // An allowed read route passes the read-only layer (it reaches the handler and
+        // is never 403'd by read-only). get_server_config is lightweight and does not
+        // touch the filesystem, so this stays fast and deterministic.
+        let allowed = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/get_server_config")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(allowed.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn read_only_enforcement_survives_base_path_nesting() {
+        // .nest(&base_path, app) strips the prefix, so the inner read-only layer must
+        // still see /api/... and block mutations under a configured base path.
+        let app = build_router(test_state_read_only(), "127.0.0.1", 3727, None, "/viewer");
+        let blocked = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/viewer/api/delete_session")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -38,6 +38,100 @@ use self::auth::{
 };
 use self::handlers as h;
 use self::state::AppState;
+/// `/api/*` POST routes that are safe to serve while the server is in read-only
+/// mode (the read/load/scan/search/export surface).
+///
+/// Read-only enforcement is **deny-by-default**: `read_only_middleware` rejects any
+/// protected POST whose path is not on this allowlist. Listing safe reads (instead
+/// of blocking known mutations) means a newly added mutating route is blocked
+/// automatically rather than silently leaking through — the safe failure direction.
+/// This list must stay in sync with the POST routes registered on `protected_api`
+/// in `build_router`; the `read_only_*` tests below pin the current classification.
+const READ_ONLY_ALLOWED_API_PATHS: &[&str] = &[
+    "/detect_providers",
+    "/export_session",
+    "/get_all_mcp_servers",
+    "/get_all_settings",
+    "/get_archive_base_path",
+    "/get_archive_disk_usage",
+    "/get_archive_sessions",
+    "/get_claude_folder_path",
+    "/get_claude_json_config",
+    "/get_expiring_sessions",
+    "/get_git_log",
+    "/get_global_stats_summary",
+    "/get_mcp_preset",
+    "/get_mcp_servers",
+    "/get_metadata_folder_path",
+    "/get_preset",
+    "/get_project_stats_summary",
+    "/get_project_token_stats",
+    "/get_recent_edits",
+    "/get_server_config",
+    "/get_session_comparison",
+    "/get_session_display_name",
+    "/get_session_message_count",
+    "/get_session_subagents",
+    "/get_session_token_stats",
+    "/get_settings_by_scope",
+    "/get_system_info",
+    "/get_unified_preset",
+    "/is_project_hidden",
+    "/list_archives",
+    "/load_archive_session_messages",
+    "/load_mcp_presets",
+    "/load_presets",
+    "/load_project_sessions",
+    "/load_provider_messages",
+    "/load_provider_sessions",
+    "/load_session_messages",
+    "/load_session_messages_paginated",
+    "/load_unified_presets",
+    "/load_user_metadata",
+    "/open_github_issues",
+    "/read_text_file",
+    "/scan_all_projects",
+    "/scan_projects",
+    "/search_all_providers",
+    "/search_messages",
+    "/validate_claude_folder",
+    "/validate_custom_claude_dir",
+];
+
+/// The mutating `/api/*` POST routes — rejected in read-only mode. This list is the
+/// complement of [`READ_ONLY_ALLOWED_API_PATHS`] over the protected POST surface and
+/// exists only so a test can assert the two together cover every registered route
+/// (so a newly added route can't be silently misclassified). `/events` is GET-only
+/// and never reaches the POST check.
+#[cfg(test)]
+const READ_ONLY_MUTATING_API_PATHS: &[&str] = &[
+    "/create_archive",
+    "/delete_archive",
+    "/delete_mcp_preset",
+    "/delete_preset",
+    "/delete_session",
+    "/delete_unified_preset",
+    "/rename_archive",
+    "/rename_opencode_session_title",
+    "/rename_session_native",
+    "/reset_session_native_name",
+    "/restore_file",
+    "/save_mcp_preset",
+    "/save_mcp_servers",
+    "/save_preset",
+    "/save_screenshot",
+    "/save_settings",
+    "/save_unified_preset",
+    "/save_user_metadata",
+    "/send_feedback",
+    "/start_file_watcher",
+    "/stop_file_watcher",
+    "/update_project_metadata",
+    "/update_session_metadata",
+    "/update_user_settings",
+    "/write_text_file",
+];
+
 /// Frontend assets embedded at compile time from the `dist/` directory.
 ///
 /// When building with `cargo build --features webui-server`, the contents of
@@ -76,6 +170,7 @@ pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Optio
     let protected_api = Router::new()
         // SSE endpoint for real-time file change events
         .route("/events", get(sse_handler))
+        .route("/get_server_config", post(h::get_server_config))
         // Project commands
         .route("/get_claude_folder_path", post(h::get_claude_folder_path))
         .route("/validate_claude_folder", post(h::validate_claude_folder))
@@ -197,6 +292,10 @@ pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Optio
         // Auth middleware — checks Bearer header or ?token= query param
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
+            read_only_middleware,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
             auth_middleware,
         ));
 
@@ -263,6 +362,34 @@ async fn security_headers_middleware(request: Request, next: Next) -> Response {
         HeaderValue::from_static("nosniff"),
     );
     response
+}
+
+async fn read_only_middleware(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.read_only
+        && request.method() == Method::POST
+        && !is_read_only_allowed_path(request.uri().path())
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "Server is running in read-only mode"
+            })),
+        )
+            .into_response();
+    }
+
+    next.run(request).await
+}
+
+/// Whether a protected `/api/*` POST path is on the read-only allowlist. Anything
+/// not listed is treated as mutating and rejected when `--read-only` is set.
+fn is_read_only_allowed_path(path: &str) -> bool {
+    let api_path = path.strip_prefix("/api").unwrap_or(path);
+    READ_ONLY_ALLOWED_API_PATHS.contains(&api_path)
 }
 
 /// Axum middleware that validates a Bearer token on every `/api/*` request.
@@ -447,6 +574,7 @@ mod tests {
                     secure_cookies: false,
                 })
                 .unwrap_or(AuthState::Disabled),
+            read_only: false,
             event_tx,
         })
     }
@@ -463,6 +591,7 @@ mod tests {
                 password_hash,
                 false,
             ))),
+            read_only: false,
             event_tx,
         })
     }
@@ -665,5 +794,96 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_read_only_blocks_mutating_api_paths() {
+        for path in [
+            "/delete_session",
+            "/api/delete_session",
+            "/api/rename_session_native",
+            "/api/update_user_settings",
+            "/api/save_settings",
+            "/api/write_text_file",
+            "/api/create_archive",
+        ] {
+            assert!(!is_read_only_allowed_path(path), "{path} should be blocked");
+        }
+    }
+
+    #[test]
+    fn test_read_only_allows_read_api_paths() {
+        for path in [
+            "/get_server_config",
+            "/api/get_server_config",
+            "/api/load_session_messages",
+            "/api/search_messages",
+            "/api/get_all_settings",
+            "/api/export_session",
+        ] {
+            assert!(
+                is_read_only_allowed_path(path),
+                "{path} should remain readable"
+            );
+        }
+    }
+
+    #[test]
+    fn test_read_only_blocks_unknown_routes_by_default() {
+        // Deny-by-default: a route that is not on the read allowlist (e.g. a future
+        // mutating command someone forgets to classify) is blocked rather than leaked.
+        for path in ["/api/some_future_command", "/api/purge_everything"] {
+            assert!(
+                !is_read_only_allowed_path(path),
+                "{path} must be denied by default"
+            );
+        }
+    }
+
+    /// Self-maintaining guard: parse every POST route registered in this file and
+    /// assert each is classified (allowed read or mutating), and that neither list
+    /// has a stale entry. Adding a `.route("/x", post(..))` without classifying it
+    /// fails here — the failure mode the read-only allowlist must never regress into.
+    #[test]
+    fn read_only_classification_covers_every_post_route() {
+        use std::collections::HashSet;
+        // Scope to the build_router body so doc-comment examples and test-only routers
+        // elsewhere in this file are not parsed as real routes.
+        let full = include_str!("mod.rs");
+        let start = full
+            .find("pub fn build_router")
+            .expect("build_router definition");
+        let end = full[start..]
+            .find("\nasync fn embedded_asset_handler")
+            .map(|i| start + i)
+            .unwrap_or(full.len());
+        let src = &full[start..end];
+        // Matches both inline and multi-line `.route( "<path>", post(` forms.
+        let re = regex::Regex::new(r#"\.route\(\s*"(/[a-z_]+)"\s*,\s*post\("#).unwrap();
+        let registered: HashSet<&str> = re
+            .captures_iter(src)
+            .map(|c| c.get(1).unwrap().as_str())
+            .collect();
+        let allowed: HashSet<&str> = READ_ONLY_ALLOWED_API_PATHS.iter().copied().collect();
+        let mutating: HashSet<&str> = READ_ONLY_MUTATING_API_PATHS.iter().copied().collect();
+
+        assert!(
+            allowed.is_disjoint(&mutating),
+            "a path is classified as both read and mutating"
+        );
+        assert!(!registered.is_empty(), "route extraction matched nothing");
+        for path in &registered {
+            assert!(
+                allowed.contains(path) || mutating.contains(path),
+                "POST route {path} is unclassified — add it to READ_ONLY_ALLOWED_API_PATHS \
+                 (reads) or READ_ONLY_MUTATING_API_PATHS (mutations)"
+            );
+        }
+        for path in allowed.iter().chain(mutating.iter()) {
+            assert!(
+                registered.contains(path),
+                "classified path {path} is not a registered POST route (stale entry)"
+            );
+        }
     }
 }

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -11,12 +11,13 @@
 //! - **External**: `--dist <path>` serves assets from the filesystem.
 //!   Useful during development or when overriding the built-in frontend.
 
+pub mod auth;
 pub mod handlers;
 pub mod state;
 
 use axum::body::Body;
 use axum::extract::{DefaultBodyLimit, Request, State};
-use axum::http::{header, HeaderValue, Method, StatusCode};
+use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use axum::middleware::Next;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
@@ -31,9 +32,12 @@ use tokio_stream::{Stream, StreamExt};
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 
+use self::auth::{
+    auth_error_response, clear_auth_cookies_response, csrf_valid, login_response, AuthLoginRequest,
+    AuthState, AuthenticatedRequest,
+};
 use self::handlers as h;
 use self::state::AppState;
-
 /// Frontend assets embedded at compile time from the `dist/` directory.
 ///
 /// When building with `cargo build --features webui-server`, the contents of
@@ -46,22 +50,30 @@ struct EmbeddedAssets;
 /// Build the complete Axum router with all API routes and SPA fallback.
 pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Option<&str>) -> Router {
     // Restrict CORS when auth is enabled; permissive only for --no-auth.
-    let cors = if state.auth_token.is_some() {
+    let cors = if state.auth.is_enabled() {
         let origin = format!("http://{host}:{port}")
             .parse::<HeaderValue>()
             .unwrap_or_else(|_| HeaderValue::from_static("http://localhost:3727"));
         CorsLayer::new()
             .allow_origin(origin)
             .allow_methods([Method::GET, Method::POST])
-            .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+            .allow_headers([
+                header::CONTENT_TYPE,
+                header::AUTHORIZATION,
+                HeaderName::from_static("x-csrf-token"),
+            ])
     } else {
         CorsLayer::new()
             .allow_origin(tower_http::cors::Any)
             .allow_methods([Method::GET, Method::POST])
-            .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+            .allow_headers([
+                header::CONTENT_TYPE,
+                header::AUTHORIZATION,
+                HeaderName::from_static("x-csrf-token"),
+            ])
     };
 
-    let api = Router::new()
+    let protected_api = Router::new()
         // SSE endpoint for real-time file change events
         .route("/events", get(sse_handler))
         // Project commands
@@ -188,6 +200,11 @@ pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Optio
             auth_middleware,
         ));
 
+    let api = Router::new()
+        .route("/auth/login", post(auth_login_handler))
+        .route("/auth/logout", post(auth_logout_handler))
+        .merge(protected_api);
+
     let mut app = Router::new()
         .route("/health", get(health_handler))
         .nest("/api", api)
@@ -219,6 +236,21 @@ pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Optio
 // Auth middleware
 // ---------------------------------------------------------------------------
 
+async fn auth_login_handler(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<AuthLoginRequest>,
+) -> Response {
+    match state.auth.login(&payload) {
+        Ok(outcome) => login_response(outcome, state.auth.secure_cookies()),
+        Err(failure) => auth_error_response(failure),
+    }
+}
+
+async fn auth_logout_handler(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    state.auth.logout(&headers);
+    clear_auth_cookies_response(state.auth.secure_cookies())
+}
+
 /// Apply response security headers globally.
 async fn security_headers_middleware(request: Request, next: Next) -> Response {
     let mut response = next.run(request).await;
@@ -237,61 +269,30 @@ async fn security_headers_middleware(request: Request, next: Next) -> Response {
 ///
 /// Accepts the token from either:
 ///   - `Authorization: Bearer <token>` header (normal API calls)
-///   - `?token=<token>` query parameter (`EventSource` / SSE connections)
+///   - legacy `cchv_auth=<token>` `HttpOnly` cookie (token mode)
+///   - `cchv_session=<random-session-id>` `HttpOnly` cookie (account mode)
+///   - `?token=<token>` query parameter for SSE only (legacy token mode)
 ///
-/// When `auth_token` is `None` (i.e. `--no-auth`), all requests pass through.
+/// When auth is disabled (`--no-auth`), all requests pass through.
 async fn auth_middleware(
     State(state): State<Arc<AppState>>,
     request: Request,
     next: Next,
 ) -> Result<impl IntoResponse, StatusCode> {
-    let Some(expected) = &state.auth_token else {
-        return Ok(next.run(request).await);
-    };
-
-    // 1. Check Authorization header
-    if let Some(header) = request.headers().get("authorization") {
-        if let Ok(value) = header.to_str() {
-            if let Some(token) = value.strip_prefix("Bearer ") {
-                if constant_time_eq(token.as_bytes(), expected.as_bytes()) {
-                    return Ok(next.run(request).await);
-                }
+    match state.auth.authenticate(&request) {
+        AuthenticatedRequest::None if matches!(state.auth, AuthState::Disabled) => {
+            Ok(next.run(request).await)
+        }
+        AuthenticatedRequest::Token => Ok(next.run(request).await),
+        AuthenticatedRequest::Account { csrf_token } => {
+            if csrf_valid(&request, &csrf_token) {
+                Ok(next.run(request).await)
+            } else {
+                Err(StatusCode::FORBIDDEN)
             }
         }
+        AuthenticatedRequest::None => Err(StatusCode::UNAUTHORIZED),
     }
-
-    // 2. Check ?token= query parameter only for SSE endpoint
-    // (EventSource cannot set custom Authorization headers).
-    if allow_query_token(&request) {
-        if let Some(query) = request.uri().query() {
-            for pair in query.split('&') {
-                if let Some(token) = pair.strip_prefix("token=") {
-                    let decoded = urlencoding::decode(token).unwrap_or_default();
-                    if constant_time_eq(decoded.as_bytes(), expected.as_bytes()) {
-                        return Ok(next.run(request).await);
-                    }
-                }
-            }
-        }
-    }
-
-    Err(StatusCode::UNAUTHORIZED)
-}
-
-/// Query-token auth is allowed only for SSE endpoint requests.
-fn allow_query_token(request: &Request) -> bool {
-    if request.method() != Method::GET {
-        return false;
-    }
-    matches!(request.uri().path(), "/api/events" | "/events")
-}
-
-/// Constant-time byte comparison to prevent timing side-channel attacks on token validation.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
 }
 
 // ---------------------------------------------------------------------------
@@ -426,29 +427,243 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::metadata::MetadataState;
+    use crate::server::auth::{
+        hash_password_argon2id, AccountAuth, CSRF_COOKIE_NAME, LEGACY_AUTH_COOKIE_NAME,
+        SESSION_COOKIE_NAME,
+    };
     use axum::body::Body;
+    use tower::ServiceExt;
+
+    fn test_state(auth_token: Option<&str>) -> Arc<AppState> {
+        let (event_tx, _rx) =
+            tokio::sync::broadcast::channel::<crate::commands::watcher::FileWatchEvent>(1);
+        Arc::new(AppState {
+            metadata: Arc::new(MetadataState::default()),
+            start_time: std::time::Instant::now(),
+            auth: auth_token
+                .map(|token| AuthState::Token {
+                    token: token.to_string(),
+                    secure_cookies: false,
+                })
+                .unwrap_or(AuthState::Disabled),
+            event_tx,
+        })
+    }
+
+    fn test_account_state() -> Arc<AppState> {
+        let (event_tx, _rx) =
+            tokio::sync::broadcast::channel::<crate::commands::watcher::FileWatchEvent>(1);
+        let password_hash = hash_password_argon2id("secret-password").unwrap();
+        Arc::new(AppState {
+            metadata: Arc::new(MetadataState::default()),
+            start_time: std::time::Instant::now(),
+            auth: AuthState::Account(Arc::new(AccountAuth::new(
+                "admin".to_string(),
+                password_hash,
+                false,
+            ))),
+            event_tx,
+        })
+    }
+
+    fn cookie_header_from_response(response: &Response) -> String {
+        response
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .filter_map(|cookie| cookie.split(';').next())
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
 
     #[test]
     fn test_allow_query_token_only_for_sse_get() {
+        let auth = AuthState::Token {
+            token: "abc".to_string(),
+            secure_cookies: false,
+        };
         let sse_get = Request::builder()
             .method(Method::GET)
             .uri("/api/events?token=abc")
             .body(Body::empty())
             .unwrap();
-        assert!(allow_query_token(&sse_get));
+        assert!(matches!(
+            auth.authenticate(&sse_get),
+            AuthenticatedRequest::Token
+        ));
 
         let api_post = Request::builder()
             .method(Method::POST)
             .uri("/api/scan_projects?token=abc")
             .body(Body::empty())
             .unwrap();
-        assert!(!allow_query_token(&api_post));
+        assert!(matches!(
+            auth.authenticate(&api_post),
+            AuthenticatedRequest::None
+        ));
 
         let non_sse_get = Request::builder()
             .method(Method::GET)
             .uri("/api/load_project_sessions?token=abc")
             .body(Body::empty())
             .unwrap();
-        assert!(!allow_query_token(&non_sse_get));
+        assert!(matches!(
+            auth.authenticate(&non_sse_get),
+            AuthenticatedRequest::None
+        ));
+    }
+    #[test]
+    fn test_auth_cookie_token_reads_named_cookie() {
+        let auth = AuthState::Token {
+            token: "abc 123".to_string(),
+            secure_cookies: false,
+        };
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/api/scan_projects")
+            .header(header::COOKIE, "theme=dark; cchv_auth=abc%20123; other=1")
+            .body(Body::empty())
+            .unwrap();
+
+        assert!(matches!(
+            auth.authenticate(&request),
+            AuthenticatedRequest::Token
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_auth_login_sets_http_only_cookie() {
+        let app = build_router(test_state(Some("secret-token")), "127.0.0.1", 3727, None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"token":"secret-token"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(cookie.contains(&format!("{LEGACY_AUTH_COOKIE_NAME}=secret-token")));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert!(cookie.contains("Path=/"));
+        assert!(cookie.contains("Max-Age=604800"));
+    }
+
+    #[tokio::test]
+    async fn test_auth_cookie_allows_protected_api() {
+        let app = build_router(test_state(Some("secret-token")), "127.0.0.1", 3727, None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/events")
+                    .header(header::COOKIE, "theme=dark; cchv_auth=secret-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_auth_login_is_rejected() {
+        let app = build_router(test_state(Some("secret-token")), "127.0.0.1", 3727, None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"token":"wrong"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_account_login_sets_session_and_csrf_cookies() {
+        let app = build_router(test_account_state(), "127.0.0.1", 3727, None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"username":"admin","password":"secret-password"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let cookies = response
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .collect::<Vec<_>>();
+        assert!(cookies
+            .iter()
+            .any(|cookie| cookie.contains(&format!("{SESSION_COOKIE_NAME}="))
+                && cookie.contains("HttpOnly")
+                && cookie.contains("SameSite=Strict")));
+        assert!(cookies.iter().any(|cookie| {
+            cookie.contains(&format!("{CSRF_COOKIE_NAME}=")) && cookie.contains("SameSite=Strict")
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_account_session_requires_csrf_for_post() {
+        let app = build_router(test_account_state(), "127.0.0.1", 3727, None);
+        let login_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"username":"admin","password":"secret-password"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let cookie_header = cookie_header_from_response(&login_response);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/get_claude_folder_path")
+                    .header(header::COOKIE, cookie_header)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -141,8 +141,22 @@ const READ_ONLY_MUTATING_API_PATHS: &[&str] = &[
 #[folder = "../dist"]
 struct EmbeddedAssets;
 
+#[derive(Clone)]
+enum SpaIndex {
+    Html(Arc<String>),
+    Embedded { base_path: String },
+}
+
 /// Build the complete Axum router with all API routes and SPA fallback.
-pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Option<&str>) -> Router {
+pub fn build_router(
+    state: Arc<AppState>,
+    host: &str,
+    port: u16,
+    dist_dir: Option<&str>,
+    base_path: &str,
+) -> Router {
+    let base_path = normalize_base_path(base_path).expect("Invalid WebUI base path");
+
     // Restrict CORS when auth is enabled; permissive only for --no-auth.
     let cors = if state.auth.is_enabled() {
         let origin = format!("http://{host}:{port}")
@@ -316,19 +330,140 @@ pub fn build_router(state: Arc<AppState>, host: &str, port: u16, dist_dir: Optio
 
     // Serve React SPA build output as static files.
     // For unknown paths, fall back to index.html with HTTP 200 so client-side routing works.
+    let spa_index: SpaIndex;
     if let Some(dist) = dist_dir {
         // External mode: serve from filesystem (development / override)
         let index_html = std::fs::read_to_string(format!("{dist}/index.html"))
             .expect("Failed to read dist/index.html — is --dist correct?");
-        let spa_fallback = get(move || std::future::ready(Html(index_html.clone())));
+        let index_html = inject_base_path(&index_html, &base_path);
+        spa_index = SpaIndex::Html(Arc::new(index_html));
+        let index_for_root = spa_index.clone();
+        let index_for_fallback = spa_index.clone();
+        let spa_root = get(move || {
+            let index = index_for_root.clone();
+            async move { spa_index_response(index) }
+        });
+        let spa_fallback = get(move || {
+            let index = index_for_fallback.clone();
+            async move { spa_index_response(index) }
+        });
         let serve_dir = ServeDir::new(dist);
-        app = app.fallback_service(serve_dir.fallback(spa_fallback));
+        app = app
+            .route("/", spa_root)
+            .fallback_service(serve_dir.fallback(spa_fallback));
     } else {
         // Embedded mode: serve from rust-embed compiled assets (production default)
-        app = app.fallback(get(embedded_asset_handler));
+        spa_index = SpaIndex::Embedded {
+            base_path: base_path.clone(),
+        };
+        let index_for_root = spa_index.clone();
+        let base_path_for_assets = base_path.clone();
+        app = app
+            .route(
+                "/",
+                get(move || {
+                    let index = index_for_root.clone();
+                    async move { spa_index_response(index) }
+                }),
+            )
+            .fallback(get(move |req| {
+                let base_path = base_path_for_assets.clone();
+                async move { embedded_asset_handler(req, base_path) }
+            }));
     }
 
-    app
+    if base_path == "/" {
+        app
+    } else {
+        let base_path_with_slash = base_href(&base_path);
+        let index_for_base_path = spa_index;
+        let base_path_for_fallback = base_path.clone();
+        Router::new()
+            .nest(&base_path, app)
+            .fallback(move |request: Request| {
+                let index = index_for_base_path.clone();
+                let base_path = base_path_for_fallback.clone();
+                let base_path_with_slash = base_path_with_slash.clone();
+                async move {
+                    let path = request.uri().path();
+                    if path == base_path || path == base_path_with_slash {
+                        spa_index_response(index)
+                    } else {
+                        StatusCode::NOT_FOUND.into_response()
+                    }
+                }
+            })
+    }
+}
+
+/// Normalize a reverse-proxy path prefix for mounting the `WebUI` below `/`.
+pub fn normalize_base_path(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "/" {
+        return Ok("/".to_string());
+    }
+
+    if !trimmed.starts_with('/') {
+        return Err("base path must start with '/'".to_string());
+    }
+    if trimmed.contains('?') || trimmed.contains('#') {
+        return Err("base path must not contain query strings or fragments".to_string());
+    }
+    if trimmed.chars().any(char::is_whitespace) {
+        return Err("base path must not contain whitespace".to_string());
+    }
+
+    let without_trailing = trimmed.trim_end_matches('/');
+    if without_trailing.is_empty() {
+        return Ok("/".to_string());
+    }
+
+    for segment in without_trailing.split('/').skip(1) {
+        if segment.is_empty() {
+            return Err("base path must not contain empty segments".to_string());
+        }
+        if segment == "." || segment == ".." {
+            return Err("base path must not contain '.' or '..' segments".to_string());
+        }
+    }
+
+    Ok(without_trailing.to_string())
+}
+
+fn base_href(base_path: &str) -> String {
+    if base_path == "/" {
+        "/".to_string()
+    } else {
+        format!("{base_path}/")
+    }
+}
+
+fn inject_base_path(index_html: &str, base_path: &str) -> String {
+    let base_path_json = serde_json::to_string(base_path).unwrap_or_else(|_| "\"/\"".to_string());
+    let snippet = format!(
+        "    <base href=\"{}\" />\n    <script>window.__WEBUI_BASE_PATH__ = {};</script>\n",
+        base_href(base_path),
+        base_path_json
+    );
+
+    if let Some(head_end) = index_html.find("<head>") {
+        let insert_at = head_end + "<head>".len();
+        let mut html = String::with_capacity(index_html.len() + snippet.len() + 1);
+        html.push_str(&index_html[..insert_at]);
+        html.push('\n');
+        html.push_str(&snippet);
+        html.push_str(&index_html[insert_at..]);
+        html
+    } else {
+        format!("{snippet}{index_html}")
+    }
+}
+
+fn spa_index_response(index: SpaIndex) -> Response {
+    match index {
+        SpaIndex::Html(html) => Html((*html).clone()).into_response(),
+        SpaIndex::Embedded { base_path } => embedded_index_response(base_path),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -466,7 +601,7 @@ async fn health_handler() -> Json<serde_json::Value> {
 ///
 /// - Exact file match → serve with correct `Content-Type`.
 /// - No match → serve `index.html` (SPA client-side routing fallback).
-async fn embedded_asset_handler(req: Request) -> Response {
+fn embedded_asset_handler(req: Request, base_path: String) -> Response {
     let path = req.uri().path().trim_start_matches('/');
 
     // Try the exact path first, then fall back to index.html for SPA routing.
@@ -474,9 +609,9 @@ async fn embedded_asset_handler(req: Request) -> Response {
         let mime = mime_guess::from_path(path)
             .first_or_octet_stream()
             .to_string();
-        (file.data, mime)
-    } else if let Some(index) = EmbeddedAssets::get("index.html") {
-        (index.data, "text/html".to_string())
+        (Body::from(file.data.into_owned()), mime)
+    } else if let Some(index) = embedded_index_body(&base_path) {
+        (index, "text/html".to_string())
     } else {
         return (
             StatusCode::NOT_FOUND,
@@ -488,13 +623,41 @@ async fn embedded_asset_handler(req: Request) -> Response {
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, mime)
-        .body(Body::from(data.into_owned()))
+        .body(data)
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
+fn embedded_index_response(base_path: String) -> Response {
+    let Some(body) = embedded_index_body(&base_path) else {
+        return (
+            StatusCode::NOT_FOUND,
+            "index.html not found in embedded assets",
+        )
+            .into_response();
+    };
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/html")
+        .body(body)
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+fn embedded_index_body(base_path: &str) -> Option<Body> {
+    let index = EmbeddedAssets::get("index.html")?;
+    let html = String::from_utf8_lossy(&index.data);
+    Some(Body::from(inject_base_path(&html, base_path)))
+}
+
 /// Start the Axum HTTP server.
-pub async fn start(state: Arc<AppState>, host: &str, port: u16, dist_dir: Option<&str>) {
-    let router = build_router(state, host, port, dist_dir);
+pub async fn start(
+    state: Arc<AppState>,
+    host: &str,
+    port: u16,
+    dist_dir: Option<&str>,
+    base_path: &str,
+) {
+    let router = build_router(state, host, port, dist_dir, base_path);
 
     let addr: SocketAddr = format!("{host}:{port}")
         .parse()
@@ -506,7 +669,10 @@ pub async fn start(state: Arc<AppState>, host: &str, port: u16, dist_dir: Option
         );
     }
 
-    eprintln!("🚀 WebUI server running at http://{addr}");
+    eprintln!(
+        "🚀 WebUI server running at http://{addr}{}",
+        base_href(base_path)
+    );
     eprintln!("   Press Ctrl+C to stop");
 
     let listener = tokio::net::TcpListener::bind(addr)
@@ -559,6 +725,7 @@ mod tests {
         hash_password_argon2id, AccountAuth, CSRF_COOKIE_NAME, LEGACY_AUTH_COOKIE_NAME,
         SESSION_COOKIE_NAME,
     };
+    use axum::body::to_bytes;
     use axum::body::Body;
     use tower::ServiceExt;
 
@@ -664,7 +831,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_auth_login_sets_http_only_cookie() {
-        let app = build_router(test_state(Some("secret-token")), "127.0.0.1", 3727, None);
+        let app = build_router(
+            test_state(Some("secret-token")),
+            "127.0.0.1",
+            3727,
+            None,
+            "/",
+        );
         let response = app
             .oneshot(
                 Request::builder()
@@ -693,7 +866,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_auth_cookie_allows_protected_api() {
-        let app = build_router(test_state(Some("secret-token")), "127.0.0.1", 3727, None);
+        let app = build_router(
+            test_state(Some("secret-token")),
+            "127.0.0.1",
+            3727,
+            None,
+            "/",
+        );
         let response = app
             .oneshot(
                 Request::builder()
@@ -711,7 +890,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_auth_login_is_rejected() {
-        let app = build_router(test_state(Some("secret-token")), "127.0.0.1", 3727, None);
+        let app = build_router(
+            test_state(Some("secret-token")),
+            "127.0.0.1",
+            3727,
+            None,
+            "/",
+        );
         let response = app
             .oneshot(
                 Request::builder()
@@ -729,7 +914,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_account_login_sets_session_and_csrf_cookies() {
-        let app = build_router(test_account_state(), "127.0.0.1", 3727, None);
+        let app = build_router(test_account_state(), "127.0.0.1", 3727, None, "/");
         let response = app
             .oneshot(
                 Request::builder()
@@ -763,7 +948,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_account_session_requires_csrf_for_post() {
-        let app = build_router(test_account_state(), "127.0.0.1", 3727, None);
+        let app = build_router(test_account_state(), "127.0.0.1", 3727, None, "/");
         let login_response = app
             .clone()
             .oneshot(
@@ -853,10 +1038,13 @@ mod tests {
         let start = full
             .find("pub fn build_router")
             .expect("build_router definition");
+        // End at the test module so this test's own doc-comment route examples and
+        // any test-only routers are never parsed as real routes. Only build_router
+        // (and the asset/start helpers, which register no routes) precede it.
         let end = full[start..]
-            .find("\nasync fn embedded_asset_handler")
+            .find("\n#[cfg(test)]")
             .map(|i| start + i)
-            .unwrap_or(full.len());
+            .expect("test module marker after build_router");
         let src = &full[start..end];
         // Matches both inline and multi-line `.route( "<path>", post(` forms.
         let re = regex::Regex::new(r#"\.route\(\s*"(/[a-z_]+)"\s*,\s*post\("#).unwrap();
@@ -884,6 +1072,111 @@ mod tests {
                 registered.contains(path),
                 "classified path {path} is not a registered POST route (stale entry)"
             );
+        }
+    }
+
+    #[test]
+    fn test_normalize_base_path() {
+        assert_eq!(normalize_base_path("").unwrap(), "/");
+        assert_eq!(normalize_base_path("/").unwrap(), "/");
+        assert_eq!(normalize_base_path("/viewer/").unwrap(), "/viewer");
+        assert_eq!(
+            normalize_base_path("/tools/claude-history").unwrap(),
+            "/tools/claude-history"
+        );
+
+        assert!(normalize_base_path("viewer").is_err());
+        assert!(normalize_base_path("/viewer//history").is_err());
+        assert!(normalize_base_path("/viewer/../history").is_err());
+        assert!(normalize_base_path("/viewer?x=1").is_err());
+        assert!(normalize_base_path("/viewer history").is_err());
+    }
+
+    #[test]
+    fn test_inject_base_path_adds_base_and_runtime_config() {
+        let html = "<html><head><title>x</title></head><body></body></html>";
+        let injected = inject_base_path(html, "/tools/history");
+
+        assert!(injected.contains("<base href=\"/tools/history/\" />"));
+        assert!(injected.contains("window.__WEBUI_BASE_PATH__ = \"/tools/history\";"));
+        assert!(injected.find("<base").unwrap() < injected.find("<title>").unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_prefixed_router_serves_api_under_base_path() {
+        let app = build_router(test_state(None), "127.0.0.1", 3727, None, "/viewer");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/viewer/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_prefixed_router_does_not_expose_root_api() {
+        let app = build_router(test_state(None), "127.0.0.1", 3727, None, "/viewer");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_prefixed_spa_fallback_injects_base_path() {
+        let app = build_router(test_state(None), "127.0.0.1", 3727, None, "/viewer");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/viewer/sessions/abc")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains("<base href=\"/viewer/\" />"));
+        assert!(body.contains("window.__WEBUI_BASE_PATH__ = \"/viewer\";"));
+    }
+
+    #[tokio::test]
+    async fn test_prefixed_router_serves_spa_root() {
+        let app = build_router(test_state(None), "127.0.0.1", 3727, None, "/viewer");
+        for uri in ["/viewer", "/viewer/"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(Method::GET)
+                        .uri(uri)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let body = String::from_utf8(body.to_vec()).unwrap();
+            assert!(body.contains("<base href=\"/viewer/\" />"));
         }
     }
 }

--- a/src-tauri/src/server/state.rs
+++ b/src-tauri/src/server/state.rs
@@ -19,6 +19,8 @@ pub struct AppState {
     pub start_time: Instant,
     /// `WebUI` authentication mode.
     pub auth: AuthState,
+    /// Whether mutating `WebUI` API endpoints should be rejected.
+    pub read_only: bool,
     /// Broadcast channel for file-change events (SSE consumers subscribe here).
     pub event_tx: broadcast::Sender<FileWatchEvent>,
 }

--- a/src-tauri/src/server/state.rs
+++ b/src-tauri/src/server/state.rs
@@ -5,6 +5,7 @@
 
 use crate::commands::metadata::MetadataState;
 use crate::commands::watcher::FileWatchEvent;
+use crate::server::auth::AuthState;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::broadcast;
@@ -16,8 +17,8 @@ pub struct AppState {
     pub metadata: Arc<MetadataState>,
     /// Server start time for uptime calculation.
     pub start_time: Instant,
-    /// Bearer token for API authentication. `None` means auth is disabled (`--no-auth`).
-    pub auth_token: Option<String>,
+    /// `WebUI` authentication mode.
+    pub auth: AuthState,
     /// Broadcast channel for file-change events (SSE consumers subscribe here).
     pub event_tx: broadcast::Sender<FileWatchEvent>,
 }

--- a/src/components/SessionItem/SessionItem.tsx
+++ b/src/components/SessionItem/SessionItem.tsx
@@ -80,6 +80,7 @@ export const SessionItem: React.FC<SessionItemProps> = ({
             isNamed={editing.isNamed}
             isSelected={isSelected}
             isContextMenuOpen={editing.isContextMenuOpen}
+            readOnly={editing.isServerReadOnly}
             providerId={editing.providerId}
             supportsNativeRename={editing.supportsNativeRename}
             supportsResumeCommand={editing.supportsResumeCommand}
@@ -117,6 +118,7 @@ export const SessionItem: React.FC<SessionItemProps> = ({
         <SessionContextMenu
           position={contextMenu}
           hasCustomName={editing.hasCustomName}
+          readOnly={editing.isServerReadOnly}
           supportsNativeRename={editing.supportsNativeRename}
           supportsResumeCommand={editing.supportsResumeCommand}
           supportsSessionDeletion={editing.supportsSessionDeletion}

--- a/src/components/SessionItem/components/SessionContextMenu.tsx
+++ b/src/components/SessionItem/components/SessionContextMenu.tsx
@@ -17,6 +17,7 @@ import { computeMenuPosition, type Boundary } from "@/utils/contextMenu";
 interface SessionContextMenuProps {
   position: { x: number; y: number; boundary?: Boundary | null };
   hasCustomName: boolean;
+  readOnly: boolean;
   supportsNativeRename: boolean;
   supportsResumeCommand: boolean;
   supportsSessionDeletion: boolean;
@@ -36,6 +37,7 @@ interface SessionContextMenuProps {
 export const SessionContextMenu: React.FC<SessionContextMenuProps> = ({
   position,
   hasCustomName,
+  readOnly,
   supportsNativeRename,
   supportsResumeCommand,
   supportsSessionDeletion,
@@ -139,19 +141,21 @@ export const SessionContextMenu: React.FC<SessionContextMenuProps> = ({
       style={{ left: adjustedPosition.x, top: adjustedPosition.y }}
     >
       <div className="p-1">
-        <button type="button" role="menuitem" onClick={handleAction(onRenameClick)} className={menuItemClass}>
-          <Pencil className="w-3.5 h-3.5" />
-          <span>{t("session.renameMenuItem", "Rename")}</span>
-        </button>
+        {!readOnly && (
+          <button type="button" role="menuitem" onClick={handleAction(onRenameClick)} className={menuItemClass}>
+            <Pencil className="w-3.5 h-3.5" />
+            <span>{t("session.renameMenuItem", "Rename")}</span>
+          </button>
+        )}
 
-        {hasCustomName && (
+        {!readOnly && hasCustomName && (
           <button type="button" role="menuitem" onClick={handleAction(onResetCustomName)} className={menuItemClass}>
             <RotateCcw className="w-3.5 h-3.5" />
             <span>{t("session.resetName", "Reset name")}</span>
           </button>
         )}
 
-        {supportsNativeRename && (
+        {!readOnly && supportsNativeRename && (
           <>
             <div className="my-1 border-t border-border/50" />
             <button type="button" role="menuitem" onClick={handleAction(onNativeRenameClick)} className={menuItemClass}>
@@ -167,7 +171,7 @@ export const SessionContextMenu: React.FC<SessionContextMenuProps> = ({
           </>
         )}
 
-        <div className="my-1 border-t border-border/50" />
+        {!readOnly && <div className="my-1 border-t border-border/50" />}
 
         <button type="button" role="menuitem" onClick={handleAction(onCopySessionId)} className={menuItemClass}>
           <Copy className="w-3.5 h-3.5" />

--- a/src/components/SessionItem/components/SessionNameEditor.tsx
+++ b/src/components/SessionItem/components/SessionNameEditor.tsx
@@ -11,6 +11,7 @@ import {
   FolderOpen,
   Play,
   Trash2,
+  MoreHorizontal,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -37,6 +38,7 @@ export const SessionNameEditor: React.FC<SessionNameEditorProps> = ({
   isNamed,
   isSelected,
   isContextMenuOpen,
+  readOnly,
   providerId,
   supportsNativeRename,
   supportsResumeCommand,
@@ -124,10 +126,11 @@ export const SessionNameEditor: React.FC<SessionNameEditorProps> = ({
       <span
         className={cn(
           "text-xs leading-relaxed line-clamp-2 transition-colors duration-300 flex-1 cursor-pointer flex items-start gap-1",
+          readOnly && "cursor-default",
           isSelected ? "text-accent font-medium" : "text-sidebar-foreground/70"
         )}
-        onDoubleClick={onDoubleClick}
-        title={t("session.renameHint", "Double-click to rename")}
+        onDoubleClick={readOnly ? undefined : onDoubleClick}
+        title={readOnly ? displayName : t("session.renameHint", "Double-click to rename")}
       >
         {hasClaudeCodeName && (
           <Tooltip>
@@ -181,24 +184,26 @@ export const SessionNameEditor: React.FC<SessionNameEditorProps> = ({
               "hover:bg-accent/20 text-muted-foreground hover:text-accent",
               isContextMenuOpen && "opacity-100"
             )}
-            title={t("session.renameAction", "Rename session")}
-            aria-label={t("session.renameAction", "Rename session")}
+            title={readOnly ? t("session.actions", "Session actions") : t("session.renameAction", "Rename session")}
+            aria-label={readOnly ? t("session.actions", "Session actions") : t("session.renameAction", "Rename session")}
           >
-            <Pencil className="w-3 h-3" />
+            {readOnly ? <MoreHorizontal className="w-3 h-3" /> : <Pencil className="w-3 h-3" />}
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuItem onClick={onRenameClick}>
-            <Pencil className="w-3 h-3 mr-2" />
-            {t("session.renameMenuItem", "Rename")}
-          </DropdownMenuItem>
-          {hasCustomName && (
+          {!readOnly && (
+            <DropdownMenuItem onClick={onRenameClick}>
+              <Pencil className="w-3 h-3 mr-2" />
+              {t("session.renameMenuItem", "Rename")}
+            </DropdownMenuItem>
+          )}
+          {!readOnly && hasCustomName && (
             <DropdownMenuItem onClick={onResetCustomName}>
               <RotateCcw className="w-3 h-3 mr-2" />
               {t("session.resetName", "Reset name")}
             </DropdownMenuItem>
           )}
-          {supportsNativeRename && (
+          {!readOnly && supportsNativeRename && (
             <>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={onNativeRenameClick}>
@@ -220,7 +225,7 @@ export const SessionNameEditor: React.FC<SessionNameEditorProps> = ({
               </DropdownMenuItem>
             </>
           )}
-          <DropdownMenuSeparator />
+          {!readOnly && <DropdownMenuSeparator />}
           <DropdownMenuItem onClick={onCopySessionId}>
             <Copy className="w-3 h-3 mr-2" />
             {t("session.copySessionId", "Copy Session ID")}

--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -53,9 +53,12 @@ export function useSessionEditing(session: ClaudeSession) {
   const ignoreBlurRef = useRef<boolean>(false);
 
   const providerId = session.provider ?? "claude";
-  const supportsNativeRename = providerSupportsNativeRename(providerId);
+  const isServerReadOnly = useAppStore((state) => state.isServerReadOnly);
+  const supportsNativeRename =
+    !isServerReadOnly && providerSupportsNativeRename(providerId);
   const supportsResumeCommand = providerSupportsResumeCommand(providerId);
-  const supportsSessionDeletion = providerSupportsSessionDeletion(providerId);
+  const supportsSessionDeletion =
+    !isServerReadOnly && providerSupportsSessionDeletion(providerId);
   const supportsRevealInFinder = isAbsolutePath(session.file_path);
   const isArchivedCodexSession =
     providerId === "codex" &&
@@ -80,11 +83,16 @@ export function useSessionEditing(session: ClaudeSession) {
   const isNamed = hasCustomName || hasClaudeCodeName || !!session.is_renamed;
 
   const startEditing = useCallback(() => {
+    if (isServerReadOnly) return;
     setEditValue(displayName || "");
     setIsEditing(true);
-  }, [displayName]);
+  }, [displayName, isServerReadOnly]);
 
   const saveCustomName = useCallback(async () => {
+    if (isServerReadOnly) {
+      setIsEditing(false);
+      return;
+    }
     try {
       const trimmedValue = editValue.trim();
       if (!trimmedValue || trimmedValue === localSummary) {
@@ -98,7 +106,7 @@ export function useSessionEditing(session: ClaudeSession) {
     } finally {
       setIsEditing(false);
     }
-  }, [editValue, localSummary, setCustomName, t]);
+  }, [editValue, isServerReadOnly, localSummary, setCustomName, t]);
 
   const cancelEditing = useCallback(() => {
     setIsEditing(false);
@@ -106,6 +114,10 @@ export function useSessionEditing(session: ClaudeSession) {
   }, []);
 
   const resetCustomName = useCallback(async () => {
+    if (isServerReadOnly) {
+      setIsContextMenuOpen(false);
+      return;
+    }
     try {
       await setCustomName(undefined);
     } catch (error) {
@@ -114,7 +126,7 @@ export function useSessionEditing(session: ClaudeSession) {
     } finally {
       setIsContextMenuOpen(false);
     }
-  }, [setCustomName, t]);
+  }, [isServerReadOnly, setCustomName, t]);
 
   // Focus input when editing starts
   useEffect(() => {
@@ -345,6 +357,7 @@ export function useSessionEditing(session: ClaudeSession) {
     supportsSessionDeletion,
     supportsRevealInFinder,
     isArchivedCodexSession,
+    isServerReadOnly,
     inputRef,
     ignoreBlurRef,
 

--- a/src/components/SessionItem/types.ts
+++ b/src/components/SessionItem/types.ts
@@ -22,6 +22,7 @@ export interface SessionNameEditorProps {
   isNamed: boolean;
   isSelected: boolean;
   isContextMenuOpen: boolean;
+  readOnly: boolean;
   providerId: string;
   supportsNativeRename: boolean;
   supportsResumeCommand: boolean;

--- a/src/components/SettingsManager/UnifiedSettingsManager.tsx
+++ b/src/components/SettingsManager/UnifiedSettingsManager.tsx
@@ -17,6 +17,7 @@ import { Card } from "@/components/ui/card";
 import { RefreshCw, FolderTree, Archive, ChevronRight } from "lucide-react";
 import { useMCPServers } from "@/hooks/useMCPServers";
 import { useAnalyticsNavigation } from "@/hooks/analytics/useAnalyticsNavigation";
+import { useAppStore } from "@/store/useAppStore";
 import type {
   AllSettingsResponse,
   SettingsScope,
@@ -99,6 +100,7 @@ export const UnifiedSettingsManager: React.FC<UnifiedSettingsManagerProps> = ({
 }) => {
   const { t } = useTranslation();
   const { switchToArchive } = useAnalyticsNavigation();
+  const serverReadOnly = useAppStore((state) => state.isServerReadOnly);
 
   // Settings state
   const [allSettings, setAllSettings] = React.useState<AllSettingsResponse | null>(null);
@@ -184,7 +186,7 @@ export const UnifiedSettingsManager: React.FC<UnifiedSettingsManagerProps> = ({
     [activeScope, projectPath, loadSettings]
   );
 
-  const isReadOnly = activeScope === "managed";
+  const isReadOnly = serverReadOnly || activeScope === "managed";
 
   // Check if there are unsaved changes
   const hasUnsavedChanges = React.useMemo(() => {
@@ -315,6 +317,7 @@ export const UnifiedSettingsManager: React.FC<UnifiedSettingsManagerProps> = ({
               <CustomDirectoriesSection
                 isExpanded={isCustomDirsExpanded}
                 onToggle={(open) => setIsCustomDirsExpanded(open)}
+                readOnly={serverReadOnly}
               />
             </Card>
 
@@ -323,6 +326,7 @@ export const UnifiedSettingsManager: React.FC<UnifiedSettingsManagerProps> = ({
               <WslSection
                 isExpanded={isWslExpanded}
                 onToggle={(open) => setIsWslExpanded(open)}
+                readOnly={serverReadOnly}
               />
             </Card>
 

--- a/src/components/SettingsManager/sections/CustomDirectoriesSection.tsx
+++ b/src/components/SettingsManager/sections/CustomDirectoriesSection.tsx
@@ -43,6 +43,7 @@ function normalizePath(p: string): string {
 interface CustomDirectoriesSectionProps {
   isExpanded: boolean;
   onToggle: (open: boolean) => void;
+  readOnly?: boolean;
 }
 
 // ============================================================================
@@ -52,6 +53,7 @@ interface CustomDirectoriesSectionProps {
 export function CustomDirectoriesSection({
   isExpanded,
   onToggle,
+  readOnly = false,
 }: CustomDirectoriesSectionProps) {
   const { t } = useTranslation();
   const {
@@ -257,7 +259,7 @@ export function CustomDirectoriesSection({
                   )
                 )}
               </div>
-              {editingPath !== cp.path && (
+              {!readOnly && editingPath !== cp.path && (
                 <div className="flex shrink-0 gap-1">
                   <Button
                     variant="ghost"
@@ -294,7 +296,7 @@ export function CustomDirectoriesSection({
           )}
 
           {/* Add form */}
-          {isAdding ? (
+          {!readOnly && isAdding ? (
             <div
               className={cn(
                 "space-y-2 rounded-md border border-border p-3",
@@ -371,7 +373,7 @@ export function CustomDirectoriesSection({
                 </Button>
               </div>
             </div>
-          ) : (
+          ) : !readOnly ? (
             <Button
               variant="outline"
               size="sm"
@@ -381,7 +383,7 @@ export function CustomDirectoriesSection({
               <FolderPlus className="h-3.5 w-3.5 mr-1.5" />
               {t("settings.customDirectories.addDirectory")}
             </Button>
-          )}
+          ) : null}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/src/components/SettingsManager/sections/WslSection.tsx
+++ b/src/components/SettingsManager/sections/WslSection.tsx
@@ -28,13 +28,14 @@ import type { WslDistro } from "@/types";
 interface WslSectionProps {
   isExpanded: boolean;
   onToggle: (open: boolean) => void;
+  readOnly?: boolean;
 }
 
 // ============================================================================
 // Inner component (rendered only when WSL is available on Windows Tauri)
 // ============================================================================
 
-function WslSectionInner({ isExpanded, onToggle }: WslSectionProps) {
+function WslSectionInner({ isExpanded, onToggle, readOnly = false }: WslSectionProps) {
   const { t } = useTranslation();
   const { userMetadata, setWslEnabled, toggleWslDistro } = useAppStore();
 
@@ -126,6 +127,7 @@ function WslSectionInner({ isExpanded, onToggle }: WslSectionProps) {
               id="wsl-enabled"
               checked={wslSettings.enabled}
               onCheckedChange={handleToggleEnabled}
+              disabled={readOnly}
             />
           </div>
 
@@ -163,6 +165,7 @@ function WslSectionInner({ isExpanded, onToggle }: WslSectionProps) {
                           type="checkbox"
                           checked={!isExcluded}
                           onChange={() => handleToggleDistro(distro.name)}
+                          disabled={readOnly}
                           aria-label={distro.name}
                           className="h-4 w-4 rounded border-border"
                         />

--- a/src/components/auth/WebUILogin.tsx
+++ b/src/components/auth/WebUILogin.tsx
@@ -1,0 +1,196 @@
+import { type FormEvent, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { KeyRound, Loader2, Lock, ShieldCheck, User } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { loginWebUI } from "@/utils/platform";
+
+type LoginMode = "account" | "token";
+
+interface WebUILoginProps {
+  onAuthenticated: () => void;
+}
+
+export default function WebUILogin({ onAuthenticated }: WebUILoginProps) {
+  const { t } = useTranslation();
+  const [mode, setMode] = useState<LoginMode>("account");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [token, setToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canSubmit = useMemo(() => {
+    if (isSubmitting) return false;
+    if (mode === "account") {
+      return username.trim().length > 0 && password.length > 0;
+    }
+    return token.trim().length > 0;
+  }, [isSubmitting, mode, password, token, username]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    setError(null);
+    setIsSubmitting(true);
+    const result =
+      mode === "account"
+        ? await loginWebUI({ username, password })
+        : await loginWebUI({ token });
+    setIsSubmitting(false);
+
+    if (result.ok) {
+      onAuthenticated();
+      return;
+    }
+
+    setError(
+      result.status === 429
+        ? t("webui.login.errorRateLimited")
+        : t("webui.login.errorFailed"),
+    );
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-8 text-foreground">
+      <section className="w-full max-w-[420px] rounded-lg border border-border bg-card p-6 shadow-lg">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold leading-tight">
+              {t("webui.login.title")}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t("common.appName")}
+            </p>
+          </div>
+        </div>
+
+        <div
+          className="mb-5 grid grid-cols-2 rounded-md border border-border bg-muted p-1"
+          role="tablist"
+          aria-label={t("webui.login.methodLabel")}
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === "account"}
+            className={`flex h-9 items-center justify-center gap-2 rounded px-3 text-sm font-medium transition-colors ${
+              mode === "account"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => {
+              setMode("account");
+              setError(null);
+            }}
+          >
+            <User className="h-4 w-4" aria-hidden="true" />
+            {t("webui.login.account")}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === "token"}
+            className={`flex h-9 items-center justify-center gap-2 rounded px-3 text-sm font-medium transition-colors ${
+              mode === "token"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => {
+              setMode("token");
+              setError(null);
+            }}
+          >
+            <KeyRound className="h-4 w-4" aria-hidden="true" />
+            {t("webui.login.token")}
+          </button>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          {mode === "account" ? (
+            <>
+              <label className="block space-y-2">
+                <span className="text-sm font-medium">
+                  {t("webui.login.username")}
+                </span>
+                <div className="relative">
+                  <User
+                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <Input
+                    autoComplete="username"
+                    className="pl-9"
+                    value={username}
+                    onChange={(event) => setUsername(event.target.value)}
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </label>
+              <label className="block space-y-2">
+                <span className="text-sm font-medium">
+                  {t("webui.login.password")}
+                </span>
+                <div className="relative">
+                  <Lock
+                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <Input
+                    type="password"
+                    autoComplete="current-password"
+                    className="pl-9"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </label>
+            </>
+          ) : (
+            <label className="block space-y-2">
+              <span className="text-sm font-medium">
+                {t("webui.login.accessToken")}
+              </span>
+              <div className="relative">
+                <KeyRound
+                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                  aria-hidden="true"
+                />
+                <Input
+                  type="password"
+                  autoComplete="off"
+                  className="pl-9"
+                  value={token}
+                  onChange={(event) => setToken(event.target.value)}
+                  disabled={isSubmitting}
+                />
+              </div>
+            </label>
+          )}
+
+          {error ? (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              role="alert"
+            >
+              {error}
+            </div>
+          ) : null}
+
+          <Button className="w-full" type="submit" disabled={!canSubmit}>
+            {isSubmitting ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : null}
+            {t("webui.login.submit")}
+          </Button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -18,6 +18,7 @@ import enUpdate from './locales/en/update.json';
 import enFeedback from './locales/en/feedback.json';
 import enRecentEdits from './locales/en/recentEdits.json';
 import enArchive from './locales/en/archive.json';
+import enWebui from './locales/en/webui.json';
 
 // Korean
 import koCommon from './locales/ko/common.json';
@@ -32,6 +33,7 @@ import koUpdate from './locales/ko/update.json';
 import koFeedback from './locales/ko/feedback.json';
 import koRecentEdits from './locales/ko/recentEdits.json';
 import koArchive from './locales/ko/archive.json';
+import koWebui from './locales/ko/webui.json';
 
 // Japanese
 import jaCommon from './locales/ja/common.json';
@@ -46,6 +48,7 @@ import jaUpdate from './locales/ja/update.json';
 import jaFeedback from './locales/ja/feedback.json';
 import jaRecentEdits from './locales/ja/recentEdits.json';
 import jaArchive from './locales/ja/archive.json';
+import jaWebui from './locales/ja/webui.json';
 
 // Simplified Chinese
 import zhCNCommon from './locales/zh-CN/common.json';
@@ -60,6 +63,7 @@ import zhCNUpdate from './locales/zh-CN/update.json';
 import zhCNFeedback from './locales/zh-CN/feedback.json';
 import zhCNRecentEdits from './locales/zh-CN/recentEdits.json';
 import zhCNArchive from './locales/zh-CN/archive.json';
+import zhCNWebui from './locales/zh-CN/webui.json';
 
 // Traditional Chinese
 import zhTWCommon from './locales/zh-TW/common.json';
@@ -74,6 +78,7 @@ import zhTWUpdate from './locales/zh-TW/update.json';
 import zhTWFeedback from './locales/zh-TW/feedback.json';
 import zhTWRecentEdits from './locales/zh-TW/recentEdits.json';
 import zhTWArchive from './locales/zh-TW/archive.json';
+import zhTWWebui from './locales/zh-TW/webui.json';
 
 export const supportedLanguages = {
   en: 'English',
@@ -113,6 +118,7 @@ export const namespaces = [
   'feedback',
   'recentEdits',
   'archive',
+  'webui',
 ] as const;
 
 export type Namespace = (typeof namespaces)[number];
@@ -144,7 +150,8 @@ const resources = {
       enUpdate,
       enFeedback,
       enRecentEdits,
-      enArchive
+      enArchive,
+      enWebui
     ),
   },
   ko: {
@@ -160,7 +167,8 @@ const resources = {
       koUpdate,
       koFeedback,
       koRecentEdits,
-      koArchive
+      koArchive,
+      koWebui
     ),
   },
   ja: {
@@ -176,7 +184,8 @@ const resources = {
       jaUpdate,
       jaFeedback,
       jaRecentEdits,
-      jaArchive
+      jaArchive,
+      jaWebui
     ),
   },
   'zh-CN': {
@@ -192,7 +201,8 @@ const resources = {
       zhCNUpdate,
       zhCNFeedback,
       zhCNRecentEdits,
-      zhCNArchive
+      zhCNArchive,
+      zhCNWebui
     ),
   },
   'zh-TW': {
@@ -208,7 +218,8 @@ const resources = {
       zhTWUpdate,
       zhTWFeedback,
       zhTWRecentEdits,
-      zhTWArchive
+      zhTWArchive,
+      zhTWWebui
     ),
   },
 };

--- a/src/i18n/locales/en/webui.json
+++ b/src/i18n/locales/en/webui.json
@@ -1,0 +1,12 @@
+{
+  "webui.login.title": "WebUI sign in",
+  "webui.login.methodLabel": "Sign-in method",
+  "webui.login.account": "Account",
+  "webui.login.token": "Token",
+  "webui.login.username": "Username",
+  "webui.login.password": "Password",
+  "webui.login.accessToken": "Access token",
+  "webui.login.submit": "Sign in",
+  "webui.login.errorRateLimited": "Too many attempts. Try again later.",
+  "webui.login.errorFailed": "Sign in failed. Check your credentials and try again."
+}

--- a/src/i18n/locales/ja/webui.json
+++ b/src/i18n/locales/ja/webui.json
@@ -1,0 +1,12 @@
+{
+  "webui.login.title": "WebUI サインイン",
+  "webui.login.methodLabel": "サインイン方法",
+  "webui.login.account": "アカウント",
+  "webui.login.token": "トークン",
+  "webui.login.username": "ユーザー名",
+  "webui.login.password": "パスワード",
+  "webui.login.accessToken": "アクセストークン",
+  "webui.login.submit": "サインイン",
+  "webui.login.errorRateLimited": "試行回数が多すぎます。しばらくしてからもう一度お試しください。",
+  "webui.login.errorFailed": "サインインに失敗しました。認証情報を確認して、もう一度お試しください。"
+}

--- a/src/i18n/locales/ko/webui.json
+++ b/src/i18n/locales/ko/webui.json
@@ -1,0 +1,12 @@
+{
+  "webui.login.title": "WebUI 로그인",
+  "webui.login.methodLabel": "로그인 방식",
+  "webui.login.account": "계정",
+  "webui.login.token": "토큰",
+  "webui.login.username": "사용자 이름",
+  "webui.login.password": "비밀번호",
+  "webui.login.accessToken": "액세스 토큰",
+  "webui.login.submit": "로그인",
+  "webui.login.errorRateLimited": "시도 횟수가 너무 많습니다. 잠시 후 다시 시도하세요.",
+  "webui.login.errorFailed": "로그인에 실패했습니다. 자격 증명을 확인하고 다시 시도하세요."
+}

--- a/src/i18n/locales/zh-CN/webui.json
+++ b/src/i18n/locales/zh-CN/webui.json
@@ -1,0 +1,12 @@
+{
+  "webui.login.title": "WebUI 登录",
+  "webui.login.methodLabel": "登录方式",
+  "webui.login.account": "账户",
+  "webui.login.token": "令牌",
+  "webui.login.username": "用户名",
+  "webui.login.password": "密码",
+  "webui.login.accessToken": "访问令牌",
+  "webui.login.submit": "登录",
+  "webui.login.errorRateLimited": "尝试次数过多，请稍后再试。",
+  "webui.login.errorFailed": "登录失败，请检查您的凭据后重试。"
+}

--- a/src/i18n/locales/zh-TW/webui.json
+++ b/src/i18n/locales/zh-TW/webui.json
@@ -1,0 +1,12 @@
+{
+  "webui.login.title": "WebUI 登入",
+  "webui.login.methodLabel": "登入方式",
+  "webui.login.account": "帳戶",
+  "webui.login.token": "權杖",
+  "webui.login.username": "使用者名稱",
+  "webui.login.password": "密碼",
+  "webui.login.accessToken": "存取權杖",
+  "webui.login.submit": "登入",
+  "webui.login.errorRateLimited": "嘗試次數過多，請稍後再試。",
+  "webui.login.errorFailed": "登入失敗，請檢查您的憑證後重試。"
+}

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-05-25T07:37:00.105Z
- * 총 키 개수: 1781
+ * 생성 시간: 2026-06-17T08:01:22.449Z
+ * 총 키 개수: 1783
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (161개)
+ * common namespace의 번역 키 (162개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -111,6 +111,7 @@ export type CommonKeys =
   | 'common.provider.antigravity'
   | 'common.provider.claude'
   | 'common.provider.cline'
+  | 'common.provider.codebuddy'
   | 'common.provider.codex'
   | 'common.provider.cursor'
   | 'common.provider.detectError'
@@ -393,7 +394,7 @@ export type AnalyticsKeys =
   | 'analytics.weeklyActivity';
 
 /**
- * session namespace의 번역 키 (205개)
+ * session namespace의 번역 키 (206개)
  * 파일: locales/{lang}/session.json
  */
 export type SessionKeys =
@@ -594,6 +595,7 @@ export type SessionKeys =
   | 'session.scanning'
   | 'session.select'
   | 'session.selectDescription'
+  | 'session.selectError'
   | 'session.showJsonlFile'
   | 'session.summaryNotFound'
   | 'session.syncError'
@@ -2255,6 +2257,7 @@ export type TranslationKey =
   | 'common.provider.antigravity'
   | 'common.provider.claude'
   | 'common.provider.cline'
+  | 'common.provider.codebuddy'
   | 'common.provider.codex'
   | 'common.provider.cursor'
   | 'common.provider.detectError'
@@ -2904,6 +2907,7 @@ export type TranslationKey =
   | 'session.scanning'
   | 'session.select'
   | 'session.selectDescription'
+  | 'session.selectError'
   | 'session.showJsonlFile'
   | 'session.summaryNotFound'
   | 'session.syncError'

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -20,7 +20,7 @@ import { useModal } from "@/contexts/modal";
 
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
-import { isMacOS, isTauri } from "@/utils/platform";
+import { getAssetPath, isMacOS, isTauri } from "@/utils/platform";
 import { SettingDropdown } from "./SettingDropdown";
 
 interface HeaderProps {
@@ -106,7 +106,7 @@ export const Header = ({ analyticsActions, analyticsComputed, updater }: HeaderP
       {/* Left: Logo & Title */}
       <div className="relative z-10 flex items-center gap-2.5 min-w-0 pointer-events-none">
         <img
-          src="/app-icon.png"
+          src={getAssetPath("app-icon.png")}
           alt="Claude Code History"
           className="w-6 h-6 hidden md:block"
         />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,34 +11,56 @@ import { PlatformProvider } from "./contexts/platform";
 import { ThemeProvider } from "./contexts/theme/ThemeProvider.tsx";
 import { ModalProvider } from "./contexts/modal/ModalProvider.tsx";
 import { Toaster } from "sonner";
-import { initAuthToken, recoverAuthFromErrorQuery } from "./utils/platform";
+import WebUILogin from "./components/auth/WebUILogin.tsx";
+import {
+  clearAuthErrorQuery,
+  hasAuthErrorQuery,
+  initAuthToken,
+  syncAuthCookieFromStoredToken,
+} from "./utils/platform";
 
-// Initialise WebUI auth token from URL before anything else.
-// (No-op in Tauri desktop mode.)
-initAuthToken();
-// If startup hit `?auth_error=1`, prompt for token and reload once recovered.
-recoverAuthFromErrorQuery();
+async function bootstrap(): Promise<void> {
+  // Initialise WebUI auth token from URL before anything else.
+  // (No-op in Tauri desktop mode.)
+  initAuthToken();
+  const cookieSynced = await syncAuthCookieFromStoredToken();
+  if (cookieSynced) {
+    clearAuthErrorQuery();
+  }
+  const showLogin = hasAuthErrorQuery();
 
-// Apply OverlayScrollbars globally to body
-OverlayScrollbars(document.body, {
-  scrollbars: {
-    theme: "os-theme-custom",
-    autoHide: "leave",
-    autoHideDelay: 400,
-  },
-});
+  // Apply OverlayScrollbars globally to body
+  OverlayScrollbars(document.body, {
+    scrollbars: {
+      theme: "os-theme-custom",
+      autoHide: "leave",
+      autoHideDelay: 400,
+    },
+  });
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <ErrorBoundary>
-      <PlatformProvider>
-        <ThemeProvider>
-          <ModalProvider>
-            <App />
-            <Toaster />
-          </ModalProvider>
-        </ThemeProvider>
-      </PlatformProvider>
-    </ErrorBoundary>
-  </StrictMode>
-);
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <ErrorBoundary>
+        <PlatformProvider>
+          <ThemeProvider>
+            <ModalProvider>
+              {showLogin ? (
+                <WebUILogin
+                  onAuthenticated={() => {
+                    clearAuthErrorQuery();
+                    window.location.reload();
+                  }}
+                />
+              ) : (
+                <App />
+              )}
+              <Toaster />
+            </ModalProvider>
+          </ThemeProvider>
+        </PlatformProvider>
+      </ErrorBoundary>
+    </StrictMode>
+  );
+}
+
+void bootstrap();

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -13,8 +13,10 @@ import {
   isTauri,
   getApiBase,
   getAuthToken,
+  getCsrfToken,
   setAuthToken,
   clearAuthToken,
+  clearAuthCookie,
 } from "@/utils/platform";
 
 /** Validate command name to prevent path traversal in URL. */
@@ -48,10 +50,15 @@ export async function api<T>(
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
+  const csrfToken = getCsrfToken();
+  if (csrfToken) {
+    headers["X-CSRF-Token"] = csrfToken;
+  }
 
   const response = await fetch(`${base}/api/${command}`, {
     method: "POST",
     headers,
+    credentials: "same-origin",
     body: JSON.stringify(args ?? {}),
   });
 
@@ -68,11 +75,13 @@ export async function api<T>(
     // Avoid redirect loops when already on an auth error page.
     if (params.get("auth_error") === "1") {
       clearAuthToken();
-      throw new Error("Authentication required. Open the app with a valid token.");
+      await clearAuthCookie();
+      throw new Error("Authentication required.");
     }
 
     // Clear stale token and redirect once to an explicit auth-error URL.
     clearAuthToken();
+    await clearAuthCookie();
     params.set("auth_error", "1");
     const query = params.toString();
     window.location.replace(

--- a/src/store/slices/archiveSlice.ts
+++ b/src/store/slices/archiveSlice.ts
@@ -91,6 +91,8 @@ const initialArchiveState: ArchiveSliceState['archive'] = {
   error: null,
 };
 
+const READ_ONLY_ERROR = "Server is running in read-only mode";
+
 // ============================================================================
 // Slice Creator
 // ============================================================================
@@ -122,6 +124,10 @@ export const createArchiveSlice: StateCreator<
     },
 
     createArchive: async (params) => {
+      if (get().isServerReadOnly) {
+        set((s) => ({ archive: { ...s.archive, error: READ_ONLY_ERROR } }));
+        throw new Error(READ_ONLY_ERROR);
+      }
       set((s) => ({ archive: { ...s.archive, isCreatingArchive: true, error: null } }));
       try {
         const entry = await archiveApi.createArchive(params);
@@ -137,6 +143,10 @@ export const createArchiveSlice: StateCreator<
     },
 
     deleteArchive: async (id) => {
+      if (get().isServerReadOnly) {
+        set((s) => ({ archive: { ...s.archive, error: READ_ONLY_ERROR } }));
+        throw new Error(READ_ONLY_ERROR);
+      }
       set((s) => ({ archive: { ...s.archive, isDeletingArchive: true, error: null } }));
       try {
         await archiveApi.deleteArchive(id);
@@ -162,6 +172,10 @@ export const createArchiveSlice: StateCreator<
     },
 
     renameArchive: async (id, name) => {
+      if (get().isServerReadOnly) {
+        set((s) => ({ archive: { ...s.archive, error: READ_ONLY_ERROR } }));
+        throw new Error(READ_ONLY_ERROR);
+      }
       set((s) => ({ archive: { ...s.archive, isRenamingArchive: true, error: null } }));
       try {
         const newId = await archiveApi.renameArchive(id, name);

--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -117,6 +117,7 @@ const areMessagesEquivalent = (
     }
 
     if (
+      !nextMessage ||
       message.uuid !== nextMessage.uuid ||
       message.type !== nextMessage.type ||
       message.timestamp !== nextMessage.timestamp

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -88,6 +88,8 @@ const isTauriAvailable = () => {
 /** Auto-register CLAUDE_CONFIG_DIR as a custom directory if not already present. */
 async function autoRegisterConfigDir(get: () => FullAppStore): Promise<void> {
   try {
+    if (get().isServerReadOnly) return;
+
     const detected = await api<string | null>("detect_claude_config_dir");
     if (!detected) return;
 
@@ -120,6 +122,8 @@ export const createProjectSlice: StateCreator<
   initializeApp: async () => {
     set({ isLoading: true, error: null });
     try {
+      await get().loadServerConfig();
+
       if (!isTauriAvailable()) {
         throw new Error(
           "Tauri API를 사용할 수 없습니다. 데스크톱 앱에서 실행해주세요."
@@ -260,7 +264,7 @@ export const createProjectSlice: StateCreator<
       const { userMetadata, updateUserSettings } = get();
       const worktreeGrouping = userMetadata?.settings?.worktreeGrouping ?? false;
       const userHasSet = userMetadata?.settings?.worktreeGroupingUserSet ?? false;
-      if (!worktreeGrouping && !userHasSet && projects.length > 0) {
+      if (!get().isServerReadOnly && !worktreeGrouping && !userHasSet && projects.length > 0) {
         const { groups } = detectWorktreeGroupsHybrid(projects);
         if (groups.length > 0) {
           if (requestId !== getRequestId("scanProjects")) {

--- a/src/store/slices/serverSlice.ts
+++ b/src/store/slices/serverSlice.ts
@@ -1,0 +1,51 @@
+import { api } from "@/services/api";
+import { isTauri } from "@/utils/platform";
+import type { StateCreator } from "zustand";
+import type { FullAppStore } from "./types";
+
+interface ServerConfig {
+  readOnly?: boolean;
+}
+
+export interface ServerSliceState {
+  isServerReadOnly: boolean;
+  isServerConfigLoaded: boolean;
+}
+
+export interface ServerSliceActions {
+  loadServerConfig: () => Promise<void>;
+}
+
+export type ServerSlice = ServerSliceState & ServerSliceActions;
+
+const initialServerState: ServerSliceState = {
+  isServerReadOnly: false,
+  isServerConfigLoaded: false,
+};
+
+export const createServerSlice: StateCreator<
+  FullAppStore,
+  [],
+  [],
+  ServerSlice
+> = (set) => ({
+  ...initialServerState,
+
+  loadServerConfig: async () => {
+    if (isTauri()) {
+      set({ isServerReadOnly: false, isServerConfigLoaded: true });
+      return;
+    }
+
+    try {
+      const config = await api<ServerConfig>("get_server_config");
+      set({
+        isServerReadOnly: config.readOnly === true,
+        isServerConfigLoaded: true,
+      });
+    } catch (error) {
+      console.warn("Failed to load server config:", error);
+      set({ isServerReadOnly: false, isServerConfigLoaded: true });
+    }
+  },
+});

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -198,6 +198,10 @@ export interface AppStoreState {
   // Session picker state (used by CLI `--session-title` hint with multi-match)
   sessionPickerCandidates: import('./sessionPickerSlice').SessionPickerCandidate[] | null;
   sessionPickerHintValue: string | null;
+
+  // WebUI server state
+  isServerReadOnly: boolean;
+  isServerConfigLoaded: boolean;
 }
 
 export interface AppStoreActions {
@@ -385,6 +389,9 @@ export interface AppStoreActions {
     hintValue: string,
   ) => void;
   closeSessionPicker: () => void;
+
+  // WebUI server actions
+  loadServerConfig: () => Promise<void>;
 }
 
 export type FullAppStore = AppStoreState & AppStoreActions;

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -70,6 +70,10 @@ import {
   type SessionPickerSlice,
   createSessionPickerSlice,
 } from "./slices/sessionPickerSlice";
+import {
+  type ServerSlice,
+  createServerSlice,
+} from "./slices/serverSlice";
 
 // Re-export types for backward compatibility
 export type {
@@ -97,7 +101,8 @@ export type AppStore = ProjectSlice &
   NavigatorSlice &
   ProviderSlice &
   ArchiveSlice &
-  SessionPickerSlice;
+  SessionPickerSlice &
+  ServerSlice;
 
 // ============================================================================
 // Store Creation
@@ -120,4 +125,5 @@ export const useAppStore = create<AppStore>()((...args) => ({
   ...createProviderSlice(...args),
   ...createArchiveSlice(...args),
   ...createSessionPickerSlice(...args),
+  ...createServerSlice(...args),
 }));

--- a/src/test/SessionContextMenu.test.tsx
+++ b/src/test/SessionContextMenu.test.tsx
@@ -16,7 +16,11 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof SessionContext
   return {
     position: { x: 100, y: 100 },
     hasCustomName: false,
+    readOnly: false,
     supportsNativeRename: false,
+    supportsResumeCommand: true,
+    supportsSessionDeletion: true,
+    supportsRevealInFinder: true,
     providerId: "claude",
     onClose: vi.fn(),
     onRenameClick: vi.fn(),

--- a/src/test/archiveSlice.test.ts
+++ b/src/test/archiveSlice.test.ts
@@ -65,11 +65,39 @@ const createTestStore = () =>
     ),
   }));
 
+const createReadOnlyTestStore = () =>
+  create<ArchiveSlice & { isServerReadOnly: boolean }>()((set, get) => ({
+    isServerReadOnly: true,
+    ...createArchiveSlice(
+      set as unknown as Parameters<typeof createArchiveSlice>[0],
+      get as unknown as Parameters<typeof createArchiveSlice>[1],
+    ),
+  }));
+
 describe("archiveSlice", () => {
   const mockGetExpiringSessions = vi.mocked(archiveApi.getExpiringSessions);
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("rejects archive mutations locally in server read-only mode", async () => {
+    const useStore = createReadOnlyTestStore();
+
+    await expect(
+      useStore.getState().createArchive({
+        name: "Snapshot",
+        sessionFilePaths: ["/tmp/session.jsonl"],
+        sourceProvider: "claude",
+        sourceProjectPath: "/tmp/project",
+        sourceProjectName: "project",
+      }),
+    ).rejects.toThrow("Server is running in read-only mode");
+
+    expect(archiveApi.createArchive).not.toHaveBeenCalled();
+    expect(useStore.getState().archive.error).toBe(
+      "Server is running in read-only mode",
+    );
   });
 
   it("ignores stale expiring-session responses when a newer request wins", async () => {

--- a/src/test/serverSlice.test.ts
+++ b/src/test/serverSlice.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import {
+  createServerSlice,
+  type ServerSlice,
+} from "@/store/slices/serverSlice";
+import { api } from "@/services/api";
+import { isTauri } from "@/utils/platform";
+
+vi.mock("@/services/api", () => ({
+  api: vi.fn(),
+}));
+
+vi.mock("@/utils/platform", () => ({
+  isTauri: vi.fn(),
+}));
+
+const createTestStore = () =>
+  create<ServerSlice>()((set, get) => ({
+    ...createServerSlice(
+      set as unknown as Parameters<typeof createServerSlice>[0],
+      get as unknown as Parameters<typeof createServerSlice>[1],
+      {} as unknown as Parameters<typeof createServerSlice>[2],
+    ),
+  }));
+
+describe("serverSlice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isTauri).mockReturnValue(false);
+  });
+
+  it("loads read-only mode from WebUI server config", async () => {
+    vi.mocked(api).mockResolvedValue({ readOnly: true });
+    const useStore = createTestStore();
+
+    await useStore.getState().loadServerConfig();
+
+    expect(api).toHaveBeenCalledWith("get_server_config");
+    expect(useStore.getState().isServerReadOnly).toBe(true);
+    expect(useStore.getState().isServerConfigLoaded).toBe(true);
+  });
+
+  it("defaults to writable in Tauri desktop mode", async () => {
+    vi.mocked(isTauri).mockReturnValue(true);
+    const useStore = createTestStore();
+
+    await useStore.getState().loadServerConfig();
+
+    expect(api).not.toHaveBeenCalled();
+    expect(useStore.getState().isServerReadOnly).toBe(false);
+    expect(useStore.getState().isServerConfigLoaded).toBe(true);
+  });
+});

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -52,7 +52,7 @@ const session: ClaudeSession & { provider: string; is_renamed: boolean } = {
 describe("useSessionEditing clipboard actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAppStore.setState({ projects: [] });
+    useAppStore.setState({ projects: [], isServerReadOnly: false });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {
@@ -218,5 +218,22 @@ describe("useSessionEditing clipboard actions", () => {
     expect(execCommand).toHaveBeenCalledWith("copy");
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith("Copy failed");
+  });
+
+  it("disables mutating session actions in server read-only mode", () => {
+    useAppStore.setState({ isServerReadOnly: true });
+
+    const { result } = renderHook(() => useSessionEditing(session));
+
+    expect(result.current.supportsNativeRename).toBe(false);
+    expect(result.current.supportsSessionDeletion).toBe(false);
+
+    act(() => {
+      result.current.handleDoubleClick({
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(result.current.isEditing).toBe(false);
   });
 });

--- a/src/utils/platform.test.ts
+++ b/src/utils/platform.test.ts
@@ -4,8 +4,11 @@ import {
   clearAuthCookie,
   clearAuthErrorQuery,
   clearAuthToken,
+  getApiBase,
+  getAssetPath,
   getAuthToken,
   getCsrfToken,
+  getWebUIBasePath,
   hasAuthErrorQuery,
   initAuthToken,
   loginWebUI,
@@ -20,6 +23,7 @@ describe("platform auth token helpers", () => {
     window.history.replaceState({}, "", "/");
     document.cookie = "cchv_csrf=; Max-Age=0; Path=/";
     delete window.__WEBUI_API_BASE__;
+    delete window.__WEBUI_BASE_PATH__;
     vi.restoreAllMocks();
   });
 
@@ -140,10 +144,41 @@ describe("platform auth token helpers", () => {
   });
 });
 
+describe("platform WebUI base path helpers", () => {
+  beforeEach(() => {
+    delete window.__WEBUI_API_BASE__;
+    delete window.__WEBUI_BASE_PATH__;
+    window.history.replaceState({}, "", "/viewer/");
+  });
+
+  it("uses the current origin at root by default", () => {
+    expect(getWebUIBasePath()).toBe("");
+    expect(getApiBase()).toBe(window.location.origin);
+    expect(getAssetPath("app-icon.png")).toBe("/app-icon.png");
+  });
+
+  it("adds the injected base path to API and asset URLs", () => {
+    window.__WEBUI_BASE_PATH__ = "/viewer/";
+
+    expect(getWebUIBasePath()).toBe("/viewer");
+    expect(getApiBase()).toBe(`${window.location.origin}/viewer`);
+    expect(getAssetPath("/app-icon.png")).toBe("/viewer/app-icon.png");
+  });
+
+  it("prefers explicit API base override", () => {
+    window.__WEBUI_BASE_PATH__ = "/viewer";
+    window.__WEBUI_API_BASE__ = "http://127.0.0.1:3727/custom";
+
+    expect(getApiBase()).toBe("http://127.0.0.1:3727/custom");
+  });
+});
+
 describe("openExternalUrl", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    delete window.__WEBUI_API_BASE__;
+    delete window.__WEBUI_BASE_PATH__;
   });
 
   it("rejects unsupported URL schemes", async () => {

--- a/src/utils/platform.test.ts
+++ b/src/utils/platform.test.ts
@@ -1,18 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   EXTERNAL_OPEN_HELPER_ATTRIBUTE,
+  clearAuthCookie,
+  clearAuthErrorQuery,
   clearAuthToken,
   getAuthToken,
+  getCsrfToken,
+  hasAuthErrorQuery,
   initAuthToken,
+  loginWebUI,
   openExternalUrl,
-  recoverAuthFromErrorQuery,
   setAuthToken,
+  syncAuthCookieFromStoredToken,
 } from "./platform";
 
 describe("platform auth token helpers", () => {
   beforeEach(() => {
     localStorage.clear();
     window.history.replaceState({}, "", "/");
+    document.cookie = "cchv_csrf=; Max-Age=0; Path=/";
+    delete window.__WEBUI_API_BASE__;
     vi.restoreAllMocks();
   });
 
@@ -41,27 +48,95 @@ describe("platform auth token helpers", () => {
     expect(new URL(window.location.href).searchParams.get("token")).toBeNull();
   });
 
-  it("recoverAuthFromErrorQuery does nothing when auth_error is absent", () => {
+  it("hasAuthErrorQuery is false when auth_error is absent", () => {
     window.history.replaceState({}, "", "/?foo=bar");
-    expect(recoverAuthFromErrorQuery()).toBe(false);
+    expect(hasAuthErrorQuery()).toBe(false);
   });
 
-  it("recoverAuthFromErrorQuery clears auth_error when token already exists", () => {
-    setAuthToken("abc");
+  it("clearAuthErrorQuery removes auth_error from the URL", () => {
     window.history.replaceState({}, "", "/?auth_error=1");
 
-    expect(recoverAuthFromErrorQuery()).toBe(false);
+    expect(hasAuthErrorQuery()).toBe(true);
+    clearAuthErrorQuery();
     expect(new URL(window.location.href).searchParams.get("auth_error")).toBeNull();
   });
 
-  it("recoverAuthFromErrorQuery keeps page when prompt is cancelled", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
-    window.history.replaceState({}, "", "/?auth_error=1");
+  it("loginWebUI posts account credentials", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
 
-    expect(recoverAuthFromErrorQuery()).toBe(false);
-    expect(promptSpy).toHaveBeenCalled();
+    await expect(
+      loginWebUI({ username: " admin ", password: "secret" })
+    ).resolves.toEqual({ ok: true, status: 204 });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${window.location.origin}/api/auth/login`,
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        body: JSON.stringify({ username: "admin", password: "secret" }),
+      })
+    );
     expect(getAuthToken()).toBeNull();
-    expect(new URL(window.location.href).searchParams.get("auth_error")).toBe("1");
+  });
+
+  it("syncAuthCookieFromStoredToken exchanges saved token for HttpOnly cookie", async () => {
+    setAuthToken("secret-token");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    await expect(syncAuthCookieFromStoredToken()).resolves.toBe(true);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${window.location.origin}/api/auth/login`,
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        body: JSON.stringify({ token: "secret-token" }),
+      })
+    );
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it("syncAuthCookieFromStoredToken keeps saved token when cookie login fails", async () => {
+    setAuthToken("secret-token");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 401 }));
+
+    await expect(syncAuthCookieFromStoredToken()).resolves.toBe(false);
+
+    expect(getAuthToken()).toBe("secret-token");
+  });
+
+  it("syncAuthCookieFromStoredToken skips request when no token is saved", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(syncAuthCookieFromStoredToken()).resolves.toBe(false);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("clearAuthCookie asks server to clear cookie", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    await clearAuthCookie();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${window.location.origin}/api/auth/logout`,
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+      })
+    );
+  });
+
+  it("getCsrfToken reads the csrf cookie", () => {
+    document.cookie = "cchv_csrf=csrf-token; Path=/";
+
+    expect(getCsrfToken()).toBe("csrf-token");
   });
 });
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -9,6 +9,7 @@ declare global {
   interface Window {
     __TAURI_INTERNALS__?: unknown;
     __WEBUI_API_BASE__?: string;
+    __WEBUI_BASE_PATH__?: string;
   }
 }
 
@@ -31,18 +32,45 @@ export const isTauri = (): boolean =>
 /** True when running in the browser against the Axum WebUI server. */
 export const isWebUI = (): boolean => !isTauri();
 
+const normalizeWebUIBasePath = (value?: string): string => {
+  if (!value) return "";
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed === "/") return "";
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.replace(/\/+$/, "");
+};
+
+/** Path prefix where the WebUI is mounted, or an empty string for root. */
+export const getWebUIBasePath = (): string =>
+  typeof window !== "undefined"
+    ? normalizeWebUIBasePath(window.__WEBUI_BASE_PATH__)
+    : "";
+
 /**
  * Base URL for WebUI API calls.
  *
  * Defaults to the current origin (same-origin requests when the SPA is
- * served by the Axum server). Can be overridden via `window.__WEBUI_API_BASE__`
- * for development scenarios (e.g. Vite dev server proxying to a remote host).
+ * served by the Axum server). If the server injected `window.__WEBUI_BASE_PATH__`,
+ * API requests are sent below that path prefix. Can be overridden via
+ * `window.__WEBUI_API_BASE__` for development scenarios (e.g. Vite dev server
+ * proxying to a remote host).
  */
 export const getApiBase = (): string => {
   if (typeof window !== "undefined" && window.__WEBUI_API_BASE__) {
     return window.__WEBUI_API_BASE__;
   }
-  return typeof window !== "undefined" ? window.location.origin : "";
+  return typeof window !== "undefined"
+    ? `${window.location.origin}${getWebUIBasePath()}`
+    : "";
+};
+
+/** URL for public WebUI assets, respecting reverse-proxy path prefixes. */
+export const getAssetPath = (path: string): string => {
+  const normalizedPath = path.replace(/^\/+/, "");
+  const basePath = getWebUIBasePath();
+  return basePath ? `${basePath}/${normalizedPath}` : `/${normalizedPath}`;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -50,7 +50,19 @@ export const getApiBase = (): string => {
 // ---------------------------------------------------------------------------
 
 const AUTH_TOKEN_KEY = "webui-auth-token";
+const CSRF_COOKIE_NAME = "cchv_csrf";
 export const EXTERNAL_OPEN_HELPER_ATTRIBUTE = "data-external-open-helper";
+
+export interface WebUILoginCredentials {
+  token?: string;
+  username?: string;
+  password?: string;
+}
+
+export interface WebUILoginResult {
+  ok: boolean;
+  status: number;
+}
 
 /**
  * Initialise the auth token from the URL query string.
@@ -72,36 +84,21 @@ export function initAuthToken(): void {
   }
 }
 
-/**
- * Recover from `?auth_error=1` by asking user for a token once.
- *
- * Returns true when a reload has been triggered and normal app bootstrap should stop.
- */
-export function recoverAuthFromErrorQuery(): boolean {
+/** True when the app should render the WebUI login screen. */
+export function hasAuthErrorQuery(): boolean {
   if (isTauri()) return false;
 
   const url = new URL(window.location.href);
-  if (url.searchParams.get("auth_error") !== "1") return false;
+  return url.searchParams.get("auth_error") === "1";
+}
 
-  const existing = getAuthToken();
-  if (existing && existing.trim().length > 0) {
-    url.searchParams.delete("auth_error");
-    window.history.replaceState(window.history.state, "", url.toString());
-    return false;
-  }
+/** Remove the explicit WebUI auth-error marker from the current URL. */
+export function clearAuthErrorQuery(): void {
+  if (isTauri()) return;
 
-  const input = window.prompt(
-    "Authentication required. Paste your WebUI token to continue:",
-  );
-  if (!input || input.trim().length === 0) {
-    return false;
-  }
-
-  setAuthToken(input);
+  const url = new URL(window.location.href);
   url.searchParams.delete("auth_error");
   window.history.replaceState(window.history.state, "", url.toString());
-  window.location.reload();
-  return true;
 }
 
 /** Read the saved auth token (returns `null` when unavailable). */
@@ -125,6 +122,91 @@ export function setAuthToken(token: string): void {
   } catch {
     // localStorage unavailable (e.g. private browsing quota exceeded)
   }
+}
+
+export async function loginWebUI(
+  credentials: WebUILoginCredentials,
+): Promise<WebUILoginResult> {
+  const body: WebUILoginCredentials = {};
+  if (credentials.token != null) {
+    body.token = credentials.token.trim();
+  }
+  if (credentials.username != null) {
+    body.username = credentials.username.trim();
+  }
+  if (credentials.password != null) {
+    body.password = credentials.password;
+  }
+
+  try {
+    const response = await fetch(`${getApiBase()}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",
+      body: JSON.stringify(body),
+    });
+
+    if (response.ok) {
+      clearAuthToken();
+    }
+
+    return { ok: response.ok, status: response.status };
+  } catch {
+    return { ok: false, status: 0 };
+  }
+}
+
+/**
+ * Exchange the temporary localStorage token for an HttpOnly auth cookie.
+ *
+ * This keeps the existing URL-token/Bearer flow backward-compatible while
+ * moving the browser session to a cookie that JavaScript cannot read. On
+ * failure, the localStorage token is kept so existing Bearer auth still works.
+ */
+export async function syncAuthCookieFromStoredToken(): Promise<boolean> {
+  if (isTauri()) return false;
+
+  const token = getAuthToken();
+  if (!token) return false;
+
+  const response = await loginWebUI({ token });
+  return response.ok;
+}
+
+/** Ask the WebUI server to clear its HttpOnly auth cookie. */
+export async function clearAuthCookie(): Promise<void> {
+  if (isTauri()) return;
+
+  try {
+    await fetch(`${getApiBase()}/api/auth/logout`, {
+      method: "POST",
+      credentials: "same-origin",
+    });
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+export function getCookieValue(name: string): string | null {
+  if (typeof document === "undefined") return null;
+
+  const prefix = `${name}=`;
+  const cookie = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+
+  if (!cookie) return null;
+
+  try {
+    return decodeURIComponent(cookie.slice(prefix.length));
+  } catch {
+    return cookie.slice(prefix.length);
+  }
+}
+
+export function getCsrfToken(): string | null {
+  return getCookieValue(CSRF_COOKIE_NAME);
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async () => {
     : null;
 
   return {
+  base: "./",
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
Consolidates @bugsyyu's five overlapping WebUI server PRs into one conflict-free, security-hardened branch, per an adversarially self-verified integration plan. All five touch `server/mod.rs` + `lib.rs`, so landing them separately would re-conflict repeatedly; this branch resolves them once, in the order **#382 → #375 → #376**, with each step compiled and tested.

Closes #382, #375, #376. Supersedes #377 and #374 (folded in — see below).

## What's included

| Source PR | Feature | Status |
|-----------|---------|--------|
| #382 | Account auth (username + Argon2id, server-side sessions, HttpOnly cookie + double-submit CSRF) | **adopted** as the auth foundation, hardened |
| #375 | `--read-only` server mode | **adopted**, re-implemented deny-by-default |
| #376 | `--base-path` for reverse-proxy deployments | **adopted** |
| #377 | Cookie auth | **superseded** — #382 delivers HttpOnly-cookie hardening as a sub-case of session auth |
| #374 | `--no-auth` non-loopback guard | **folded in** — #382 already ships the identical `validate_auth_startup_options` + `--allow-unsafe-no-auth` |

## Security hardening applied on top of #382

- **Rate-limiter can't be used for memory-exhaustion or cross-user lockout.** Failed logins are bucketed only by *whether the username matched* (`account` vs a shared `_unknown`), never by attacker-supplied text — so the attempts map is capped at two entries and unknown-username spam can't lock out the real account. Argon2 still runs unconditionally, so response time never reveals whether a username exists (no enumeration oracle).
- **Sessions map is bounded** (expired-sweep + LRU eviction past a hard cap).
- **Account auth refuses to start on a non-loopback bind without `--secure-cookies`** (the multi-day session cookie would otherwise travel in cleartext and be hijackable). Mirrors the `--no-auth` guard.
- **`argon2` is now an optional dep** gated behind the `webui-server` feature (was bloating the default desktop build).

## Read-only is deny-by-default

`read_only_middleware` now rejects any protected POST **not** on an explicit read allowlist (the original used a blocklist of known mutations, which silently leaks a newly added mutating route). A self-maintaining test parses `build_router` and fails if any registered POST route is unclassified or any list entry is stale — this caught **7 read routes** (paginated load, stats summaries, metadata, etc.) that a naive blocklist→allowlist flip would have wrongly blocked.

## Conflict-free integration

The adversarial review flagged two **silent build-breaks** (git merges clean, `cargo build` fails) — both resolved here:
1. #376's 5-arg `build_router` (`+ base_path`) orphaned #382's 4-arg test callsites → all updated.
2. #376's duplicate no-arg `test_state` (with the deleted `auth_token` field) → dropped in favor of #382's `test_state(Option<&str>)`.

## i18n

New `webui` namespace for the login screen across all 5 locales (en/ko/ja/zh-CN/zh-TW); types regenerated; `i18n:validate` green.

## Verification (local)

- `cargo clippy --features webui-server --all-targets -- -D warnings` — clean
- `cargo test --features webui-server` — **616 passed** (incl. new auth/read-only/base-path/guard tests)
- `pnpm tsc --build .` — clean · `pnpm vitest run` — **819 passed** · `pnpm run i18n:validate` — pass

Also fixes two pre-existing errors surfaced during verification (both invisible to CI, which runs Rust clippy on Linux only and has no frontend tsc): a `nextMessage` possibly-undefined tsc error from #367, and a non-Linux dead-code warning for `linux_ime_environment_updates` from #360.

Desktop safety verified at the code level: read-only is forced off under `isTauri()` (`serverSlice`), the login screen only renders on an auth-error query (server-mode only), and `vite base: "./"` is Tauri-relative. A desktop smoke is still recommended before release.

## ⚠️ BREAKING change (for release notes)

`--serve --no-auth` on a **non-loopback** bind (including the default `0.0.0.0`) now exits with code 2. Mitigation: add `--allow-unsafe-no-auth`, or bind `--host 127.0.0.1`.

## Before release (maintainer)

- README highlights + the 5-locale README updates + `docs/server-guide` flag tables (Authentication section, new flags: `--auth-user`, `--auth-password-hash`, `--secure-cookies`, `--print-password-hash`, `--read-only`, `--base-path`, `--allow-unsafe-no-auth`; env: `CCHV_AUTH_*`, `CCHV_SECURE_COOKIES`). Kept out of this PR per the develop-first / docs-in-release-commit branch strategy.
- Fix the README quickstart `--serve --no-auth` example (now exits on the default bind).
- Desktop 3-point smoke (assets load / login suppressed / writable in Tauri).
- Decide whether to add proxy-aware IP rate-limiting as a follow-up (intentionally out of v1 — see the known residual: a network attacker can still lock the real account by hammering the correct username; acceptable for a single-user viewer).

Co-Authored-By: bugsyyu <bugsyyu@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WebUI authentication with token and account-based login modes.
  * Implemented server read-only mode that restricts editing operations across the application.
  * Added WebUI login interface with multi-language support.
  * Added base path/reverse proxy support for custom WebUI mounting locations.
  * Implemented CSRF protection for secure API requests.

* **Localization**
  * Added WebUI login translations for English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->