### PR TITLE
fix(subagent): map clicks via meta.json toolUseId for multi-subagent sessions (#288)

### DIFF
--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -1401,6 +1401,10 @@ pub struct SubagentSession {
     pub first_message_time: Option<String>,
     pub last_message_time: Option<String>,
     pub summary: Option<String>,
+    /// Task `tool_use` id that spawned this subagent, read from the sibling
+    /// `agent-<id>.meta.json` (newer Claude Code format). `None` for older sessions
+    /// that have no meta file; the frontend then falls back to progress messages.
+    pub tool_use_id: Option<String>,
 }
 
 /// Returns subagent sessions for a given parent session file.
@@ -1437,6 +1441,12 @@ pub async fn get_session_subagents(session_path: String) -> Result<Vec<SubagentS
         // Quick scan: first and last lines + line count
         let (message_count, first_time, last_time, summary) = extract_subagent_metadata(&sa_path);
 
+        // Newer Claude Code persists the spawning Task tool_use id in a sibling
+        // `agent-<id>.meta.json`. Read it so multi-subagent sessions can map a click
+        // to the right file (#288); older sessions have no meta file -> None.
+        let meta_path = sa_path.with_file_name(format!("{file_name}.meta.json"));
+        let tool_use_id = read_subagent_tool_use_id(&meta_path);
+
         sessions.push(SubagentSession {
             agent_id,
             file_path: sa_path.to_string_lossy().to_string(),
@@ -1445,6 +1455,7 @@ pub async fn get_session_subagents(session_path: String) -> Result<Vec<SubagentS
             first_message_time: first_time,
             last_message_time: last_time,
             summary,
+            tool_use_id,
         });
     }
 
@@ -1452,6 +1463,27 @@ pub async fn get_session_subagents(session_path: String) -> Result<Vec<SubagentS
     sessions.sort_by(|a, b| a.first_message_time.cmp(&b.first_message_time));
 
     Ok(sessions)
+}
+
+/// Read the `toolUseId` from a subagent's sibling `agent-<id>.meta.json`.
+/// Returns `None` if the file is missing, a symlink, unreadable, or has no
+/// non-empty `toolUseId` — all non-fatal, so a subagent without a meta file still
+/// lists. The symlink guard mirrors the session-path hardening.
+fn read_subagent_tool_use_id(meta_path: &std::path::Path) -> Option<String> {
+    let meta = std::fs::symlink_metadata(meta_path).ok()?;
+    if meta.file_type().is_symlink() {
+        return None;
+    }
+    let content = std::fs::read_to_string(meta_path).ok()?;
+
+    #[derive(serde::Deserialize)]
+    struct SubagentMeta {
+        #[serde(rename = "toolUseId")]
+        tool_use_id: Option<String>,
+    }
+
+    let parsed: SubagentMeta = serde_json::from_str(&content).ok()?;
+    parsed.tool_use_id.filter(|s| !s.is_empty())
 }
 
 /// Metadata extraction from a subagent JSONL file.
