### PR TITLE
fix(messages): remove blank gaps in virtualized history (#371, rebased)

### DIFF
--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -123,9 +123,11 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
   const { t } = useTranslation();
   const scrollContainerRef = useRef<OverlayScrollbarsComponentRef>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const virtualHeaderRef = useRef<HTMLDivElement>(null);
 
   // Track when OverlayScrollbars is initialized
   const [scrollElementReady, setScrollElementReady] = useState(false);
+  const [virtualScrollMargin, setVirtualScrollMargin] = useState(0);
 
   // SubAgent 패널 접힘 상태 — MessageViewer에 lift해야 filter toggle 같은
   // 분기 재렌더(패널 자식 unmount)에서 유저 선택이 보존됨.
@@ -338,6 +340,35 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollElementReady]);
 
+  const hasMessageListHeader = displayMessages.length > 0 && !sessionSearch.query;
+
+  useEffect(() => {
+    if (!hasMessageListHeader) {
+      setVirtualScrollMargin(0);
+      return;
+    }
+
+    const element = virtualHeaderRef.current;
+    if (!element) {
+      setVirtualScrollMargin(0);
+      return;
+    }
+
+    const updateMargin = () => {
+      setVirtualScrollMargin(Math.ceil(element.getBoundingClientRect().height));
+    };
+
+    updateMargin();
+
+    if (!("ResizeObserver" in window)) {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateMargin);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [hasMessageListHeader]);
+
   // Wait for OverlayScrollbars to initialize
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -381,6 +412,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     virtualRows,
     totalSize,
     getScrollIndex,
+    rowTranslateOffset,
   } = useMessageVirtualization({
     messages: displayMessages,
     agentTaskGroups,
@@ -393,6 +425,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     hiddenMessageIds,
     isCaptureMode,
     isInSubagent,
+    scrollMargin: virtualScrollMargin,
   });
 
   // Set of selected message UUIDs for O(1) lookup
@@ -986,8 +1019,11 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
         )}
 
         {/* 메시지 목록 헤더 */}
-        {displayMessages.length > 0 && !sessionSearch.query && (
-          <div className="max-w-4xl mx-auto flex items-center justify-center py-4">
+        {hasMessageListHeader && (
+          <div
+            ref={virtualHeaderRef}
+            className="max-w-4xl mx-auto flex items-center justify-center py-4"
+          >
             <div className="text-sm text-muted-foreground">
               {t("messageViewer.allMessagesLoaded", {
                 count: messages.length,
@@ -1037,6 +1073,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
                   ref={virtualizer.measureElement}
                   virtualRow={virtualRow}
                   item={item}
+                  translateOffset={rowTranslateOffset}
                   isMatch={isMatch}
                   isCurrentMatch={isCurrentMatch}
                   searchQuery={sessionSearch.query}

--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -161,6 +161,8 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     isLoadingMessages,
   } = useAppStore();
 
+  const isInSubagent = parentSessionStack.length > 0;
+
   // Apply role + content type filters
   const displayMessages = useMemo(() => {
     const { roles, contentTypes } = messageFilter;
@@ -390,6 +392,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     getScrollElement,
     hiddenMessageIds,
     isCaptureMode,
+    isInSubagent,
   });
 
   // Set of selected message UUIDs for O(1) lookup
@@ -1045,6 +1048,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
                   onRestoreAll={restoreMessages}
                   isSelected={itemIsSelected}
                   onRangeSelect={isCaptureMode ? handleRangeSelect : undefined}
+                  isInSubagent={isInSubagent}
                 />
               );
             })}

--- a/src/components/MessageViewer/components/VirtualizedMessageRow.tsx
+++ b/src/components/MessageViewer/components/VirtualizedMessageRow.tsx
@@ -19,6 +19,7 @@ import { isZeroHeightMessageRow } from "../helpers/heightEstimation";
 interface VirtualizedMessageRowProps {
   virtualRow: VirtualItem;
   item: FlattenedMessage;
+  translateOffset?: number;
   isMatch: boolean;
   isCurrentMatch: boolean;
   searchQuery?: string;
@@ -45,6 +46,7 @@ export const VirtualizedMessageRow = forwardRef<
   {
     virtualRow,
     item,
+    translateOffset = 0,
     isMatch,
     isCurrentMatch,
     searchQuery,
@@ -60,6 +62,8 @@ export const VirtualizedMessageRow = forwardRef<
   },
   ref
 ) {
+  const translateY = virtualRow.start - translateOffset;
+
   // Handle date divider
   if (item.type === "date-divider") {
     return (
@@ -71,7 +75,7 @@ export const VirtualizedMessageRow = forwardRef<
           top: 0,
           left: 0,
           width: "100%",
-          transform: `translateY(${virtualRow.start}px)`,
+          transform: `translateY(${translateY}px)`,
         }}
       >
         <DateDivider timestamp={item.timestamp} />
@@ -90,7 +94,7 @@ export const VirtualizedMessageRow = forwardRef<
           top: 0,
           left: 0,
           width: "100%",
-          transform: `translateY(${virtualRow.start}px)`,
+          transform: `translateY(${translateY}px)`,
         }}
       >
         <HiddenBlocksIndicator
@@ -126,7 +130,7 @@ export const VirtualizedMessageRow = forwardRef<
           top: 0,
           left: 0,
           width: "100%",
-          transform: `translateY(${virtualRow.start}px)`,
+          transform: `translateY(${translateY}px)`,
           height: 0,
           overflow: "hidden",
         }}
