### PR TITLE
feat: add Kimi CLI provider (#349, rebased)

### DIFF
--- a/scripts/validate-i18n.mjs
+++ b/scripts/validate-i18n.mjs
@@ -30,7 +30,7 @@ function warn(msg) {
 
 const INTENTIONAL_UNTRANSLATED_KEY_PATTERNS = [
   /^common\.appName$/,
-  /^common\.provider\.(claude|codex|opencode)$/,
+  /^common\.provider\.(claude|codex|kimi|opencode)$/,
   /^error\.copyTemplate\.separator$/,
   /^messageViewer\.(codex|opencode)$/,
   /^progressRenderer\.types\.bash$/,

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -33,6 +33,7 @@ pub async fn scan_all_projects(
             "claude".to_string(),
             "codex".to_string(),
             "gemini".to_string(),
+            "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
             "cline".to_string(),
@@ -105,6 +106,16 @@ pub async fn scan_all_projects(
             Ok(projects) => all_projects.extend(projects),
             Err(e) => {
                 log::warn!("Gemini scan failed: {e}");
+            }
+        }
+    }
+
+    // Kimi
+    if providers_to_scan.iter().any(|p| p == "kimi") {
+        match providers::kimi::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("Kimi scan failed: {e}");
             }
         }
     }
@@ -243,6 +254,7 @@ pub async fn load_provider_sessions(
         }
         "codex" => providers::codex::load_sessions(&project_path, exclude),
         "gemini" => providers::gemini::load_sessions(&project_path, exclude),
+        "kimi" => providers::kimi::load_sessions(&project_path, exclude),
         "forgecode" => providers::forgecode::load_sessions(&project_path, exclude),
         "opencode" => providers::opencode::load_sessions(&project_path, exclude),
         "cline" => providers::cline::load_sessions(&project_path, exclude),
@@ -272,6 +284,7 @@ pub async fn load_provider_messages(
         }
         "codex" => providers::codex::load_messages(&session_path)?,
         "gemini" => providers::gemini::load_messages(&session_path)?,
+        "kimi" => providers::kimi::load_messages(&session_path)?,
         "forgecode" => providers::forgecode::load_messages(&session_path)?,
         "opencode" => providers::opencode::load_messages(&session_path)?,
         "cline" => providers::cline::load_messages(&session_path)?,
@@ -307,6 +320,7 @@ pub async fn search_all_providers(
             "claude".to_string(),
             "codex".to_string(),
             "gemini".to_string(),
+            "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
             "cline".to_string(),
@@ -391,6 +405,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Gemini search failed: {e}");
+            }
+        }
+    }
+
+    // Kimi
+    if providers_to_search.iter().any(|p| p == "kimi") {
+        match providers::kimi::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Kimi search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -41,14 +41,18 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     let home = home_raw.canonicalize().unwrap_or_else(|_| home_raw.clone());
     let home = strip_windows_prefix(&home);
 
-    let allowed: [PathBuf; 6] = [
+    let mut allowed = vec![
         home.join(".claude").join("projects"),
         home.join(".codex").join("sessions"),
         home.join(".gemini"),
+        home.join(".kimi").join("sessions"),
         home.join(".local").join("share").join("opencode"),
         home.join(".cline").join("tasks"),
         home.join(".cursor"),
     ];
+    if let Some(kimi_base) = crate::providers::kimi::get_base_path() {
+        allowed.push(PathBuf::from(kimi_base).join("sessions"));
+    }
 
     let canonical = if path.exists() {
         path.canonicalize()
@@ -65,5 +69,67 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
         Ok(())
     } else {
         Err("Session path not in allowed provider directories".to_string())
+    }
+}
+
+#[cfg(all(test, feature = "webui-server"))]
+mod tests {
+    use super::is_safe_session_path;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    #[test]
+    #[serial]
+    fn test_safe_session_path_allows_kimi_sessions() {
+        let temp = TempDir::new().unwrap();
+        let old_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", temp.path());
+
+        let session_dir = temp
+            .path()
+            .join(".kimi")
+            .join("sessions")
+            .join("project_hash")
+            .join("session_1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let session_file = session_dir.join("context.jsonl");
+        std::fs::write(&session_file, "{}\n").unwrap();
+
+        let result = is_safe_session_path(&session_file);
+
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_safe_session_path_allows_custom_kimi_home() {
+        let temp = TempDir::new().unwrap();
+        let old_kimi_home = std::env::var_os("KIMI_HOME");
+        std::env::set_var("KIMI_HOME", temp.path());
+
+        let session_dir = temp
+            .path()
+            .join("sessions")
+            .join("project_hash")
+            .join("session_1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let session_file = session_dir.join("context.jsonl");
+        std::fs::write(&session_file, "{}\n").unwrap();
+
+        let result = is_safe_session_path(&session_file);
+
+        if let Some(kimi_home) = old_kimi_home {
+            std::env::set_var("KIMI_HOME", kimi_home);
+        } else {
+            std::env::remove_var("KIMI_HOME");
+        }
+
+        assert!(result.is_ok());
     }
 }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -45,7 +45,6 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
         home.join(".claude").join("projects"),
         home.join(".codex").join("sessions"),
         home.join(".gemini"),
-        home.join(".kimi").join("sessions"),
         home.join(".local").join("share").join("opencode"),
         home.join(".cline").join("tasks"),
         home.join(".cursor"),

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -24,6 +24,7 @@ enum StatsProvider {
     Codex,
     ForgeCode,
     OpenCode,
+    Kimi,
     Antigravity,
 }
 
@@ -59,6 +60,7 @@ fn stats_provider_id(provider: StatsProvider) -> &'static str {
         StatsProvider::Codex => "codex",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
+        StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
     }
 }
@@ -212,6 +214,7 @@ fn all_stats_providers() -> HashSet<StatsProvider> {
         StatsProvider::Codex,
         StatsProvider::ForgeCode,
         StatsProvider::OpenCode,
+        StatsProvider::Kimi,
         StatsProvider::Antigravity,
     ]
     .into_iter()
@@ -232,6 +235,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
             "codex" => Some(StatsProvider::Codex),
             "forgecode" => Some(StatsProvider::ForgeCode),
             "opencode" => Some(StatsProvider::OpenCode),
+            "kimi" => Some(StatsProvider::Kimi),
             "antigravity" => Some(StatsProvider::Antigravity),
             _ => {
                 unknown.push(provider);
@@ -258,6 +262,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::ForgeCode
     } else if project_path.starts_with("opencode://") {
         StatsProvider::OpenCode
+    } else if project_path.starts_with("kimi://") {
+        StatsProvider::Kimi
     } else if is_antigravity_path(project_path) {
         StatsProvider::Antigravity
     } else {
@@ -269,6 +275,10 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
 fn detect_session_provider(session_path: &str) -> StatsProvider {
     if session_path.starts_with("opencode://") {
         return StatsProvider::OpenCode;
+    }
+
+    if is_kimi_path(session_path) {
+        return StatsProvider::Kimi;
     }
 
     if is_antigravity_path(session_path) {
@@ -299,6 +309,12 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
 fn is_antigravity_path(path: &str) -> bool {
     crate::commands::antigravity::resolve_antigravity_root()
         .map(|root| Path::new(path).starts_with(root.as_path()))
+        .unwrap_or(false)
+}
+
+fn is_kimi_path(path: &str) -> bool {
+    providers::kimi::get_base_path()
+        .map(|root| Path::new(path).starts_with(root))
         .unwrap_or(false)
 }
 
@@ -969,6 +985,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Codex => providers::codex::scan_projects().unwrap_or_default(),
         StatsProvider::ForgeCode => providers::forgecode::scan_projects().unwrap_or_default(),
         StatsProvider::OpenCode => providers::opencode::scan_projects().unwrap_or_default(),
+        StatsProvider::Kimi => providers::kimi::scan_projects().unwrap_or_default(),
         StatsProvider::Antigravity => providers::antigravity::scan_projects().unwrap_or_default(),
         StatsProvider::Claude => Vec::new(),
     };
@@ -977,6 +994,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Codex => "codex",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
+        StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
         StatsProvider::Claude => "claude",
     };
@@ -992,6 +1010,7 @@ fn collect_provider_global_file_stats(
             StatsProvider::Codex => providers::codex::load_sessions(&project.path, false),
             StatsProvider::ForgeCode => providers::forgecode::load_sessions(&project.path, false),
             StatsProvider::OpenCode => providers::opencode::load_sessions(&project.path, false),
+            StatsProvider::Kimi => providers::kimi::load_sessions(&project.path, false),
             StatsProvider::Antigravity => {
                 providers::antigravity::load_sessions(&project.path, false)
             }
@@ -1012,6 +1031,7 @@ fn collect_provider_global_file_stats(
                 StatsProvider::Codex => providers::codex::load_messages(file_path),
                 StatsProvider::ForgeCode => providers::forgecode::load_messages(file_path),
                 StatsProvider::OpenCode => providers::opencode::load_messages(file_path),
+                StatsProvider::Kimi => providers::kimi::load_messages(file_path),
                 StatsProvider::Antigravity => providers::antigravity::load_messages(file_path),
                 StatsProvider::Claude => Ok(Vec::new()),
             }
@@ -1612,6 +1632,21 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                 .unwrap_or(project_path)
                 .to_string()
         }
+        StatsProvider::Kimi => {
+            if let Ok(projects) = providers::kimi::scan_projects() {
+                if let Some(project) = projects.into_iter().find(|p| p.path == project_path) {
+                    return project.name;
+                }
+            }
+            project_path
+                .strip_prefix("kimi://")
+                .and_then(|p| {
+                    PathBuf::from(p)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| project_path.to_string())
+        }
         StatsProvider::Antigravity => {
             if let Ok(projects) = providers::antigravity::scan_projects() {
                 if let Some(project) = projects.into_iter().find(|p| p.path == project_path) {
@@ -1658,6 +1693,18 @@ fn resolve_provider_project_name_from_session(
             }
             "codex".to_string()
         }
+        StatsProvider::Kimi => {
+            if let Ok(projects) = providers::kimi::scan_projects() {
+                for project in projects {
+                    if let Ok(sessions) = providers::kimi::load_sessions(&project.path, false) {
+                        if sessions.iter().any(|s| s.file_path == session_path) {
+                            return project.name;
+                        }
+                    }
+                }
+            }
+            "kimi".to_string()
+        }
         StatsProvider::Antigravity => "Antigravity".to_string(),
         StatsProvider::Claude => "unknown".to_string(),
     }
@@ -1672,6 +1719,7 @@ fn load_provider_sessions_for_stats(
         StatsProvider::Codex => providers::codex::load_sessions(project_path, false),
         StatsProvider::ForgeCode => providers::forgecode::load_sessions(project_path, false),
         StatsProvider::OpenCode => providers::opencode::load_sessions(project_path, false),
+        StatsProvider::Kimi => providers::kimi::load_sessions(project_path, false),
         StatsProvider::Antigravity => providers::antigravity::load_sessions(project_path, false),
         StatsProvider::Claude => {
             Err("Claude sessions are handled by legacy stats path".to_string())
@@ -1688,6 +1736,7 @@ fn load_provider_messages_for_stats(
         StatsProvider::Codex => providers::codex::load_messages(&session.file_path),
         StatsProvider::ForgeCode => providers::forgecode::load_messages(&session.file_path),
         StatsProvider::OpenCode => providers::opencode::load_messages(&session.file_path),
+        StatsProvider::Kimi => providers::kimi::load_messages(&session.file_path),
         StatsProvider::Antigravity => providers::antigravity::load_messages(&session.file_path),
         StatsProvider::Claude => {
             Err("Claude messages are handled by legacy stats path".to_string())
@@ -2432,6 +2481,7 @@ pub async fn get_session_token_stats(
             StatsProvider::Codex => providers::codex::load_messages(&session_path)?,
             StatsProvider::ForgeCode => providers::forgecode::load_messages(&session_path)?,
             StatsProvider::OpenCode => providers::opencode::load_messages(&session_path)?,
+            StatsProvider::Kimi => providers::kimi::load_messages(&session_path)?,
             StatsProvider::Antigravity => providers::antigravity::load_messages(&session_path)?,
             StatsProvider::Claude => Vec::new(),
         };
@@ -3292,6 +3342,13 @@ pub async fn get_global_stats_summary(
         file_stats.extend(opencode_stats);
     }
 
+    if providers_to_include.contains(&StatsProvider::Kimi) {
+        let (kimi_stats, kimi_projects) =
+            collect_provider_global_file_stats(StatsProvider::Kimi, mode, s_ref, e_ref);
+        project_names.extend(kimi_projects);
+        file_stats.extend(kimi_stats);
+    }
+
     if providers_to_include.contains(&StatsProvider::Antigravity) {
         let (antigravity_stats, antigravity_projects) =
             collect_provider_global_file_stats(StatsProvider::Antigravity, mode, s_ref, e_ref);
@@ -4094,6 +4151,10 @@ mod tests {
             StatsProvider::OpenCode
         );
         assert_eq!(
+            detect_project_provider("kimi:///Users/jack/.kimi/sessions/project-hash"),
+            StatsProvider::Kimi
+        );
+        assert_eq!(
             detect_project_provider("/Users/jack/.claude/projects/my-project"),
             StatsProvider::Claude
         );
@@ -4126,6 +4187,15 @@ mod tests {
             detect_session_provider("opencode://project/ses_abc"),
             StatsProvider::OpenCode
         );
+        if let Some(root) = providers::kimi::get_base_path() {
+            let kimi_session = PathBuf::from(root)
+                .join("sessions")
+                .join("project-hash")
+                .join("session-id")
+                .to_string_lossy()
+                .to_string();
+            assert_eq!(detect_session_provider(&kimi_session), StatsProvider::Kimi);
+        }
         assert_eq!(
             detect_session_provider(
                 "/Users/jack/.codex/sessions/2026/02/20/rollout-2026-02-20T11-04-52-1234.jsonl"
@@ -4161,6 +4231,7 @@ mod tests {
         assert!(providers.contains(&StatsProvider::Codex));
         assert!(providers.contains(&StatsProvider::ForgeCode));
         assert!(providers.contains(&StatsProvider::OpenCode));
+        assert!(providers.contains(&StatsProvider::Kimi));
         assert!(providers.contains(&StatsProvider::Antigravity));
     }
 
@@ -4193,6 +4264,14 @@ mod tests {
         let providers = parse_active_stats_providers(Some(vec!["forgecode".to_string()]));
         assert_eq!(providers.len(), 1);
         assert!(providers.contains(&StatsProvider::ForgeCode));
+    }
+
+    #[test]
+    /// Verify parse active stats providers supports Kimi.
+    fn test_parse_active_stats_providers_supports_kimi() {
+        let providers = parse_active_stats_providers(Some(vec!["kimi".to_string()]));
+        assert_eq!(providers.len(), 1);
+        assert!(providers.contains(&StatsProvider::Kimi));
     }
 
     #[test]

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1694,14 +1694,9 @@ fn resolve_provider_project_name_from_session(
             "codex".to_string()
         }
         StatsProvider::Kimi => {
-            if let Ok(projects) = providers::kimi::scan_projects() {
-                for project in projects {
-                    if let Ok(sessions) = providers::kimi::load_sessions(&project.path, false) {
-                        if sessions.iter().any(|s| s.file_path == session_path) {
-                            return project.name;
-                        }
-                    }
-                }
+            if let Some(project_dir) = Path::new(session_path).parent() {
+                let project_path = format!("kimi://{}", project_dir.to_string_lossy());
+                return resolve_provider_project_name(provider, &project_path);
             }
             "kimi".to_string()
         }
@@ -4343,6 +4338,28 @@ mod tests {
             true,
             StatsMode::ConversationOnly
         ));
+        assert!(!should_include_stats_entry(
+            "tool",
+            Some(false),
+            false,
+            StatsMode::ConversationOnly
+        ));
+        assert!(!should_include_stats_entry(
+            "tool",
+            Some(false),
+            false,
+            StatsMode::BillingTotal
+        ));
+    }
+
+    #[test]
+    fn test_kimi_project_name_resolves_from_session_parent_directory() {
+        let session_path = "/tmp/kimi/sessions/project-hash/session-1";
+
+        assert_eq!(
+            resolve_provider_project_name_from_session(StatsProvider::Kimi, session_path),
+            "project-hash"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -164,6 +164,9 @@ fn extract_provider_paths(path: &Path) -> Option<(String, String)> {
     match ext {
         // Claude + Codex rollout logs
         "jsonl" => {
+            if let Some(paths) = extract_kimi_paths(path) {
+                return Some(paths);
+            }
             if let Some((project_path, session_path)) = extract_paths(path) {
                 return Some((
                     project_path.to_string_lossy().to_string(),
@@ -172,8 +175,8 @@ fn extract_provider_paths(path: &Path) -> Option<(String, String)> {
             }
             extract_codex_paths(path)
         }
-        // OpenCode storage files
-        "json" => extract_opencode_paths(path),
+        // Kimi state files and OpenCode storage files
+        "json" => extract_kimi_paths(path).or_else(|| extract_opencode_paths(path)),
         // OpenCode SQLite database change — emit broad refresh for all OpenCode projects
         "db" | "db-wal" => extract_opencode_db_event(path),
         _ => None,
@@ -249,6 +252,32 @@ fn extract_codex_paths(path: &Path) -> Option<(String, String)> {
     Some((
         "codex://watch".to_string(),
         path.to_string_lossy().to_string(),
+    ))
+}
+
+/// Extract Kimi session identifiers from files under
+/// `~/.kimi/sessions/{project_hash}/{session_id}/`.
+fn extract_kimi_paths(path: &Path) -> Option<(String, String)> {
+    let filename = path.file_name()?.to_str()?;
+    if !matches!(filename, "context.jsonl" | "wire.jsonl" | "state.json") {
+        return None;
+    }
+
+    let sessions_root = crate::providers::kimi::get_base_path()
+        .map(PathBuf::from)
+        .map(|base| base.join("sessions"))?;
+    let relative = path.strip_prefix(&sessions_root).ok()?;
+    let parts: Vec<_> = relative.components().collect();
+    if parts.len() != 3 {
+        return None;
+    }
+
+    let project_path = sessions_root.join(parts[0].as_os_str());
+    let session_path = project_path.join(parts[1].as_os_str());
+
+    Some((
+        format!("kimi://{}", project_path.to_string_lossy()),
+        session_path.to_string_lossy().to_string(),
     ))
 }
 
@@ -382,6 +411,7 @@ fn remember_opencode_project_id(storage_root: &Path, session_id: &str, project_i
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     #[test]
@@ -423,6 +453,124 @@ mod tests {
 
         assert_eq!(result.0, "codex://watch");
         assert_eq!(result.1, path.to_string_lossy());
+    }
+
+    #[test]
+    #[serial]
+    fn test_extract_kimi_context_paths() {
+        let temp = TempDir::new().unwrap();
+        let old_kimi_home = std::env::var_os("KIMI_HOME");
+        std::env::set_var("KIMI_HOME", temp.path());
+
+        let path = temp
+            .path()
+            .join("sessions")
+            .join("project_hash")
+            .join("session_1")
+            .join("context.jsonl");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{}\n").unwrap();
+
+        let result = extract_provider_paths(&path).unwrap();
+
+        if let Some(kimi_home) = old_kimi_home {
+            std::env::set_var("KIMI_HOME", kimi_home);
+        } else {
+            std::env::remove_var("KIMI_HOME");
+        }
+
+        assert_eq!(
+            result.0,
+            format!(
+                "kimi://{}",
+                temp.path().join("sessions/project_hash").display()
+            )
+        );
+        assert_eq!(
+            result.1,
+            temp.path()
+                .join("sessions/project_hash/session_1")
+                .to_string_lossy()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_extract_kimi_state_paths() {
+        let temp = TempDir::new().unwrap();
+        let old_kimi_home = std::env::var_os("KIMI_HOME");
+        std::env::set_var("KIMI_HOME", temp.path());
+
+        let path = temp
+            .path()
+            .join("sessions")
+            .join("project_hash")
+            .join("session_1")
+            .join("state.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{}\n").unwrap();
+
+        let result = extract_provider_paths(&path).unwrap();
+
+        if let Some(kimi_home) = old_kimi_home {
+            std::env::set_var("KIMI_HOME", kimi_home);
+        } else {
+            std::env::remove_var("KIMI_HOME");
+        }
+
+        assert_eq!(
+            result.0,
+            format!(
+                "kimi://{}",
+                temp.path().join("sessions/project_hash").display()
+            )
+        );
+        assert_eq!(
+            result.1,
+            temp.path()
+                .join("sessions/project_hash/session_1")
+                .to_string_lossy()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_extract_kimi_paths_from_custom_home() {
+        let temp = TempDir::new().unwrap();
+        let old_kimi_home = std::env::var_os("KIMI_HOME");
+        std::env::set_var("KIMI_HOME", temp.path());
+
+        let path = temp
+            .path()
+            .join("sessions")
+            .join("project_hash")
+            .join("session_1")
+            .join("wire.jsonl");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{}\n").unwrap();
+
+        let result = extract_provider_paths(&path);
+
+        if let Some(kimi_home) = old_kimi_home {
+            std::env::set_var("KIMI_HOME", kimi_home);
+        } else {
+            std::env::remove_var("KIMI_HOME");
+        }
+
+        let result = result.unwrap();
+        assert_eq!(
+            result.0,
+            format!(
+                "kimi://{}",
+                temp.path().join("sessions/project_hash").display()
+            )
+        );
+        assert_eq!(
+            result.1,
+            temp.path()
+                .join("sessions/project_hash/session_1")
+                .to_string_lossy()
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -524,6 +524,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(kimi_base) = providers::kimi::get_base_path() {
+        let sessions = PathBuf::from(kimi_base).join("sessions");
+        if sessions.is_dir() {
+            paths.push(sessions);
+        }
+    }
+
     if let Some(opencode_base) = providers::opencode::get_base_path() {
         let base = PathBuf::from(&opencode_base);
         let storage = base.join("storage");

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -1,0 +1,626 @@
+use super::ProviderInfo;
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::utils::{
+    build_provider_message, detect_git_worktree_info, is_symlink,
+    search_json_value_case_insensitive,
+};
+use chrono::{DateTime, TimeZone, Utc};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PROVIDER_ID: &str = "kimi";
+const SESSIONS_DIR: &str = "sessions";
+const CONTEXT_FILE: &str = "context.jsonl";
+const STATE_FILE: &str = "state.json";
+const WIRE_FILE: &str = "wire.jsonl";
+
+pub fn detect() -> Option<ProviderInfo> {
+    let base = get_base_path()?;
+    let sessions_path = Path::new(&base).join(SESSIONS_DIR);
+
+    Some(ProviderInfo {
+        id: PROVIDER_ID.to_string(),
+        display_name: "Kimi CLI".to_string(),
+        base_path: base,
+        is_available: sessions_path.exists() && sessions_path.is_dir(),
+    })
+}
+
+pub fn get_base_path() -> Option<String> {
+    if let Ok(kimi_home) = std::env::var("KIMI_HOME") {
+        let path = PathBuf::from(&kimi_home);
+        if path.exists() {
+            return Some(kimi_home);
+        }
+    }
+
+    dirs::home_dir().map(|home| home.join(".kimi").to_string_lossy().to_string())
+}
+
+pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
+    crate::utils::require_absolute_path(base_path, "Kimi base path")?;
+    let base = Path::new(base_path);
+    let sessions_root = base.join(SESSIONS_DIR);
+
+    if is_symlink(&sessions_root) || !sessions_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let canonical_base = canonical_existing(base, "Kimi base path")?;
+    let mut projects = Vec::new();
+
+    for entry in
+        fs::read_dir(&sessions_root).map_err(|e| format!("Failed to read Kimi sessions: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Kimi project entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let project_dir = entry.path();
+        if !path_is_inside(&project_dir, &canonical_base)? {
+            continue;
+        }
+
+        let mut infos = Vec::new();
+        for session_entry in fs::read_dir(&project_dir)
+            .map_err(|e| format!("Failed to read Kimi project dir: {e}"))?
+        {
+            let session_entry =
+                session_entry.map_err(|e| format!("Failed to read Kimi session entry: {e}"))?;
+            if session_entry
+                .file_type()
+                .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+            {
+                continue;
+            }
+            if let Some(info) = extract_session_info(&session_entry.path()) {
+                infos.push(info);
+            }
+        }
+
+        if infos.is_empty() {
+            continue;
+        }
+
+        let fallback_name = project_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| "kimi".to_string());
+        let actual_path = infos
+            .iter()
+            .find_map(|info| info.cwd.clone())
+            .unwrap_or_else(|| fallback_name.clone());
+        let name = project_name_from_actual_path(&actual_path, &fallback_name);
+        let message_count = infos.iter().map(|info| info.message_count).sum();
+        let last_modified = infos
+            .iter()
+            .map(|info| info.last_modified.as_str())
+            .max()
+            .unwrap_or_default()
+            .to_string();
+
+        projects.push(ClaudeProject {
+            name,
+            path: format!("kimi://{}", project_dir.to_string_lossy()),
+            actual_path: actual_path.clone(),
+            session_count: infos.len(),
+            message_count,
+            last_modified,
+            git_info: if Path::new(&actual_path).is_absolute() {
+                detect_git_worktree_info(&actual_path)
+            } else {
+                None
+            },
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            custom_directory_label: None,
+        });
+    }
+
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let base = get_base_path().ok_or("Kimi base path not found")?;
+    scan_projects_from_path(&base)
+}
+
+pub fn load_sessions(
+    project_path: &str,
+    exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let base = get_base_path().ok_or("Kimi base path not found")?;
+    load_sessions_from_base_path(&base, project_path, exclude_sidechain)
+}
+
+pub fn load_sessions_from_base_path(
+    base_path: &str,
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    crate::utils::require_absolute_path(base_path, "Kimi base path")?;
+    let base = Path::new(base_path);
+    let project_dir = resolve_project_dir(base, project_path)?;
+    let canonical_base = canonical_existing(base, "Kimi base path")?;
+    if !path_is_inside(&project_dir, &canonical_base)? {
+        return Err("Kimi project path is outside Kimi base path".to_string());
+    }
+
+    let fallback_project_name = project_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "kimi".to_string());
+
+    let mut sessions = Vec::new();
+    for entry in
+        fs::read_dir(&project_dir).map_err(|e| format!("Failed to read Kimi project dir: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Kimi session entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let session_dir = entry.path();
+        let Some(info) = extract_session_info(&session_dir) else {
+            continue;
+        };
+        let project_name = info
+            .cwd
+            .as_deref()
+            .map(|cwd| project_name_from_actual_path(cwd, &fallback_project_name))
+            .unwrap_or_else(|| fallback_project_name.clone());
+
+        sessions.push(ClaudeSession {
+            session_id: session_dir.to_string_lossy().to_string(),
+            actual_session_id: info.session_id.clone(),
+            file_path: session_dir.to_string_lossy().to_string(),
+            project_name,
+            message_count: info.message_count,
+            first_message_time: info.first_message_time,
+            last_message_time: info.last_message_time,
+            last_modified: info.last_modified,
+            has_tool_use: info.has_tool_use,
+            has_errors: false,
+            summary: info.summary,
+            is_renamed: false,
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            entrypoint: None,
+        });
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Kimi base path not found")?;
+    load_messages_from_base_path(&base, session_path)
+}
+
+pub fn load_messages_from_base_path(
+    base_path: &str,
+    session_path: &str,
+) -> Result<Vec<ClaudeMessage>, String> {
+    crate::utils::require_absolute_path(base_path, "Kimi base path")?;
+    let base = Path::new(base_path);
+    let session_dir = PathBuf::from(session_path);
+    let canonical_base = canonical_existing(base, "Kimi base path")?;
+    if !session_dir.is_absolute() || !path_is_inside(&session_dir, &canonical_base)? {
+        return Err("Kimi session path is outside Kimi base path".to_string());
+    }
+    if is_symlink(&session_dir) || !session_dir.is_dir() {
+        return Err("Kimi session path is not a directory".to_string());
+    }
+
+    let session_id = session_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let timestamps = read_wire_timestamps(&session_dir);
+    let fallback_timestamp = timestamps.first().cloned().unwrap_or_default();
+    let mut timestamp_index = 0usize;
+    let mut messages = Vec::new();
+    let mut counter = 0u64;
+
+    for value in read_jsonl_values(&session_dir.join(CONTEXT_FILE))? {
+        let role = value.get("role").and_then(Value::as_str).unwrap_or("");
+        if role.starts_with('_') {
+            continue;
+        }
+
+        let timestamp = timestamps
+            .get(timestamp_index)
+            .cloned()
+            .unwrap_or_else(|| fallback_timestamp.clone());
+        timestamp_index += 1;
+
+        if let Some(message) =
+            convert_context_message(&value, role, &session_id, &timestamp, &mut counter)
+        {
+            messages.push(message);
+        }
+    }
+
+    Ok(messages)
+}
+
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Kimi base path not found")?;
+    search_from_base_path(&base, query, limit)
+}
+
+pub fn search_from_base_path(
+    base_path: &str,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<ClaudeMessage>, String> {
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for project in scan_projects_from_path(base_path)? {
+        for session in load_sessions_from_base_path(base_path, &project.path, false)? {
+            for mut message in load_messages_from_base_path(base_path, &session.file_path)? {
+                if let Some(content) = &message.content {
+                    if search_json_value_case_insensitive(content, &query_lower) {
+                        message.project_name = Some(project.name.clone());
+                        results.push(message);
+                        if results.len() >= limit {
+                            return Ok(results);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[derive(Debug, Clone)]
+struct SessionInfo {
+    session_id: String,
+    cwd: Option<String>,
+    message_count: usize,
+    first_message_time: String,
+    last_message_time: String,
+    last_modified: String,
+    has_tool_use: bool,
+    summary: Option<String>,
+}
+
+fn extract_session_info(session_dir: &Path) -> Option<SessionInfo> {
+    if is_symlink(session_dir) || !session_dir.is_dir() {
+        return None;
+    }
+    let context_path = session_dir.join(CONTEXT_FILE);
+    if is_symlink(&context_path) || !context_path.is_file() {
+        return None;
+    }
+
+    let session_id = session_dir.file_name()?.to_string_lossy().to_string();
+    let state = read_json_file(&session_dir.join(STATE_FILE)).unwrap_or(Value::Null);
+    let title = state
+        .get("custom_title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned);
+    let timestamps = read_wire_timestamps(session_dir);
+    let mut cwd = None;
+    let mut first_user = None;
+    let mut message_count = 0usize;
+    let mut has_tool_use = false;
+
+    let values = read_jsonl_values(&context_path).ok()?;
+    for value in values {
+        let role = value.get("role").and_then(Value::as_str).unwrap_or("");
+        if role == "_system_prompt" && cwd.is_none() {
+            cwd = value
+                .get("content")
+                .and_then(Value::as_str)
+                .and_then(extract_working_directory);
+            continue;
+        }
+        if role.starts_with('_') {
+            continue;
+        }
+        if role == "user" || role == "assistant" {
+            message_count += 1;
+        }
+        if role == "tool"
+            || value
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .is_some_and(|calls| !calls.is_empty())
+        {
+            has_tool_use = true;
+        }
+        if role == "user" && first_user.is_none() {
+            first_user = extract_content_summary(&value);
+        }
+    }
+
+    if message_count == 0 {
+        return None;
+    }
+
+    let first_message_time = timestamps.first().cloned().unwrap_or_default();
+    let last_message_time = timestamps
+        .last()
+        .cloned()
+        .unwrap_or_else(|| first_message_time.clone());
+    let last_modified = if last_message_time.is_empty() {
+        file_modified_iso(&context_path).unwrap_or_default()
+    } else {
+        last_message_time.clone()
+    };
+
+    Some(SessionInfo {
+        session_id,
+        cwd,
+        message_count,
+        first_message_time,
+        last_message_time,
+        last_modified,
+        has_tool_use,
+        summary: title.or(first_user),
+    })
+}
+
+fn convert_context_message(
+    value: &Value,
+    role: &str,
+    session_id: &str,
+    timestamp: &str,
+    counter: &mut u64,
+) -> Option<ClaudeMessage> {
+    *counter += 1;
+    let uuid = value
+        .get("id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("{session_id}-{counter}"));
+
+    match role {
+        "user" => Some(build_provider_message(
+            PROVIDER_ID,
+            uuid,
+            session_id,
+            timestamp.to_string(),
+            "user",
+            Some("user"),
+            Some(content_to_blocks(value.get("content"))),
+            None,
+        )),
+        "assistant" => {
+            let mut blocks = content_to_blocks(value.get("content"));
+            if let Some(calls) = value.get("tool_calls").and_then(Value::as_array) {
+                if let Some(arr) = blocks.as_array_mut() {
+                    for call in calls {
+                        arr.push(convert_tool_call(call));
+                    }
+                }
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp.to_string(),
+                "assistant",
+                Some("assistant"),
+                Some(blocks),
+                None,
+            ))
+        }
+        "tool" => Some(build_provider_message(
+            PROVIDER_ID,
+            uuid,
+            session_id,
+            timestamp.to_string(),
+            "user",
+            Some("user"),
+            Some(json!([{
+                "type": "tool_result",
+                "tool_use_id": value.get("tool_call_id").and_then(Value::as_str).unwrap_or(""),
+                "content": value.get("content").cloned().unwrap_or(Value::Null)
+            }])),
+            None,
+        )),
+        _ => None,
+    }
+}
+
+fn content_to_blocks(content: Option<&Value>) -> Value {
+    match content {
+        Some(Value::Array(items)) => {
+            Value::Array(items.iter().map(normalize_content_block).collect())
+        }
+        Some(Value::String(text)) => json!([{ "type": "text", "text": text }]),
+        Some(Value::Null) | None => Value::Array(Vec::new()),
+        Some(other) => json!([{ "type": "text", "text": other.to_string() }]),
+    }
+}
+
+fn normalize_content_block(item: &Value) -> Value {
+    if item.get("type").and_then(Value::as_str) == Some("think") {
+        return json!({
+            "type": "thinking",
+            "thinking": item.get("think").and_then(Value::as_str).unwrap_or("")
+        });
+    }
+
+    item.clone()
+}
+
+fn convert_tool_call(call: &Value) -> Value {
+    let function = call.get("function").unwrap_or(&Value::Null);
+    let name = function
+        .get("name")
+        .or_else(|| call.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("tool");
+    let input = function
+        .get("arguments")
+        .or_else(|| call.get("arguments"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    json!({
+        "type": "tool_use",
+        "id": call.get("id").and_then(Value::as_str).unwrap_or(""),
+        "name": name,
+        "input": normalize_tool_input(input)
+    })
+}
+
+fn normalize_tool_input(input: Value) -> Value {
+    if let Some(s) = input.as_str() {
+        serde_json::from_str(s).unwrap_or_else(|_| json!({ "input": s }))
+    } else {
+        input
+    }
+}
+
+fn extract_content_summary(value: &Value) -> Option<String> {
+    let content = value.get("content")?;
+    let text = if let Some(text) = content.as_str() {
+        text.to_string()
+    } else if let Some(arr) = content.as_array() {
+        arr.iter()
+            .find_map(|item| item.get("text").and_then(Value::as_str))
+            .unwrap_or("")
+            .to_string()
+    } else {
+        return None;
+    };
+
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(truncate_chars(trimmed, 200))
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    match text.char_indices().nth(max_chars) {
+        Some((idx, _)) => format!("{}...", &text[..idx]),
+        None => text.to_string(),
+    }
+}
+
+fn extract_working_directory(system_prompt: &str) -> Option<String> {
+    const MARKER: &str = "The current working directory is `";
+    let start = system_prompt.find(MARKER)? + MARKER.len();
+    let rest = &system_prompt[start..];
+    let end = rest.find('`')?;
+    let cwd = &rest[..end];
+    if cwd.starts_with('/') {
+        Some(cwd.to_string())
+    } else {
+        None
+    }
+}
+
+fn read_json_file(path: &Path) -> Result<Value, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Kimi JSON file".to_string());
+    }
+    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read JSON file: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON file: {e}"))
+}
+
+fn read_jsonl_values(path: &Path) -> Result<Vec<Value>, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Kimi JSONL file".to_string());
+    }
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read JSONL file: {e}"))?;
+    let mut values = Vec::new();
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        if let Ok(value) = serde_json::from_str::<Value>(line) {
+            values.push(value);
+        }
+    }
+    Ok(values)
+}
+
+fn read_wire_timestamps(session_dir: &Path) -> Vec<String> {
+    let path = session_dir.join(WIRE_FILE);
+    let Ok(values) = read_jsonl_values(&path) else {
+        return Vec::new();
+    };
+
+    values
+        .into_iter()
+        .filter_map(|value| {
+            value
+                .get("timestamp")
+                .and_then(Value::as_f64)
+                .and_then(epoch_to_iso)
+        })
+        .collect()
+}
+
+fn epoch_to_iso(seconds: f64) -> Option<String> {
+    let whole = seconds.trunc() as i64;
+    let nanos = ((seconds.fract() * 1_000_000_000.0).round() as u32).min(999_999_999);
+    Utc.timestamp_opt(whole, nanos)
+        .single()
+        .map(|dt| dt.to_rfc3339())
+}
+
+fn file_modified_iso(path: &Path) -> Option<String> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .map(|time| {
+            let dt: DateTime<Utc> = time.into();
+            dt.to_rfc3339()
+        })
+}
+
+fn resolve_project_dir(base: &Path, project_path: &str) -> Result<PathBuf, String> {
+    let raw = project_path.strip_prefix("kimi://").unwrap_or(project_path);
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err("Kimi project path must be absolute".to_string());
+    }
+    if is_symlink(&path) || !path.is_dir() {
+        return Err("Kimi project path is not a directory".to_string());
+    }
+    let sessions_root = base.join(SESSIONS_DIR);
+    if !path.starts_with(&sessions_root) {
+        return Err("Kimi project path is outside Kimi sessions directory".to_string());
+    }
+    Ok(path)
+}
+
+fn canonical_existing(path: &Path, label: &str) -> Result<PathBuf, String> {
+    path.canonicalize()
+        .map_err(|e| format!("Failed to resolve {label}: {e}"))
+}
+
+fn path_is_inside(path: &Path, canonical_base: &Path) -> Result<bool, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve path: {e}"))?;
+    Ok(canonical.starts_with(canonical_base))
+}
+
+fn project_name_from_actual_path(actual_path: &str, fallback: &str) -> String {
+    Path::new(actual_path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -30,8 +30,14 @@ pub fn detect() -> Option<ProviderInfo> {
 pub fn get_base_path() -> Option<String> {
     if let Ok(kimi_home) = std::env::var("KIMI_HOME") {
         let path = PathBuf::from(&kimi_home);
-        if path.exists() {
-            return Some(kimi_home);
+        let absolute_path = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir().ok()?.join(path)
+        };
+        if absolute_path.exists() {
+            let normalized = absolute_path.canonicalize().unwrap_or(absolute_path);
+            return Some(normalized.to_string_lossy().to_string());
         }
     }
 
@@ -427,8 +433,8 @@ fn convert_context_message(
             uuid,
             session_id,
             timestamp.to_string(),
-            "user",
-            Some("user"),
+            "tool",
+            Some("tool"),
             Some(json!([{
                 "type": "tool_result",
                 "tool_use_id": value.get("tool_call_id").and_then(Value::as_str).unwrap_or(""),
@@ -524,11 +530,23 @@ fn extract_working_directory(system_prompt: &str) -> Option<String> {
     let rest = &system_prompt[start..];
     let end = rest.find('`')?;
     let cwd = &rest[..end];
-    if cwd.starts_with('/') {
+    if is_absolute_working_directory(cwd) {
         Some(cwd.to_string())
     } else {
         None
     }
+}
+
+fn is_absolute_working_directory(cwd: &str) -> bool {
+    Path::new(cwd).is_absolute() || looks_like_windows_absolute_path(cwd)
+}
+
+fn looks_like_windows_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/')
 }
 
 fn read_json_file(path: &Path) -> Result<Value, String> {
@@ -623,4 +641,19 @@ fn project_name_from_actual_path(actual_path: &str, fallback: &str) -> String {
         .map(|name| name.to_string_lossy().to_string())
         .filter(|name| !name.is_empty())
         .unwrap_or_else(|| fallback.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_working_directory_accepts_windows_absolute_paths() {
+        let prompt = "The current working directory is `C:\\Users\\max\\repo`.";
+
+        assert_eq!(
+            extract_working_directory(prompt).as_deref(),
+            Some("C:\\Users\\max\\repo")
+        );
+    }
 }

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -28,8 +28,8 @@ pub fn detect() -> Option<ProviderInfo> {
 }
 
 pub fn get_base_path() -> Option<String> {
-    if let Ok(kimi_home) = std::env::var("KIMI_HOME") {
-        let path = PathBuf::from(&kimi_home);
+    if let Ok(env_val) = std::env::var("KIMI_SHARE_DIR").or_else(|_| std::env::var("KIMI_HOME")) {
+        let path = PathBuf::from(&env_val);
         let absolute_path = if path.is_absolute() {
             path
         } else {
@@ -41,7 +41,13 @@ pub fn get_base_path() -> Option<String> {
         }
     }
 
-    dirs::home_dir().map(|home| home.join(".kimi").to_string_lossy().to_string())
+    let default = dirs::home_dir()?.join(".kimi");
+    if default.exists() {
+        let normalized = default.canonicalize().unwrap_or(default);
+        Some(normalized.to_string_lossy().to_string())
+    } else {
+        None
+    }
 }
 
 pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
@@ -233,8 +239,10 @@ pub fn load_messages_from_base_path(
         .map(|name| name.to_string_lossy().to_string())
         .unwrap_or_else(|| "unknown".to_string());
     let timestamps = read_wire_timestamps(&session_dir);
-    let fallback_timestamp = timestamps.first().cloned().unwrap_or_default();
-    let mut timestamp_index = 0usize;
+    let session_timestamp = timestamps
+        .first()
+        .cloned()
+        .unwrap_or_else(|| file_modified_iso(&session_dir.join(CONTEXT_FILE)).unwrap_or_default());
     let mut messages = Vec::new();
     let mut counter = 0u64;
 
@@ -243,15 +251,8 @@ pub fn load_messages_from_base_path(
         if role.starts_with('_') {
             continue;
         }
-
-        let timestamp = timestamps
-            .get(timestamp_index)
-            .cloned()
-            .unwrap_or_else(|| fallback_timestamp.clone());
-        timestamp_index += 1;
-
         if let Some(message) =
-            convert_context_message(&value, role, &session_id, &timestamp, &mut counter)
+            convert_context_message(&value, role, &session_id, &session_timestamp, &mut counter)
         {
             messages.push(message);
         }
@@ -340,7 +341,7 @@ fn extract_session_info(session_dir: &Path) -> Option<SessionInfo> {
         if role.starts_with('_') {
             continue;
         }
-        if role == "user" || role == "assistant" {
+        if role == "user" || role == "assistant" || role == "tool" {
             message_count += 1;
         }
         if role == "tool"
@@ -543,10 +544,19 @@ fn is_absolute_working_directory(cwd: &str) -> bool {
 
 fn looks_like_windows_absolute_path(path: &str) -> bool {
     let bytes = path.as_bytes();
-    bytes.len() >= 3
+    // Drive-letter path: C:\ or C:/
+    if bytes.len() >= 3
         && bytes[0].is_ascii_alphabetic()
         && bytes[1] == b':'
         && matches!(bytes[2], b'\\' | b'/')
+    {
+        return true;
+    }
+    // UNC path: \\server\share or //server/share
+    if bytes.len() >= 2 && matches!(bytes[0], b'\\' | b'/') && bytes[0] == bytes[1] {
+        return true;
+    }
+    false
 }
 
 fn read_json_file(path: &Path) -> Result<Value, String> {
@@ -590,6 +600,10 @@ fn read_wire_timestamps(session_dir: &Path) -> Vec<String> {
 }
 
 fn epoch_to_iso(seconds: f64) -> Option<String> {
+    // Valid range: 1970-2100 (Unix seconds 0 ~ 4_102_444_800)
+    if !(0.0..=4_102_444_800.0).contains(&seconds) {
+        return None;
+    }
     let whole = seconds.trunc() as i64;
     let nanos = ((seconds.fract() * 1_000_000_000.0).round() as u32).min(999_999_999);
     Utc.timestamp_opt(whole, nanos)
@@ -646,6 +660,38 @@ fn project_name_from_actual_path(actual_path: &str, fallback: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::fs;
+    use tempfile::TempDir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: std::ffi::OsString) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.original.as_ref() {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 
     #[test]
     fn extract_working_directory_accepts_windows_absolute_paths() {
@@ -655,5 +701,45 @@ mod tests {
             extract_working_directory(prompt).as_deref(),
             Some("C:\\Users\\max\\repo")
         );
+    }
+
+    #[test]
+    fn extract_working_directory_accepts_unc_paths() {
+        let prompt = r"The current working directory is `\\fileserver\share\project`.";
+        assert_eq!(
+            extract_working_directory(prompt).as_deref(),
+            Some(r"\\fileserver\share\project")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_prefers_kimi_share_dir_over_kimi_home() {
+        let temp = TempDir::new().unwrap();
+        let share_dir = temp.path().join("share");
+        let home_dir = temp.path().join("home");
+        fs::create_dir_all(&share_dir).unwrap();
+        fs::create_dir_all(&home_dir).unwrap();
+        let _share = EnvVarGuard::set("KIMI_SHARE_DIR", share_dir.as_os_str().to_owned());
+        let _home = EnvVarGuard::set("KIMI_HOME", home_dir.as_os_str().to_owned());
+        let path = get_base_path().unwrap();
+        assert_eq!(
+            std::path::PathBuf::from(path),
+            share_dir.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_returns_none_when_default_dir_absent() {
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home_env = EnvVarGuard::remove("KIMI_HOME");
+        if dirs::home_dir()
+            .map(|h| h.join(".kimi").exists())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        assert!(get_base_path().is_none());
     }
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -8,6 +8,7 @@ pub mod codex;
 pub mod cursor;
 pub mod forgecode;
 pub mod gemini;
+pub mod kimi;
 pub mod opencode;
 
 /// Provider identifier
@@ -20,6 +21,7 @@ pub enum ProviderId {
     Codex,
     Cursor,
     Gemini,
+    Kimi,
     ForgeCode,
     OpenCode,
     Antigravity,
@@ -34,6 +36,7 @@ impl ProviderId {
             Self::Codex => "codex",
             Self::Cursor => "cursor",
             Self::Gemini => "gemini",
+            Self::Kimi => "kimi",
             Self::ForgeCode => "forgecode",
             Self::OpenCode => "opencode",
             Self::Antigravity => "antigravity",
@@ -48,6 +51,7 @@ impl ProviderId {
             "codex" => Some(Self::Codex),
             "cursor" => Some(Self::Cursor),
             "gemini" => Some(Self::Gemini),
+            "kimi" => Some(Self::Kimi),
             "forgecode" => Some(Self::ForgeCode),
             "opencode" => Some(Self::OpenCode),
             "antigravity" => Some(Self::Antigravity),
@@ -63,6 +67,7 @@ impl ProviderId {
             Self::Codex => "Codex CLI",
             Self::Cursor => "Cursor",
             Self::Gemini => "Gemini CLI",
+            Self::Kimi => "Kimi CLI",
             Self::ForgeCode => "ForgeCode",
             Self::OpenCode => "OpenCode",
             Self::Antigravity => "Antigravity",
@@ -90,6 +95,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = gemini::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = kimi::detect() {
         providers.push(info);
     }
     if let Some(info) = forgecode::detect() {

--- a/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-1/context.jsonl
+++ b/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-1/context.jsonl
@@ -1,0 +1,7 @@
+{"role":"_system_prompt","content":"You are Kimi Code CLI."}
+{"role":"_checkpoint","id":"cp-1"}
+{"role":"user","content":"Add a Kimi provider"}
+{"role":"_usage","token_count":{"input_tokens":12,"output_tokens":0}}
+{"role":"assistant","content":[{"type":"think","think":"I should inspect the provider registry first.","encrypted":null},{"type":"text","text":"I will inspect the provider registry."}],"tool_calls":[{"id":"tool_1","type":"function","function":{"name":"Shell","arguments":"{\"command\":\"rg provider\"}"}}]}
+{"role":"tool","tool_call_id":"tool_1","content":"src-tauri/src/providers/mod.rs"}
+{"role":"assistant","content":[{"type":"text","text":"The provider registry is in Rust."}]}

--- a/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-1/state.json
+++ b/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-1/state.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "custom_title": "Implement Kimi provider",
+  "title_generated": false,
+  "wire_mtime": null,
+  "archived": false
+}

--- a/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-1/wire.jsonl
+++ b/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-1/wire.jsonl
@@ -1,0 +1,4 @@
+{"protocol_version":1,"type":"hello"}
+{"timestamp":1770000000.0,"message":{"type":"TurnBegin"}}
+{"timestamp":1770000005.5,"message":{"type":"ToolCall"}}
+{"timestamp":1770000010.25,"message":{"type":"TurnEnd"}}

--- a/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-2/context.jsonl
+++ b/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-2/context.jsonl
@@ -1,0 +1,3 @@
+{"role":"_system_prompt","content":"You are Kimi Code CLI."}
+{"role":"user","content":"Second session prompt"}
+{"role":"assistant","content":[{"type":"text","text":"Second session answer"}]}

--- a/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-2/state.json
+++ b/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-2/state.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "custom_title": "",
+  "title_generated": false,
+  "wire_mtime": null,
+  "archived": false
+}

--- a/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-2/wire.jsonl
+++ b/src-tauri/tests/fixtures/kimi/sessions/project-hash/session-2/wire.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":1770000100.0,"message":{"type":"TurnBegin"}}
+{"timestamp":1770000120.0,"message":{"type":"TurnEnd"}}

--- a/src-tauri/tests/kimi_provider_test.rs
+++ b/src-tauri/tests/kimi_provider_test.rs
@@ -1,0 +1,99 @@
+use claude_code_history_viewer_lib::providers;
+
+#[test]
+fn kimi_provider_scans_projects_from_sessions_tree() {
+    let base = fixture_base();
+
+    let projects = providers::kimi::scan_projects_from_path(base.to_str().unwrap())
+        .expect("scan_projects_from_path should parse fixture");
+
+    assert_eq!(projects.len(), 1);
+    let project = &projects[0];
+    assert_eq!(project.name, "project-hash");
+    assert_eq!(
+        project.path,
+        format!("kimi://{}", base.join("sessions/project-hash").display())
+    );
+    assert_eq!(project.actual_path, "project-hash");
+    assert_eq!(project.session_count, 2);
+    assert_eq!(project.message_count, 5);
+    assert_eq!(project.provider.as_deref(), Some("kimi"));
+    assert_eq!(project.storage_type.as_deref(), Some("jsonl"));
+}
+
+#[test]
+fn kimi_provider_loads_sessions_with_titles_and_timestamps() {
+    let base = fixture_base();
+    let project_path = format!("kimi://{}", base.join("sessions/project-hash").display());
+
+    let sessions =
+        providers::kimi::load_sessions_from_base_path(base.to_str().unwrap(), &project_path, false)
+            .expect("load_sessions_from_base_path should parse fixture");
+
+    assert_eq!(sessions.len(), 2);
+    let first = &sessions[0];
+    assert_eq!(first.actual_session_id, "session-2");
+    assert_eq!(first.summary.as_deref(), Some("Second session prompt"));
+    assert_eq!(first.last_message_time, "2026-02-02T02:42:00+00:00");
+
+    let second = &sessions[1];
+    assert_eq!(second.actual_session_id, "session-1");
+    assert_eq!(second.summary.as_deref(), Some("Implement Kimi provider"));
+    assert!(second.has_tool_use);
+    assert_eq!(second.message_count, 3);
+    assert_eq!(second.provider.as_deref(), Some("kimi"));
+}
+
+#[test]
+fn kimi_provider_loads_messages_without_internal_roles() {
+    let base = fixture_base();
+    let session_dir = base.join("sessions/project-hash/session-1");
+
+    let messages = providers::kimi::load_messages_from_base_path(
+        base.to_str().unwrap(),
+        session_dir.to_str().unwrap(),
+    )
+    .expect("load_messages_from_base_path should parse fixture");
+
+    assert_eq!(messages.len(), 4);
+    assert!(messages
+        .iter()
+        .all(|m| m.provider.as_deref() == Some("kimi")));
+    assert!(messages.iter().all(|m| m.message_type != "_system_prompt"));
+    assert_eq!(messages[0].message_type, "user");
+    assert_eq!(messages[1].message_type, "assistant");
+    assert_eq!(messages[1].content.as_ref().unwrap()[0]["type"], "thinking");
+    assert_eq!(
+        messages[1].content.as_ref().unwrap()[0]["thinking"],
+        "I should inspect the provider registry first."
+    );
+    assert_eq!(messages[2].message_type, "user");
+    assert_eq!(
+        messages[2].content.as_ref().unwrap()[0]["type"],
+        "tool_result"
+    );
+    assert_eq!(messages[3].message_type, "assistant");
+}
+
+#[test]
+fn kimi_provider_searches_messages_from_base_path() {
+    let base = fixture_base();
+
+    let results = providers::kimi::search_from_base_path(
+        base.to_str().unwrap(),
+        "inspect the provider registry",
+        10,
+    )
+    .expect("search_from_base_path should parse fixture");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].message_type, "assistant");
+    assert_eq!(results[0].project_name.as_deref(), Some("project-hash"));
+}
+
+fn fixture_base() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("kimi")
+}

--- a/src-tauri/tests/kimi_provider_test.rs
+++ b/src-tauri/tests/kimi_provider_test.rs
@@ -20,7 +20,7 @@ fn kimi_provider_scans_projects_from_sessions_tree() {
     );
     assert_eq!(project.actual_path, "project-hash");
     assert_eq!(project.session_count, 2);
-    assert_eq!(project.message_count, 5);
+    assert_eq!(project.message_count, 6);
     assert_eq!(project.provider.as_deref(), Some("kimi"));
     assert_eq!(project.storage_type.as_deref(), Some("jsonl"));
 }
@@ -44,7 +44,7 @@ fn kimi_provider_loads_sessions_with_titles_and_timestamps() {
     assert_eq!(second.actual_session_id, "session-1");
     assert_eq!(second.summary.as_deref(), Some("Implement Kimi provider"));
     assert!(second.has_tool_use);
-    assert_eq!(second.message_count, 3);
+    assert_eq!(second.message_count, 4);
     assert_eq!(second.provider.as_deref(), Some("kimi"));
 }
 
@@ -77,6 +77,9 @@ fn kimi_provider_loads_messages_without_internal_roles() {
         "tool_result"
     );
     assert_eq!(messages[3].message_type, "assistant");
+
+    let first_wire_ts = "2026-02-02T02:40:00+00:00";
+    assert!(messages.iter().all(|m| m.timestamp == first_wire_ts));
 }
 
 #[test]
@@ -131,6 +134,13 @@ impl EnvVarGuard {
     fn set(key: &'static str, value: OsString) -> Self {
         let original = std::env::var_os(key);
         std::env::set_var(key, value);
+        Self { key, original }
+    }
+
+    #[allow(dead_code)]
+    fn remove(key: &'static str) -> Self {
+        let original = std::env::var_os(key);
+        std::env::remove_var(key);
         Self { key, original }
     }
 }

--- a/src-tauri/tests/kimi_provider_test.rs
+++ b/src-tauri/tests/kimi_provider_test.rs
@@ -1,4 +1,8 @@
 use claude_code_history_viewer_lib::providers;
+use serial_test::serial;
+use std::ffi::OsString;
+use std::fs;
+use tempfile::TempDir;
 
 #[test]
 fn kimi_provider_scans_projects_from_sessions_tree() {
@@ -67,12 +71,32 @@ fn kimi_provider_loads_messages_without_internal_roles() {
         messages[1].content.as_ref().unwrap()[0]["thinking"],
         "I should inspect the provider registry first."
     );
-    assert_eq!(messages[2].message_type, "user");
+    assert_eq!(messages[2].message_type, "tool");
     assert_eq!(
         messages[2].content.as_ref().unwrap()[0]["type"],
         "tool_result"
     );
     assert_eq!(messages[3].message_type, "assistant");
+}
+
+#[test]
+#[serial]
+fn kimi_provider_normalizes_relative_kimi_home_to_absolute_path() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let original_cwd = std::env::current_dir().expect("current dir should exist");
+    let _cwd_guard = CurrentDirGuard::set(temp_dir.path());
+    let _env_guard = EnvVarGuard::set("KIMI_HOME", OsString::from(".kimi"));
+    fs::create_dir(temp_dir.path().join(".kimi")).expect("KIMI_HOME dir should be created");
+
+    let base_path = providers::kimi::get_base_path().expect("KIMI_HOME should be detected");
+
+    assert!(std::path::Path::new(&base_path).is_absolute());
+    assert_eq!(
+        std::path::PathBuf::from(base_path),
+        temp_dir.path().join(".kimi").canonicalize().unwrap()
+    );
+
+    std::env::set_current_dir(original_cwd).expect("current dir should be restored");
 }
 
 #[test]
@@ -96,4 +120,45 @@ fn fixture_base() -> std::path::PathBuf {
         .join("tests")
         .join("fixtures")
         .join("kimi")
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: OsString) -> Self {
+        let original = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = self.original.as_ref() {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+struct CurrentDirGuard {
+    original: std::path::PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let original = std::env::current_dir().expect("current dir should exist");
+        std::env::set_current_dir(path).expect("current dir should be set");
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.original).expect("current dir should be restored");
+    }
 }

--- a/src-tauri/tests/scan_all_test.rs
+++ b/src-tauri/tests/scan_all_test.rs
@@ -100,12 +100,15 @@ mod integration_tests {
         }
 
         // Test other providers if they are detected as available
-        for provider in &["codex", "gemini", "opencode", "cline", "cursor", "aider"] {
+        for provider in &[
+            "codex", "gemini", "kimi", "opencode", "cline", "cursor", "aider",
+        ] {
             let is_available = detected.iter().any(|p| p.id == *provider && p.is_available);
             if is_available {
                 let result = match *provider {
                     "codex" => providers::codex::scan_projects(),
                     "gemini" => providers::gemini::scan_projects(),
+                    "kimi" => providers::kimi::scan_projects(),
                     "opencode" => providers::opencode::scan_projects(),
                     "cline" => providers::cline::scan_projects(),
                     "cursor" => providers::cursor::scan_projects(),

--- a/src/components/ProjectTree/components/ProjectItem.tsx
+++ b/src/components/ProjectTree/components/ProjectItem.tsx
@@ -152,6 +152,7 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
             providerId === "codex" && "bg-green-500/15 text-green-600 dark:text-green-400",
             providerId === "cursor" && "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",
             providerId === "gemini" && "bg-purple-500/15 text-purple-600 dark:text-purple-400",
+            providerId === "kimi" && "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-300",
             providerId === "opencode" && "bg-blue-500/15 text-blue-600 dark:text-blue-400",
             providerId === "aider" && "bg-rose-500/15 text-rose-600 dark:text-rose-400",
             providerId === "forgecode" && "bg-orange-500/15 text-orange-700 dark:text-orange-300"

--- a/src/components/ProjectTree/components/ProjectItem.tsx
+++ b/src/components/ProjectTree/components/ProjectItem.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import type { ProjectItemProps } from "../types";
 import { getWorktreeLabel } from "../../../utils/worktreeUtils";
-import { getProviderId, getProviderLabel } from "../../../utils/providers";
+import { getProviderBadgeStyle, getProviderId, getProviderLabel } from "../../../utils/providers";
 
 export const ProjectItem: React.FC<ProjectItemProps> = ({
   project,
@@ -147,15 +147,7 @@ export const ProjectItem: React.FC<ProjectItemProps> = ({
         <span
           className={cn(
             "px-1.5 py-0.5 text-2xs font-medium rounded-full flex-shrink-0 leading-none",
-            providerId === "claude" && "bg-amber-500/15 text-amber-700 dark:text-amber-300",
-            providerId === "cline" && "bg-teal-500/15 text-teal-600 dark:text-teal-400",
-            providerId === "codex" && "bg-green-500/15 text-green-600 dark:text-green-400",
-            providerId === "cursor" && "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",
-            providerId === "gemini" && "bg-purple-500/15 text-purple-600 dark:text-purple-400",
-            providerId === "kimi" && "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-300",
-            providerId === "opencode" && "bg-blue-500/15 text-blue-600 dark:text-blue-400",
-            providerId === "aider" && "bg-rose-500/15 text-rose-600 dark:text-rose-400",
-            providerId === "forgecode" && "bg-orange-500/15 text-orange-700 dark:text-orange-300"
+            getProviderBadgeStyle(providerId)
           )}
         >
           {providerLabel}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -109,6 +109,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       cursor: 0,
       forgecode: 0,
       gemini: 0,
+      kimi: 0,
       opencode: 0,
     };
 

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -124,6 +124,7 @@
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
+  "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "Failed to detect providers. Using Claude only.",
   "common.provider.antigravity": "Antigravity",
   "common.provider.opencode": "OpenCode",

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -149,6 +149,7 @@
   "session.item.archivedDescription": "Stored under Codex archived_sessions.",
   "session.item.containsErrors": "Contains Errors",
   "session.item.storageType.json": "JSON",
+  "session.item.storageType.jsonl": "JSONL",
   "session.item.storageType.sqlite": "SQLite",
   "session.item.containsToolUse": "Contains Tool Use",
   "session.item.lastModified": "Last Modified",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -124,6 +124,7 @@
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
+  "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "プロバイダーの検出に失敗しました。Claude のみ使用します。",
   "common.provider.antigravity": "Antigravity",
   "common.provider.opencode": "OpenCode",

--- a/src/i18n/locales/ja/session.json
+++ b/src/i18n/locales/ja/session.json
@@ -149,6 +149,7 @@
   "session.item.archivedDescription": "Codex archived_sessionsに保存されています。",
   "session.item.containsErrors": "エラーを含む",
   "session.item.storageType.json": "JSON",
+  "session.item.storageType.jsonl": "JSONL",
   "session.item.storageType.sqlite": "SQLite",
   "session.item.containsToolUse": "ツール使用を含む",
   "session.item.lastModified": "最終更新",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -124,6 +124,7 @@
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
+  "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "프로바이더 감지에 실패했습니다. Claude만 사용합니다.",
   "common.provider.antigravity": "Antigravity",
   "common.provider.opencode": "OpenCode",

--- a/src/i18n/locales/ko/session.json
+++ b/src/i18n/locales/ko/session.json
@@ -149,6 +149,7 @@
   "session.item.archivedDescription": "Codex archived_sessions에 저장되어 있습니다.",
   "session.item.containsErrors": "오류 포함",
   "session.item.storageType.json": "JSON",
+  "session.item.storageType.jsonl": "JSONL",
   "session.item.storageType.sqlite": "SQLite",
   "session.item.containsToolUse": "도구 사용 포함",
   "session.item.lastModified": "마지막 수정",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -124,6 +124,7 @@
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
+  "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "检测提供商失败。将仅使用 Claude。",
   "common.provider.antigravity": "Antigravity",
   "common.provider.opencode": "OpenCode",

--- a/src/i18n/locales/zh-CN/session.json
+++ b/src/i18n/locales/zh-CN/session.json
@@ -149,6 +149,7 @@
   "session.item.archivedDescription": "存储在 Codex archived_sessions 中。",
   "session.item.containsErrors": "包含错误",
   "session.item.storageType.json": "JSON",
+  "session.item.storageType.jsonl": "JSONL",
   "session.item.storageType.sqlite": "SQLite",
   "session.item.containsToolUse": "包含工具使用",
   "session.item.lastModified": "最后修改",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -124,6 +124,7 @@
   "common.provider.cursor": "Cursor",
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
+  "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "偵測提供者失敗。將僅使用 Claude。",
   "common.provider.antigravity": "Antigravity",
   "common.provider.opencode": "OpenCode",

--- a/src/i18n/locales/zh-TW/session.json
+++ b/src/i18n/locales/zh-TW/session.json
@@ -149,6 +149,7 @@
   "session.item.archivedDescription": "儲存於 Codex archived_sessions 中。",
   "session.item.containsErrors": "包含錯誤",
   "session.item.storageType.json": "JSON",
+  "session.item.storageType.jsonl": "JSONL",
   "session.item.storageType.sqlite": "SQLite",
   "session.item.containsToolUse": "包含工具使用",
   "session.item.lastModified": "最後修改",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-05-25T07:37:00.105Z
- * 총 키 개수: 1781
+ * 생성 시간: 2026-05-26T01:00:15.247Z
+ * 총 키 개수: 1783
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (161개)
+ * common namespace의 번역 키 (162개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -116,6 +116,7 @@ export type CommonKeys =
   | 'common.provider.detectError'
   | 'common.provider.forgecode'
   | 'common.provider.gemini'
+  | 'common.provider.kimi'
   | 'common.provider.opencode'
   | 'common.refresh'
   | 'common.remove'
@@ -393,7 +394,7 @@ export type AnalyticsKeys =
   | 'analytics.weeklyActivity';
 
 /**
- * session namespace의 번역 키 (205개)
+ * session namespace의 번역 키 (206개)
  * 파일: locales/{lang}/session.json
  */
 export type SessionKeys =
@@ -559,6 +560,7 @@ export type SessionKeys =
   | 'session.item.messageCount'
   | 'session.item.session'
   | 'session.item.storageType.json'
+  | 'session.item.storageType.jsonl'
   | 'session.item.storageType.sqlite'
   | 'session.loading'
   | 'session.nativeRename.currentName'
@@ -2260,6 +2262,7 @@ export type TranslationKey =
   | 'common.provider.detectError'
   | 'common.provider.forgecode'
   | 'common.provider.gemini'
+  | 'common.provider.kimi'
   | 'common.provider.opencode'
   | 'common.refresh'
   | 'common.remove'
@@ -2869,6 +2872,7 @@ export type TranslationKey =
   | 'session.item.messageCount'
   | 'session.item.session'
   | 'session.item.storageType.json'
+  | 'session.item.storageType.jsonl'
   | 'session.item.storageType.sqlite'
   | 'session.loading'
   | 'session.nativeRename.currentName'

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -16,8 +16,8 @@ import {
 
 describe("providers utils", () => {
   it("normalizes provider ids by canonical order", () => {
-    const ids = normalizeProviderIds(["opencode", "claude", "opencode"]);
-    expect(ids).toEqual(["claude", "opencode"]);
+    const ids = normalizeProviderIds(["opencode", "kimi", "claude", "opencode"]);
+    expect(ids).toEqual(["claude", "kimi", "opencode"]);
   });
 
   it("falls back to default provider for unknown values", () => {
@@ -47,6 +47,7 @@ describe("providers utils", () => {
       "cursor",
       "forgecode",
       "gemini",
+      "kimi",
       "opencode",
     ]);
   });
@@ -56,6 +57,7 @@ describe("providers utils", () => {
     expect(supportsConversationBreakdown("antigravity")).toBe(true);
     expect(supportsConversationBreakdown("forgecode")).toBe(true);
     expect(supportsConversationBreakdown("codex")).toBe(false);
+    expect(supportsConversationBreakdown("kimi")).toBe(false);
     expect(supportsConversationBreakdown("opencode")).toBe(false);
     expect(supportsConversationBreakdown("unknown")).toBe(false);
   });
@@ -70,6 +72,13 @@ describe("providers utils", () => {
 
   it("returns the codex resume subcommand for codex sessions", () => {
     expect(getResumeCommand("codex", "abc-123")).toBe("codex resume abc-123");
+  });
+
+  it("returns the kimi resume subcommand for kimi sessions", () => {
+    expect(getProviderLabel((key, fallback) => `${key}:${fallback}`, "kimi")).toBe(
+      "common.provider.kimi:Kimi CLI"
+    );
+    expect(getResumeCommand("kimi", "abc-123")).toBe("kimi -r abc-123");
   });
 
   it("getResumeCommand fails closed for unknown provider strings", () => {
@@ -89,6 +98,9 @@ describe("providers utils", () => {
     );
     expect(getResumeCommand("forgecode", "abc", "/Users/foo/proj")).toBe(
       "cd '/Users/foo/proj' && forge conversation resume abc"
+    );
+    expect(getResumeCommand("kimi", "abc", "/Users/foo/proj")).toBe(
+      "cd '/Users/foo/proj' && kimi -r abc"
     );
   });
 
@@ -129,6 +141,7 @@ describe("providers utils", () => {
     expect(hasAnyConversationBreakdownProvider(["codex", "opencode"])).toBe(
       false
     );
+    expect(hasAnyConversationBreakdownProvider(["kimi"])).toBe(false);
     expect(hasAnyConversationBreakdownProvider([])).toBe(false);
     expect(hasAnyConversationBreakdownProvider(undefined)).toBe(false);
   });

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "antigravity" | "claude" | "cline" | "codex" | "cursor" | "forgecode" | "gemini" | "opencode";
+export type ProviderId = "aider" | "antigravity" | "claude" | "cline" | "codex" | "cursor" | "forgecode" | "gemini" | "kimi" | "opencode";
 
 export interface ProviderInfo {
   id: ProviderId;
@@ -56,7 +56,7 @@ export interface ClaudeProject {
   /** Provider identifier (claude, codex, opencode) */
   provider?: ProviderId;
   /** Storage type (json, sqlite) — OpenCode only */
-  storage_type?: "json" | "sqlite";
+  storage_type?: "json" | "jsonl" | "sqlite";
   /** Label for custom Claude directory source (e.g., "Personal") */
   custom_directory_label?: string;
 }
@@ -78,8 +78,8 @@ export interface ClaudeSession {
   relevance?: number;
   /** Provider identifier (claude, codex, opencode) */
   provider?: ProviderId;
-  /** Storage type (json, sqlite) — OpenCode only */
-  storage_type?: "json" | "sqlite";
+  /** Storage type (json, jsonl, sqlite) */
+  storage_type?: "json" | "jsonl" | "sqlite";
   /**
    * Originating client for Claude Code sessions: "cli" / "claude-vscode" /
    * "claude-desktop". Raw value from the JSONL `entrypoint` field. Undefined

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -55,7 +55,7 @@ export interface ClaudeProject {
   git_info?: GitInfo;
   /** Provider identifier (claude, codex, opencode) */
   provider?: ProviderId;
-  /** Storage type (json, sqlite) — OpenCode only */
+  /** Storage type (json, jsonl, sqlite) */
   storage_type?: "json" | "jsonl" | "sqlite";
   /** Label for custom Claude directory source (e.g., "Personal") */
   custom_directory_label?: string;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "antigravity", "claude", "cline", "codex", "cursor", "forgecode", "gemini", "opencode"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "antigravity", "claude", "cline", "codex", "cursor", "forgecode", "gemini", "kimi", "opencode"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -15,6 +15,7 @@ const PROVIDER_TRANSLATIONS: Record<
   cursor: { key: "common.provider.cursor", fallback: "Cursor" },
   forgecode: { key: "common.provider.forgecode", fallback: "ForgeCode" },
   gemini: { key: "common.provider.gemini", fallback: "Gemini CLI" },
+  kimi: { key: "common.provider.kimi", fallback: "Kimi CLI" },
   opencode: { key: "common.provider.opencode", fallback: "OpenCode" },
 };
 
@@ -85,6 +86,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  kimi: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: true,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   opencode: {
     supportsConversationBreakdown: false,
     supportsNativeRename: true,
@@ -114,6 +122,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "codex":
     case "cursor":
     case "gemini":
+    case "kimi":
     case "forgecode":
     case "opencode":
     case "claude":
@@ -204,6 +213,9 @@ export function getResumeCommand(
     case "forgecode":
       resume = `forge conversation resume ${sessionId}`;
       break;
+    case "kimi":
+      resume = `kimi -r ${sessionId}`;
+      break;
     default:
       resume = null;
   }
@@ -234,6 +246,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   cursor: "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",
   forgecode: "bg-orange-500/15 text-orange-700 dark:text-orange-300",
   gemini: "bg-purple-500/15 text-purple-600 dark:text-purple-400",
+  kimi: "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-300",
   opencode: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
   aider: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
   antigravity: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",


### PR DESCRIPTION
Rebase of #349 (@00010110) onto develop. Code is @00010110's; I resolved the provider-registration conflicts (Co-Authored-By preserved).

## What
Read-only **Kimi CLI** provider — `~/.kimi/sessions/<project>/<session>/` (context.jsonl + wire.jsonl + state.json). detect/scan/load/search, wired into multi_provider, stats, the watcher, the session-path allowlist, and the frontend registry. Defensive path handling, `think`→`thinking` / `tool_calls`→`tool_use` conversion, `kimi -r` resume.

## Conflict resolution (all mechanical "keep both" alongside #353 CodeBuddy / #397 Cursor Agent)
- `session/mod.rs`: allowlist `[PathBuf; 7]` → `vec!` + kimi push; merged the two `mod tests` into one unix-gated `#[cfg]`.
- `stats.rs`: kept both `is_codebuddy_path` and `is_kimi_path`.
- `providers.ts` + `types/core/session.ts`: unioned (kimi + codebuddy + cursor-agent); regenerated `i18n/types.generated.ts`.

## Verification
**616 Rust lib tests pass, clippy + fmt clean, tsc + vitest + i18n:validate clean** locally.

## ⚠️ Known follow-up (macOS)
3 watcher tests (`test_extract_kimi_*`) fail **on macOS only**: `TempDir` lives under `/var` (a symlink to `/private/var`) and `kimi::get_base_path()` canonicalizes while the watcher event path doesn't, so `strip_prefix` misses. They pass on the Linux rust-tests CI. The same gap means kimi **watcher auto-refresh may not fire on macOS** (manual refresh works) — worth a follow-up to canonicalize the event path consistently. Not a blocker for landing given CI is the gate, but flagging it.

Supersedes #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Kimi CLI provider integration for accessing projects and sessions
- Implemented real-time file monitoring for Kimi session updates
- Integrated search functionality across Kimi sessions and messages
- Support for JSONL storage format alongside existing formats
- Multi-language localization for Kimi provider across supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->