### PR TITLE
fix(filter): persist message filter across session switches and restarts (#363)

### DIFF
--- a/src/store/slices/filterSlice.ts
+++ b/src/store/slices/filterSlice.ts
@@ -19,9 +19,62 @@ export interface MessageFilter {
     contentTypes: MessageFilterContentTypes;
 }
 
-const DEFAULT_MESSAGE_FILTER: MessageFilter = {
+const MESSAGE_FILTER_STORAGE_KEY = "message-filter";
+
+const defaultMessageFilter = (): MessageFilter => ({
     roles: { user: true, assistant: true },
     contentTypes: { text: true, thinking: true, toolCalls: true, commands: true },
+});
+
+const isBool = (value: unknown): value is boolean => typeof value === "boolean";
+
+/**
+ * Load the persisted message filter, validating every field. Any missing or
+ * malformed field falls back to the default so an older/corrupt payload can never
+ * break the toolbar. localStorage access is wrapped in try/catch per repo convention.
+ */
+const loadPersistedMessageFilter = (): MessageFilter => {
+    const fallback = defaultMessageFilter();
+    try {
+        const raw = localStorage.getItem(MESSAGE_FILTER_STORAGE_KEY);
+        if (!raw) return fallback;
+        const parsed = JSON.parse(raw) as Partial<MessageFilter> | null;
+        const roles = parsed?.roles;
+        const contentTypes = parsed?.contentTypes;
+        if (!roles || !contentTypes) return fallback;
+        return {
+            roles: {
+                user: isBool(roles.user) ? roles.user : fallback.roles.user,
+                assistant: isBool(roles.assistant)
+                    ? roles.assistant
+                    : fallback.roles.assistant,
+            },
+            contentTypes: {
+                text: isBool(contentTypes.text)
+                    ? contentTypes.text
+                    : fallback.contentTypes.text,
+                thinking: isBool(contentTypes.thinking)
+                    ? contentTypes.thinking
+                    : fallback.contentTypes.thinking,
+                toolCalls: isBool(contentTypes.toolCalls)
+                    ? contentTypes.toolCalls
+                    : fallback.contentTypes.toolCalls,
+                commands: isBool(contentTypes.commands)
+                    ? contentTypes.commands
+                    : fallback.contentTypes.commands,
+            },
+        };
+    } catch {
+        return fallback;
+    }
+};
+
+const persistMessageFilter = (filter: MessageFilter): void => {
+    try {
+        localStorage.setItem(MESSAGE_FILTER_STORAGE_KEY, JSON.stringify(filter));
+    } catch {
+        // Persistence is best-effort; ignore quota/availability failures.
+    }
 };
 
 export interface FilterSliceState {
@@ -45,11 +98,14 @@ export type FilterSlice = FilterSliceState & FilterSliceActions;
 
 const getInitialDateFilter = () => ({ start: null, end: null });
 
-const initialFilterState: FilterSliceState = {
+// A factory (not a const) so the persisted filter is read when the slice/store is
+// created, not once at module import — keeps the load fresh on every store creation.
+const initialFilterState = (): FilterSliceState => ({
     dateFilter: getInitialDateFilter(),
     userOnlyFilter: false,
-    messageFilter: { ...DEFAULT_MESSAGE_FILTER },
-};
+    // Seed from localStorage so the user's filter survives session switches and restarts.
+    messageFilter: loadPersistedMessageFilter(),
+});
 
 export const createFilterSlice: StateCreator<
     FullAppStore,
@@ -57,7 +113,7 @@ export const createFilterSlice: StateCreator<
     [],
     FilterSlice
 > = (set, get) => ({
-    ...initialFilterState,
+    ...initialFilterState(),
 
     setDateFilter: (dateFilter) => {
         set({ dateFilter });
@@ -76,36 +132,32 @@ export const createFilterSlice: StateCreator<
     },
 
     toggleRole: (role) => {
-        set((state) => ({
-            messageFilter: {
-                ...state.messageFilter,
-                roles: {
-                    ...state.messageFilter.roles,
-                    [role]: !state.messageFilter.roles[role],
-                },
-            },
-        }));
+        const current = get().messageFilter;
+        const next: MessageFilter = {
+            ...current,
+            roles: { ...current.roles, [role]: !current.roles[role] },
+        };
+        persistMessageFilter(next);
+        set({ messageFilter: next });
     },
 
     toggleContentType: (contentType) => {
-        set((state) => ({
-            messageFilter: {
-                ...state.messageFilter,
-                contentTypes: {
-                    ...state.messageFilter.contentTypes,
-                    [contentType]: !state.messageFilter.contentTypes[contentType],
-                },
+        const current = get().messageFilter;
+        const next: MessageFilter = {
+            ...current,
+            contentTypes: {
+                ...current.contentTypes,
+                [contentType]: !current.contentTypes[contentType],
             },
-        }));
+        };
+        persistMessageFilter(next);
+        set({ messageFilter: next });
     },
 
     resetMessageFilter: () => {
-        set({
-            messageFilter: {
-                roles: { user: true, assistant: true },
-                contentTypes: { text: true, thinking: true, toolCalls: true, commands: true },
-            },
-        });
+        const next = defaultMessageFilter();
+        persistMessageFilter(next);
+        set({ messageFilter: next });
     },
 
     isMessageFilterActive: () => {

--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -227,8 +227,8 @@ export const createMessageSlice: StateCreator<
         ...(preserveStack ? {} : { parentSessionStack: [] }),
       });
 
-      // Reset message filters on session switch
-      get().resetMessageFilter();
+      // Message filters intentionally persist across session switches (see
+      // filterSlice localStorage persistence); the toolbar reset button clears them.
     }
 
     get().setSelectedSession(session);

--- a/src/test/filterSlice.test.ts
+++ b/src/test/filterSlice.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { create, type StoreApi } from "zustand";
+import {
+  createFilterSlice,
+  type FilterSlice,
+} from "../store/slices/filterSlice";
+import type { FullAppStore } from "../store/slices/types";
+
+// The filter slice only reads/writes its own state, so it can be exercised in
+// isolation; the casts bridge the FullAppStore-typed StateCreator to a slice store.
+const makeStore = () =>
+  create<FilterSlice>()((set, get, api) =>
+    createFilterSlice(
+      set as unknown as Parameters<typeof createFilterSlice>[0],
+      get as unknown as () => FullAppStore,
+      api as unknown as StoreApi<FullAppStore>,
+    ),
+  );
+
+const STORAGE_KEY = "message-filter";
+const readSaved = () => JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null");
+
+describe("filterSlice message-filter persistence", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("persists a role toggle and updates state", () => {
+    const store = makeStore();
+    store.getState().toggleRole("user");
+    expect(store.getState().messageFilter.roles.user).toBe(false);
+    expect(readSaved().roles.user).toBe(false);
+  });
+
+  it("persists a content-type toggle", () => {
+    const store = makeStore();
+    store.getState().toggleContentType("thinking");
+    expect(store.getState().messageFilter.contentTypes.thinking).toBe(false);
+    expect(readSaved().contentTypes.thinking).toBe(false);
+  });
+
+  it("loads the persisted filter as initial state on a fresh slice (survives restart/switch)", () => {
+    makeStore().getState().toggleRole("assistant");
+    const restored = makeStore();
+    expect(restored.getState().messageFilter.roles.assistant).toBe(false);
+    expect(restored.getState().isMessageFilterActive()).toBe(true);
+  });
+
+  it("resetMessageFilter restores defaults and persists them", () => {
+    const store = makeStore();
+    store.getState().toggleRole("user");
+    store.getState().resetMessageFilter();
+    expect(store.getState().messageFilter.roles.user).toBe(true);
+    expect(store.getState().isMessageFilterActive()).toBe(false);
+    expect(readSaved().roles.user).toBe(true);
+  });
+
+  it("falls back to defaults on corrupt or partial persisted data", () => {
+    localStorage.setItem(STORAGE_KEY, "not json");
+    expect(makeStore().getState().messageFilter).toEqual({
+      roles: { user: true, assistant: true },
+      contentTypes: { text: true, thinking: true, toolCalls: true, commands: true },
+    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ roles: { user: "nope" } }));
+    expect(makeStore().getState().messageFilter.roles.user).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem
The advanced message filter (role + content-type toggles) reset every time you switched sessions, and was lost on restart — so deselections never stuck. (#363)

## Fix
- `filterSlice`: persist `messageFilter` to `localStorage` on every toggle/reset, with a **validated load** that falls back to defaults on missing/corrupt/partial data (per-field boolean checks, try/catch — matching the repo's manual-localStorage convention).
- `messageSlice.selectSession`: remove the `resetMessageFilter()` call on session switch (the toolbar reset button still clears the filter).
- Load at slice creation (factory, not a module-level const) so it's read fresh per store.

`dateFilter` / `userOnlyFilter` are intentionally not persisted — only the message filter the issue references.

## Tests
New `filterSlice.test.ts`: persist-on-toggle, load-as-initial-state (survives restart/switch), reset persists defaults, and corrupt/partial data falls back. tsc + vitest + eslint green.

Closes #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message filters are now persisted across app sessions and automatically restored on startup.
  * Filter preferences remain active when switching between sessions instead of being cleared.

* **Improvements**
  * Enhanced error handling to gracefully recover from corrupted or invalid stored filter data.

* **Tests**
  * Added comprehensive test coverage for filter persistence functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->