### PR TITLE
fix(messages): estimate full height for subagent rows to prevent React #185 crash (#334)

### DIFF
--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -373,6 +373,9 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     getScrollElement,
     hiddenMessageIds,
     isCaptureMode,
+    // Inside a subagent session every row is `isSidechain` but rendered at full
+    // height, so the height estimate must not collapse them to 0 (issue #334).
+    isInSubagent: parentSessionStack.length > 0,
   });
 
   // Set of selected message UUIDs for O(1) lookup

--- a/src/components/MessageViewer/helpers/heightEstimation.ts
+++ b/src/components/MessageViewer/helpers/heightEstimation.ts
@@ -24,8 +24,17 @@ const HEIGHT_DEFAULTS = {
 /**
  * Estimate the height of a message for virtual scrolling.
  * This is used as the initial estimate before actual measurement.
+ *
+ * @param isInSubagent Whether the viewer is currently inside a subagent
+ *   session. Subagent sessions consist entirely of `isSidechain` messages
+ *   that are rendered at full height (the sidechain hide-rule is bypassed),
+ *   so they must NOT be estimated at 0 — see {@link estimateMessageHeight}
+ *   sidechain branch and `ClaudeMessageNode`'s matching `isInSubagent` guard.
  */
-export function estimateMessageHeight(item: FlattenedMessage): number {
+export function estimateMessageHeight(
+  item: FlattenedMessage,
+  isInSubagent = false
+): number {
   // Hidden placeholder has fixed height
   if (item.type === "hidden-placeholder") {
     return 40; // Compact placeholder height
@@ -43,8 +52,12 @@ export function estimateMessageHeight(item: FlattenedMessage): number {
     return HEIGHT_DEFAULTS.hidden;
   }
 
-  // Sidechain messages are hidden
-  if (message.isSidechain) {
+  // Sidechain messages are hidden in normal sessions (ClaudeMessageNode returns
+  // null for them), so estimate 0. Inside a subagent session the hide-rule is
+  // bypassed and every row IS sidechain rendered at full height — estimating 0
+  // there makes the virtualizer believe the whole list has ~0 total height and
+  // mount all rows at once (the #334 crash on large subagent sessions).
+  if (message.isSidechain && !isInSubagent) {
     return HEIGHT_DEFAULTS.hidden;
   }
 

--- a/src/components/MessageViewer/hooks/useMessageVirtualization.ts
+++ b/src/components/MessageViewer/hooks/useMessageVirtualization.ts
@@ -38,6 +38,12 @@ interface UseMessageVirtualizationOptions {
   hiddenMessageIds?: string[];
   /** Whether capture mode is active */
   isCaptureMode?: boolean;
+  /**
+   * Whether the viewer is inside a subagent session (parentSessionStack > 0).
+   * Subagent rows are all `isSidechain` but rendered at full height, so the
+   * height estimate must not collapse them to 0 (issue #334).
+   */
+  isInSubagent?: boolean;
 }
 
 interface UseMessageVirtualizationReturn {
@@ -63,6 +69,7 @@ export const useMessageVirtualization = ({
   getScrollElement,
   hiddenMessageIds = [],
   isCaptureMode = false,
+  isInSubagent = false,
 }: UseMessageVirtualizationOptions): UseMessageVirtualizationReturn => {
   // Only apply hidden filter when in capture mode (hybrid approach)
   const effectiveHiddenIds = useMemo(
@@ -124,9 +131,9 @@ export const useMessageVirtualization = ({
     (index: number) => {
       const item = flattenedMessages[index];
       if (!item) return MIN_ROW_HEIGHT;
-      return estimateMessageHeight(item);
+      return estimateMessageHeight(item, isInSubagent);
     },
-    [flattenedMessages]
+    [flattenedMessages, isInSubagent]
   );
 
   // Initialize virtualizer

--- a/src/test/heightEstimation.test.ts
+++ b/src/test/heightEstimation.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for estimateMessageHeight (issue #334).
+ *
+ * A subagent session is rendered entirely from `isSidechain` messages whose
+ * hide-rule is bypassed (ClaudeMessageNode renders them at full height when
+ * `parentSessionStack.length > 0`). The height estimate must therefore NOT
+ * collapse those rows to 0 — otherwise the virtualizer believes the whole list
+ * has ~0 total height, mounts every row at once, and a large subagent session
+ * (e.g. 259 messages) triggers a measurement storm / React #185 crash.
+ */
+
+import { describe, expect, it } from "vitest";
+import { estimateMessageHeight } from "../components/MessageViewer/helpers/heightEstimation";
+import type { FlattenedMessage, FlattenedMessageItem } from "../components/MessageViewer/types";
+import type { ClaudeMessage } from "../types";
+
+const makeMessage = (
+  overrides: Partial<ClaudeMessage> & { isSidechain: boolean }
+): ClaudeMessage =>
+  ({
+    type: "assistant",
+    uuid: "u1",
+    parentUuid: null,
+    sessionId: "sess",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    message: { role: "assistant", content: "hello" },
+    ...overrides,
+  }) as unknown as ClaudeMessage;
+
+const makeItem = (
+  message: ClaudeMessage,
+  overrides: Partial<FlattenedMessageItem> = {}
+): FlattenedMessage =>
+  ({
+    type: "message",
+    message,
+    depth: 0,
+    originalIndex: 0,
+    isGroupLeader: false,
+    isGroupMember: false,
+    isProgressGroupLeader: false,
+    isProgressGroupMember: false,
+    isTaskOperationGroupLeader: false,
+    isTaskOperationGroupMember: false,
+    ...overrides,
+  }) as FlattenedMessageItem;
+
+describe("estimateMessageHeight — sidechain rows in subagent sessions (#334)", () => {
+  it("collapses sidechain rows to 0 in a normal session (hide-rule applies)", () => {
+    const item = makeItem(makeMessage({ isSidechain: true }));
+    // Default (isInSubagent omitted) and explicit false both estimate 0.
+    expect(estimateMessageHeight(item)).toBe(0);
+    expect(estimateMessageHeight(item, false)).toBe(0);
+  });
+
+  it("gives sidechain rows a real estimate inside a subagent session", () => {
+    const item = makeItem(makeMessage({ type: "assistant", isSidechain: true }));
+    const height = estimateMessageHeight(item, true);
+    // Must be the assistant type estimate (180), never the hidden 0 that causes
+    // the virtualizer to mount the entire list at once.
+    expect(height).toBeGreaterThan(0);
+    expect(height).toBe(180);
+  });
+
+  it("estimates a sidechain user row at its user height in a subagent session", () => {
+    const item = makeItem(makeMessage({ type: "user", isSidechain: true }));
+    expect(estimateMessageHeight(item, true)).toBe(120);
+  });
+
+  it("still collapses group-member rows to 0 even inside a subagent session", () => {
+    // Group members are always hidden regardless of subagent context.
+    const item = makeItem(makeMessage({ isSidechain: true }), {
+      isGroupMember: true,
+    });
+    expect(estimateMessageHeight(item, true)).toBe(0);
+  });
+
+  it("does not change non-sidechain estimates", () => {
+    const assistant = makeItem(makeMessage({ type: "assistant", isSidechain: false }));
+    expect(estimateMessageHeight(assistant, false)).toBe(180);
+    expect(estimateMessageHeight(assistant, true)).toBe(180);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #334. Opening a large SubAgent session (reporter: 259 messages) **occasionally crashes** with `Minified React error #185` — "Maximum update depth exceeded".

## Root cause

A subagent session is rendered entirely from `isSidechain` messages. `selectSession` bypasses the sidechain filter for subagent views (`shouldTreatAsSubagent`), and `ClaudeMessageNode` renders those rows at **full height** (the `if (message.isSidechain && !isInSubagent) return null` hide-rule only fires *outside* a subagent — `MessageViewer/components/ClaudeMessageNode.tsx:141`).

But `estimateMessageHeight` collapsed **every** `isSidechain` row to `0`:

```ts
// Sidechain messages are hidden
if (message.isSidechain) {
  return HEIGHT_DEFAULTS.hidden; // 0
}
```

So inside a subagent session, all N rows estimate to 0 → the virtualizer computes ~0 total height → the **entire list falls inside the viewport+overscan window** → all N message nodes mount and measure their real (~180px) heights **simultaneously**. At 259 rows this measurement storm surfaces as React #185. This matches the issue signature exactly: large session (volume-sensitive) + subagent (all-sidechain) + occasional (measurement-timing dependent).

## Fix

Thread an `isInSubagent` flag (`parentSessionStack.length > 0`) from `MessageViewer` → `useMessageVirtualization` → `estimateMessageHeight`, so the estimate mirrors `ClaudeMessageNode`'s render decision exactly:

- **Normal session**, sidechain row → still estimated `0` (it renders `null`). Unchanged.
- **Subagent session**, sidechain row → normal type-based estimate (e.g. `180` for assistant). The virtualizer now only mounts the visible window (~10–15 rows) instead of all N.
- **Group members** → still `0` regardless of context.

## Verification

- `src/test/heightEstimation.test.ts` — new regression tests (subagent vs normal vs group-member; default-arg back-compat).
- Full suite: **834 tests pass**; `tsc --build` clean; `eslint` clean.

## Notes

Diagnosed with a hypothesis-driven multi-agent review across the virtualizer / Zustand-selector / effect / setState-in-render / subagent-data lenses. The classic "infinite loop" candidates were all refuted (TanStack Virtual caches measurements and converges), which pointed to this estimate-vs-actual contradiction on the subagent path as the real, volume-amplified trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message rendering issue in subagent sessions where certain message types were collapsing unexpectedly. Messages now maintain proper display heights, ensuring full visibility and correct layout throughout extended subagent interactions.

* **Tests**
  * Added comprehensive test suite covering message height estimation and display integrity verification within subagent session contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->