@@ -145,7 +149,7 @@ export const VirtualizedMessageRow = forwardRef<
         top: 0,
         left: 0,
         width: "100%",
-        transform: `translateY(${virtualRow.start}px)`,
+        transform: `translateY(${translateY}px)`,
       }}
     >
       <ClaudeMessageNode

--- a/src/components/MessageViewer/components/VirtualizedMessageRow.tsx
+++ b/src/components/MessageViewer/components/VirtualizedMessageRow.tsx
@@ -14,6 +14,7 @@ import type { FlattenedMessage } from "../types";
 import { ClaudeMessageNode } from "./ClaudeMessageNode";
 import { DateDivider } from "./DateDivider";
 import { HiddenBlocksIndicator } from "./HiddenBlocksIndicator";
+import { isZeroHeightMessageRow } from "../helpers/heightEstimation";
 
 interface VirtualizedMessageRowProps {
   virtualRow: VirtualItem;
@@ -31,6 +32,7 @@ interface VirtualizedMessageRowProps {
   // Multi-selection
   isSelected?: boolean;
   onRangeSelect?: (uuid: string, modifiers: { shift: boolean; cmdOrCtrl: boolean }) => void;
+  isInSubagent?: boolean;
 }
 
 /**
@@ -54,6 +56,7 @@ export const VirtualizedMessageRow = forwardRef<
     onRestoreAll,
     isSelected,
     onRangeSelect,
+    isInSubagent = false,
   },
   ref
 ) {
@@ -104,18 +107,15 @@ export const VirtualizedMessageRow = forwardRef<
   const {
     message,
     depth,
-    isGroupMember,
-    isProgressGroupMember,
-    isTaskOperationGroupMember,
     agentTaskGroup,
     agentProgressGroup,
     taskOperationGroup,
     taskRegistry,
   } = item;
 
-  // Group members render as hidden placeholders for DOM presence (search needs them)
-  // but with zero height they won't affect layout
-  if (isGroupMember || isProgressGroupMember || isTaskOperationGroupMember) {
+  // Hidden rows stay in the virtual index space for navigation/search metadata,
+  // but must measure as 0px or long hidden runs create blank scroll gaps.
+  if (isZeroHeightMessageRow(item, isInSubagent)) {
     return (
       <div
         ref={ref}

--- a/src/components/MessageViewer/helpers/heightEstimation.ts
+++ b/src/components/MessageViewer/helpers/heightEstimation.ts
@@ -22,6 +22,82 @@ const HEIGHT_DEFAULTS = {
   hidden: 0,
 } as const;
 
+const CONTENT_WRAP_CHARS = 88;
+const CONTENT_LINE_HEIGHT = 18;
+const MAX_TEXT_EXTRA_HEIGHT = 1400;
+const MAX_TOOL_EXTRA_HEIGHT = 2200;
+const MAX_INSPECTED_CHARS = 16000;
+
+interface ContentMeasure {
+  chars: number;
+  lineBreaks: number;
+}
+
+function measureUnknownContent(value: unknown, measure: ContentMeasure): void {
+  if (measure.chars >= MAX_INSPECTED_CHARS || value == null) {
+    return;
+  }
+
+  if (typeof value === "string") {
+    const remaining = MAX_INSPECTED_CHARS - measure.chars;
+    const slice = value.slice(0, remaining);
+    measure.chars += slice.length;
+    measure.lineBreaks += slice.split("\n").length - 1;
+    return;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    measure.chars += String(value).length;
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      measureUnknownContent(item, measure);
+      if (measure.chars >= MAX_INSPECTED_CHARS) return;
+    }
+    return;
+  }
+
+  if (typeof value === "object") {
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      measureUnknownContent(nested, measure);
+      if (measure.chars >= MAX_INSPECTED_CHARS) return;
+    }
+  }
+}
+
+function estimateContentExtraHeight(
+  item: Extract<FlattenedMessage, { type: "message" }>
+): number {
+  const { message } = item;
+  const messageRecord = message as Record<string, unknown>;
+  const measure: ContentMeasure = { chars: 0, lineBreaks: 0 };
+
+  measureUnknownContent(messageRecord.content, measure);
+  measureUnknownContent(messageRecord.summary, measure);
+  measureUnknownContent(messageRecord.data, measure);
+  measureUnknownContent(messageRecord.toolUse, measure);
+  measureUnknownContent(messageRecord.toolUseResult, measure);
+
+  if (measure.chars === 0) {
+    return 0;
+  }
+
+  const wrappedLines = Math.ceil(measure.chars / CONTENT_WRAP_CHARS);
+  const explicitLines = measure.lineBreaks + 1;
+  const estimatedLines = Math.max(wrappedLines, explicitLines);
+  const includedBaseLines = message.type === "progress" ? 2 : 4;
+  const extraLines = Math.max(0, estimatedLines - includedBaseLines);
+  const hasToolPayload =
+    messageRecord.toolUse != null || messageRecord.toolUseResult != null;
+
+  return Math.min(
+    extraLines * CONTENT_LINE_HEIGHT,
+    hasToolPayload ? MAX_TOOL_EXTRA_HEIGHT : MAX_TEXT_EXTRA_HEIGHT
+  );
+}
+
 export function isZeroHeightMessageRow(
   item: FlattenedMessage,
   isInSubagent = false
@@ -75,7 +151,11 @@ export function estimateMessageHeight(
   // Agent task group leader
   if (agentTaskGroup && agentTaskGroup.length > 0) {
     // Estimate based on number of tasks
-    return HEIGHT_DEFAULTS.agentTaskGroup + agentTaskGroup.length * 40;
+    return (
+      HEIGHT_DEFAULTS.agentTaskGroup +
+      agentTaskGroup.length * 40 +
+      estimateContentExtraHeight(item)
+    );
   }
 
   // Agent progress group leader
@@ -95,19 +175,21 @@ export function estimateMessageHeight(
 
   // Messages with tool results tend to be taller
   if ((message.type === "user" || message.type === "assistant") && message.toolUseResult) {
-    return HEIGHT_DEFAULTS.toolResult;
+    return HEIGHT_DEFAULTS.toolResult + estimateContentExtraHeight(item);
   }
+
+  const contentExtra = estimateContentExtraHeight(item);
 
   // Type-based estimation
   switch (message.type) {
     case "assistant":
-      return HEIGHT_DEFAULTS.assistant;
+      return HEIGHT_DEFAULTS.assistant + contentExtra;
     case "user":
-      return HEIGHT_DEFAULTS.user;
+      return HEIGHT_DEFAULTS.user + contentExtra;
     case "system":
-      return HEIGHT_DEFAULTS.system;
+      return HEIGHT_DEFAULTS.system + contentExtra;
     default:
-      return HEIGHT_DEFAULTS.default;
+      return HEIGHT_DEFAULTS.default + contentExtra;
   }
 }
 
@@ -115,7 +197,7 @@ export function estimateMessageHeight(
  * Get default overscan count based on performance needs.
  * Higher values = smoother scrolling but more DOM nodes.
  */
-export const VIRTUALIZER_OVERSCAN = 5;
+export const VIRTUALIZER_OVERSCAN = 12;
 
 /**
  * Minimum height for measurement (prevents zero-height issues).

--- a/src/components/MessageViewer/helpers/heightEstimation.ts
+++ b/src/components/MessageViewer/helpers/heightEstimation.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FlattenedMessage } from "../types";
+import { isEmptyMessage } from "./messageHelpers";
 
 // Default heights by message type (in pixels)
 const HEIGHT_DEFAULTS = {
@@ -21,11 +22,40 @@ const HEIGHT_DEFAULTS = {
   hidden: 0,
 } as const;
 
+export function isZeroHeightMessageRow(
+  item: FlattenedMessage,
+  isInSubagent = false
+): boolean {
+  if (item.type !== "message") {
+    return false;
+  }
+
+  const {
+    message,
+    isGroupMember,
+    isProgressGroupMember,
+    isTaskOperationGroupMember,
+  } = item;
+
+  if (isGroupMember || isProgressGroupMember || isTaskOperationGroupMember) {
+    return true;
+  }
+
+  if (message.isSidechain && !isInSubagent) {
+    return true;
+  }
+
+  return isEmptyMessage(message);
+}
+
 /**
  * Estimate the height of a message for virtual scrolling.
  * This is used as the initial estimate before actual measurement.
  */
-export function estimateMessageHeight(item: FlattenedMessage): number {
+export function estimateMessageHeight(
+  item: FlattenedMessage,
+  isInSubagent = false
+): number {
   // Hidden placeholder has fixed height
   if (item.type === "hidden-placeholder") {
     return 40; // Compact placeholder height
@@ -36,15 +66,9 @@ export function estimateMessageHeight(item: FlattenedMessage): number {
     return 36;
   }
 
-  const { message, isGroupMember, isProgressGroupMember, isTaskOperationGroupMember, agentTaskGroup, agentProgressGroup } = item;
+  const { message, agentTaskGroup, agentProgressGroup } = item;
 
-  // Group members are hidden (height: 0)
-  if (isGroupMember || isProgressGroupMember || isTaskOperationGroupMember) {
-    return HEIGHT_DEFAULTS.hidden;
-  }
-
-  // Sidechain messages are hidden
-  if (message.isSidechain) {
+  if (isZeroHeightMessageRow(item, isInSubagent)) {
     return HEIGHT_DEFAULTS.hidden;
   }
 

--- a/src/components/MessageViewer/hooks/useMessageVirtualization.ts
+++ b/src/components/MessageViewer/hooks/useMessageVirtualization.ts
@@ -38,6 +38,8 @@ interface UseMessageVirtualizationOptions {
   hiddenMessageIds?: string[];
   /** Whether capture mode is active */
   isCaptureMode?: boolean;
+  /** Whether the viewer is currently showing a subagent session. */
+  isInSubagent?: boolean;
 }
 
 interface UseMessageVirtualizationReturn {
@@ -63,6 +65,7 @@ export const useMessageVirtualization = ({
   getScrollElement,
   hiddenMessageIds = [],
   isCaptureMode = false,
+  isInSubagent = false,
 }: UseMessageVirtualizationOptions): UseMessageVirtualizationReturn => {
   // Only apply hidden filter when in capture mode (hybrid approach)
   const effectiveHiddenIds = useMemo(
@@ -124,9 +127,9 @@ export const useMessageVirtualization = ({
     (index: number) => {
       const item = flattenedMessages[index];
       if (!item) return MIN_ROW_HEIGHT;
-      return estimateMessageHeight(item);
+      return estimateMessageHeight(item, isInSubagent);
     },
-    [flattenedMessages]
+    [flattenedMessages, isInSubagent]
   );
 
   // Initialize virtualizer

--- a/src/components/MessageViewer/hooks/useMessageVirtualization.ts
+++ b/src/components/MessageViewer/hooks/useMessageVirtualization.ts
@@ -40,6 +40,8 @@ interface UseMessageVirtualizationOptions {
   isCaptureMode?: boolean;
   /** Whether the viewer is currently showing a subagent session. */
   isInSubagent?: boolean;
+  /** Height before the virtual list inside the same scroll viewport. */
+  scrollMargin?: number;
 }
 
 interface UseMessageVirtualizationReturn {
@@ -52,6 +54,8 @@ interface UseMessageVirtualizationReturn {
   scrollToMessage: (uuid: string) => void;
   /** Get index for a UUID (handles group member -> leader resolution) */
   getScrollIndex: (uuid: string) => number | null;
+  /** Offset that row transforms should subtract from `virtualRow.start`. */
+  rowTranslateOffset: number;
 }
 
 export const useMessageVirtualization = ({
@@ -66,6 +70,7 @@ export const useMessageVirtualization = ({
   hiddenMessageIds = [],
   isCaptureMode = false,
   isInSubagent = false,
+  scrollMargin = 0,
 }: UseMessageVirtualizationOptions): UseMessageVirtualizationReturn => {
   // Only apply hidden filter when in capture mode (hybrid approach)
   const effectiveHiddenIds = useMemo(
@@ -132,12 +137,33 @@ export const useMessageVirtualization = ({
     [flattenedMessages, isInSubagent]
   );
 
+  const getItemKey = useCallback(
+    (index: number) => {
+      const item = flattenedMessages[index];
+      if (!item) return index;
+
+      if (item.type === "message") {
+        return item.message.uuid;
+      }
+
+      if (item.type === "date-divider") {
+        return `date-divider:${item.timestamp}:${index}`;
+      }
+
+      return `hidden:${item.hiddenUuids[0] ?? index}:${item.hiddenCount}`;
+    },
+    [flattenedMessages]
+  );
+
   // Initialize virtualizer
   const virtualizer = useVirtualizer({
     count: flattenedMessages.length,
     getScrollElement,
     estimateSize,
+    getItemKey,
     overscan: VIRTUALIZER_OVERSCAN,
+    scrollMargin,
+    useAnimationFrameWithResizeObserver: true,
     // Enable dynamic measurement
     measureElement: (element) => {
       if (!element) return MIN_ROW_HEIGHT;
@@ -196,5 +222,6 @@ export const useMessageVirtualization = ({
     totalSize: virtualizer.getTotalSize(),
     scrollToMessage,
     getScrollIndex,
+    rowTranslateOffset: scrollMargin,
   };
 };

--- a/src/test/heightEstimation.test.ts
+++ b/src/test/heightEstimation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { ClaudeMessage } from "../types";
+import type { FlattenedMessage } from "../components/MessageViewer/types";
+import {
+  estimateMessageHeight,
+  isZeroHeightMessageRow,
+} from "../components/MessageViewer/helpers/heightEstimation";
+
+const makeMessage = (
+  overrides: Partial<ClaudeMessage> = {},
+): ClaudeMessage =>
+  ({
+    type: "user",
+    role: "user",
+    uuid: "message-1",
+    sessionId: "session-1",
+    timestamp: "2026-06-13T00:00:00.000Z",
+    content: "hello",
+    ...overrides,
+  }) as ClaudeMessage;
+
+const makeFlattenedMessage = (
+  message: ClaudeMessage,
+  overrides: Partial<Extract<FlattenedMessage, { type: "message" }>> = {},
+): FlattenedMessage => ({
+  type: "message",
+  message,
+  depth: 0,
+  originalIndex: 0,
+  isGroupLeader: false,
+  isGroupMember: false,
+  isProgressGroupLeader: false,
+  isProgressGroupMember: false,
+  isTaskOperationGroupLeader: false,
+  isTaskOperationGroupMember: false,
+  ...overrides,
+});
+
+describe("message height estimation", () => {
+  it("treats sidechain rows as zero-height outside subagent views", () => {
+    const item = makeFlattenedMessage(makeMessage({ isSidechain: true }));
+
+    expect(isZeroHeightMessageRow(item, false)).toBe(true);
+    expect(estimateMessageHeight(item, false)).toBe(0);
+  });
+
+  it("keeps sidechain rows visible inside subagent views", () => {
+    const item = makeFlattenedMessage(makeMessage({ isSidechain: true }));
+
+    expect(isZeroHeightMessageRow(item, true)).toBe(false);
+    expect(estimateMessageHeight(item, true)).toBeGreaterThan(0);
+  });
+
+  it("treats empty rows as zero-height", () => {
+    const item = makeFlattenedMessage(
+      makeMessage({
+        content: "",
+      }),
+    );
+
+    expect(isZeroHeightMessageRow(item)).toBe(true);
+    expect(estimateMessageHeight(item)).toBe(0);
+  });
+});

--- a/src/test/heightEstimation.test.ts
+++ b/src/test/heightEstimation.test.ts
@@ -22,7 +22,7 @@ const makeMessage = (
 const makeFlattenedMessage = (
   message: ClaudeMessage,
   overrides: Partial<Extract<FlattenedMessage, { type: "message" }>> = {},
-): FlattenedMessage => ({
+): Extract<FlattenedMessage, { type: "message" }> => ({
   type: "message",
   message,
   depth: 0,
@@ -60,5 +60,44 @@ describe("message height estimation", () => {
 
     expect(isZeroHeightMessageRow(item)).toBe(true);
     expect(estimateMessageHeight(item)).toBe(0);
+  });
+
+  it("scales assistant message estimates with long text content", () => {
+    const shortHeight = estimateMessageHeight(
+      makeFlattenedMessage(
+        makeMessage({
+          type: "assistant",
+          role: "assistant",
+          content: "short",
+        } as Partial<ClaudeMessage>),
+      ),
+    );
+    const longHeight = estimateMessageHeight(
+      makeFlattenedMessage(
+        makeMessage({
+          type: "assistant",
+          role: "assistant",
+          content: "line\n".repeat(180),
+        } as Partial<ClaudeMessage>),
+      ),
+    );
+
+    expect(longHeight).toBeGreaterThan(shortHeight + 500);
+  });
+
+  it("scales tool-result estimates with nested payload content", () => {
+    const height = estimateMessageHeight(
+      makeFlattenedMessage(
+        makeMessage({
+          type: "assistant",
+          role: "assistant",
+          toolUseResult: {
+            content: "tool output\n".repeat(220),
+          },
+        } as Partial<ClaudeMessage>),
+      ),
+    );
+
+    expect(height).toBeGreaterThan(900);
   });
 });


### PR DESCRIPTION
Rebase of #371 (@bugsyyu) onto current develop. Code is @bugsyyu's; I resolved conflicts with this week's virtualization work (Co-Authored-By preserved).

## What
Empty/hidden rows now estimate AND render at 0px consistently (`isZeroHeightMessageRow` + content-measure `estimateMessageHeight`), and a top `scrollMargin` equal to the sticky "all messages loaded" header keeps the first rows from rendering under it as a blank gap.

## Conflict resolution (overlapped #351 / #389 / #334)
- **heightEstimation.ts / useMessageVirtualization.ts**: took the PR versions — `isZeroHeightMessageRow` already encodes #389's `isSidechain && !isInSubagent` rule, so the **#334 subagent-crash fix is preserved** (real content → non-zero estimate; only genuinely empty rows → 0). Fixed the PR's TS2352 (`as Record` → `as unknown as`).
- **MessageViewer.tsx**: kept #351's `handleScrollbarsInitialized` **and** added the PR's `scrollMargin` ResizeObserver effect; merged the `useMessageVirtualization` options to pass both `isInSubagent` (#389) and `scrollMargin` (#371).
- **heightEstimation.test.ts**: kept #389's #334 coverage; updated exact-bucket assertions to the `>0` invariant (estimation is content-measure based now) + gave fixtures top-level content.

## Verification
tsc + vitest (**841**) + eslint (0 errors) pass locally. Frontend-only.

Supersedes #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed messages being hidden behind sticky headers when scrolling through message history.
  * Improved message rendering in subagent sessions.

* **Performance**
  * Optimized virtual scrolling with enhanced height estimation for message content.
  * Improved rendering efficiency for large message lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->