### PR TITLE
ci: gate the frontend (tsc/eslint/vitest/i18n) on PRs

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,63 @@
+name: Frontend Tests
+
+# Gates the React/TypeScript frontend on every PR/push that touches it.
+# `rust-tests.yml` only covers `src-tauri/**` (cargo fmt/clippy/test), and
+# `update-flow-tests.yml` runs vitest for just the 4 update-flow files, so the
+# rest of the ~860 frontend tests (plus tsc/eslint/i18n) were previously
+# ungated — a broad frontend regression could land on develop unnoticed.
+on:
+  push:
+    branches: [main, develop]
+    paths: &frontend_paths
+      - "src/**"
+      - "scripts/**"
+      - "index.html"
+      - "vite.config.ts"
+      - "tsconfig*.json"
+      - "eslint.config.js"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/frontend-tests.yml"
+  pull_request:
+    branches: [main, develop]
+    paths: *frontend_paths
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend Test Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        # No `version:` — `packageManager` in package.json is the source of truth
+        # (pinning here has historically conflicted with it).
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck (tsc)
+        run: pnpm tsc --build .
+
+      - name: Lint (eslint)
+        run: pnpm lint
+
+      - name: Unit tests (vitest)
+        run: pnpm -s vitest run
+
+      - name: i18n key validation
+        run: pnpm run i18n:validate


### PR DESCRIPTION
## Why
The frontend had effectively **no CI gate**:
- `rust-tests.yml` triggers on `src-tauri/**` only and runs cargo fmt/clippy/test.
- `update-flow-tests.yml` runs vitest, but only for 4 update-flow test files and only on update-flow paths.

So `tsc`, `eslint`, the full ~860-test vitest suite, and i18n key validation never ran on a general frontend PR. That's how the `providers.utils.test.ts` provider-id assertion went stale on develop during the #324 Kimi re-merge while CI stayed green (fixed separately in 3a51992).

## What
A new **Frontend Tests** workflow that runs on any `src/**`, `scripts/**`, or frontend-config change (and on the workflow file itself, so this PR self-tests):

1. `tsc --build .` (typecheck)
2. `eslint src` (lint)
3. `vitest run` (full unit suite)
4. `i18n:validate` (5-language key sync)

Mirrors the release-gate Phase 1 frontend checks, so regressions surface at PR time instead of at release time. develop currently passes all four, so this lands green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated frontend testing pipeline to ensure code quality through continuous type checking, linting, and unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->