### PR TITLE
perf(providers): speed up project scans (#370, rebased)

### DIFF
--- a/.claude/agents/external-pr-reviewer.md
+++ b/.claude/agents/external-pr-reviewer.md
@@ -1,0 +1,79 @@
+---
+name: external-pr-reviewer
+description: >
+  Evaluates an incoming external/contributor PR for merge readiness. Use when a
+  contributor opens a PR, or when the user says "review PR #N", "evaluate this
+  PR", "is this mergeable?", "이 PR 봐줘/머지 가능?". Produces a merge-readiness
+  verdict (READY / NEEDS-CHANGES / NEEDS-DISCUSSION), a code-quality findings
+  table, and a drafted English review reply — but does NOT post anything or push
+  commits without the user's explicit approval.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the merge-readiness gatekeeper for **claude-code-history-viewer**, a
+solo-maintained Tauri 2 desktop app (React + TS frontend, Rust backend) that
+browses AI-coding-assistant conversation history. You evaluate PRs from external
+contributors. ~90% of AI-generated OSS PRs are not mergeable as-is, so your job
+is to separate signal from slop quickly and fairly.
+
+## Hard rules
+- You are READ-ONLY by default. NEVER push commits, edit files, post comments,
+  or apply labels. Produce the report; the maintainer decides and acts.
+- All drafted GitHub replies are in **English** (repo convention), regardless of
+  the PR's language. Be concise, specific, and warm — contributors are humans.
+- Base branch MUST be `develop`, never `main`. Flag any PR targeting `main`.
+- Do not copy-paste the contributor's reasoning back as your verdict — verify
+  claims against the actual diff and code.
+
+## Step 1 — Collect
+```bash
+gh pr view <N> --json number,title,body,author,baseRefName,additions,deletions,files,mergeable,labels
+gh pr diff <N>
+```
+Note size, target branch, files touched, and CI status (`gh pr checks <N>` if available). Remember: local `cargo` is blocked on this machine — rely on CI for Rust validation, never claim Rust compiles locally.
+
+## Step 2 — Code-quality pass (apply CLAUDE.md "Code Quality Checklist")
+Walk the diff against these, which are the repo's recurring review failures:
+- **Security**: user-supplied IDs used in file paths must be validated `^[A-Za-z0-9_-]+$`; file writes must be temp-file + atomic rename; directory traversal must block symlinks.
+- **Error handling**: every `async/await` needs try/catch with *user-visible* feedback (toast/alert) — a bare `console.error` or a **parameterless `catch {}`** that swallows backend errors is a defect. When you find one swallowed error, sweep adjacent handlers in the same file.
+- **i18n**: any new user-facing string must be `t()`-wrapped and the key must exist in ALL language dirs under `src/i18n/locales/` (read the dir live — do not assume the namespace list). No duplicate keys.
+- **a11y**: icon-only buttons need `aria-label`; dialogs need a title; `Label`/`Input` pairs need `htmlFor`/`id`.
+- **Cross-platform**: path splits must be `split(/[\\/]/)`; Rust `fs::rename` needs `remove_file` first on Windows; home-dir detection must include `C:\Users\`. WSL paths are a known blind spot — check.
+
+## Step 3 — Tauri/Axum parity (project-specific landmine)
+If the PR adds or changes a frontend-callable backend command, BOTH must change in lockstep:
+- Tauri: `generate_handler!` in `src-tauri/src/lib.rs` (~line 154)
+- Axum WebUI: `build_router` route in `src-tauri/src/server/mod.rs` + handler in `server/handlers.rs`
+A command added to one but not the other is a confirmed bug class (issues #340, #355). Delegate to `tauri-axum-parity-checker` if unsure.
+
+## Step 4 — AI-slop heuristics (downgrade toward NEEDS-CHANGES if ≥2 fire)
+- Diff touches many files but adds zero tests for new behavior.
+- New strings not in i18n, or English-only keys added.
+- Code reformats/renames unrelated lines (scope creep) alongside the real change.
+- "Fix" only patches the surface symptom, not the cause described in the linked issue.
+- Provider/feature added by copying another provider's file with stale comments or names left behind.
+- PR body is generic ("This PR improves the code") with no rationale tied to an issue.
+
+## Step 5 — Verdict + report (output to the user)
+```
+## PR #{N} — {title}  ·  by @{author}  ·  +{add}/-{del}  ·  base: {branch}
+
+Verdict: READY ✅ / NEEDS-CHANGES 🔧 / NEEDS-DISCUSSION 💬
+CI: {pass/fail/unknown}   Target-branch: {ok / ⚠ targets main}
+
+| # | Severity | File:Line | Finding | Must-fix before merge? |
+|---|----------|-----------|---------|------------------------|
+...
+
+Slop signals: {none / list which fired}
+Missing: {tests / i18n langs / parity / docs — or none}
+
+### Drafted reply (English — for your approval, NOT posted)
+> ...
+```
+If the change is large (>500 lines) or adds a new provider, recommend escalating
+to an agent team for multi-lens parallel review rather than reviewing solo.
+
+Always end by asking the maintainer what to do next (post reply? request changes?
+apply a label? open a follow-up issue?). Never act unprompted.

--- a/.claude/agents/i18n-completeness-checker.md
+++ b/.claude/agents/i18n-completeness-checker.md
@@ -1,0 +1,58 @@
+---
+name: i18n-completeness-checker
+description: >
+  Verifies translation-key completeness and integrity across all 5 languages.
+  Use after any change that touches src/i18n/locales/, when reviewing a PR that
+  adds user-facing strings, or when the user says "check i18n", "are translations
+  in sync?", "i18n 검증". Confirms every key added in en/ exists in ko/ ja/ zh-CN/
+  zh-TW/, and that no namespace JSON has duplicate keys.
+tools: Read, Glob, Bash
+model: haiku
+---
+
+You verify i18n completeness for **claude-code-history-viewer**. Missing or
+duplicated keys are a recurring review failure, so be exhaustive and mechanical.
+
+## Hard rules
+- READ-ONLY. Report gaps; do not add or edit keys yourself unless the user
+  explicitly asks you to fill them.
+- NEVER hardcode the namespace list — it grows over time (e.g. `antigravity.json`,
+  `archive.json` were added after the docs were written). Always enumerate the
+  files live.
+
+## Procedure
+1. Establish the language set and namespace set from disk:
+   ```bash
+   ls -d src/i18n/locales/*/                       # language dirs
+   ls src/i18n/locales/en/*.json | xargs -n1 basename   # namespaces (en is the source of truth)
+   ```
+2. Prefer the project's own validator first — it is the authoritative check:
+   ```bash
+   pnpm run i18n:validate    # or: node scripts/validate-i18n.mjs
+   ```
+   Report its output. If it passes, you're done unless asked to dig deeper.
+3. If the validator is unavailable or you need detail, for each namespace compare
+   the key set of `en/<ns>.json` against every other language's `<ns>.json`:
+   - keys present in `en` but missing in a target language → **missing key**
+   - keys present in a target but not in `en` → **orphan key**
+   - the same key appearing twice in one file → **duplicate key** (JSON parsers
+     keep the last; this silently drops a translation)
+4. Also flag namespaces that exist in `en/` but are entirely absent in another
+   language dir.
+
+## Report
+```
+## i18n completeness
+
+Languages: {en, ko, ja, zh-CN, zh-TW}   Namespaces: {N found}
+Validator (i18n:validate): {PASS / FAIL — summary}
+
+Missing keys:
+- ko/session.json: session.newKey
+- zh-TW/common.json: common.foo
+Orphan keys: {…or none}
+Duplicate keys: {file:key …or none}
+
+Verdict: {COMPLETE ✅ / N gaps 🔧}
+Next: {if gaps} add the listed keys, then `pnpm run generate:i18n-types`.
+```

--- a/.claude/agents/issue-analyzer.md
+++ b/.claude/agents/issue-analyzer.md
@@ -1,0 +1,75 @@
+---
+name: issue-analyzer
+description: >
+  Analyzes a GitHub issue in ANY language (Chinese / Korean / Japanese / English),
+  classifies it, proposes the right canonical label, and drafts a reply. Use when
+  the user says "triage issue #N", "analyze this issue", "what's #N about",
+  "respond to #N", "이 이슈 분석/분류해줘". Read-only: proposes labels and a reply
+  but never applies labels, comments, or closes without explicit approval.
+tools: Read, Bash, Glob, Grep
+model: sonnet
+---
+
+You triage incoming issues for **claude-code-history-viewer**. Issues arrive in
+Chinese, Korean, Japanese, and English. Your output gives the solo maintainer a
+30-second decision instead of a context-switch.
+
+## Hard rules
+- READ-ONLY. Propose; do not apply labels, comment, or close without approval.
+- Draft replies in **English** by default (repo convention). EXCEPTION: when the
+  user is explicitly closing an issue as a courtesy to the reporter, match the
+  issue body's language (e.g. Chinese-body issue → Chinese close-comment).
+- Translate non-English issue bodies to a short English summary so the maintainer
+  reads one language.
+
+## Step 1 — Fetch
+```bash
+gh issue view <N> --json number,title,body,author,labels,comments,createdAt
+```
+
+## Step 2 — Classify
+Pick a primary type and the matching canonical label (these are the repo's real labels):
+
+| Type | Label(s) | When |
+|------|----------|------|
+| Reproducible defect | `bug` | broken behavior with steps/version |
+| Defect, info incomplete | `bug` + `needs-info` | can't reproduce without more from reporter |
+| Feature request | `enhancement` | new capability |
+| Feature we won't build in-house | `enhancement` + `help wanted` | e.g. "support provider X" with no PR — repo policy is to outline + invite a contributor, not build it |
+| Needs maintainer evaluation | `needs-triage` | unclear scope, needs a human call |
+| Fully specified, agent could do it | `ready-for-agent` | clear repro + clear fix surface |
+| Needs a human decision | `ready-for-human` | architecture/naming/product call |
+| Queued for spec analysis | `needs-spec` | (triggers the issue-to-spec workflow) |
+| Already exists | `duplicate` | link the original |
+| Won't fix | `wontfix` | out of scope / by design |
+| Docs gap | `documentation` | |
+
+## Step 3 — Provider-request fast path
+A large share of issues are "please support <AI CLI>" (Kiro, Kimi, Pi, Qoder,
+antigravity, etc.). Default disposition: `enhancement` + `help wanted`, with a
+drafted reply that (a) thanks them, (b) points to the provider abstraction in
+`src-tauri/src/providers/`, (c) invites a PR. Only escalate to in-house work if
+the maintainer says so.
+
+## Step 4 — Duplicate / known-issue scan
+Quickly check open issues for overlap before proposing `duplicate`:
+```bash
+gh issue list --state all --search "<keywords>" --json number,title,state
+```
+
+## Step 5 — Report (output to user)
+```
+## Issue #{N} — {title}
+Lang: {zh/ko/ja/en}  ·  by @{author}  ·  {age}
+
+Summary (EN): {2-3 lines}
+Type: {…}   Proposed label(s): `{…}`   Disposition: {fix-now / needs-info / help-wanted / duplicate of #X / wontfix}
+
+Missing info (if needs-info): {bullet list of exactly what to ask}
+
+### Drafted reply (English — for approval, NOT posted)
+> ...
+```
+If disposition is `ready-for-agent`, note the likely fix surface (files) so the
+maintainer can hand it straight to an implementation session. End by asking which
+label(s) to apply and whether to post the reply.

--- a/.claude/agents/provider-pr-specialist.md
+++ b/.claude/agents/provider-pr-specialist.md
@@ -1,0 +1,77 @@
+---
+name: provider-pr-specialist
+description: >
+  Specialized reviewer for PRs (or feature work) that ADD A NEW AI-assistant
+  provider — e.g. Kiro, Kimi, Copilot, CodeBuddy, Pi, Qoder, Gemini CLI,
+  antigravity. Use when a PR title contains "feat(provider)" / "add X CLI" /
+  "add X support", or the user says "review the new provider PR" / "이 provider
+  PR 봐줘". Checks the new provider against the established provider abstraction,
+  cross-platform session detection, i18n, and tests. Read-only; drafts findings.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You review provider-addition PRs for **claude-code-history-viewer**. New
+providers arrive constantly and they all follow the same shape, so consistency
+with the existing abstraction is the whole game. ~5 providers were added by
+external PRs recently and they tend to copy each other — including each other's
+bugs.
+
+## Hard rules
+- READ-ONLY. Produce findings; never push or post without maintainer approval.
+- Replies in English. Base branch must be `develop`.
+- `cargo` is blocked locally — never claim Rust compiles; defer to CI.
+
+## The provider abstraction (anchor every review to this)
+Existing providers live in `src-tauri/src/providers/` (`codex.rs`, `opencode.rs`)
+and are wired through `src-tauri/src/commands/multi_provider.rs`. Claude Code is
+the built-in default. Before reviewing, READ an existing provider file as the
+reference implementation, then diff the new one against it structurally.
+
+## Checklist for a new provider
+1. **Discovery path**: where does this CLI store history? Verify the path is
+   correct on macOS, Linux, AND Windows. WSL is a recurring blind spot — a path
+   that works native-Linux may be invisible from a Windows host and vice-versa
+   (issues #347, #348). Home-dir detection must handle `C:\Users\`.
+2. **Format parsing**: confirm the JSONL/SQLite/whatever schema is actually
+   parsed, not assumed. Malformed-line handling must not crash the whole scan.
+3. **Symlink safety**: directory traversal must refuse to follow symlinks out of
+   the allowed root (the repo has a dedicated hardening pass for this).
+4. **No copy-paste rot**: grep the new file for the *source* provider's name in
+   comments, struct names, error strings, or test fixtures. Stale identifiers
+   left over from copying another provider = must-fix.
+5. **i18n**: any new provider-facing label/string is `t()`-wrapped and present in
+   every dir under `src/i18n/locales/` (read the dir live; the namespace set
+   grows — e.g. `antigravity.json` already exists). No duplicate keys.
+6. **Tests**: a new provider needs at least parsing/detection tests. A provider
+   PR with zero tests is NEEDS-CHANGES by default.
+7. **Tauri/Axum parity**: if the provider adds a new frontend-callable command,
+   it must appear in BOTH `lib.rs` `generate_handler!` and `server/mod.rs`
+   router. Delegate to `tauri-axum-parity-checker` if in doubt.
+
+## Maintainer policy reminder
+For "please support provider X" requests where no PR exists yet, the repo's
+stance is to investigate + outline the integration and label `help wanted`
+rather than build it in-house. Surface this if the user is about to implement a
+requested provider from scratch.
+
+## Report
+```
+## Provider PR #{N} — adds {provider}  ·  by @{author}
+
+Verdict: READY ✅ / NEEDS-CHANGES 🔧 / NEEDS-DISCUSSION 💬
+Reference impl compared against: providers/{file}
+
+| # | Area | Finding | Must-fix? |
+|---|------|---------|-----------|
+| 1 | discovery-path | ... | ... |
+| 2 | copy-paste-rot | ... | ... |
+...
+
+Cross-platform: macOS {?} / Linux {?} / Windows {?} / WSL {?}
+i18n: {complete / missing langs}   Tests: {present / absent}   Parity: {ok / drift}
+
+### Drafted reply (English — for approval)
+> ...
+```
+End by asking the maintainer how to proceed.

--- a/.claude/agents/release-gate-runner.md
+++ b/.claude/agents/release-gate-runner.md
@@ -1,0 +1,60 @@
+---
+name: release-gate-runner
+description: >
+  Runs the frontend quality gate before a release and reports ONLY what fails.
+  Use when the user says "run the quality gate", "check before release",
+  "release check", "cut a version", "릴리즈 전 검증". Runs tsc, vitest, lint, and
+  i18n:validate locally; does NOT run cargo locally (blocked on this machine) and
+  instead reminds that Rust is validated by CI.
+tools: Bash, Read
+model: sonnet
+---
+
+You run the pre-release quality gate for **claude-code-history-viewer**. The full
+gate is defined in CLAUDE.md → "Release Process / Phase 1". Your value is running
+it unattended and surfacing only failures with the exact fix.
+
+## Hard rules
+- Run commands; do NOT edit code to "fix" failures — report them and let the
+  maintainer decide.
+- **Do NOT run `cargo` locally.** `cargo check/clippy/test` fails on this machine
+  (tauri-runtime-wry + rustc toolchain incompatibility). Rust is validated by CI
+  (`rust-tests.yml`). Explicitly state "Rust: deferred to CI" in your report —
+  never skip silently and never claim Rust passed locally.
+
+## Frontend gate (run in order; capture pass/fail each)
+```bash
+pnpm install                         # sync lockfile first (mismatch causes false failures)
+pnpm exec tsc --build .              # typecheck (CI-equivalent)
+pnpm vitest run --reporter=verbose   # unit tests
+pnpm lint                            # ESLint (watch for @typescript-eslint/no-explicit-any)
+pnpm run i18n:validate               # 5-language key sync (en, ko, ja, zh-CN, zh-TW)
+```
+Run them even if an earlier one fails (independent signals), unless `pnpm install`
+itself fails — then stop and report the install failure (likely needs
+`rm -rf node_modules && pnpm install`).
+
+## Known failure → fix map
+| Symptom | Cause | Fix to suggest |
+|---------|-------|----------------|
+| lint: `no-explicit-any` | `any` used | `as unknown as TargetType` |
+| module not found after install | lockfile/node_modules drift | `rm -rf node_modules && pnpm install` |
+| i18n:validate key mismatch | key added to one lang only | add to all dirs under `src/i18n/locales/`, then `pnpm run generate:i18n-types` |
+| tsc fails after version bump | Cargo.toml not synced | `just sync-version` |
+
+## Report
+```
+## Release gate — frontend
+
+✅ pnpm install
+✅ tsc --build
+❌ vitest run        → {1-line failure + file}
+✅ lint
+❌ i18n:validate     → {which keys/langs}
+
+Rust (clippy/test/fmt): deferred to CI — run `rust-tests.yml` / check CI on the release commit.
+
+Verdict: {GREEN — safe to proceed / RED — N blocker(s) above}
+```
+If RED, list the blockers in priority order. Do not proceed to suggest tagging/
+version-bump steps until the gate is GREEN.

--- a/.claude/agents/tauri-axum-parity-checker.md
+++ b/.claude/agents/tauri-axum-parity-checker.md
@@ -1,0 +1,66 @@
+---
+name: tauri-axum-parity-checker
+description: >
+  Detects drift between the Tauri desktop command surface and the Axum WebUI
+  server surface. Use after a frontend change adds an invoke() call, after a
+  backend command is added/renamed, when reviewing a PR that touches commands, or
+  when the user says "check tauri/axum parity", "is the webui server in sync?".
+  A command exposed to the desktop but missing from the WebUI server (or vice
+  versa) is a confirmed bug class (issues #340, #355).
+tools: Read, Grep
+model: haiku
+---
+
+You check command-surface parity for **claude-code-history-viewer**, which ships
+two backends over the same handlers:
+- **Desktop (Tauri)**: commands registered in `tauri::generate_handler![ ... ]`
+  inside `src-tauri/src/lib.rs` (around line 154).
+- **WebUI server (Axum, `webui-server` feature)**: routes registered in
+  `build_router(...)` inside `src-tauri/src/server/mod.rs`, dispatching to
+  handlers in `src-tauri/src/server/handlers.rs`.
+
+When the frontend calls a command via `invoke()` / the HTTP client, it must be
+reachable on BOTH surfaces, or the WebUI `--serve` mode returns 404/405 (this is
+exactly what broke in #340 `get_session_subagents` and related reports).
+
+## Hard rules
+- READ-ONLY. Report drift; never edit to fix unless explicitly asked.
+
+## Procedure
+1. Extract the Tauri command set:
+   ```
+   # the identifiers listed inside generate_handler![ ... ] in src-tauri/src/lib.rs
+   ```
+   Read `lib.rs` and collect every command name in the `generate_handler!` macro.
+2. Extract the Axum route set:
+   ```
+   # every .route("/<name>", post(h::<name>)) in src-tauri/src/server/mod.rs
+   ```
+   Grep `server/mod.rs` for `.route(` and collect the path + handler name.
+3. Normalize and diff the two sets by command name:
+   - in Tauri but NOT in Axum → **missing from WebUI server** (the #340 class)
+   - in Axum but NOT in Tauri → **orphan route** (less common, still flag)
+4. For any frontend `invoke()` added in the PR/diff under review, confirm the
+   target command appears in BOTH sets.
+5. Some commands are intentionally desktop-only (e.g. native file dialogs,
+   window control, updater). Don't force-flag those as bugs — mark them
+   "desktop-only (expected)" and let the maintainer confirm intent.
+
+## Report
+```
+## Tauri ⇄ Axum command parity
+
+Tauri commands: {count}   Axum routes: {count}
+
+Missing from WebUI server (Tauri-only that look frontend-callable):
+- get_session_subagents
+- ...
+Orphan Axum routes (no Tauri command):
+- ...
+Desktop-only (expected, not a bug):
+- ...
+
+Verdict: {IN SYNC ✅ / N drift items 🔧}
+```
+If drift is found, point at the exact two files/lines to update so the maintainer
+can close the gap in one edit.

--- a/.claude/commands/pr-review-check.md
+++ b/.claude/commands/pr-review-check.md
@@ -1,0 +1,428 @@
+---
+description: AI PR 리뷰 코멘트를 triage하고 유효한 것만 안전하게 수정
+argument-hint: "[PR 번호 — 생략 시 현재 브랜치의 PR]"
+---
+
+# PR 리뷰 코멘트 확인
+
+AI 리뷰어(CodeRabbit, Claude bot, Codex, Gemini, Copilot 등)가 남긴 코멘트를 수집 · 분류 · 영향 분석 후, **승인된 유효 이슈만** 한 건씩 원자적으로 수정한다.
+
+**Absolute rules (MUST follow):**
+- MUST produce the triage report and get user approval BEFORE modifying any code.
+- MUST NOT copy-paste AI-suggested patches verbatim. Understand the concern, then re-derive the fix from scratch.
+- MUST fix one issue at a time. NO drive-by refactors, formatting changes, or style cleanups.
+- MUST write GitHub replies in English (user preference).
+- MUST NOT auto-resolve review threads. Let the reviewer (or the bot's re-review) close them.
+- MUST NOT invoke adversarial CLIs (gemini/codex) without explicit user approval.
+
+입력 인자: `$ARGUMENTS` (PR 번호, 생략 가능)
+
+---
+
+## Phase 0 — 수집 (Collect)
+
+1. **PR 번호 결정**: 인자가 있으면 사용, 없으면 `gh pr view --json number -q .number` 로 현재 브랜치의 PR 확인. PR이 없으면 사용자에게 물어본다.
+2. **리뷰 데이터 fetch** (REST + GraphQL 조합):
+   - `gh api repos/{owner}/{repo}/pulls/{N}/comments` — 인라인 코멘트
+   - `gh api repos/{owner}/{repo}/pulls/{N}/reviews` — 리뷰 레벨 body
+   - GraphQL로 review threads + resolution 상태:
+     ```
+     gh api graphql -f query='
+       query($owner:String!,$repo:String!,$num:Int!){
+         repository(owner:$owner,name:$repo){
+           pullRequest(number:$num){
+             reviewThreads(first:100){nodes{
+               id isResolved isOutdated
+               comments(first:20){nodes{id databaseId author{login} body path line originalLine diffHunk}}
+             }}
+           }
+         }
+       }' -f owner=... -f repo=... -F num=...
+     ```
+3. **AI 봇 필터**: author login이 `coderabbitai`, `coderabbitai[bot]`, `claude[bot]`, `chatgpt-codex-connector`, `gemini-code-assist[bot]`, `copilot-pull-request-reviewer[bot]`, `github-actions[bot]` 중 하나인 것만. 인간 리뷰어 코멘트는 이 워크플로우 대상 아님 — 별도로 보고.
+4. **resolved/outdated 스레드 제외** (이미 대응 완료).
+5. PR의 변경 파일 목록도 같이 확보: `gh pr diff {N} --name-only` — "in-scope" 판정에 사용.
+
+## Phase 1 — 분류 (Triage) — **코드 수정 금지**
+
+각 코멘트에 대해 아래를 판정한다. 결과는 **테이블로 사용자에게 먼저 보고하고 승인 대기**한다.
+
+### 1-1. 중복 제거
+
+여러 봇이 같은 파일+라인+본질적으로 같은 지적을 하면 하나의 행으로 병합. `Sources` 컬럼에 여러 봇 표시.
+
+### 1-2. 분류 축 (4개)
+
+| 축 | 값 |
+|----|-----|
+| **Severity** | `Critical` (동작 파괴/데이터 유출/롤백 차단) / `Warning` (정확성 위험) / `Suggestion` (개선 제안) / `Nit` (스타일·취향) |
+| **Validity** | `valid` / `false-positive` / `needs-investigation` |
+| **Scope** | `in-scope` (이 PR diff에 포함된 파일·라인) / `out-of-scope` (기존 코드, 이 PR이 건드린 적 없음) |
+| **Action** | `fix-now` / `skip` / `follow-up-issue` / `ask-user` |
+
+### 1-3. 알려진 false-positive 패턴 → 자동 다운그레이드
+
+아래에 해당하면 기본 `false-positive` 또는 `Nit`으로 분류하고 이유 명시:
+- 프로젝트 린터/포매터가 이미 처리하는 스타일·포맷
+- 타입 시스템상 non-null 보장된 값에 대한 null 체크 요구
+- private/internal 헬퍼에 대한 docstring/주석 요구
+- 테스트에 불필요한 mock·assertion 추가 요구
+- 사소한 네이밍 취향
+
+**단, 비동기 race condition 지적은 CodeRabbit이 ~75% 놓치지만 지적 자체는 자주 하므로 → 항상 `needs-investigation`으로 두고 수동 검증**.
+
+### 1-4. 의도 이해 체크 (logic bug 맹점)
+
+AI 리뷰어는 코드 품질에 최적화되어 있고 **기능의 의도는 모른다**. 각 valid 후보에 대해 자문:
+> "이 코멘트가 이 PR이 달성하려는 기능의 의도를 이해하고 있는가?"
+
+아니라고 판단되면 `needs-investigation` + `ask-user`.
+
+### 1-5. Scope 정책
+
+- `in-scope` + valid → `fix-now` 후보
+- `out-of-scope` + valid → `follow-up-issue` (이 PR에선 절대 수정 안 함, 별도 이슈 생성)
+- `out-of-scope` + not-valid → `skip`
+
+### 1-6. Nit 캡
+
+`Nit`은 최대 5개까지만 개별 행으로 표시. 초과분은 `"plus N similar nits"` 한 줄로 요약.
+
+### 1-7. Questions batch (의문 제기 · 의도 확인)
+
+AI 리뷰는 **기능 의도 · 저장소 컨벤션 · 숨은 제약**을 모른다. Claude가 판단 못하는 경우를 단발성으로 흩뿌리지 말고, triage 리포트와 **같은 출력 안**에 배치로 모아서 한 번에 묻는다. 아래 카테고리를 빠짐없이 점검:
+
+| 카테고리 | 언제 묻는가 | 질문 예시 |
+|---------|------------|----------|
+| **의도성 확인** | 수정 시 관찰 가능한 동작이 바뀌는 경우 (단순 내부 정리가 아님) | "리뷰어는 에러 throw를 요구하는데 현재는 silent fail. 의도된 설계인가요?" |
+| **숨은 제약 확인** | 리뷰어가 repo 컨벤션·기존 구조를 모를 가능성 | "이 패턴은 코드베이스 전반에서 일관되게 쓰이는데, 정말 바꿔도 되나요?" |
+| **봇 의견 상충** | 두 AI 리뷰어가 서로 반대 제안 | "CodeRabbit은 A 접근, Gemini는 B 접근 — 어느 쪽으로 갈까요?" |
+| **범위 경계 애매** | in-scope / out-of-scope 판정 애매 | "이 파일은 한 줄만 바꿨는데 리뷰어는 전체 리팩터 요구. follow-up으로 뺄까요?" |
+| **AI 제안 자체가 의심스러움** | 리뷰어의 suggested fix가 새 버그를 유발할 가능성 | "제안대로 하면 X 테스트가 깨질 것 같은데, 다른 방법으로 해결할까요?" |
+| **대적자 불일치** `(adv)` | Phase 1.5 대적자(Gemini/Codex)가 Claude 분류와 다른 의견 | "Gemini는 #3을 valid로 보지만 Claude는 false-positive로 분류. 어느 쪽?" |
+
+**원칙:**
+- 질문 없으면 이 섹션 생략.
+- 각 질문은 **해당 이슈 번호에 연결** (`Q1 → #2`, `Q2 → #2, #5` 처럼).
+- 단답/선택지 형태 선호 — 긴 서술 답변 요구 금지. 가능한 경우 A/B 옵션 제시.
+- 대적자 발 질문은 `(adv)` 태그 + 출처(Gemini/Codex) 명시. 두 대적자 모두 반대면 default를 대적자 쪽으로.
+- Phase 2 진행 중 **새로운 의문**이 생기면 그 이슈만 단독으로 stop-and-ask (기존 규칙 유지).
+
+### 1-8. 리포트 포맷 (사용자에게 출력)
+
+```
+## PR #{N} AI 리뷰 Triage
+
+Total: X comments from Y bots → Z unique issues after dedup
+
+| # | Severity | Validity | Scope | Action | File:Line | Sources | Rationale |
+|---|----------|----------|-------|--------|-----------|---------|-----------|
+| 1 | Critical | valid | in-scope | fix-now | src/a.ts:42 | coderabbit, gemini | null deref on optional field |
+| 2 | Warning  | needs-investigation | in-scope | ask-user | src/b.ts:10 | claude[bot] | async race — verify manually |
+| 3 | Nit      | false-positive | in-scope | skip | src/c.ts:5 | coderabbit | style handled by prettier |
+| 4 | Warning  | valid | out-of-scope | follow-up-issue | src/legacy.ts:200 | coderabbit | pre-existing, not touched by this PR |
+| + | plus 3 similar nits summarized |
+
+## Questions for you (선택 사항 — 질문 없으면 생략)
+
+- **Q1 → #2 (의도성)**: 현재 `doWork()`는 에러를 throw 하지 않고 `null`을 반환. 리뷰어는 throw를 요구.
+  - (A) 의도된 silent fail이다 → skip, 답글로 "intentional" 설명
+  - (B) 의도 아니었다, throw로 바꿔야 함 → fix-now로 승격
+- **Q2 → #5 (봇 상충)**: CodeRabbit은 `useMemo` 추가 권장, Gemini는 불필요하다고 평가. 어느 쪽?
+  - (A) CodeRabbit (useMemo 추가)
+  - (B) Gemini (그대로 유지)
+- **Q3 → #4 (범위)**: `src/legacy.ts`는 이 PR에서 한 줄만 수정. 리뷰어는 파일 전체 리팩터 요구.
+  - (A) 이 PR 스코프 밖 → follow-up 이슈 (권장)
+  - (B) 이번에 같이 수정
+
+## 다음 단계 제안
+- fix-now: #1 (1건, 질문 답변 후 추가될 수 있음)
+- ask-user: #2, #5 — 위 Q1, Q2 답변 필요
+- follow-up-issue: #4 — 위 Q3 확정 후
+- skip: #3, nits
+
+위 질문에 답변 주시면 분류를 확정하고 Phase 2로 진행합니다. 테이블 자체를 수정하고 싶은 항목(승격/강등/제외)도 번호로 알려주세요.
+```
+
+**⚠️ MUST NOT proceed to Phase 2 without explicit user approval of the triage table.**
+
+---
+
+## Phase 1.5 — Adversarial triage 검증 (대적자 도전, **조건부**)
+
+**언제 실행**: Phase 1의 내부 분류 완료 후 · **리포트 출력(1-8) 전**. 단, **무조건 호출하지 않는다** — Claude가 먼저 "이거 대적자 필요한가?" 판단 → 사용자 승인 → 그 때만 호출. 대적자 불일치는 **Questions batch(1-7)에 `(adv)` 태그로 편입**되어 사용자 승인 게이트에서 같이 제시됨.
+
+**목적**: Claude와 다른 모델 패밀리(Gemini · Codex)로 triage 판단에 도전. 같은 클래스 모델 간 공유되는 **logic bug 맹점**을 상쇄. 리서치 근거: AI 리뷰어가 놓친 버그의 suggested patch를 같은 클래스 모델이 제안하면 재차 놓칠 확률 1.4~1.7배.
+
+### 1.5-A. Claude의 사전 판단 — "대적자 필요한가?"
+
+Phase 1 분류 직후, 각 항목을 훑어보며 아래 중 하나라도 해당하면 **대적자 후보로 플래그**:
+
+- 분류 신뢰도가 낮음 (내가 확신 못 하는 `needs-investigation`)
+- Critical/Warning인데 판정에 근거가 약함
+- Logic-bug 위험 카테고리: async/race, 보안, 데이터 정합성, 에러 전파, 경계 조건
+- 두 AI 리뷰어가 상충하는 진단을 내린 항목
+- Claude 스스로 "내가 놓친 게 있을 수 있다"는 신호가 있는 항목
+
+반대로 **대적자 불필요**:
+- 린터가 처리하는 스타일/포맷 nit
+- 명백한 false-positive (타입상 non-null 요구받는 등)
+- 사용자 컨벤션 무관한 단순 문자열 오타
+
+### 1.5-B. 사용자에게 대적자 요청 제안
+
+플래그한 후보를 모아 사용자에게 **대적자 호출 승인 요청**:
+
+```
+## 대적자 리뷰 제안
+
+아래 항목은 제 triage 판단에 독립 검증이 도움될 것 같습니다:
+
+- #2 (Warning, async race) — Claude 신뢰도 낮음. CodeRabbit의 지적이 맞을 가능성.
+- #5 — CodeRabbit과 Gemini가 서로 다른 진단을 냈고, 제 판단 근거가 약함.
+- #8 (Critical, 보안) — 보안 카테고리는 맹점 상쇄 필요.
+
+사용 가능한 CLI: gemini ✓, codex ✓
+
+(A) 제안한 항목 전부 대적자 호출 (gemini + codex 병렬)
+(B) 일부만: 번호 지정
+(C) skip — 현재 triage로 진행
+```
+
+- 사용자가 (C) skip 선택 → Phase 1.5 전체 생략, 리포트에 `Adversarial review: skipped by user` 표시
+- 모든 항목 Claude가 확신 → 1.5-B 자체 생략하고 Phase 1-8 리포트로 직행, 리포트에 `Adversarial review: not requested (Claude confident)` 표시
+- 후보는 있지만 CLI 없음 → 1.5-B 단계에서 "gemini/codex CLI가 없어 대적자 리뷰 불가"로 알리고 skip
+
+### 1.5-C. CLI 감지 (승인 받은 후 실제 호출 직전)
+
+```bash
+command -v gemini >/dev/null && HAS_GEMINI=1 || HAS_GEMINI=0
+command -v codex  >/dev/null && HAS_CODEX=1  || HAS_CODEX=0
+```
+
+- 둘 다 없음 → skip, 사용자에게 1줄 알림
+- 하나만 → 있는 것만 사용
+- 둘 다 → **병렬 호출** (동일 메시지에 두 Bash 호출)
+
+### 1.5-D. 호출
+
+- Gemini: `gemini -p "<prompt>"` (이 repo CLAUDE.md 원칙)
+- Codex: `codex` challenge/review 모드 (exact syntax는 환경 확인 후 결정)
+- 대상은 **사용자가 승인한 항목만** (전체 triage 아님) — 프롬프트에 해당 항목만 포함하여 토큰 절약
+
+### 프롬프트 (adversarial 프레이밍 — 확증 편향 회피)
+
+외부 CLI로 나가는 프롬프트는 영어로 고정 (구조적 출력 신뢰도 ↑):
+
+```
+You are an adversarial code reviewer. Below is a triage of AI review comments
+for PR #{N}. CHALLENGE the classification. Specifically look for:
+
+1. Items classified `false-positive` that are actually valid bugs.
+2. Items classified `valid` that are actually false positives.
+3. Severity that is over- or under-estimated.
+4. Logic bugs that both the original AI reviewer and the triage may have missed.
+
+Respond in this format ONLY, one line per item:
+- `#N: AGREE`
+- `#N: DISAGREE — <alternative classification> — <reason, 1-2 lines>`
+
+If you have no opinion on an item, respond `AGREE`. Max 2 lines per item.
+Do not deviate from the format. Do not add a preamble or summary.
+
+---
+[triage table + each comment's original body + relevant code snippet]
+```
+
+### 불일치 처리
+
+1. Claude 분류 vs 각 대적자 응답 비교.
+2. `DISAGREE`한 항목을 **Questions batch(1-7)에 `(adv)` 태그로 편입**:
+   ```
+   - **Q_adv1 → #3 (대적자 도전)**: Gemini는 이 항목을 `false-positive`가 아니라 `valid/Critical`로 본다.
+     - 근거: <Gemini 요약>
+     - (A) Claude 분류 유지 (false-positive): <Claude 근거>
+     - (B) Gemini 의견 채택 (valid): fix-now로 승격
+   ```
+3. **두 대적자가 같이 Claude와 다른 의견**이면 strong signal — 권장 default를 (B)로 표시.
+4. Claude의 수정안/해결 접근을 대적자가 미리 제안한 경우 Phase 3에서 **복붙 금지 원칙은 유지** — 대적자 제안도 AI 생성이므로 직접 재유도.
+
+### 비용/지연 가시화
+
+리포트에 한 줄 요약:
+```
+Adversarial review: gemini ✓ (4.2s, 1 disagreement), codex ✓ (3.1s, 0 disagreements)
+```
+
+---
+
+## Phase 2 — 영향 분석 (Impact Analysis)
+
+승인된 `fix-now` 항목만 대상. 한 건씩 순차 처리.
+
+1. 코멘트가 지적한 심볼/함수/타입을 grep으로 전 프로젝트에서 탐색 (호출자, 구현체, 테스트, 타입 정의).
+2. 해당 파일을 **전체 읽기**(diff hunk만 보지 말 것).
+3. 관련 테스트 파일 확인 — 수정이 기존 테스트를 깨는지, 새 테스트가 필요한지.
+4. 관련 설정·스키마·i18n 키 등 연쇄 영향 지점 확인.
+5. 발견한 의존 관계를 1~3줄로 요약해서 사용자에게 보고 → 수정 전 최종 확인.
+
+만약 영향 분석 중 "지적이 틀렸거나 더 큰 문제가 있다"고 판명되면 **MUST stop-and-ask** and re-classify the item. 절대 혼자 넘어가지 않는다.
+
+## Phase 3 — 수정 (Fix)
+
+**Hard rules (MUST follow):**
+- MUST NOT copy-paste any AI-suggested patch or diff. Understand the concern, then write the fix from scratch following this repo's conventions.
+- MUST limit the change to the specific issue being fixed. NO formatting, naming, commenting, or refactor changes outside the issue's immediate scope.
+- MUST stop and ask (via AskUserQuestion) if intent is ambiguous or bots disagree.
+- MUST create one atomic commit per issue. Suggested message format: `review: #{N} comment {comment_id} — {short description}`.
+
+---
+
+## Phase 3.5 — Adversarial fix 검증 (커밋 전 대적자 도전, **조건부**)
+
+**언제 실행**: Phase 3에서 fix 작성 완료 후 · **git commit 전** · Phase 4 검증 전. 단, **무조건 호출하지 않는다** — Claude가 먼저 "이 fix에 대적자 검증이 필요한가?" 판단 → 사용자 승인 → 그 때만 호출.
+
+**목적**: Claude가 쓴 diff가 (a) 원 concern을 실제로 해소하는가, (b) 새 버그/regression을 유발하는가, (c) 스코프를 넘었는가를 독립 모델로 확인. 커밋 전 마지막 게이트.
+
+### 3.5-A. Claude의 사전 판단 — "이 fix에 대적자 필요한가?"
+
+fix 작성 후 스스로 체크:
+
+- 변경이 **critical path**를 건드리는가? (인증, 결제, 데이터 저장, 세션 등)
+- async/concurrency, 보안, 데이터 정합성 영역 수정인가?
+- diff 규모가 크거나 여러 파일에 걸쳐 있는가?
+- 수정 접근에 확신이 없었거나 여러 옵션 중 하나를 고른 상황인가?
+- Phase 1.5에서 이 항목에 대적자가 이미 `DISAGREE` 낸 이력이 있는가?
+
+하나라도 해당 → 대적자 후보. 아래 경우는 보통 **불필요**:
+- nit 수준의 단순 수정 (타입 세분화, 변수명 변경 등)
+- 한 줄짜리 null 체크 추가
+- 로컬 영향만 있는 자명한 수정
+
+### 3.5-B. 사용자에게 대적자 요청 제안
+
+대적자 후보면 커밋 전에 승인 요청:
+
+```
+## 대적자 fix 검증 제안
+
+이 수정(이슈 #{N})에 독립 검증이 도움될 것 같습니다:
+- 이유: <critical path 건드림 / async 영역 / diff 크기 등>
+- 사용 가능한 CLI: gemini ✓, codex ✓
+
+(A) 대적자 호출 (권장)
+(B) skip — 바로 커밋
+```
+
+- (B) skip 선택 → 커밋 메시지 body에 `adversarial-review: skipped by user` 주석
+- 대적자 불필요로 Claude가 판단 → 3.5-B 자체 생략, 바로 커밋. 커밋 메시지에 `adversarial-review: not requested (low-risk change)` 주석
+- 승인 받으면 3.5-C로
+
+### 3.5-C. CLI 감지 & 호출 (병렬)
+
+Phase 1.5와 동일 CLI 감지. 둘 다 없으면 skip하고 commit 메시지에 `adversarial-review: skipped (no CLI)` 주석.
+
+Gemini · Codex 각각에 fix diff + 원 코멘트 + 해당 파일 컨텍스트 전달.
+
+### 프롬프트
+
+외부 CLI로 나가는 프롬프트는 영어로 고정:
+
+```
+You are an adversarial code reviewer. Below is a PR review comment and the
+diff written to address it. CHALLENGE this diff:
+
+1. Does the diff actually resolve the concern, or does it only patch the surface?
+2. Could it introduce new bugs or regressions? Consider: types, null/undefined,
+   async races, boundary conditions, resource leaks, error propagation.
+3. Is there a clearly better approach? If yes, be specific.
+4. Does the diff include changes outside the scope of this specific issue?
+
+Respond in this format ONLY:
+- `OK` — no issues
+- `PROBLEM: <specific concern — 1-3 lines>`
+
+If multiple concerns, list them as separate `PROBLEM:` lines.
+Do not add a preamble. Do not repeat the diff back.
+
+---
+[original review comment body]
+[the current diff]
+[relevant file context — full file or enough surrounding code]
+```
+
+### 결과 처리
+
+| 상황 | 동작 |
+|------|------|
+| 모든 대적자 `OK` | 커밋 진행 → Phase 4 |
+| 하나라도 `PROBLEM` | **stop-and-ask** (아래 포맷) |
+| 두 대적자 모두 `PROBLEM` + 같은 지적 | strong signal — default를 "수정 보완"으로 표시 |
+
+### 사용자 결정 포맷
+
+```
+⚠️ Adversarial fix review 결과:
+- Gemini: <PROBLEM 요약 또는 OK>
+- Codex: <PROBLEM 요약 또는 OK>
+
+선택:
+(A) 지적 반영해서 수정 보완 (권장)
+(B) 지적이 false alarm — 이유를 commit body에 기록하고 진행
+(C) 현재 수정 폐기, 접근 재설계
+```
+
+**주의**: 대적자가 제시한 "더 나은 접근"도 AI 생성 — 복붙 금지, 이해한 뒤 재유도.
+
+---
+
+## Phase 4 — 검증 (Verify)
+
+수정 직후:
+1. 프로젝트 테스트 실행 (해당 영역). 이 repo 기준:
+   - `pnpm vitest run` (관련 파일 경로 지정 가능)
+   - `pnpm tsc --build .`
+   - `pnpm lint`
+   - Rust 쪽 변경이면 `cd src-tauri && cargo test -- --test-threads=1 && cargo clippy --all-targets --all-features -- -D warnings`
+2. 원래 지적된 concern이 실제로 해소됐는지 재확인 (단순히 코드가 바뀌었다는 것과 다름).
+3. 실패하면 되돌리거나 수정 보완 — **스코프 벗어나지 않는 선에서만**.
+
+## Phase 5 — 답글 & 마무리
+
+각 수정 완료된 코멘트에 대해:
+
+1. **답글 작성 (영어, 간결)**: 무엇이 왜 바뀌었는지 + 커밋 SHA.
+   ```
+   gh api repos/{owner}/{repo}/pulls/{N}/comments/{comment_id}/replies -f body="..."
+   ```
+   또는 리뷰 스레드에 답: GraphQL `addPullRequestReviewThreadReply`.
+   예:
+   > Addressed in abc1234 — extracted null check to early return, verified against existing `xxx.test.ts`. Thanks!
+2. **스레드 자동 resolve 금지**. 리뷰어가 닫도록 둔다. 사용자가 명시적으로 "resolve" 요청한 건만 예외.
+3. **follow-up-issue 항목**: `gh issue create`로 별도 이슈 생성, 원 코멘트에 답글로 이슈 링크 남김.
+4. **ask-user 항목**: 사용자 결정에 따라 fix 또는 skip — skip이면 "investigated and intentional" 답글.
+
+모든 처리 끝나면 요약 보고:
+```
+Handled: #1, #5 (fixed), #4 (follow-up issue #123)
+Skipped with reply: #2, #3
+Pending user decision: (없음)
+```
+
+---
+
+## Execution checklist (MUST verify each before moving on)
+
+- [ ] Phase 0: Filtered to AI-bot authors only? Human reviewer comments reported separately?
+- [ ] Phase 1: Produced the triage table and obtained explicit user approval BEFORE any code change?
+- [ ] Phase 1: Applied dedup, intent-understanding check, out-of-scope separation, and nit cap?
+- [ ] Phase 1: Consolidated ambiguous items into a SINGLE Questions batch (never scatter one-off questions)?
+- [ ] Phase 1.5: NEVER invoked CLIs unprompted — first flagged candidates, then asked user, then called only approved ones?
+- [ ] Phase 1.5: Detected CLI availability, ran parallel calls only for approved items, and explicitly noted skip if unavailable?
+- [ ] Phase 1.5: Merged any adversarial disagreements into the Questions batch with the `(adv)` tag?
+- [ ] Phase 2: Read the full file(s) + callers + tests, not just the diff hunk?
+- [ ] Phase 3: Wrote the fix from scratch (no verbatim AI patch) and kept scope tight?
+- [ ] Phase 3.5: NEVER invoked CLIs unprompted — judged risk (critical path / async / large diff) first, then asked user?
+- [ ] Phase 3.5: On any `PROBLEM` response, stopped and asked the user before committing?
+- [ ] Phase 4: Actually ran tests/lint (not just assumed they pass)?
+- [ ] Phase 5: Replied in English, did NOT auto-resolve threads, and opened follow-up issues for out-of-scope items?

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "$comment": "Shared maintainer-harness config (committed). Personal overrides live in settings.local.json (gitignored).",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh label list:*)",
+      "Bash(pnpm run i18n:validate)",
+      "Bash(pnpm exec tsc:*)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm vitest run:*)",
+      "Bash(rg:*)",
+      "Bash(grep:*)"
+    ],
+    "deny": [
+      "Bash(cargo:*)"
+    ]
+  }
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Thanks for contributing to claude-code-history-viewer! 🙏
+Please target the `develop` branch (NOT `main` — main is release-only).
+-->
+
+## What & why
+
+<!-- What does this change and why? Link the issue it closes. -->
+
+Closes #
+
+## Type
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
+- [ ] Refactor / perf
+- [ ] Docs
+
+## Checklist
+
+- [ ] PR targets **`develop`**, not `main`
+- [ ] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
+- [ ] `pnpm exec tsc --build .` and `pnpm lint` pass
+- [ ] **i18n**: any new user-facing string is `t()`-wrapped and the key exists in **all 5 languages** (`en, ko, ja, zh-CN, zh-TW`) — verified with `pnpm run i18n:validate`
+
+## If this adds a frontend-callable backend command
+
+- [ ] Registered in **both** the Tauri `generate_handler!` (`src-tauri/src/lib.rs`) **and** the Axum WebUI router (`src-tauri/src/server/mod.rs`) — otherwise `--serve` mode 404s
+
+## If this adds a new provider
+
+- [ ] Followed the existing provider pattern in `src-tauri/src/providers/`
+- [ ] Session discovery verified on macOS / Linux / Windows (and WSL if applicable)
+- [ ] No leftover identifiers copied from another provider (names, comments, fixtures)
+
+<!--
+Note: a maintainer (and possibly the @claude bot) will review. You can mention
+@claude in a comment to ask for an automated i18n/parity check.
+-->

--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -1,0 +1,43 @@
+name: Claude Mentions
+
+# Responds to @claude mentions in issues and PRs. A contributor (or the
+# maintainer) can ask Claude to investigate, explain, check i18n, or scaffold a
+# fix directly from a comment — reducing the maintainer-response bottleneck.
+#
+# REQUIRES: an ANTHROPIC_API_KEY repo secret, or the Claude GitHub App installed
+# via `/install-github-app`. Without it this workflow is a no-op (it won't error
+# on PRs from forks because it only triggers on the @claude phrase).
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 12
+            --append-system-prompt "This is claude-code-history-viewer, a solo-maintained Tauri 2 desktop app. Follow CLAUDE.md. PRs target the develop branch, never main. Reply in English. Do not run cargo locally. For any user-facing string, ensure the key exists in all dirs under src/i18n/locales/. If a frontend-callable command is added, update BOTH the Tauri generate_handler! in src-tauri/src/lib.rs AND the Axum router in src-tauri/src/server/mod.rs."

--- a/.github/workflows/daily-pr-health.yml
+++ b/.github/workflows/daily-pr-health.yml
@@ -1,0 +1,52 @@
+name: Daily PR Health Digest
+
+# Once a day, Claude reviews all open PRs and posts/updates a single digest issue
+# titled "📋 Open PR Health Digest" — flagging which PRs are mergeable, which are
+# stale (no maintainer response > 7 days), and which need a decision. Gives the
+# solo maintainer a one-glance triage queue.
+#
+# REQUIRES: ANTHROPIC_API_KEY repo secret. Trigger manually first via the Actions
+# tab ("Run workflow") to confirm setup before relying on the schedule.
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # 00:00 UTC = 09:00 KST
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 20
+          prompt: |
+            You are maintaining claude-code-history-viewer. Produce a daily open-PR
+            health digest for the solo maintainer.
+
+            1. List open PRs:  gh pr list --state open --json number,title,author,createdAt,updatedAt,additions,deletions,mergeable,labels,reviewDecision
+            2. For each PR, classify:
+               - Mergeable now (CI green, small, in-scope) — recommend MERGE
+               - Needs changes (failing CI, missing tests/i18n, scope creep)
+               - Needs maintainer decision (architecture/naming/provider policy)
+               - STALE: no maintainer comment in > 7 days (compute from updatedAt and comments)
+            3. PRs targeting `main` instead of `develop` are a policy violation — flag loudly.
+            4. Provider-addition PRs: note them as a group; consistency review needed.
+
+            Then upsert a SINGLE tracking issue:
+            - Search for an open issue titled exactly "📋 Open PR Health Digest".
+            - If it exists, edit its body with the new digest (do not open a new one).
+            - If not, create it with that exact title and a `needs-triage` label.
+            Body: a markdown table (PR # | title | author | age | size | status | recommended action)
+            plus a short "Top 3 to act on today" list. Keep it under 60 lines.
+            Write everything in English. Do not modify any PR or push code.

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,89 @@
+name: PR Auto Label
+
+# Zero-cost labeler — pure github-script, no Claude API. Parses the conventional-
+# commit prefix in the PR title and applies a type label + a size label, creating
+# either label if it doesn't exist yet. Runs on every PR open/edit/sync.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-auto-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || "";
+            const { owner, repo } = context.repo;
+
+            // --- ensure a label exists (idempotent) ---
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                } else { throw e; }
+              }
+            }
+
+            const toAdd = new Set();
+
+            // --- type from conventional-commit prefix: type(scope)!: ... ---
+            const m = title.match(/^(\w+)(\([^)]*\))?(!)?:/);
+            const type = m ? m[1].toLowerCase() : null;
+            const scope = m && m[2] ? m[2].slice(1, -1).toLowerCase() : "";
+
+            const typeMap = {
+              feat: "enhancement",
+              fix: "bug",
+              perf: "enhancement",
+              docs: "documentation",
+              doc: "documentation",
+            };
+            if (type && typeMap[type]) toAdd.add(typeMap[type]);
+
+            // provider PRs get a dedicated label (created on demand)
+            if (scope.includes("provider")) {
+              await ensureLabel("provider", "5319e7", "Adds or changes an AI-assistant provider");
+              toAdd.add("provider");
+            }
+
+            // --- size label from total churn ---
+            const churn = (pr.additions || 0) + (pr.deletions || 0);
+            const size =
+              churn < 10   ? "size/XS" :
+              churn < 100  ? "size/S"  :
+              churn < 500  ? "size/M"  :
+              churn < 1000 ? "size/L"  : "size/XL";
+            const sizeColors = {
+              "size/XS": "c2e0c6", "size/S": "c2e0c6", "size/M": "fbca04",
+              "size/L": "e99695", "size/XL": "d93f0b",
+            };
+            await ensureLabel(size, sizeColors[size], "PR size by total lines changed");
+
+            // remove any stale size labels before adding the current one
+            const current = (pr.labels || []).map(l => l.name);
+            for (const l of current) {
+              if (l.startsWith("size/") && l !== size) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: l }).catch(() => {});
+              }
+            }
+            toAdd.add(size);
+
+            const labels = [...toAdd];
+            if (labels.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels });
+              core.notice(`Applied labels: ${labels.join(", ")}`);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -71,15 +71,18 @@ debug.log*
 **/*/CLAUDE.md
 .serena/memories/
 
-# AFC plugin state
+# AFC plugin state (abandoned tooling — kept out of the repo)
 .claude/afc/
 .claude/afc.config.md
+.claude/.afc-timeline.jsonl
 
-# Claude Code worktrees
+# Claude Code worktrees and runtime locks (local-only)
 .claude/worktrees/
-
-# Local user-defined slash commands and runtime locks
-.claude/commands/
 .claude/scheduled_tasks.lock
+
+# Tracked maintainer harness (committed, do NOT ignore):
+#   .claude/agents/      — natural-language-routed subagents
+#   .claude/commands/    — shared slash commands (e.g. pr-review-check)
+#   .claude/settings.json — shared harness config
 
 PLAN.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,11 @@ The enhanced prompts will follow the language of the original prompt (e.g., Kore
 
 ## Principal
 
-First, You must use command "gemini -p {prompt}" and then use the result that returned response
-Use pnpm Package Manager
+Use pnpm Package Manager.
+
+`gemini`/`codex` CLIs are **opt-in adversarial reviewers only** — invoke them
+solely with explicit user approval (see `.claude/commands/pr-review-check.md`),
+never as a mandatory first step.
 
 가독성이 높은 설계 추구
 예측 가능성이 높은 설계 추구

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -1,7 +1,11 @@
 use super::ProviderInfo;
 use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
-use crate::utils::{build_provider_message, find_line_ranges, search_json_value_case_insensitive};
+use crate::utils::{
+    build_provider_message, estimate_message_count_from_size, find_line_ranges,
+    search_json_value_case_insensitive,
+};
 use chrono::{DateTime, Utc};
+use memchr::{memchr_iter, memmem};
 use memmap2::Mmap;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -120,6 +124,13 @@ struct SessionInfo {
     summary: Option<String>,
 }
 
+/// Lightweight metadata used by project-level scans.
+struct ProjectScanInfo {
+    cwd: Option<String>,
+    message_count: usize,
+    last_modified: String,
+}
+
 /// Scan Codex projects from a specific base path.
 pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
     crate::utils::require_absolute_path(base_path, "Codex base path")?;
@@ -142,7 +153,7 @@ pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, St
     }
 
     // Group sessions by cwd
-    let mut project_map: HashMap<String, Vec<SessionInfo>> = HashMap::new();
+    let mut project_map: HashMap<String, Vec<ProjectScanInfo>> = HashMap::new();
 
     for session_dir in session_dirs {
         for entry in WalkDir::new(session_dir)
@@ -154,7 +165,7 @@ pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, St
         {
             let rollout_path = entry.path();
 
-            if let Ok(info) = extract_session_info(rollout_path) {
+            if let Ok(info) = extract_project_scan_info(rollout_path) {
                 let cwd = info.cwd.clone().unwrap_or_else(|| "unknown".to_string());
                 project_map.entry(cwd).or_default().push(info);
             }
@@ -231,8 +242,13 @@ pub fn load_sessions(
         {
             let rollout_path = entry.path();
 
+            match extract_session_cwd(rollout_path) {
+                Ok(Some(session_cwd)) if session_cwd != target_cwd => continue,
+                Ok(_) | Err(_) => {}
+            }
+
             if let Ok(info) = extract_session_info(rollout_path) {
-                let session_cwd = info.cwd.as_deref().unwrap_or("");
+                let session_cwd = info.cwd.as_deref().unwrap_or("unknown");
                 if session_cwd != target_cwd {
                     continue;
                 }
@@ -454,6 +470,132 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
 // Internal helpers
 // ============================================================================
 
+const JSON_TYPE_KEY: &[u8] = b"\"type\"";
+fn skip_json_ws(bytes: &[u8], mut index: usize) -> usize {
+    while bytes
+        .get(index)
+        .is_some_and(|b| matches!(b, b' ' | b'\n' | b'\r' | b'\t'))
+    {
+        index += 1;
+    }
+    index
+}
+
+fn has_json_string_field_value(line: &[u8], key: &[u8], value: &[u8]) -> bool {
+    let mut search_offset = 0;
+    while search_offset < line.len() {
+        let Some(relative_pos) = memmem::find(&line[search_offset..], key) else {
+            return false;
+        };
+
+        let mut index = search_offset + relative_pos + key.len();
+        index = skip_json_ws(line, index);
+        if line.get(index) != Some(&b':') {
+            search_offset = index.min(line.len());
+            continue;
+        }
+
+        index = skip_json_ws(line, index + 1);
+        if line.get(index) != Some(&b'"') {
+            search_offset = index.min(line.len());
+            continue;
+        }
+
+        let value_start = index + 1;
+        let value_end = value_start + value.len();
+        if line.get(value_start..value_end) == Some(value) && line.get(value_end) == Some(&b'"') {
+            return true;
+        }
+
+        search_offset = value_end.min(line.len());
+    }
+
+    false
+}
+
+fn for_each_jsonl_line(data: &[u8], mut visit: impl FnMut(&[u8]) -> bool) {
+    let mut start = 0;
+    for end in memchr_iter(b'\n', data) {
+        let line_end = if end > start && data[end - 1] == b'\r' {
+            end - 1
+        } else {
+            end
+        };
+        if !visit(&data[start..line_end]) {
+            return;
+        }
+        start = end + 1;
+    }
+
+    if start < data.len() {
+        let line = &data[start..];
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        visit(line);
+    }
+}
+
+fn parse_session_meta_cwd(line: &[u8]) -> Option<String> {
+    if !has_json_string_field_value(line, JSON_TYPE_KEY, b"session_meta") {
+        return None;
+    }
+
+    let mut buf = line.to_vec();
+    let val: Value = simd_json::from_slice(&mut buf).ok()?;
+    if val.get("type").and_then(|t| t.as_str()) != Some("session_meta") {
+        return None;
+    }
+
+    val.get("payload")?
+        .get("cwd")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+fn file_modified_rfc3339(path: &Path) -> String {
+    fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .map(|t| {
+            let dt: DateTime<Utc> = t.into();
+            dt.to_rfc3339()
+        })
+        .unwrap_or_else(|| Utc::now().to_rfc3339())
+}
+
+fn estimate_rollout_message_count(path: &Path) -> usize {
+    fs::metadata(path)
+        .map(|metadata| estimate_message_count_from_size(metadata.len()))
+        .unwrap_or(0)
+}
+
+#[allow(unsafe_code)] // Required for mmap performance optimization
+fn extract_session_cwd(rollout_path: &Path) -> Result<Option<String>, String> {
+    let file = File::open(rollout_path).map_err(|e| e.to_string())?;
+    // SAFETY: File is read-only and we only read from the mapping
+    let mmap = unsafe { Mmap::map(&file) }.map_err(|e| e.to_string())?;
+
+    let mut cwd = None;
+    for_each_jsonl_line(&mmap, |line| {
+        if let Some(found) = parse_session_meta_cwd(line) {
+            cwd = Some(found);
+            return false;
+        }
+        true
+    });
+
+    Ok(cwd)
+}
+
+fn extract_project_scan_info(rollout_path: &Path) -> Result<ProjectScanInfo, String> {
+    Ok(ProjectScanInfo {
+        cwd: extract_session_cwd(rollout_path)?,
+        // Project list scans stay lightweight; session-level message counts
+        // are still computed exactly when the project is opened.
+        message_count: estimate_rollout_message_count(rollout_path),
+        last_modified: file_modified_rfc3339(rollout_path),
+    })
+}
+
 #[allow(unsafe_code)] // Required for mmap performance optimization
 fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
     let file = File::open(rollout_path).map_err(|e| e.to_string())?;
@@ -556,14 +698,7 @@ fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
     }
 
     let last_modified = if last_time.is_empty() {
-        fs::metadata(rollout_path)
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .map(|t| {
-                let dt: DateTime<Utc> = t.into();
-                dt.to_rfc3339()
-            })
-            .unwrap_or_else(|| Utc::now().to_rfc3339())
+        file_modified_rfc3339(rollout_path)
     } else {
         last_time.clone()
     };
@@ -2286,6 +2421,56 @@ mod tests {
 
     #[test]
     #[serial]
+    fn missing_cwd_sessions_load_from_unknown_project() {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let codex_home = tmp.path().join("codex-home");
+        let sessions_dir = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("02")
+            .join("21");
+        fs::create_dir_all(&sessions_dir).expect("sessions dir should be created");
+        let _guard = EnvVarGuard::set("CODEX_HOME", &codex_home);
+
+        let rollout_path = sessions_dir.join("rollout-no-cwd.jsonl");
+        let lines = [
+            json!({
+                "type": "session_meta",
+                "payload": { "id": "no-cwd-session" }
+            }),
+            json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "created_at": "2026-02-21T10:00:00Z",
+                    "content": [{ "type": "input_text", "text": "missing cwd" }]
+                }
+            }),
+        ];
+        let content = lines
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&rollout_path, format!("{content}\n")).expect("fixture should be written");
+
+        let projects = scan_projects_from_path(
+            codex_home
+                .to_str()
+                .expect("codex home path should be valid UTF-8"),
+        )
+        .expect("projects should be scanned");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].path, "codex://unknown");
+
+        let sessions = load_sessions("codex://unknown", false).expect("sessions should be loaded");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].actual_session_id, "no-cwd-session");
+    }
+
+    #[test]
+    #[serial]
     fn load_messages_accepts_archived_session_path() {
         let tmp = TempDir::new().expect("temp dir should be created");
         let codex_home = tmp.path().join("codex-home");
@@ -2342,6 +2527,18 @@ mod tests {
         extract_session_info(&rollout_path).expect("extract_session_info should succeed")
     }
 
+    fn run_extract_project_scan_info_on_lines(lines: Vec<Value>) -> ProjectScanInfo {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let rollout_path = tmp.path().join("rollout-2026-05-13.jsonl");
+        let body = lines
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&rollout_path, format!("{body}\n")).expect("rollout fixture should be written");
+        extract_project_scan_info(&rollout_path).expect("extract_project_scan_info should succeed")
+    }
+
     fn session_meta_line() -> Value {
         json!({
             "timestamp": "2026-05-13T08:00:00Z",
@@ -2363,6 +2560,66 @@ mod tests {
     }
 
     const ENV_CONTEXT_BLOCK: &str = "<environment_context>\n  <cwd>/tmp/proj</cwd>\n  <shell>powershell</shell>\n  <current_date>2026-05-13</current_date>\n  <timezone>Asia/Shanghai</timezone>\n</environment_context>";
+
+    #[test]
+    fn project_scan_info_uses_lightweight_metadata() {
+        let info = run_extract_project_scan_info_on_lines(vec![
+            session_meta_line(),
+            json!({
+                "timestamp": "2026-05-13T08:00:01Z",
+                "type": "event_msg",
+                "payload": { "type": "user_message", "message": "duplicate event" }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "hello" }]
+                }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "arguments": "{}"
+                }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:04Z",
+                "type": "response_item",
+                "payload": { "type": "reasoning", "summary": [] }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:05Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "done"
+                }
+            }),
+        ]);
+
+        assert_eq!(info.cwd.as_deref(), Some("/tmp/proj"));
+        assert!(info.message_count > 0);
+        assert!(!info.last_modified.is_empty());
+    }
+
+    #[test]
+    fn json_field_matcher_accepts_whitespace_around_colon() {
+        let line = br#"{ "type" : "response_item", "payload": { "type" : "message" } }"#;
+
+        assert!(has_json_string_field_value(
+            line,
+            JSON_TYPE_KEY,
+            b"response_item"
+        ));
+        assert!(has_json_string_field_value(line, JSON_TYPE_KEY, b"message"));
+    }
 
     #[test]
     /// First user message is an auto-injected `<environment_context>` block;

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -248,7 +248,7 @@ pub fn load_sessions(
             }
 
             if let Ok(info) = extract_session_info(rollout_path) {
-                let session_cwd = info.cwd.as_deref().unwrap_or("");
+                let session_cwd = info.cwd.as_deref().unwrap_or("unknown");
                 if session_cwd != target_cwd {
                     continue;
                 }
@@ -2417,6 +2417,56 @@ mod tests {
         assert!(sessions
             .iter()
             .any(|s| s.file_path.contains("/archived_sessions/")));
+    }
+
+    #[test]
+    #[serial]
+    fn missing_cwd_sessions_load_from_unknown_project() {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let codex_home = tmp.path().join("codex-home");
+        let sessions_dir = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("02")
+            .join("21");
+        fs::create_dir_all(&sessions_dir).expect("sessions dir should be created");
+        let _guard = EnvVarGuard::set("CODEX_HOME", &codex_home);
+
+        let rollout_path = sessions_dir.join("rollout-no-cwd.jsonl");
+        let lines = [
+            json!({
+                "type": "session_meta",
+                "payload": { "id": "no-cwd-session" }
+            }),
+            json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "created_at": "2026-02-21T10:00:00Z",
+                    "content": [{ "type": "input_text", "text": "missing cwd" }]
+                }
+            }),
+        ];
+        let content = lines
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&rollout_path, format!("{content}\n")).expect("fixture should be written");
+
+        let projects = scan_projects_from_path(
+            codex_home
+                .to_str()
+                .expect("codex home path should be valid UTF-8"),
+        )
+        .expect("projects should be scanned");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].path, "codex://unknown");
+
+        let sessions = load_sessions("codex://unknown", false).expect("sessions should be loaded");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].actual_session_id, "no-cwd-session");
     }
 
     #[test]

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -1,7 +1,11 @@
 use super::ProviderInfo;
 use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
