### PR TITLE
fix(projects): project-list scrollbar doesn't reach the bottom on long lists (#101)

### DIFF
--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -857,7 +857,11 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
 
         {/* Projects List */}
         <OverlayScrollbarsComponent
-          className="relative flex-1 py-2"
+          // min-h-0 lets this flex child shrink to its basis instead of growing
+          // to full content height (default min-height:auto). Without it,
+          // OverlayScrollbars measures a skewed content/viewport ratio and the
+          // thumb never reaches the bottom on long project lists (issue #101).
+          className="relative flex-1 min-h-0 py-2"
           options={{
             scrollbars: {
               theme: "os-theme-custom",


### PR DESCRIPTION
Closes #101.

## Problem
On a long project list, scrolling to the very bottom leaves the scrollbar thumb sitting high in the track with empty space below — the scrollbar over-reports content length and never aligns to the end of the list.

## Root cause
The project-list scroll host is a flex child:
```tsx
<OverlayScrollbarsComponent className="relative flex-1 py-2">
```
`flex-1` without `min-h-0` keeps the default `min-height: auto`, which prevents the item from shrinking to its flex basis — so when the content is taller than the pane, the host grows to full content height. OverlayScrollbars then measures a skewed content-vs-viewport ratio and the thumb under-fills the track. This only reproduces with enough projects to overflow the pane (which is why it wasn't seen with a short list).

## Fix
Add `min-h-0` to the host — the same pattern already used by `MessageViewer` (`relative flex-1 min-h-0`) and the other `h-full` scroll hosts in `AppLayout`. This bounds the host to the available height so OverlayScrollbars measures the correct scrollable range.

One-line CSS change, no behavior change for short lists. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrollbar behavior on long project lists, ensuring proper scrolling to the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->