### PR TITLE
fix(search): global-search result click does nothing in non-messages views (#390)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,6 +222,19 @@ function App() {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
 
+  // A selected session and the project-agnostic global-stats overview are
+  // mutually exclusive — entering global stats clears the project/session
+  // (clearProjectSelection). The sidebar resets this flag explicitly on
+  // session select, but the global search modal selects sessions via store
+  // actions and can't reach this local state, so it would otherwise stay in
+  // the global-stats view and hide the navigated conversation. Guarantee the
+  // exit here whenever a session becomes selected (issue #390).
+  useEffect(() => {
+    if (selectedSession) {
+      setIsViewingGlobalStats(false);
+    }
+  }, [selectedSession]);
+
   // Sidebar resize
   const {
     width: sidebarWidth,

--- a/src/components/modals/globalSearch/GlobalSearchModal.tsx
+++ b/src/components/modals/globalSearch/GlobalSearchModal.tsx
@@ -48,7 +48,7 @@ export const GlobalSearchModal = ({
     const resultsContainerRef = useRef<HTMLDivElement>(null);
     const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const { claudePath, projects, selectProject, selectSession, sessions, getSessionDisplayName, activeProviders, navigateToMessage, clearTargetMessage, userMetadata } =
+    const { claudePath, projects, selectProject, selectSession, sessions, getSessionDisplayName, activeProviders, navigateToMessage, clearTargetMessage, setAnalyticsCurrentView, userMetadata } =
         useAppStore();
     const [selectedProjectPath, setSelectedProjectPath] = useState<string>("all");
 
@@ -162,6 +162,10 @@ export const GlobalSearchModal = ({
                 );
 
                 if (targetSession) {
+                    // Ensure the conversation pane is the active view — otherwise
+                    // a result clicked while in analytics/tokenStats/etc. loads the
+                    // session but stays hidden behind the other view (issue #390).
+                    setAnalyticsCurrentView("messages");
                     if (result.uuid) navigateToMessage(result.uuid);
                     await selectSession(targetSession);
                     onClose();
@@ -190,6 +194,7 @@ export const GlobalSearchModal = ({
                         );
 
                         if (targetSession) {
+                            setAnalyticsCurrentView("messages");
                             if (result.uuid) navigateToMessage(result.uuid);
                             await selectProject(project);
                             await selectSession(targetSession);
@@ -215,7 +220,7 @@ export const GlobalSearchModal = ({
                 onClose();
             }
         },
-        [projects, sessions, selectProject, selectSession, navigateToMessage, clearTargetMessage, onClose, t],
+        [projects, sessions, selectProject, selectSession, navigateToMessage, clearTargetMessage, setAnalyticsCurrentView, onClose, t],
     );
 
     // Keyboard navigation


### PR DESCRIPTION
Closes #390 (the navigation bug; the secondary ask to auto-expand the left nav tree is left out of scope).

## Problem
From the global search (Cmd+K), clicking a result sometimes does nothing. Clean repro: search → open a result → switch to another view (e.g. analytics) → search again → click a result → nothing happens / the conversation isn't displayed.

## Root cause
`handleSelectResult` calls `navigateToMessage(uuid)` + `selectSession`/`selectProject` but **never resets the active view**. The sidebar's `handleSessionSelect` (App.tsx) does `setIsViewingGlobalStats(false)` + `setAnalyticsCurrentView("messages")` first — the global-search path omits both. `MessageViewer` (which consumes `targetMessageUuid` to scroll/highlight the result) only mounts when `currentView === "messages"` **and** `isViewingGlobalStats === false` (AppLayout render chain). So while any other view is active, the session loads but stays hidden behind it. First search works only because you start in the messages view.

This is a missing-view-reset, not a `targetMessageUuid` timing race (the deep-link effect re-fires correctly once `MessageViewer` is mounted).

## Fix
- **Modal:** call `setAnalyticsCurrentView("messages")` on both success paths — a store action the modal already has access to. Covers analytics / token stats / recent edits / settings / board / archive.
- **App:** `isViewingGlobalStats` is local App state the modal can't reach, so App resets it via an effect when a session becomes selected. Safe because a selected session and the project-agnostic global-stats overview are mutually exclusive — entering global stats calls `clearProjectSelection()` which nulls `selectedSession` — so the effect only flips the flag at the exact bug moment (no-op otherwise, incl. during in-place refresh which keeps the same session reference).

## Verification
`tsc` clean, `eslint` 0 errors (1 pre-existing unrelated warning), full suite **834 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed view state to properly update when navigating to sessions from search results, ensuring the selected conversation displays correctly instead of remaining in an alternative view mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->