### PR TITLE
fix(stats): include custom Claude directories in the global summary (#362)

### DIFF
--- a/src-tauri/benches/performance.rs
+++ b/src-tauri/benches/performance.rs
@@ -528,6 +528,7 @@ fn bench_get_global_stats_summary(c: &mut Criterion) {
                             black_box(mode.clone()),
                             black_box(None),
                             black_box(None),
+                            black_box(None),
                         )
                         .await
                     })

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -3275,18 +3275,27 @@ pub async fn get_global_stats_summary(
     stats_mode: Option<String>,
     start_date: Option<String>,
     end_date: Option<String>,
+    custom_claude_paths: Option<Vec<crate::commands::multi_provider::CustomClaudePathParam>>,
 ) -> Result<GlobalStatsSummary, String> {
     let mode = parse_stats_mode(stats_mode);
     let providers_to_include = parse_active_stats_providers(active_providers);
     let s_limit = parse_date_limit(start_date, "global start_date");
     let e_limit = parse_date_limit(end_date, "global end_date");
-    let projects_path = PathBuf::from(&claude_path).join("projects");
 
-    // Phase 1: Collect all session files and their project names
+    // Phase 1: Collect all session files and their project names from the default
+    // Claude root AND any user-configured custom Claude directories (#362). Without
+    // the custom roots the global summary undercounts everything for users who added
+    // extra Claude directories, even though the project list and search honor them.
     let mut session_files: Vec<PathBuf> = Vec::new();
     let mut project_names: HashSet<String> = HashSet::new();
-    if providers_to_include.contains(&StatsProvider::Claude) && projects_path.exists() {
-        match fs::read_dir(&projects_path) {
+
+    let collect_claude_base = |projects_path: &Path,
+                               session_files: &mut Vec<PathBuf>,
+                               project_names: &mut HashSet<String>| {
+        if !projects_path.exists() {
+            return;
+        }
+        match fs::read_dir(projects_path) {
             Ok(entries) => {
                 for project_entry in entries {
                     let project_entry = match project_entry {
@@ -3320,6 +3329,29 @@ pub async fn get_global_stats_summary(
             }
             Err(e) => {
                 log::warn!("Failed to read Claude projects directory: {e}");
+            }
+        }
+    };
+
+    if providers_to_include.contains(&StatsProvider::Claude) {
+        collect_claude_base(
+            &PathBuf::from(&claude_path).join("projects"),
+            &mut session_files,
+            &mut project_names,
+        );
+
+        if let Some(ref custom_paths) = custom_claude_paths {
+            for custom in custom_paths {
+                let base = PathBuf::from(&custom.path);
+                if let Err(e) = crate::utils::validate_custom_claude_path(&base) {
+                    log::warn!("Skipping invalid custom Claude path for global stats: {e}");
+                    continue;
+                }
+                collect_claude_base(
+                    &base.join("projects"),
+                    &mut session_files,
+                    &mut project_names,
+                );
             }
         }
     }
@@ -4539,6 +4571,7 @@ mod tests {
             Some("billing_total".to_string()),
             None,
             None,
+            None,
         )
         .await
         .expect("failed to get global billing stats");
@@ -4546,6 +4579,7 @@ mod tests {
             claude_path_str,
             Some(vec!["claude".to_string()]),
             Some("conversation_only".to_string()),
+            None,
             None,
             None,
         )
@@ -5011,6 +5045,7 @@ mod tests {
             Some("billing_total".to_string()),
             Some("2025-01-10T00:00:00Z".to_string()),
             Some("2025-01-10T23:59:59.999Z".to_string()),
+            None,
         )
         .await
         .expect("failed to get filtered global summary");
@@ -5018,6 +5053,91 @@ mod tests {
         assert_eq!(summary.total_projects, 1);
         assert_eq!(summary.total_sessions, 1);
         assert_eq!(summary.total_tokens, 22);
+    }
+
+    /// Write one assistant session line with the given token counts under
+    /// `<base>/projects/<project>/session.jsonl`.
+    fn write_claude_session(base: &Path, project: &str, input: u32, output: u32) {
+        let dir = base.join("projects").join(project);
+        fs::create_dir_all(&dir).expect("failed to create project dir");
+        let mut file = File::create(dir.join("session.jsonl")).expect("failed to create session");
+        let line = format!(
+            r#"{{"uuid":"u-{project}","sessionId":"s-{project}","timestamp":"2025-01-05T12:00:00Z","type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"x"}}],"id":"m-{project}","model":"claude-sonnet-4","usage":{{"input_tokens":{input},"output_tokens":{output}}}}},"isSidechain":false}}"#
+        );
+        writeln!(file, "{line}").expect("failed to write session");
+    }
+
+    #[tokio::test]
+    /// Global summary must aggregate custom Claude directories, not just the default
+    /// root (#362) — and must NOT when no custom paths are supplied.
+    async fn test_global_summary_includes_custom_claude_paths() {
+        let default_dir = TempDir::new().expect("default tempdir");
+        let custom_dir = TempDir::new().expect("custom tempdir");
+        write_claude_session(default_dir.path(), "proj-default", 10, 1);
+        write_claude_session(custom_dir.path(), "proj-custom", 20, 2);
+
+        let customs = Some(vec![
+            crate::commands::multi_provider::CustomClaudePathParam {
+                path: custom_dir.path().to_string_lossy().to_string(),
+                label: Some("Personal".to_string()),
+            },
+        ]);
+
+        let with_custom = get_global_stats_summary(
+            default_dir.path().to_string_lossy().to_string(),
+            Some(vec!["claude".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            customs,
+        )
+        .await
+        .expect("failed to get global summary with custom paths");
+        assert_eq!(with_custom.total_projects, 2);
+        assert_eq!(with_custom.total_sessions, 2);
+        assert_eq!(with_custom.total_tokens, 11 + 22);
+
+        // Control: without custom paths, only the default root is aggregated.
+        let default_only = get_global_stats_summary(
+            default_dir.path().to_string_lossy().to_string(),
+            Some(vec!["claude".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("failed to get default-only global summary");
+        assert_eq!(default_only.total_projects, 1);
+        assert_eq!(default_only.total_tokens, 11);
+    }
+
+    #[tokio::test]
+    /// An invalid custom Claude path (no projects/ dir) is skipped, not fatal.
+    async fn test_global_summary_skips_invalid_custom_claude_path() {
+        let default_dir = TempDir::new().expect("default tempdir");
+        let bogus_dir = TempDir::new().expect("bogus tempdir"); // exists but has no projects/
+        write_claude_session(default_dir.path(), "proj-default", 10, 1);
+
+        let customs = Some(vec![
+            crate::commands::multi_provider::CustomClaudePathParam {
+                path: bogus_dir.path().to_string_lossy().to_string(),
+                label: None,
+            },
+        ]);
+
+        let summary = get_global_stats_summary(
+            default_dir.path().to_string_lossy().to_string(),
+            Some(vec!["claude".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            customs,
+        )
+        .await
+        .expect("invalid custom path must not be fatal");
+        assert_eq!(summary.total_projects, 1);
+        assert_eq!(summary.total_tokens, 11);
     }
 
     #[tokio::test]
@@ -5071,6 +5191,7 @@ mod tests {
             home.to_string_lossy().to_string(),
             Some(vec!["antigravity".to_string()]),
             Some("billing_total".to_string()),
+            None,
             None,
             None,
         )
@@ -5221,6 +5342,7 @@ mod tests {
             forge_dir.path().to_string_lossy().to_string(),
             Some(vec!["forgecode".to_string()]),
             Some("billing_total".to_string()),
+            None,
             None,
             None,
         )

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -219,6 +219,8 @@ pub struct GlobalStatsParams {
     pub start_date: Option<String>,
     #[serde(default)]
     pub end_date: Option<String>,
+    #[serde(default)]
+    pub custom_claude_paths: Option<Vec<commands::multi_provider::CustomClaudePathParam>>,
 }
 
 #[derive(Deserialize)]
@@ -720,6 +722,7 @@ handler_json!(
             p.stats_mode,
             p.start_date,
             p.end_date,
+            p.custom_claude_paths,
         )
         .await
     }

--- a/src-tauri/tests/scan_all_test.rs
+++ b/src-tauri/tests/scan_all_test.rs
@@ -348,6 +348,7 @@ mod integration_tests {
             Some("billing_total".to_string()),
             None,
             None,
+            None,
         )
         .await
         .expect("get_global_stats_summary failed");
@@ -383,6 +384,7 @@ mod integration_tests {
             Some("billing_total".to_string()),
             Some("2026-04-12T00:00:00.000Z".to_string()),
             Some("2026-04-17T23:59:59.999Z".to_string()),
+            None,
         )
         .await
         .expect("get_global_stats_summary failed");
@@ -418,6 +420,7 @@ mod integration_tests {
             Some("billing_total".to_string()),
             Some("2026-04-12T00:00:00.000Z".to_string()),
             Some("2026-04-17T23:59:59.999Z".to_string()),
+            None,
         )
         .await
         .expect("billing summary failed");
@@ -428,6 +431,7 @@ mod integration_tests {
             Some("conversation_only".to_string()),
             Some("2026-04-12T00:00:00.000Z".to_string()),
             Some("2026-04-17T23:59:59.999Z".to_string()),
+            None,
         )
         .await
         .expect("conversation summary failed");

--- a/src/services/analyticsApi.ts
+++ b/src/services/analyticsApi.ts
@@ -15,6 +15,7 @@ import type {
   GlobalStatsSummary,
   ProviderId,
   StatsMode,
+  CustomClaudePath,
 } from "../types";
 
 // ============================================================================
@@ -243,13 +244,19 @@ export async function fetchGlobalStatsSummary(
   activeProviders?: ProviderId[],
   startDate?: string,
   endDate?: string,
+  customClaudePaths?: CustomClaudePath[],
 ): Promise<GlobalStatsSummary> {
   const normalizedProviders = [...new Set(activeProviders ?? [])].sort();
   const providersKey = normalizedProviders.length > 0
     ? normalizedProviders.join(",")
     : "all";
   const dateKey = `${startDate ?? "none"}:${endDate ?? "none"}`;
-  const key = `globalStatsSummary:${claudePath}:${providersKey}:${statsMode}:${dateKey}`;
+  const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
+  // Include custom paths in the dedupe key so requests with/without them don't collapse.
+  const customKey = hasCustomPaths
+    ? customClaudePaths.map((p) => p.path).join("|")
+    : "none";
+  const key = `globalStatsSummary:${claudePath}:${providersKey}:${statsMode}:${dateKey}:${customKey}`;
   return dedupeInFlight(key, async () => {
     const start = performance.now();
 
@@ -259,6 +266,7 @@ export async function fetchGlobalStatsSummary(
       statsMode,
       startDate,
       endDate,
+      customClaudePaths: hasCustomPaths ? customClaudePaths : undefined,
     });
 
     if (import.meta.env.DEV) {

--- a/src/store/slices/globalStatsSlice.ts
+++ b/src/store/slices/globalStatsSlice.ts
@@ -61,6 +61,10 @@ export const createGlobalStatsSlice: StateCreator<
     const { claudePath, activeProviders, dateFilter } = get();
     if (!claudePath) return;
 
+    // Custom Claude directories must be aggregated into the global summary too,
+    // matching the project list and search (#362).
+    const customClaudePaths = get().userMetadata?.settings?.customClaudePaths;
+
     set({ isLoadingGlobalStats: true });
     get().setError(null);
 
@@ -88,6 +92,7 @@ export const createGlobalStatsSlice: StateCreator<
           activeProviders,
           startDate,
           endDate,
+          customClaudePaths,
         ),
         canLoadConversationSummary
           ? fetchGlobalStatsSummary(
@@ -96,6 +101,7 @@ export const createGlobalStatsSlice: StateCreator<
               activeProviders,
               startDate,
               endDate,
+              customClaudePaths,
             ).catch((error) => {
               if (requestId !== getRequestId("globalStats")) {
                 return null;

--- a/src/test/globalStatsSlice.test.ts
+++ b/src/test/globalStatsSlice.test.ts
@@ -120,10 +120,33 @@ describe("globalStatsSlice", () => {
       ["codex"],
       undefined,
       undefined,
+      undefined,
     );
     expect(useStore.getState().globalSummary).toEqual(summary);
     // No conversation breakdown for codex → conversation summary falls back to billing.
     expect(useStore.getState().globalConversationSummary).toEqual(summary);
+  });
+
+  it("forwards customClaudePaths from settings to the global stats fetch (#362)", async () => {
+    const useStore = createTestStore();
+    const summary = buildGlobalSummary();
+    const customClaudePaths = [{ path: "/extra/claude", label: "Extra" }];
+    useStore.setState({
+      activeProviders: ["codex"],
+      userMetadata: { settings: { customClaudePaths } },
+    } as unknown as Partial<TestStore>);
+    mockFetchGlobalStatsSummary.mockResolvedValue(summary);
+
+    await useStore.getState().loadGlobalStats();
+
+    expect(mockFetchGlobalStatsSummary).toHaveBeenCalledWith(
+      "/tmp/claude",
+      "billing_total",
+      ["codex"],
+      undefined,
+      undefined,
+      customClaudePaths,
+    );
   });
 
   it("keeps billing summary when conversation-only request fails", async () => {
@@ -165,6 +188,7 @@ describe("globalStatsSlice", () => {
       ["claude"],
       start.toISOString(),
       expectedEnd.toISOString(),
+      undefined,
     );
     expect(mockFetchGlobalStatsSummary).toHaveBeenNthCalledWith(
       2,
@@ -173,6 +197,7 @@ describe("globalStatsSlice", () => {
       ["claude"],
       start.toISOString(),
       expectedEnd.toISOString(),
+      undefined,
     );
   });
 });


### PR DESCRIPTION
## Problem
Global statistics aggregated **only** the default `~/.claude/projects` root. Users who added custom Claude directories saw undercounted totals (projects, sessions, messages, tokens, tool usage), even though the **project list** (`scan_all_projects`) and **search** (`search_all_providers`) already honor those paths. (#362)

## Fix
- **Rust** `get_global_stats_summary`: extract the per-base collection into a closure and run it for the default root **plus** each configured custom base, validating each via `validate_custom_claude_path` and skipping invalid ones (`log::warn`) — mirroring `scan_all_projects`.
- **Axum** `GlobalStatsParams` + handler: add `customClaudePaths` for WebUI parity.
- **Frontend** `fetchGlobalStatsSummary` + `loadGlobalStats`: read `settings.customClaudePaths` and forward it (and fold it into the dedupe key so with/without-custom requests don't collapse).

## Tests
- Rust: `test_global_summary_includes_custom_claude_paths` (default + custom both counted; control without customs counts only default) and `test_global_summary_skips_invalid_custom_claude_path` (invalid path skipped, not fatal).
- Frontend: `globalStatsSlice` now asserts `customClaudePaths` is forwarded; existing arg assertions updated.
- cargo clippy `--features webui-server --all-targets -D warnings`, cargo test, tsc, vitest, eslint all green.

Closes #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now include custom Claude installation directories when calculating global statistics and billing information, aggregating data from both default and user-specified locations.

* **Tests**
  * Added test coverage to verify custom Claude directories are correctly included in global stats calculations and that invalid paths are gracefully skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->