-use crate::utils::{build_provider_message, find_line_ranges, search_json_value_case_insensitive};
+use crate::utils::{
+    build_provider_message, estimate_message_count_from_size, find_line_ranges,
+    search_json_value_case_insensitive,
+};
 use chrono::{DateTime, Utc};
+use memchr::{memchr_iter, memmem};
 use memmap2::Mmap;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -120,6 +124,13 @@ struct SessionInfo {
     summary: Option<String>,
 }
 
+/// Lightweight metadata used by project-level scans.
+struct ProjectScanInfo {
+    cwd: Option<String>,
+    message_count: usize,
+    last_modified: String,
+}
+
 /// Scan Codex projects from a specific base path.
 pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
     crate::utils::require_absolute_path(base_path, "Codex base path")?;
@@ -142,7 +153,7 @@ pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, St
     }
 
     // Group sessions by cwd
-    let mut project_map: HashMap<String, Vec<SessionInfo>> = HashMap::new();
+    let mut project_map: HashMap<String, Vec<ProjectScanInfo>> = HashMap::new();
 
     for session_dir in session_dirs {
         for entry in WalkDir::new(session_dir)
@@ -154,7 +165,7 @@ pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, St
         {
             let rollout_path = entry.path();
 
-            if let Ok(info) = extract_session_info(rollout_path) {
+            if let Ok(info) = extract_project_scan_info(rollout_path) {
                 let cwd = info.cwd.clone().unwrap_or_else(|| "unknown".to_string());
                 project_map.entry(cwd).or_default().push(info);
             }
@@ -230,6 +241,11 @@ pub fn load_sessions(
             .filter(|e| is_rollout_jsonl(e.path()))
         {
             let rollout_path = entry.path();
+
+            match extract_session_cwd(rollout_path) {
+                Ok(Some(session_cwd)) if session_cwd != target_cwd => continue,
+                Ok(_) | Err(_) => {}
+            }
 
             if let Ok(info) = extract_session_info(rollout_path) {
                 let session_cwd = info.cwd.as_deref().unwrap_or("");
@@ -454,6 +470,132 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
 // Internal helpers
 // ============================================================================
 
+const JSON_TYPE_KEY: &[u8] = b"\"type\"";
+fn skip_json_ws(bytes: &[u8], mut index: usize) -> usize {
+    while bytes
+        .get(index)
+        .is_some_and(|b| matches!(b, b' ' | b'\n' | b'\r' | b'\t'))
+    {
+        index += 1;
+    }
+    index
+}
+
+fn has_json_string_field_value(line: &[u8], key: &[u8], value: &[u8]) -> bool {
+    let mut search_offset = 0;
+    while search_offset < line.len() {
+        let Some(relative_pos) = memmem::find(&line[search_offset..], key) else {
+            return false;
+        };
+
+        let mut index = search_offset + relative_pos + key.len();
+        index = skip_json_ws(line, index);
+        if line.get(index) != Some(&b':') {
+            search_offset = index.min(line.len());
+            continue;
+        }
+
+        index = skip_json_ws(line, index + 1);
+        if line.get(index) != Some(&b'"') {
+            search_offset = index.min(line.len());
+            continue;
+        }
+
+        let value_start = index + 1;
+        let value_end = value_start + value.len();
+        if line.get(value_start..value_end) == Some(value) && line.get(value_end) == Some(&b'"') {
+            return true;
+        }
+
+        search_offset = value_end.min(line.len());
+    }
+
+    false
+}
+
+fn for_each_jsonl_line(data: &[u8], mut visit: impl FnMut(&[u8]) -> bool) {
+    let mut start = 0;
+    for end in memchr_iter(b'\n', data) {
+        let line_end = if end > start && data[end - 1] == b'\r' {
+            end - 1
+        } else {
+            end
+        };
+        if !visit(&data[start..line_end]) {
+            return;
+        }
+        start = end + 1;
+    }
+
+    if start < data.len() {
+        let line = &data[start..];
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        visit(line);
+    }
+}
+
+fn parse_session_meta_cwd(line: &[u8]) -> Option<String> {
+    if !has_json_string_field_value(line, JSON_TYPE_KEY, b"session_meta") {
+        return None;
+    }
+
+    let mut buf = line.to_vec();
+    let val: Value = simd_json::from_slice(&mut buf).ok()?;
+    if val.get("type").and_then(|t| t.as_str()) != Some("session_meta") {
+        return None;
+    }
+
+    val.get("payload")?
+        .get("cwd")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+fn file_modified_rfc3339(path: &Path) -> String {
+    fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .map(|t| {
+            let dt: DateTime<Utc> = t.into();
+            dt.to_rfc3339()
+        })
+        .unwrap_or_else(|| Utc::now().to_rfc3339())
+}
+
+fn estimate_rollout_message_count(path: &Path) -> usize {
+    fs::metadata(path)
+        .map(|metadata| estimate_message_count_from_size(metadata.len()))
+        .unwrap_or(0)
+}
+
+#[allow(unsafe_code)] // Required for mmap performance optimization
+fn extract_session_cwd(rollout_path: &Path) -> Result<Option<String>, String> {
+    let file = File::open(rollout_path).map_err(|e| e.to_string())?;
+    // SAFETY: File is read-only and we only read from the mapping
+    let mmap = unsafe { Mmap::map(&file) }.map_err(|e| e.to_string())?;
+
+    let mut cwd = None;
+    for_each_jsonl_line(&mmap, |line| {
+        if let Some(found) = parse_session_meta_cwd(line) {
+            cwd = Some(found);
+            return false;
+        }
+        true
+    });
+
+    Ok(cwd)
+}
+
+fn extract_project_scan_info(rollout_path: &Path) -> Result<ProjectScanInfo, String> {
+    Ok(ProjectScanInfo {
+        cwd: extract_session_cwd(rollout_path)?,
+        // Project list scans stay lightweight; session-level message counts
+        // are still computed exactly when the project is opened.
+        message_count: estimate_rollout_message_count(rollout_path),
+        last_modified: file_modified_rfc3339(rollout_path),
+    })
+}
+
 #[allow(unsafe_code)] // Required for mmap performance optimization
 fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
     let file = File::open(rollout_path).map_err(|e| e.to_string())?;
@@ -556,14 +698,7 @@ fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
     }
 
     let last_modified = if last_time.is_empty() {
-        fs::metadata(rollout_path)
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .map(|t| {
-                let dt: DateTime<Utc> = t.into();
-                dt.to_rfc3339()
-            })
-            .unwrap_or_else(|| Utc::now().to_rfc3339())
+        file_modified_rfc3339(rollout_path)
     } else {
         last_time.clone()
     };
@@ -2342,6 +2477,18 @@ mod tests {
         extract_session_info(&rollout_path).expect("extract_session_info should succeed")
     }
 
+    fn run_extract_project_scan_info_on_lines(lines: Vec<Value>) -> ProjectScanInfo {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let rollout_path = tmp.path().join("rollout-2026-05-13.jsonl");
+        let body = lines
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&rollout_path, format!("{body}\n")).expect("rollout fixture should be written");
+        extract_project_scan_info(&rollout_path).expect("extract_project_scan_info should succeed")
+    }
+
     fn session_meta_line() -> Value {
         json!({
             "timestamp": "2026-05-13T08:00:00Z",
@@ -2363,6 +2510,66 @@ mod tests {
     }
 
     const ENV_CONTEXT_BLOCK: &str = "<environment_context>\n  <cwd>/tmp/proj</cwd>\n  <shell>powershell</shell>\n  <current_date>2026-05-13</current_date>\n  <timezone>Asia/Shanghai</timezone>\n</environment_context>";
+
+    #[test]
+    fn project_scan_info_uses_lightweight_metadata() {
+        let info = run_extract_project_scan_info_on_lines(vec![
+            session_meta_line(),
+            json!({
+                "timestamp": "2026-05-13T08:00:01Z",
+                "type": "event_msg",
+                "payload": { "type": "user_message", "message": "duplicate event" }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "hello" }]
+                }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "arguments": "{}"
+                }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:04Z",
+                "type": "response_item",
+                "payload": { "type": "reasoning", "summary": [] }
+            }),
+            json!({
+                "timestamp": "2026-05-13T08:00:05Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "done"
+                }
+            }),
+        ]);
+
+        assert_eq!(info.cwd.as_deref(), Some("/tmp/proj"));
+        assert!(info.message_count > 0);
+        assert!(!info.last_modified.is_empty());
+    }
+
+    #[test]
+    fn json_field_matcher_accepts_whitespace_around_colon() {
+        let line = br#"{ "type" : "response_item", "payload": { "type" : "message" } }"#;
+
+        assert!(has_json_string_field_value(
+            line,
+            JSON_TYPE_KEY,
+            b"response_item"
+        ));
+        assert!(has_json_string_field_value(line, JSON_TYPE_KEY, b"message"));
+    }
 
     #[test]
     /// First user message is an auto-injected `<environment_context>` block;

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -6,7 +6,7 @@
 
 import { api } from "@/services/api";
 import { storageAdapter } from "@/services/storage";
-import type { ClaudeProject, ClaudeSession, AppError } from "../../types";
+import type { ClaudeProject, ClaudeSession, AppError, ProviderId, UserSettings } from "../../types";
 import { AppErrorType } from "../../types";
 import type { StateCreator } from "zustand";
 import type { FullAppStore } from "./types";
@@ -17,7 +17,7 @@ import {
   type DirectoryGroupingResult,
 } from "../../utils/worktreeUtils";
 import type { GroupingMode } from "../../types/metadata.types";
-import { DEFAULT_PROVIDER_ID } from "../../utils/providers";
+import { DEFAULT_PROVIDER_ID, getProviderId, PROVIDER_IDS } from "../../utils/providers";
 import { INITIAL_PAGINATION } from "./messageSlice";
 import { nextRequestId, getRequestId } from "../../utils/requestId";
 
@@ -79,6 +79,76 @@ const isTauriAvailable = () => {
   } catch {
     return false;
   }
+};
+
+const projectTimestamp = (project: ClaudeProject): number | null => {
+  const timestamp = Date.parse(project.last_modified);
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+const sortProjectsByLastModified = (projects: ClaudeProject[]): ClaudeProject[] =>
+  [...projects].sort((a, b) => {
+    const aTimestamp = projectTimestamp(a);
+    const bTimestamp = projectTimestamp(b);
+    if (aTimestamp != null && bTimestamp != null) {
+      return bTimestamp - aTimestamp;
+    }
+    if (aTimestamp != null) {
+      return -1;
+    }
+    if (bTimestamp != null) {
+      return 1;
+    }
+    return b.last_modified.localeCompare(a.last_modified);
+  });
+
+const withProvider = (
+  projects: ClaudeProject[],
+  provider: ProviderId,
+): ClaudeProject[] =>
+  projects.map((project) => ({
+    ...project,
+    provider: project.provider ?? provider,
+  }));
+
+const scanProviderProjects = async ({
+  provider,
+  claudePath,
+  customClaudePaths,
+  settings,
+}: {
+  provider: ProviderId;
+  claudePath: string;
+  customClaudePaths: UserSettings["customClaudePaths"];
+  settings: UserSettings | undefined;
+}): Promise<ClaudeProject[]> => {
+  const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
+  const wslEnabled = settings?.wsl?.enabled ?? false;
+
+  if (provider === DEFAULT_PROVIDER_ID && !hasCustomPaths && !wslEnabled) {
+    if (!claudePath) {
+      return [];
+    }
+    const projects = await api<ClaudeProject[]>("scan_projects", {
+      claudePath,
+    });
+    return withProvider(projects, provider);
+  }
+
+  const projects = await api<ClaudeProject[]>("scan_all_projects", {
+    ...(claudePath && { claudePath }),
+    activeProviders: [provider],
+    ...(provider === DEFAULT_PROVIDER_ID && hasCustomPaths
+      ? { customClaudePaths }
+      : {}),
+    ...(provider === DEFAULT_PROVIDER_ID
+      ? {
+          wslEnabled,
+          wslExcludedDistros: settings?.wsl?.excludedDistros ?? [],
+        }
+      : {}),
+  });
+  return withProvider(projects, provider);
 };
 
 // ============================================================================
@@ -213,20 +283,23 @@ export const createProjectSlice: StateCreator<
     }
   },
 
-  // NOTE: scanProjects always loads ALL available providers' projects.
-  // Filtering by activeProviders happens client-side in the ProjectTree UI.
-  // This is intentionally asymmetric with loadGlobalStats (which filters server-side)
-  // because project scanning is fast and we want instant client-side tab switching,
-  // whereas global stats aggregation is expensive and benefits from server-side filtering.
+  // NOTE: scanProjects loads ALL available providers' projects, while filtering
+  // by activeProviders happens client-side in the ProjectTree UI. Provider scans
+  // are launched independently so a slow provider does not block fast providers
+  // from appearing in the sidebar.
   scanProjects: async () => {
     const requestId = nextRequestId("scanProjects");
     const { claudePath, providers } = get();
     const customClaudePaths = get().userMetadata?.settings?.customClaudePaths;
     const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
-    const availableProviders = providers
+    const detectedAvailableProviders = providers
       .filter((provider) => provider.is_available)
       .map((provider) => provider.id);
-    const scanProviders = availableProviders.length > 0 ? availableProviders : [DEFAULT_PROVIDER_ID];
+    const providerSet = new Set<ProviderId>(detectedAvailableProviders);
+    if (claudePath || hasCustomPaths || providerSet.size === 0) {
+      providerSet.add(DEFAULT_PROVIDER_ID);
+    }
+    const scanProviders = PROVIDER_IDS.filter((provider) => providerSet.has(provider));
     const hasNonClaudeProviders = scanProviders.some((provider) => provider !== DEFAULT_PROVIDER_ID);
     // Allow scanning when at least one source is available: a saved Claude path,
     // a custom Claude path, or any non-Claude provider detected on disk (#222).
@@ -236,19 +309,57 @@ export const createProjectSlice: StateCreator<
     try {
       const start = performance.now();
       const settings = get().userMetadata?.settings;
-      const wslEnabled = settings?.wsl?.enabled ?? false;
-      const projects = (hasNonClaudeProviders || hasCustomPaths || wslEnabled)
-        ? await api<ClaudeProject[]>("scan_all_projects", {
-            ...(claudePath && { claudePath }),
-            activeProviders: scanProviders,
-            customClaudePaths: hasCustomPaths ? customClaudePaths : undefined,
-            wslEnabled,
-            wslExcludedDistros: settings?.wsl?.excludedDistros ?? [],
-          })
-        : await api<ClaudeProject[]>("scan_projects", {
-            claudePath,
-          });
+      const previouslyLoadedProjects = get().projects.filter((project) =>
+        scanProviders.includes(getProviderId(project.provider))
+      );
+      const loadedProviders = new Set<ProviderId>();
+      const projectsByProvider = new Map<ProviderId, ClaudeProject[]>();
+      const providerErrors: string[] = [];
+
+      const publishPartialResults = () => {
+        const pendingPreviousProjects = previouslyLoadedProjects.filter(
+          (project) => !loadedProviders.has(getProviderId(project.provider))
+        );
+        const loadedProjects = Array.from(projectsByProvider.values()).flat();
+        set({
+          projects: sortProjectsByLastModified([
+            ...pendingPreviousProjects,
+            ...loadedProjects,
+          ]),
+        });
+      };
+
+      await Promise.all(
+        scanProviders.map(async (provider) => {
+          try {
+            const providerProjects = await scanProviderProjects({
+              provider,
+              claudePath,
+              customClaudePaths,
+              settings,
+            });
+            if (requestId !== getRequestId("scanProjects")) {
+              return;
+            }
+            loadedProviders.add(provider);
+            projectsByProvider.set(provider, providerProjects);
+            publishPartialResults();
+          } catch (scanError) {
+            const message = scanError instanceof Error
+              ? scanError.message
+              : String(scanError);
+            providerErrors.push(`${provider}: ${message}`);
+            if (import.meta.env.DEV) {
+              console.warn(`[Frontend] ${provider} project scan failed:`, scanError);
+            }
+          }
+        })
+      );
+
       const duration = performance.now() - start;
+      const projects = sortProjectsByLastModified(
+        Array.from(projectsByProvider.values()).flat()
+      );
       if (import.meta.env.DEV) {
         console.log(
           `[Frontend] scanProjects: ${projects.length}개 프로젝트, ${duration.toFixed(1)}ms`
@@ -258,6 +369,14 @@ export const createProjectSlice: StateCreator<
         return;
       }
       set({ projects });
+      if (projects.length === 0 && providerErrors.length > 0) {
+        set({
+          error: {
+            type: AppErrorType.UNKNOWN,
+            message: providerErrors.join("; "),
+          },
+        });
+      }
 
       // Auto-enable worktree grouping if worktrees are detected
       // Only auto-enable if user has never explicitly set the preference

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -6,7 +6,7 @@
 
 import { api } from "@/services/api";
 import { storageAdapter } from "@/services/storage";
-import type { ClaudeProject, ClaudeSession, AppError } from "../../types";
+import type { ClaudeProject, ClaudeSession, AppError, ProviderId, UserSettings } from "../../types";
 import { AppErrorType } from "../../types";
 import type { StateCreator } from "zustand";
 import type { FullAppStore } from "./types";
@@ -17,7 +17,7 @@ import {
   type DirectoryGroupingResult,
 } from "../../utils/worktreeUtils";
 import type { GroupingMode } from "../../types/metadata.types";
-import { DEFAULT_PROVIDER_ID } from "../../utils/providers";
+import { DEFAULT_PROVIDER_ID, getProviderId, PROVIDER_IDS } from "../../utils/providers";
 import { INITIAL_PAGINATION } from "./messageSlice";
 import { nextRequestId, getRequestId } from "../../utils/requestId";
 
@@ -79,6 +79,76 @@ const isTauriAvailable = () => {
   } catch {
     return false;
   }
+};
+
+const projectTimestamp = (project: ClaudeProject): number | null => {
+  const timestamp = Date.parse(project.last_modified);
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+const sortProjectsByLastModified = (projects: ClaudeProject[]): ClaudeProject[] =>
+  [...projects].sort((a, b) => {
+    const aTimestamp = projectTimestamp(a);
+    const bTimestamp = projectTimestamp(b);
+    if (aTimestamp != null && bTimestamp != null) {
+      return bTimestamp - aTimestamp;
+    }
+    if (aTimestamp != null) {
+      return -1;
+    }
+    if (bTimestamp != null) {
+      return 1;
+    }
+    return b.last_modified.localeCompare(a.last_modified);
+  });
+
+const withProvider = (
+  projects: ClaudeProject[],
+  provider: ProviderId,
+): ClaudeProject[] =>
+  projects.map((project) => ({
+    ...project,
+    provider: project.provider ?? provider,
+  }));
+
+const scanProviderProjects = async ({
+  provider,
+  claudePath,
+  customClaudePaths,
+  settings,
+}: {
+  provider: ProviderId;
+  claudePath: string;
+  customClaudePaths: UserSettings["customClaudePaths"];
+  settings: UserSettings | undefined;
+}): Promise<ClaudeProject[]> => {
+  const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
+  const wslEnabled = settings?.wsl?.enabled ?? false;
+
+  if (provider === DEFAULT_PROVIDER_ID && !hasCustomPaths && !wslEnabled) {
+    if (!claudePath) {
+      return [];
+    }
+    const projects = await api<ClaudeProject[]>("scan_projects", {
+      claudePath,
+    });
+    return withProvider(projects, provider);
+  }
+
+  const projects = await api<ClaudeProject[]>("scan_all_projects", {
+    ...(claudePath && { claudePath }),
+    activeProviders: [provider],
+    ...(provider === DEFAULT_PROVIDER_ID && hasCustomPaths
+      ? { customClaudePaths }
+      : {}),
+    ...(provider === DEFAULT_PROVIDER_ID
+      ? {
+          wslEnabled,
+          wslExcludedDistros: settings?.wsl?.excludedDistros ?? [],
+        }
+      : {}),
+  });
+  return withProvider(projects, provider);
 };
 
 // ============================================================================
@@ -209,20 +279,23 @@ export const createProjectSlice: StateCreator<
     }
   },
 
-  // NOTE: scanProjects always loads ALL available providers' projects.
-  // Filtering by activeProviders happens client-side in the ProjectTree UI.
-  // This is intentionally asymmetric with loadGlobalStats (which filters server-side)
-  // because project scanning is fast and we want instant client-side tab switching,
-  // whereas global stats aggregation is expensive and benefits from server-side filtering.
+  // NOTE: scanProjects loads ALL available providers' projects, while filtering
+  // by activeProviders happens client-side in the ProjectTree UI. Provider scans
+  // are launched independently so a slow provider does not block fast providers
+  // from appearing in the sidebar.
   scanProjects: async () => {
     const requestId = nextRequestId("scanProjects");
     const { claudePath, providers } = get();
     const customClaudePaths = get().userMetadata?.settings?.customClaudePaths;
     const hasCustomPaths = customClaudePaths != null && customClaudePaths.length > 0;
-    const availableProviders = providers
+    const detectedAvailableProviders = providers
       .filter((provider) => provider.is_available)
       .map((provider) => provider.id);
-    const scanProviders = availableProviders.length > 0 ? availableProviders : [DEFAULT_PROVIDER_ID];
+    const providerSet = new Set<ProviderId>(detectedAvailableProviders);
+    if (claudePath || hasCustomPaths || providerSet.size === 0) {
+      providerSet.add(DEFAULT_PROVIDER_ID);
+    }
+    const scanProviders = PROVIDER_IDS.filter((provider) => providerSet.has(provider));
     const hasNonClaudeProviders = scanProviders.some((provider) => provider !== DEFAULT_PROVIDER_ID);
     // Allow scanning when at least one source is available: a saved Claude path,
     // a custom Claude path, or any non-Claude provider detected on disk (#222).
@@ -232,45 +305,57 @@ export const createProjectSlice: StateCreator<
     try {
       const start = performance.now();
       const settings = get().userMetadata?.settings;
-      const shouldHydrateClaudeFirst =
-        Boolean(claudePath) &&
-        scanProviders.includes(DEFAULT_PROVIDER_ID) &&
-        (hasNonClaudeProviders || hasCustomPaths) &&
-        get().projects.length === 0;
+      const previouslyLoadedProjects = get().projects.filter((project) =>
+        scanProviders.includes(getProviderId(project.provider))
+      );
+      const loadedProviders = new Set<ProviderId>();
+      const projectsByProvider = new Map<ProviderId, ClaudeProject[]>();
+      const providerErrors: string[] = [];
 
-      if (shouldHydrateClaudeFirst) {
-        try {
-          const claudeProjects = await api<ClaudeProject[]>("scan_projects", {
-            claudePath,
-          });
-          if (requestId !== getRequestId("scanProjects")) {
-            return;
-          }
-          set({
-            projects: claudeProjects.map((project) => ({
-              ...project,
-              provider: project.provider ?? DEFAULT_PROVIDER_ID,
-            })),
-          });
-        } catch (quickScanError) {
-          if (import.meta.env.DEV) {
-            console.warn("[Frontend] Claude quick project scan failed:", quickScanError);
-          }
-        }
-      }
+      const publishPartialResults = () => {
+        const pendingPreviousProjects = previouslyLoadedProjects.filter(
+          (project) => !loadedProviders.has(getProviderId(project.provider))
+        );
+        const loadedProjects = Array.from(projectsByProvider.values()).flat();
+        set({
+          projects: sortProjectsByLastModified([
+            ...pendingPreviousProjects,
+            ...loadedProjects,
+          ]),
+        });
+      };
 
-      const projects = (hasNonClaudeProviders || hasCustomPaths)
-        ? await api<ClaudeProject[]>("scan_all_projects", {
-            ...(claudePath && { claudePath }),
-            activeProviders: scanProviders,
-            customClaudePaths: hasCustomPaths ? customClaudePaths : undefined,
-            wslEnabled: settings?.wsl?.enabled ?? false,
-            wslExcludedDistros: settings?.wsl?.excludedDistros ?? [],
-          })
-        : await api<ClaudeProject[]>("scan_projects", {
-            claudePath,
-          });
+      await Promise.all(
+        scanProviders.map(async (provider) => {
+          try {
+            const providerProjects = await scanProviderProjects({
+              provider,
+              claudePath,
+              customClaudePaths,
+              settings,
+            });
+            if (requestId !== getRequestId("scanProjects")) {
+              return;
+            }
+            loadedProviders.add(provider);
+            projectsByProvider.set(provider, providerProjects);
+            publishPartialResults();
+          } catch (scanError) {
+            const message = scanError instanceof Error
+              ? scanError.message
+              : String(scanError);
+            providerErrors.push(`${provider}: ${message}`);
+            if (import.meta.env.DEV) {
+              console.warn(`[Frontend] ${provider} project scan failed:`, scanError);
+            }
+          }
+        })
+      );
+
       const duration = performance.now() - start;
+      const projects = sortProjectsByLastModified(
+        Array.from(projectsByProvider.values()).flat()
+      );
       if (import.meta.env.DEV) {
         console.log(
           `[Frontend] scanProjects: ${projects.length}개 프로젝트, ${duration.toFixed(1)}ms`
@@ -280,6 +365,14 @@ export const createProjectSlice: StateCreator<
         return;
       }
       set({ projects });
+      if (projectsByProvider.size === 0 && providerErrors.length > 0) {
+        set({
+          error: {
+            type: AppErrorType.UNKNOWN,
+            message: providerErrors.join("; "),
+          },
+        });
+      }
 
       // Auto-enable worktree grouping if worktrees are detected
       // Only auto-enable if user has never explicitly set the preference

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -365,7 +365,7 @@ export const createProjectSlice: StateCreator<
         return;
       }
       set({ projects });
-      if (projectsByProvider.size === 0 && providerErrors.length > 0) {
+      if (projects.length === 0 && providerErrors.length > 0) {
         set({
           error: {
             type: AppErrorType.UNKNOWN,

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -232,6 +232,33 @@ export const createProjectSlice: StateCreator<
     try {
       const start = performance.now();
       const settings = get().userMetadata?.settings;
+      const shouldHydrateClaudeFirst =
+        Boolean(claudePath) &&
+        scanProviders.includes(DEFAULT_PROVIDER_ID) &&
+        (hasNonClaudeProviders || hasCustomPaths) &&
+        get().projects.length === 0;
+
+      if (shouldHydrateClaudeFirst) {
+        try {
+          const claudeProjects = await api<ClaudeProject[]>("scan_projects", {
+            claudePath,
+          });
+          if (requestId !== getRequestId("scanProjects")) {
+            return;
+          }
+          set({
+            projects: claudeProjects.map((project) => ({
+              ...project,
+              provider: project.provider ?? DEFAULT_PROVIDER_ID,
+            })),
+          });
+        } catch (quickScanError) {
+          if (import.meta.env.DEV) {
+            console.warn("[Frontend] Claude quick project scan failed:", quickScanError);
+          }
+        }
+      }
+
       const projects = (hasNonClaudeProviders || hasCustomPaths)
         ? await api<ClaudeProject[]>("scan_all_projects", {
             ...(claudePath && { claudePath }),

--- a/src/test/projectSlice.scanProjects.test.ts
+++ b/src/test/projectSlice.scanProjects.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import { api } from "../services/api";
+import {
+  createProjectSlice,
+  type ProjectSlice,
+} from "../store/slices/projectSlice";
+import {
+  AppErrorType,
+  DEFAULT_USER_METADATA,
+  type ClaudeProject,
+  type ProviderInfo,
+  type UserMetadata,
+} from "../types";
+
+vi.mock("../services/api", () => ({
+  api: vi.fn(),
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+type TestStore = ProjectSlice & {
+  providers: ProviderInfo[];
+  userMetadata: UserMetadata;
+  updateUserSettings: ReturnType<typeof vi.fn>;
+  excludeSidechain: boolean;
+};
+
+const createMockProject = (
+  name: string,
+  provider?: ClaudeProject["provider"],
+  lastModified = "2026-01-01T00:00:00.000Z",
+): ClaudeProject => ({
+  name,
+  path: `/sessions/${name}`,
+  actual_path: `/workspace/${name}`,
+  session_count: 1,
+  message_count: 1,
+  last_modified: lastModified,
+  git_info: null,
+  ...(provider ? { provider } : {}),
+});
+
+const createTestStore = () =>
+  create<TestStore>()((set, get) => ({
+    providers: [],
+    userMetadata: DEFAULT_USER_METADATA,
+    updateUserSettings: vi.fn().mockResolvedValue(undefined),
+    excludeSidechain: true,
+    ...createProjectSlice(
+      set as Parameters<typeof createProjectSlice>[0],
+      get as Parameters<typeof createProjectSlice>[1],
+      undefined as never,
+    ),
+  }));
+
+describe("projectSlice scanProjects", () => {
+  beforeEach(() => {
+    vi.mocked(api).mockReset();
+  });
+
+  it("publishes each provider as soon as that provider scan completes", async () => {
+    const store = createTestStore();
+    const claudeProject = createMockProject(
+      "claude-only",
+      undefined,
+      "2026-01-03T00:00:00.000Z",
+    );
+    const geminiProject = createMockProject(
+      "gemini-project",
+      "gemini",
+      "2026-01-02T00:00:00.000Z",
+    );
+    const codexProject = createMockProject(
+      "codex-project",
+      "codex",
+      "2026-01-01T00:00:00.000Z",
+    );
+    const codexScan = createDeferred<ClaudeProject[]>();
+    const geminiScan = createDeferred<ClaudeProject[]>();
+
+    store.setState({
+      claudePath: "/root/.claude",
+      providers: [
+        {
+          id: "claude",
+          display_name: "Claude Code",
+          base_path: "/root/.claude",
+          is_available: true,
+        },
+        {
+          id: "codex",
+          display_name: "Codex",
+          base_path: "/root/.codex",
+          is_available: true,
+        },
+        {
+          id: "gemini",
+          display_name: "Gemini CLI",
+          base_path: "/root/.gemini",
+          is_available: true,
+        },
+      ],
+    });
+
+    vi.mocked(api).mockImplementation((command, args) => {
+      if (command === "scan_projects") {
+        return Promise.resolve([claudeProject]);
+      }
+      if (command === "scan_all_projects") {
+        const provider = (args?.activeProviders as string[] | undefined)?.[0];
+        if (provider === "codex") {
+          return codexScan.promise;
+        }
+        if (provider === "gemini") {
+          return geminiScan.promise;
+        }
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    const scanPromise = store.getState().scanProjects();
+    await flushMicrotasks();
+
+    expect(store.getState().isLoadingProjects).toBe(true);
+    expect(store.getState().projects).toEqual([
+      { ...claudeProject, provider: "claude" },
+    ]);
+
+    geminiScan.resolve([geminiProject]);
+    await flushMicrotasks();
+
+    expect(store.getState().isLoadingProjects).toBe(true);
+    expect(store.getState().projects).toEqual([
+      { ...claudeProject, provider: "claude" },
+      geminiProject,
+    ]);
+
+    codexScan.resolve([codexProject]);
+    await scanPromise;
+
+    expect(store.getState().isLoadingProjects).toBe(false);
+    expect(store.getState().projects).toEqual([
+      { ...claudeProject, provider: "claude" },
+      geminiProject,
+      codexProject,
+    ]);
+  });
+
+  it("reports provider errors when successful scans return no projects", async () => {
+    const store = createTestStore();
+
+    store.setState({
+      providers: [
+        {
+          id: "codex",
+          display_name: "Codex",
+          base_path: "/root/.codex",
+          is_available: true,
+        },
+        {
+          id: "gemini",
+          display_name: "Gemini CLI",
+          base_path: "/root/.gemini",
+          is_available: true,
+        },
+      ],
+    });
+
+    vi.mocked(api).mockImplementation((command, args) => {
+      if (command === "scan_all_projects") {
+        const provider = (args?.activeProviders as string[] | undefined)?.[0];
+        if (provider === "codex") {
+          return Promise.resolve([]);
+        }
+        if (provider === "gemini") {
+          return Promise.reject(new Error("scan failed"));
+        }
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    await store.getState().scanProjects();
+
+    expect(store.getState().projects).toEqual([]);
+    expect(store.getState().error).toEqual({
+      type: AppErrorType.UNKNOWN,
+      message: "gemini: scan failed",
+    });
+  });
+});

--- a/src/test/projectSlice.scanProjects.test.ts
+++ b/src/test/projectSlice.scanProjects.test.ts
@@ -29,6 +29,11 @@ const createDeferred = <T,>(): Deferred<T> => {
   return { promise, resolve };
 };
 
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
 type TestStore = ProjectSlice & {
   providers: ProviderInfo[];
   userMetadata: UserMetadata;
@@ -39,13 +44,14 @@ type TestStore = ProjectSlice & {
 const createMockProject = (
   name: string,
   provider?: ClaudeProject["provider"],
+  lastModified = "2026-01-01T00:00:00.000Z",
 ): ClaudeProject => ({
   name,
   path: `/sessions/${name}`,
   actual_path: `/workspace/${name}`,
   session_count: 1,
   message_count: 1,
-  last_modified: "2026-01-01T00:00:00.000Z",
+  last_modified: lastModified,
   git_info: null,
   ...(provider ? { provider } : {}),
 });
@@ -68,11 +74,25 @@ describe("projectSlice scanProjects", () => {
     vi.mocked(api).mockReset();
   });
 
-  it("hydrates Claude projects before a slower multi-provider scan completes", async () => {
+  it("publishes each provider as soon as that provider scan completes", async () => {
     const store = createTestStore();
-    const claudeProject = createMockProject("claude-only");
-    const codexProject = createMockProject("codex-project", "codex");
-    const fullScan = createDeferred<ClaudeProject[]>();
+    const claudeProject = createMockProject(
+      "claude-only",
+      undefined,
+      "2026-01-03T00:00:00.000Z",
+    );
+    const geminiProject = createMockProject(
+      "gemini-project",
+      "gemini",
+      "2026-01-02T00:00:00.000Z",
+    );
+    const codexProject = createMockProject(
+      "codex-project",
+      "codex",
+      "2026-01-01T00:00:00.000Z",
+    );
+    const codexScan = createDeferred<ClaudeProject[]>();
+    const geminiScan = createDeferred<ClaudeProject[]>();
 
     store.setState({
       claudePath: "/root/.claude",
@@ -89,33 +109,55 @@ describe("projectSlice scanProjects", () => {
           base_path: "/root/.codex",
           is_available: true,
         },
+        {
+          id: "gemini",
+          display_name: "Gemini CLI",
+          base_path: "/root/.gemini",
+          is_available: true,
+        },
       ],
     });
 
-    vi.mocked(api).mockImplementation((command) => {
+    vi.mocked(api).mockImplementation((command, args) => {
       if (command === "scan_projects") {
         return Promise.resolve([claudeProject]);
       }
       if (command === "scan_all_projects") {
-        return fullScan.promise;
+        const provider = (args?.activeProviders as string[] | undefined)?.[0];
+        if (provider === "codex") {
+          return codexScan.promise;
+        }
+        if (provider === "gemini") {
+          return geminiScan.promise;
+        }
       }
       return Promise.reject(new Error(`Unexpected command: ${command}`));
     });
 
     const scanPromise = store.getState().scanProjects();
-    await Promise.resolve();
+    await flushMicrotasks();
 
     expect(store.getState().isLoadingProjects).toBe(true);
     expect(store.getState().projects).toEqual([
       { ...claudeProject, provider: "claude" },
     ]);
 
-    fullScan.resolve([{ ...claudeProject, provider: "claude" }, codexProject]);
+    geminiScan.resolve([geminiProject]);
+    await flushMicrotasks();
+
+    expect(store.getState().isLoadingProjects).toBe(true);
+    expect(store.getState().projects).toEqual([
+      { ...claudeProject, provider: "claude" },
+      geminiProject,
+    ]);
+
+    codexScan.resolve([codexProject]);
     await scanPromise;
 
     expect(store.getState().isLoadingProjects).toBe(false);
     expect(store.getState().projects).toEqual([
       { ...claudeProject, provider: "claude" },
+      geminiProject,
       codexProject,
     ]);
   });

--- a/src/test/projectSlice.scanProjects.test.ts
+++ b/src/test/projectSlice.scanProjects.test.ts
@@ -6,6 +6,7 @@ import {
   type ProjectSlice,
 } from "../store/slices/projectSlice";
 import {
+  AppErrorType,
   DEFAULT_USER_METADATA,
   type ClaudeProject,
   type ProviderInfo,
@@ -160,5 +161,47 @@ describe("projectSlice scanProjects", () => {
       geminiProject,
       codexProject,
     ]);
+  });
+
+  it("reports provider errors when successful scans return no projects", async () => {
+    const store = createTestStore();
+
+    store.setState({
+      providers: [
+        {
+          id: "codex",
+          display_name: "Codex",
+          base_path: "/root/.codex",
+          is_available: true,
+        },
+        {
+          id: "gemini",
+          display_name: "Gemini CLI",
+          base_path: "/root/.gemini",
+          is_available: true,
+        },
+      ],
+    });
+
+    vi.mocked(api).mockImplementation((command, args) => {
+      if (command === "scan_all_projects") {
+        const provider = (args?.activeProviders as string[] | undefined)?.[0];
+        if (provider === "codex") {
+          return Promise.resolve([]);
+        }
+        if (provider === "gemini") {
+          return Promise.reject(new Error("scan failed"));
+        }
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    await store.getState().scanProjects();
+
+    expect(store.getState().projects).toEqual([]);
+    expect(store.getState().error).toEqual({
+      type: AppErrorType.UNKNOWN,
+      message: "gemini: scan failed",
+    });
   });
 });

--- a/src/test/projectSlice.scanProjects.test.ts
+++ b/src/test/projectSlice.scanProjects.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import { api } from "../services/api";
+import {
+  createProjectSlice,
+  type ProjectSlice,
+} from "../store/slices/projectSlice";
+import {
+  DEFAULT_USER_METADATA,
+  type ClaudeProject,
+  type ProviderInfo,
+  type UserMetadata,
+} from "../types";
+
+vi.mock("../services/api", () => ({
+  api: vi.fn(),
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+type TestStore = ProjectSlice & {
+  providers: ProviderInfo[];
+  userMetadata: UserMetadata;
+  updateUserSettings: ReturnType<typeof vi.fn>;
+  excludeSidechain: boolean;
+};
+
+const createMockProject = (
+  name: string,
+  provider?: ClaudeProject["provider"],
+): ClaudeProject => ({
+  name,
+  path: `/sessions/${name}`,
+  actual_path: `/workspace/${name}`,
+  session_count: 1,
+  message_count: 1,
+  last_modified: "2026-01-01T00:00:00.000Z",
+  git_info: null,
+  ...(provider ? { provider } : {}),
+});
+
+const createTestStore = () =>
+  create<TestStore>()((set, get) => ({
+    providers: [],
+    userMetadata: DEFAULT_USER_METADATA,
+    updateUserSettings: vi.fn().mockResolvedValue(undefined),
+    excludeSidechain: true,
+    ...createProjectSlice(
+      set as Parameters<typeof createProjectSlice>[0],
+      get as Parameters<typeof createProjectSlice>[1],
+      undefined as never,
+    ),
+  }));
+
+describe("projectSlice scanProjects", () => {
+  beforeEach(() => {
+    vi.mocked(api).mockReset();
+  });
+
+  it("hydrates Claude projects before a slower multi-provider scan completes", async () => {
+    const store = createTestStore();
+    const claudeProject = createMockProject("claude-only");
+    const codexProject = createMockProject("codex-project", "codex");
+    const fullScan = createDeferred<ClaudeProject[]>();
+
+    store.setState({
+      claudePath: "/root/.claude",
+      providers: [
+        {
+          id: "claude",
+          display_name: "Claude Code",
+          base_path: "/root/.claude",
+          is_available: true,
+        },
+        {
+          id: "codex",
+          display_name: "Codex",
+          base_path: "/root/.codex",
+          is_available: true,
+        },
+      ],
+    });
+
+    vi.mocked(api).mockImplementation((command) => {
+      if (command === "scan_projects") {
+        return Promise.resolve([claudeProject]);
+      }
+      if (command === "scan_all_projects") {
+        return fullScan.promise;
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    const scanPromise = store.getState().scanProjects();
+    await Promise.resolve();
+
+    expect(store.getState().isLoadingProjects).toBe(true);
+    expect(store.getState().projects).toEqual([
+      { ...claudeProject, provider: "claude" },
+    ]);
+
+    fullScan.resolve([{ ...claudeProject, provider: "claude" }, codexProject]);
+    await scanPromise;
+
+    expect(store.getState().isLoadingProjects).toBe(false);
+    expect(store.getState().projects).toEqual([
+      { ...claudeProject, provider: "claude" },
+      codexProject,
+    ]);
+  });
+});


### PR DESCRIPTION
Rebase of #370 (@bugsyyu) onto current develop — the original conflicts with develop after today's merges. Code is @bugsyyu's; I resolved the one conflict and preserved attribution (Co-Authored-By).

## What
- **Rust**: Codex project-list scans mmap + memchr-scan only the `session_meta` line (`extract_project_scan_info`) instead of fully parsing every rollout; estimate `message_count` from file size. Also fixes missing-cwd Codex sessions being orphaned.
- **Frontend**: `scanProjects` scans each provider independently (`Promise.all` + `publishPartialResults`) so a slow provider no longer blocks fast ones from appearing.

## Conflict resolution
Only `src/store/slices/projectSlice.ts` conflicted. Took the PR's per-provider `scanProviderProjects` (it already includes develop's WSL handling) over develop's single `scan_all_projects` ternary — WSL preserved.

## Verification
tsc + `projectSlice.scanProjects.test.ts` pass locally; Rust (`codex.rs`) is unmodified from the PR (clean merge) — relying on the rust-tests CI here.

Supersedes #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project scanning now displays results progressively during scans, allowing users to view projects as they finish loading
  * Projects are automatically sorted by last modification date

* **Performance**
  * Optimized project scanning backend for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->