@@ -2617,5 +2649,53 @@ mod tests {
         assert_eq!(result[0].summary, Some("AppendedRename".to_string()));
         // System message not counted
         assert_eq!(result[0].message_count, 5);
+    }
+
+    #[test]
+    fn read_subagent_tool_use_id_reads_meta_json() {
+        let dir = TempDir::new().unwrap();
+        let meta = dir.path().join("agent-x.meta.json");
+        std::fs::write(
+            &meta,
+            r#"{"agentType":"task","description":"d","toolUseId":"toolu_123"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_subagent_tool_use_id(&meta),
+            Some("toolu_123".to_string())
+        );
+    }
+
+    #[test]
+    fn read_subagent_tool_use_id_none_when_missing_invalid_or_empty() {
+        let dir = TempDir::new().unwrap();
+        // Missing file.
+        assert_eq!(
+            read_subagent_tool_use_id(&dir.path().join("nope.meta.json")),
+            None
+        );
+        // Present but no toolUseId (older meta or different shape).
+        let meta = dir.path().join("agent-y.meta.json");
+        std::fs::write(&meta, r#"{"agentType":"task"}"#).unwrap();
+        assert_eq!(read_subagent_tool_use_id(&meta), None);
+        // Empty toolUseId is treated as absent.
+        let meta_empty = dir.path().join("agent-z.meta.json");
+        std::fs::write(&meta_empty, r#"{"toolUseId":""}"#).unwrap();
+        assert_eq!(read_subagent_tool_use_id(&meta_empty), None);
+        // Invalid JSON is non-fatal.
+        let meta_bad = dir.path().join("agent-bad.meta.json");
+        std::fs::write(&meta_bad, "not json").unwrap();
+        assert_eq!(read_subagent_tool_use_id(&meta_bad), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_subagent_tool_use_id_rejects_symlink() {
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("real.meta.json");
+        std::fs::write(&real, r#"{"toolUseId":"toolu_real"}"#).unwrap();
+        let link = dir.path().join("agent-link.meta.json");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert_eq!(read_subagent_tool_use_id(&link), None);
     }
 }

--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -759,17 +759,30 @@ export const createMessageSlice: StateCreator<
       });
       // Guard: only update if still viewing the same session
       if (get().selectedSession?.file_path === sessionPath) {
-        // progress 메시지만 parentToolUseID와 agentId를 함께 보유 → 유일한 매핑 소스.
+        // toolUseId → subagent file_path 매핑. 두 소스 사용:
+        // 1) (신형) subagent.tool_use_id — agent-<id>.meta.json에서 읽은 Task tool_use id.
+        //    progress 메시지가 없는 다중 subagent 세션도 정확히 매핑 (#288).
+        // 2) (구형 back-compat) progress 메시지의 parentToolUseID ↔ agentId.
         // Map 값은 file_path(유일 식별자) — agent_id는 filename stem 기반이라 충돌 가능.
         // sourceMessages는 반드시 pre-filter(allMessages) — post-filter는 progress 제거됨.
         let map: Map<string, string> | ReadonlyMap<string, string> =
           EMPTY_SUBAGENT_MAP;
         if (subagents.length > 0) {
-          // O(1) lookup을 위해 agent_id → subagent 인덱스 선구축
-          const byAgentId = new Map(subagents.map((s) => [s.agent_id, s]));
           const built = new Map<string, string>();
+
+          // Primary (newer format): meta.json toolUseId, authoritative per file.
+          for (const sub of subagents) {
+            if (sub.tool_use_id) {
+              built.set(sub.tool_use_id, sub.file_path);
+            }
+          }
+
+          // Back-compat (older sessions without meta.json): progress messages.
+          // Only fill gaps not already mapped from meta.json (meta.json wins).
+          const byAgentId = new Map(subagents.map((s) => [s.agent_id, s]));
           for (const msg of sourceMessages) {
             if (msg.type !== "progress" || !msg.parentToolUseID) continue;
+            if (built.has(msg.parentToolUseID)) continue;
             const agentId = getAgentIdFromProgress(msg);
             if (!agentId) continue;
             const sub = byAgentId.get(agentId);
@@ -777,6 +790,7 @@ export const createMessageSlice: StateCreator<
               built.set(msg.parentToolUseID, sub.file_path);
             }
           }
+
           if (built.size > 0) map = built;
         }
         set({

--- a/src/test/messageSlice.subagent.test.ts
+++ b/src/test/messageSlice.subagent.test.ts
@@ -146,6 +146,7 @@ const makeSession = (overrides: Partial<ClaudeSession> = {}): ClaudeSession => (
 const makeSubagent = (
   agent_id: string,
   file_path: string,
+  tool_use_id: string | null = null,
 ): SubagentSession => ({
   agent_id,
   file_path,
@@ -154,6 +155,7 @@ const makeSubagent = (
   first_message_time: null,
   last_message_time: null,
   summary: null,
+  tool_use_id,
 });
 
 const makeProgress = (
@@ -392,6 +394,51 @@ describe("messageSlice.loadSubagents — map building from pre-filter messages",
     const map = store.getState().toolUseToSubagentMap;
     expect(map.get("tool-1")).toBe("/tmp/subA.jsonl");
     expect(map.get("tool-2")).toBe("/tmp/subB.jsonl");
+  });
+
+  it("maps multiple subagents via meta.json tool_use_id with no progress messages (#288)", async () => {
+    const store = createTestStore();
+    // Newer Claude Code format: each subagent carries its spawning Task tool_use id
+    // (from agent-<id>.meta.json) and the session emits NO progress messages.
+    const subA = makeSubagent("agent-A", "/tmp/subA.jsonl", "toolu_A");
+    const subB = makeSubagent("agent-B", "/tmp/subB.jsonl", "toolu_B");
+    const session = makeSession({ file_path: "/tmp/parent.jsonl" });
+    store.setState({ selectedSession: session });
+
+    mockApi.mockImplementation((cmd: string) => {
+      if (cmd === "get_session_subagents")
+        return Promise.resolve([subA, subB]);
+      return Promise.reject(new Error(`unexpected: ${cmd}`));
+    });
+
+    await store.getState().loadSubagents(session.file_path, []);
+
+    const map = store.getState().toolUseToSubagentMap;
+    expect(map.get("toolu_A")).toBe("/tmp/subA.jsonl");
+    expect(map.get("toolu_B")).toBe("/tmp/subB.jsonl");
+  });
+
+  it("prefers meta.json tool_use_id and falls back to progress for subagents without one", async () => {
+    const store = createTestStore();
+    const subA = makeSubagent("agent-A", "/tmp/subA.jsonl", "toolu_A"); // new format
+    const subB = makeSubagent("agent-B", "/tmp/subB.jsonl", null); // old format
+    const session = makeSession({ file_path: "/tmp/parent.jsonl" });
+    store.setState({ selectedSession: session });
+
+    mockApi.mockImplementation((cmd: string) => {
+      if (cmd === "get_session_subagents")
+        return Promise.resolve([subA, subB]);
+      return Promise.reject(new Error(`unexpected: ${cmd}`));
+    });
+
+    const sourceMessages: ClaudeMessage[] = [
+      makeProgress("tool-2", "agent-B"), // back-compat mapping for B
+    ];
+    await store.getState().loadSubagents(session.file_path, sourceMessages);
+
+    const map = store.getState().toolUseToSubagentMap;
+    expect(map.get("toolu_A")).toBe("/tmp/subA.jsonl"); // from meta.json
+    expect(map.get("tool-2")).toBe("/tmp/subB.jsonl"); // from progress
   });
 
   it("skips progress messages missing parentToolUseID or with unknown agent_id", async () => {

--- a/src/types/session.types.ts
+++ b/src/types/session.types.ts
@@ -75,6 +75,8 @@ export interface SubagentSession {
   first_message_time: string | null;
   last_message_time: string | null;
   summary: string | null;
+  /** Task tool_use id that spawned this subagent (from agent-<id>.meta.json); null for older sessions. */
+  tool_use_id: string | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem
When a session had **multiple** subagents, clicking any of them showed nothing (high severity). With a single subagent it worked. (#288)

Root cause: the frontend built the `toolUseId → subagent file` map **only** from `agent_progress` messages. Newer Claude Code sessions emit **no** progress messages and instead persist the spawning Task `toolUseId` in a sibling `agent-<id>.meta.json`. With no progress messages the map was empty, so `viewSubagent` only navigated via the `subagentSessions.length === 1` fallback — fine for one subagent, broken for 2+.

## Fix
- **Rust** `get_session_subagents`: read each subagent's sibling `agent-<id>.meta.json` and add `SubagentSession.tool_use_id` (symlink-guarded; missing/invalid/empty → `None`, all non-fatal). The command is shared with the Axum WebUI router, so parity is automatic.
- **Frontend** `loadSubagents`: seed `toolUseToSubagentMap` **primarily** from `subagent.tool_use_id` (authoritative for the new format, works with zero progress messages), keeping the progress-message source as back-compat for older sessions (meta.json wins on conflict).
- `SubagentSession` TS type gains `tool_use_id: string | null`.

## Tests
- Rust: `read_subagent_tool_use_id` reads the meta `toolUseId`, returns `None` for missing/invalid/empty, and rejects symlinks.
- Frontend: maps 2+ subagents from `tool_use_id` with **no** progress messages (the regression), and a mixed case where meta.json + progress both contribute.
- clippy `--features webui-server -D warnings`, cargo test, tsc, vitest (15), eslint all green.

Closes #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subagent sessions now include tracking of their originating task reference
  * Enhanced metadata-based subagent-to-task relationship mapping

* **Improvements**
  * Backward compatibility maintained for sessions using legacy tracking formats
  * Automatic fallback to legacy relationship detection when metadata unavailable

* **Tests**
  * Added comprehensive test coverage for metadata handling and fallback scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->