### PR TITLE
fix(session): resolve Claude project cwd/name from JSONL metadata (#369, rebased)

### DIFF
--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -325,12 +325,19 @@ fn extract_cwd_from_session_file(file_path: &Path) -> Option<String> {
 
     let file = fs::File::open(file_path).ok()?;
     let reader = BufReader::new(file);
+    let mut checked_non_empty = 0;
 
-    for line in reader.lines().map_while(Result::ok).take(100) {
-        if line.trim().is_empty() {
+    for line in reader.lines().map_while(Result::ok) {
+        let line = line.trim();
+        if line.is_empty() {
             continue;
         }
-        let Ok(entry) = serde_json::from_str::<CwdEntry>(&line) else {
+        if checked_non_empty >= 100 {
+            break;
+        }
+        checked_non_empty += 1;
+
+        let Ok(entry) = serde_json::from_str::<CwdEntry>(line) else {
             continue;
         };
         let Some(cwd) = entry.cwd else {
@@ -572,6 +579,30 @@ mod tests {
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].actual_path, actual_cwd);
         assert_eq!(projects[0].name, "claude_prompt_design");
+    }
+
+    #[test]
+    fn test_extract_cwd_from_session_file_ignores_empty_lines_before_limit() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut lines = vec![String::new(); 150];
+        lines.push(
+            serde_json::json!({
+                "type": "user",
+                "cwd": "/tmp/cchv-empty-line-test",
+            })
+            .to_string(),
+        );
+        create_test_jsonl_file(
+            &temp_dir.path().to_path_buf(),
+            "session.jsonl",
+            &lines.join("\n"),
+        );
+
+        let file_path = temp_dir.path().join("session.jsonl");
+        assert_eq!(
+            extract_cwd_from_session_file(&file_path),
+            Some("/tmp/cchv-empty-line-test".to_string())
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -379,6 +379,14 @@ mod tests {
         file.write_all(content.as_bytes()).unwrap();
     }
 
+    fn jsonl_lines(lines: Vec<serde_json::Value>) -> String {
+        lines
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     // Test validate_claude_folder
     #[tokio::test]
     async fn test_validate_claude_folder_nonexistent() {
@@ -533,14 +541,28 @@ mod tests {
 
         let actual_cwd = temp_dir.path().join("claude_prompt_design");
         fs::create_dir_all(&actual_cwd).unwrap();
-        let actual_cwd = actual_cwd.to_string_lossy();
+        let actual_cwd = actual_cwd.to_string_lossy().to_string();
         create_test_jsonl_file(
             &project_dir,
             "session.jsonl",
-            &format!(
-                r#"{{"type":"mode","mode":"normal","sessionId":"session-1"}}
-{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{actual_cwd}","message":{{"role":"user","content":"Hello"}}}}"#
-            ),
+            &jsonl_lines(vec![
+                serde_json::json!({
+                    "type": "mode",
+                    "mode": "normal",
+                    "sessionId": "session-1",
+                }),
+                serde_json::json!({
+                    "uuid": "uuid-1",
+                    "sessionId": "session-1",
+                    "timestamp": "2025-06-26T10:00:00Z",
+                    "type": "user",
+                    "cwd": actual_cwd,
+                    "message": {
+                        "role": "user",
+                        "content": "Hello",
+                    },
+                }),
+            ]),
         );
 
         let projects = scan_projects(claude_dir.to_string_lossy().to_string())
@@ -564,23 +586,45 @@ mod tests {
         let parent_cwd = temp_dir.path().join("cym");
         let subagent_cwd = parent_cwd.join("paseo");
         fs::create_dir_all(&subagent_cwd).unwrap();
-        let parent_cwd = parent_cwd.to_string_lossy();
-        let subagent_cwd = subagent_cwd.to_string_lossy();
+        let parent_cwd = parent_cwd.to_string_lossy().to_string();
+        let subagent_cwd = subagent_cwd.to_string_lossy().to_string();
 
         create_test_jsonl_file(
             &project_dir,
             "parent-session.jsonl",
-            &format!(
-                r#"{{"type":"mode","mode":"normal","sessionId":"session-1"}}
-{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{parent_cwd}","message":{{"role":"user","content":"Clone paseo here"}}}}"#
-            ),
+            &jsonl_lines(vec![
+                serde_json::json!({
+                    "type": "mode",
+                    "mode": "normal",
+                    "sessionId": "session-1",
+                }),
+                serde_json::json!({
+                    "uuid": "uuid-1",
+                    "sessionId": "session-1",
+                    "timestamp": "2025-06-26T10:00:00Z",
+                    "type": "user",
+                    "cwd": parent_cwd,
+                    "message": {
+                        "role": "user",
+                        "content": "Clone paseo here",
+                    },
+                }),
+            ]),
         );
         create_test_jsonl_file(
             &subagent_dir,
             "agent-a.jsonl",
-            &format!(
-                r#"{{"uuid":"uuid-2","sessionId":"session-1","timestamp":"2025-06-26T10:01:00Z","type":"user","cwd":"{subagent_cwd}","message":{{"role":"user","content":"Analyze paseo"}}}}"#
-            ),
+            &jsonl_lines(vec![serde_json::json!({
+                "uuid": "uuid-2",
+                "sessionId": "session-1",
+                "timestamp": "2025-06-26T10:01:00Z",
+                "type": "user",
+                "cwd": subagent_cwd,
+                "message": {
+                    "role": "user",
+                    "content": "Analyze paseo",
+                },
+            })]),
         );
 
         let projects = scan_projects(claude_dir.to_string_lossy().to_string())

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -206,7 +206,8 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         let mut session_count = 0;
         let mut message_count = 0;
         let mut last_modified = None;
-        let mut cwd_candidate: Option<(SystemTime, String)> = None;
+        let mut direct_cwd_candidate: Option<(SystemTime, String)> = None;
+        let mut nested_cwd_candidate: Option<(SystemTime, String)> = None;
 
         for jsonl_entry in WalkDir::new(entry.path())
             .into_iter()
@@ -227,6 +228,15 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
                 let estimated_messages = estimate_message_count_from_size(metadata.len());
                 message_count += estimated_messages;
 
+                let is_direct_session = jsonl_entry
+                    .path()
+                    .strip_prefix(entry.path())
+                    .is_ok_and(|relative| relative.components().count() == 1);
+                let cwd_candidate = if is_direct_session {
+                    &mut direct_cwd_candidate
+                } else {
+                    &mut nested_cwd_candidate
+                };
                 let should_check_cwd = match (&cwd_candidate, modified) {
                     (None, _) => true,
                     (Some((current_modified, _)), Some(modified)) => modified > *current_modified,
@@ -234,7 +244,7 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
                 };
                 if should_check_cwd {
                     if let Some(cwd) = extract_cwd_from_session_file(jsonl_entry.path()) {
-                        cwd_candidate = Some((modified.unwrap_or(SystemTime::UNIX_EPOCH), cwd));
+                        *cwd_candidate = Some((modified.unwrap_or(SystemTime::UNIX_EPOCH), cwd));
                     }
                 }
             }
@@ -263,7 +273,13 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         // Prefer the exact cwd Claude wrote into JSONL. Claude's storage
         // directory names are lossy (`_` and path separators can both become
         // `-`), so decoding the folder name can produce a non-existent cwd.
-        let actual_path = cwd_candidate
+        // Project-level identity should come from top-level session files.
+        // Subagent JSONL files can run in narrower cwd values (for example
+        // `/home/cym/paseo`) while the parent Claude project directory remains
+        // `/home/cym`; using nested files here would rename the whole project
+        // based on whichever subagent was modified most recently.
+        let actual_path = direct_cwd_candidate
+            .or(nested_cwd_candidate)
             .map(|(_, cwd)| cwd)
             .unwrap_or_else(|| crate::utils::decode_project_path(&project_path));
         let project_name = project_display_name_from_path(&actual_path)
@@ -302,6 +318,11 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
 }
 
 fn extract_cwd_from_session_file(file_path: &Path) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct CwdEntry {
+        cwd: Option<String>,
+    }
+
     let file = fs::File::open(file_path).ok()?;
     let reader = BufReader::new(file);
 
@@ -309,12 +330,15 @@ fn extract_cwd_from_session_file(file_path: &Path) -> Option<String> {
         if line.trim().is_empty() {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+        let Ok(entry) = serde_json::from_str::<CwdEntry>(&line) else {
             continue;
         };
-        let cwd = value.get("cwd").and_then(serde_json::Value::as_str)?.trim();
+        let Some(cwd) = entry.cwd else {
+            continue;
+        };
+        let cwd = cwd.trim().to_string();
         if !cwd.is_empty() {
-            return Some(cwd.to_string());
+            return Some(cwd);
         }
     }
 
@@ -514,7 +538,8 @@ mod tests {
             &project_dir,
             "session.jsonl",
             &format!(
-                r#"{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{actual_cwd}","message":{{"role":"user","content":"Hello"}}}}"#
+                r#"{{"type":"mode","mode":"normal","sessionId":"session-1"}}
+{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{actual_cwd}","message":{{"role":"user","content":"Hello"}}}}"#
             ),
         );
 
@@ -525,6 +550,47 @@ mod tests {
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].actual_path, actual_cwd);
         assert_eq!(projects[0].name, "claude_prompt_design");
+    }
+
+    #[tokio::test]
+    async fn test_scan_projects_prefers_top_level_cwd_over_subagent_cwd() {
+        let temp_dir = TempDir::new().unwrap();
+        let claude_dir = temp_dir.path().join(".claude");
+        let projects_dir = claude_dir.join("projects");
+        let project_dir = projects_dir.join("-home-cym");
+        let subagent_dir = project_dir.join("parent-session").join("subagents");
+        fs::create_dir_all(&subagent_dir).unwrap();
+
+        let parent_cwd = temp_dir.path().join("cym");
+        let subagent_cwd = parent_cwd.join("paseo");
+        fs::create_dir_all(&subagent_cwd).unwrap();
+        let parent_cwd = parent_cwd.to_string_lossy();
+        let subagent_cwd = subagent_cwd.to_string_lossy();
+
+        create_test_jsonl_file(
+            &project_dir,
+            "parent-session.jsonl",
+            &format!(
+                r#"{{"type":"mode","mode":"normal","sessionId":"session-1"}}
+{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{parent_cwd}","message":{{"role":"user","content":"Clone paseo here"}}}}"#
+            ),
+        );
+        create_test_jsonl_file(
+            &subagent_dir,
+            "agent-a.jsonl",
+            &format!(
+                r#"{{"uuid":"uuid-2","sessionId":"session-1","timestamp":"2025-06-26T10:01:00Z","type":"user","cwd":"{subagent_cwd}","message":{{"role":"user","content":"Analyze paseo"}}}}"#
+            ),
+        );
+
+        let projects = scan_projects(claude_dir.to_string_lossy().to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].actual_path, parent_cwd);
+        assert_eq!(projects[0].name, "cym");
+        assert_eq!(projects[0].session_count, 2);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -4,8 +4,10 @@ use crate::utils::{
 };
 use chrono::{DateTime, Utc};
 use std::fs;
-use std::path::PathBuf;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::SystemTime;
 use walkdir::WalkDir;
 
 #[tauri::command]
@@ -205,6 +207,7 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         let mut session_count = 0;
         let mut message_count = 0;
         let mut last_modified = None;
+        let mut cwd_candidate: Option<(SystemTime, String)> = None;
 
         for jsonl_entry in WalkDir::new(entry.path())
             .into_iter()
@@ -214,7 +217,8 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
             session_count += 1;
 
             if let Ok(metadata) = jsonl_entry.metadata() {
-                if let Ok(modified) = metadata.modified() {
+                let modified = metadata.modified().ok();
+                if let Some(modified) = modified {
                     if last_modified.is_none() || modified > last_modified.unwrap() {
                         last_modified = Some(modified);
                     }
@@ -223,6 +227,17 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
                 // Estimate message count from file size - much faster
                 let estimated_messages = estimate_message_count_from_size(metadata.len());
                 message_count += estimated_messages;
+
+                let should_check_cwd = match (&cwd_candidate, modified) {
+                    (None, _) => true,
+                    (Some((current_modified, _)), Some(modified)) => modified > *current_modified,
+                    (Some(_), None) => false,
+                };
+                if should_check_cwd {
+                    if let Some(cwd) = extract_cwd_from_session_file(jsonl_entry.path()) {
+                        cwd_candidate = Some((modified.unwrap_or(SystemTime::UNIX_EPOCH), cwd));
+                    }
+                }
             }
         }
 
@@ -246,8 +261,12 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
             continue;
         }
 
-        // Decode the actual filesystem path FIRST
-        let actual_path = crate::utils::decode_project_path(&project_path);
+        // Prefer the exact cwd Claude wrote into JSONL. Claude's storage
+        // directory names are lossy (`_` and path separators can both become
+        // `-`), so decoding the folder name can produce a non-existent cwd.
+        let actual_path = cwd_candidate
+            .map(|(_, cwd)| cwd)
+            .unwrap_or_else(|| crate::utils::decode_project_path(&project_path));
 
         // Detect git worktree information using the actual filesystem path
         let git_info = detect_git_worktree_info(&actual_path);
@@ -279,6 +298,26 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
     }
 
     Ok(projects)
+}
+
+fn extract_cwd_from_session_file(file_path: &Path) -> Option<String> {
+    let file = fs::File::open(file_path).ok()?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines().map_while(Result::ok).take(100) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let cwd = value.get("cwd").and_then(serde_json::Value::as_str)?.trim();
+        if !cwd.is_empty() {
+            return Some(cwd.to_string());
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -445,6 +484,33 @@ mod tests {
         // extract_project_name extracts the 4th part from splitn(4, '-')
         // "-Users-jack-client-myapp" -> ["", "Users", "jack", "client-myapp"]
         assert_eq!(projects[0].name, "client-myapp");
+    }
+
+    #[tokio::test]
+    async fn test_scan_projects_prefers_jsonl_cwd_over_lossy_storage_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let claude_dir = temp_dir.path().join(".claude");
+        let projects_dir = claude_dir.join("projects");
+        let project_dir = projects_dir.join("-home-cym-claude-prompt-design");
+        fs::create_dir_all(&project_dir).unwrap();
+
+        let actual_cwd = temp_dir.path().join("claude_prompt_design");
+        fs::create_dir_all(&actual_cwd).unwrap();
+        let actual_cwd = actual_cwd.to_string_lossy();
+        create_test_jsonl_file(
+            &project_dir,
+            "session.jsonl",
+            &format!(
+                r#"{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{actual_cwd}","message":{{"role":"user","content":"Hello"}}}}"#
+            ),
+        );
+
+        let projects = scan_projects(claude_dir.to_string_lossy().to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].actual_path, actual_cwd);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -202,7 +202,6 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
 
         let raw_project_name = entry.file_name().to_string_lossy().to_string();
         let project_path = entry.path().to_string_lossy().to_string();
-        let project_name = extract_project_name(&raw_project_name);
 
         let mut session_count = 0;
         let mut message_count = 0;
@@ -267,6 +266,8 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         let actual_path = cwd_candidate
             .map(|(_, cwd)| cwd)
             .unwrap_or_else(|| crate::utils::decode_project_path(&project_path));
+        let project_name = project_display_name_from_path(&actual_path)
+            .unwrap_or_else(|| extract_project_name(&raw_project_name));
 
         // Detect git worktree information using the actual filesystem path
         let git_info = detect_git_worktree_info(&actual_path);
@@ -318,6 +319,18 @@ fn extract_cwd_from_session_file(file_path: &Path) -> Option<String> {
     }
 
     None
+}
+
+fn project_display_name_from_path(path: &str) -> Option<String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 #[cfg(test)]
@@ -511,6 +524,7 @@ mod tests {
 
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].actual_path, actual_cwd);
+        assert_eq!(projects[0].name, "claude_prompt_design");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use uuid::Uuid;
 use walkdir::WalkDir;
@@ -53,9 +53,9 @@ struct SessionMetadataCache {
     entries: HashMap<String, CachedSessionMetadata>,
 }
 
-// Bumped 8 -> 9: ClaudeSession gained the `entrypoint` field, so stale caches
-// must be invalidated to force a reparse that populates it.
-const CACHE_VERSION: u32 = 9;
+// Bumped 9 -> 10: Claude project names are now derived from JSONL `cwd`
+// when available, so stale caches must be invalidated.
+const CACHE_VERSION: u32 = 10;
 
 /// Get the cache file path for a project
 fn get_cache_path(project_path: &str) -> PathBuf {
@@ -142,6 +142,8 @@ struct IncrementalParseState {
     rename_name: Option<String>,
     /// Originating client entrypoint (already known)
     entrypoint: Option<String>,
+    /// Project display name (already known)
+    project_name: Option<String>,
 }
 
 /// Minimal struct for fast line classification (avoids full parsing)
@@ -176,6 +178,7 @@ struct SessionMetadataEntry {
     #[serde(rename = "toolUseResult")]
     tool_use_result: Option<serde_json::Value>,
     entrypoint: Option<String>,
+    cwd: Option<String>,
     message: Option<SessionMetadataMessage>,
 }
 
@@ -270,6 +273,8 @@ fn extract_session_metadata_internal(
         mut first_assistant_text,
         mut rename_name,
         mut entrypoint,
+        mut session_cwd,
+        incremental_project_name,
     ) = if let Some(ref state) = incremental_state {
         (
             state.start_offset,
@@ -286,11 +291,13 @@ fn extract_session_metadata_internal(
             state.first_assistant_text.clone(),
             state.rename_name.clone(),
             state.entrypoint.clone(),
+            None,
+            state.project_name.clone(),
         )
     } else {
         (
             0u64, 0usize, 0usize, None, None, None, None, false, false, None, None, None, None,
-            None,
+            None, None, None,
         )
     };
 
@@ -324,6 +331,15 @@ fn extract_session_metadata_internal(
         // Phase 1: Full metadata extraction for first N lines (skip if incremental)
         if !metadata_complete && lines_processed <= METADATA_PHASE_LINES {
             if let Ok(entry) = serde_json::from_str::<SessionMetadataEntry>(&line) {
+                if session_cwd.is_none() {
+                    if let Some(ref cwd) = entry.cwd {
+                        let trimmed = cwd.trim();
+                        if !trimmed.is_empty() {
+                            session_cwd = Some(trimmed.to_string());
+                        }
+                    }
+                }
+
                 // Handle summary messages
                 if entry.message_type == "summary" {
                     if session_summary.is_none() {
@@ -544,7 +560,11 @@ fn extract_session_metadata_internal(
         .unwrap_or("Unknown")
         .to_string();
 
-    let project_name = extract_project_name(&raw_project_name);
+    let project_name = session_cwd
+        .as_deref()
+        .and_then(project_display_name_from_path)
+        .or(incremental_project_name)
+        .unwrap_or_else(|| extract_project_name(&raw_project_name));
     // Rename name takes highest priority, then existing summary fallback chain
     let final_summary = rename_name
         .clone()
@@ -640,6 +660,18 @@ fn try_extract_rename(entry: &SessionMetadataEntry) -> Option<String> {
         return None;
     }
     entry.content.as_ref().and_then(extract_rename_from_content)
+}
+
+fn project_display_name_from_path(path: &str) -> Option<String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 /// Fast classification of a line without full parsing
@@ -894,6 +926,7 @@ pub async fn load_project_sessions(
                             first_assistant_text: cached.first_assistant_text.clone(),
                             rename_name: cached.rename_name.clone(),
                             entrypoint: session.entrypoint.clone(),
+                            project_name: Some(session.project_name.clone()),
                         },
                     ));
                     continue;
@@ -1978,6 +2011,31 @@ mod tests {
         let sessions = result.unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].message_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_load_project_sessions_prefers_jsonl_cwd_for_project_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_dir = temp_dir.path().join("-home-cym-claude-prompt-design");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let actual_cwd = temp_dir.path().join("claude_prompt_design");
+        std::fs::create_dir_all(&actual_cwd).unwrap();
+        let actual_cwd = actual_cwd.to_string_lossy();
+
+        let content = format!(
+            r#"{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{actual_cwd}","message":{{"role":"user","content":"Hello world"}}}}
+"#
+        );
+        let file_path = project_dir.join("test.jsonl");
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+
+        let result = load_project_sessions(project_dir.to_string_lossy().to_string(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].project_name, "claude_prompt_design");
     }
 
     #[tokio::test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,7 +281,19 @@ function App() {
         setAnalyticsCurrentView("messages");
 
         const currentProject = useAppStore.getState().selectedProject;
-        if (!currentProject || currentProject.name !== session.project_name) {
+        const currentSessions = useAppStore.getState().sessions;
+        const isCurrentProjectSession =
+          !!currentProject &&
+          currentSessions.some(
+            (loadedSession) =>
+              loadedSession.session_id === session.session_id ||
+              loadedSession.file_path === session.file_path
+          );
+
+        if (
+          !isCurrentProjectSession &&
+          (!currentProject || currentProject.name !== session.project_name)
+        ) {
           const project = projects.find((p) => p.name === session.project_name);
           if (project) {
             await selectProject(project);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,11 @@ import {
   type SessionTokenStats,
   type GroupingMode,
 } from "./types";
-import { getProviderLabel, normalizeProviderIds } from "./utils/providers";
+import {
+  getProviderId,
+  getProviderLabel,
+  normalizeProviderIds,
+} from "./utils/providers";
 import {
   fetchStartupSessionHint,
   preloadSessionFromCli,
@@ -282,19 +286,27 @@ function App() {
 
         const currentProject = useAppStore.getState().selectedProject;
         const currentSessions = useAppStore.getState().sessions;
+        const sessionProvider = getProviderId(session.provider);
+        const projectMatchesSession = (project: ClaudeProject) =>
+          project.name === session.project_name &&
+          getProviderId(project.provider) === sessionProvider;
         const isCurrentProjectSession =
           !!currentProject &&
+          projectMatchesSession(currentProject) &&
           currentSessions.some(
             (loadedSession) =>
-              loadedSession.session_id === session.session_id ||
-              loadedSession.file_path === session.file_path
+              getProviderId(loadedSession.provider) === sessionProvider &&
+              (loadedSession.session_id === session.session_id ||
+                loadedSession.file_path === session.file_path)
           );
 
         if (
           !isCurrentProjectSession &&
-          (!currentProject || currentProject.name !== session.project_name)
+          (!currentProject || !projectMatchesSession(currentProject))
         ) {
-          const project = projects.find((p) => p.name === session.project_name);
+          const project =
+            projects.find(projectMatchesSession) ??
+            projects.find((p) => p.name === session.project_name);
           if (project) {
             await selectProject(project);
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { useAppStore } from "./store/useAppStore";
 import { useAnalytics } from "./hooks/useAnalytics";
 import { useUpdater } from "./hooks/useUpdater";
@@ -315,9 +316,10 @@ function App() {
         await selectSession(session);
       } catch (error) {
         console.error("Failed to select session:", error);
+        toast.error(t("session.selectError", "Failed to select session"));
       }
     },
-    [projects, selectProject, selectSession, setAnalyticsCurrentView]
+    [projects, selectProject, selectSession, setAnalyticsCurrentView, t]
   );
 
   const handleTokenStatClick = useCallback(

--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -187,8 +187,30 @@ export function useSessionEditing(session: ClaudeSession) {
   );
 
   const projectCwd = useAppStore(
-    (state) =>
-      state.projects.find((p) => p.name === session.project_name)?.actual_path
+    (state) => {
+      const selectedProject = state.selectedProject;
+      const isLoadedInSelectedProject =
+        !!selectedProject &&
+        state.sessions.some(
+          (loadedSession) =>
+            loadedSession.session_id === session.session_id ||
+            loadedSession.file_path === session.file_path
+        );
+
+      if (isLoadedInSelectedProject) {
+        return selectedProject.actual_path;
+      }
+
+      const providerMatch = state.projects.find(
+        (project) =>
+          (project.provider ?? "claude") === providerId &&
+          project.name === session.project_name
+      );
+      return (
+        providerMatch?.actual_path ??
+        state.projects.find((p) => p.name === session.project_name)?.actual_path
+      );
+    }
   );
 
   const handleCopyResumeCommand = useCallback(

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -196,14 +196,14 @@ describe("useSessionEditing clipboard actions", () => {
       last_modified: session.last_modified,
       provider: "claude",
     };
-    const sameNameCodexProject: ClaudeProject = {
+    const sameNameClaudeProject: ClaudeProject = {
       name: "cym",
-      path: "codex:///home/cym",
-      actual_path: "/wrong/codex/cym",
+      path: "/root/.claude/projects/-home-cym-alt",
+      actual_path: "/wrong/claude/cym",
       session_count: 1,
       message_count: 1,
       last_modified: session.last_modified,
-      provider: "codex",
+      provider: "claude",
     };
     const loadedSession: ClaudeSession = {
       ...session,
@@ -211,7 +211,7 @@ describe("useSessionEditing clipboard actions", () => {
       file_path: "/root/.claude/projects/-home-cym/session.jsonl",
     };
     useAppStore.setState({
-      projects: [sameNameCodexProject, selectedProject],
+      projects: [sameNameClaudeProject, selectedProject],
       selectedProject,
       sessions: [loadedSession],
     });

--- a/src/test/useSessionEditing.test.tsx
+++ b/src/test/useSessionEditing.test.tsx
@@ -52,7 +52,11 @@ const session: ClaudeSession & { provider: string; is_renamed: boolean } = {
 describe("useSessionEditing clipboard actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAppStore.setState({ projects: [] });
+    useAppStore.setState({
+      projects: [],
+      selectedProject: null,
+      sessions: [],
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {
@@ -180,6 +184,55 @@ describe("useSessionEditing clipboard actions", () => {
     expect(toast.success).toHaveBeenCalledWith("Resume command copied");
 
     useAppStore.setState({ projects: [] });
+  });
+
+  it("uses the selected project cwd for a loaded session before same-name projects", async () => {
+    const selectedProject: ClaudeProject = {
+      name: "cym",
+      path: "/root/.claude/projects/-home-cym",
+      actual_path: "/home/cym",
+      session_count: 1,
+      message_count: 1,
+      last_modified: session.last_modified,
+      provider: "claude",
+    };
+    const sameNameCodexProject: ClaudeProject = {
+      name: "cym",
+      path: "codex:///home/cym",
+      actual_path: "/wrong/codex/cym",
+      session_count: 1,
+      message_count: 1,
+      last_modified: session.last_modified,
+      provider: "codex",
+    };
+    const loadedSession: ClaudeSession = {
+      ...session,
+      project_name: "cym",
+      file_path: "/root/.claude/projects/-home-cym/session.jsonl",
+    };
+    useAppStore.setState({
+      projects: [sameNameCodexProject, selectedProject],
+      selectedProject,
+      sessions: [loadedSession],
+    });
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const { result } = renderHook(() => useSessionEditing(loadedSession));
+
+    await act(async () => {
+      await result.current.handleCopyResumeCommand({
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      "cd '/home/cym' && claude --resume actual-session-id"
+    );
   });
 
   it("reports copy failure when fallback cannot write clipboard payload", async () => {


### PR DESCRIPTION
Rebase of #369 (@bugsyyu) onto develop. Reads the real project `cwd` from the session JSONL (Claude's dir encoding is lossy) for the project name/actual_path + `claude --resume` cwd. Conflicts: kept both #395 custom-title + the PR's display-name helper in load.rs (CACHE_VERSION→10); kept develop's #354 `findProjectForSession` in App.tsx (discarded the PR's superseded rewrite); unioned the test reset keys. cargo test (614) + clippy + fmt + tsc + vitest pass locally. Supersedes #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved project identification and path resolution by prioritizing session data over directory names.
  * Enhanced session-to-project matching when working with multiple projects.
  * Fixed resume command generation to correctly identify the working directory across different project contexts.

* **Improvements**
  * Project names are now derived more accurately from session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->