### PR TITLE
fix(watcher): canonicalize event path before Kimi base-path match (macOS auto-refresh)

### DIFF
--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -352,7 +352,14 @@ fn extract_kimi_paths(path: &Path) -> Option<(String, String)> {
     let sessions_root = crate::providers::kimi::get_base_path()
         .map(PathBuf::from)
         .map(|base| base.join("sessions"))?;
-    let relative = path.strip_prefix(&sessions_root).ok()?;
+    // `get_base_path()` canonicalizes, but the watcher event path may not be
+    // (e.g. on macOS `/var` is a symlink to `/private/var`), so a raw
+    // `strip_prefix` would miss and the Kimi change event would be silently
+    // dropped — breaking watcher auto-refresh on macOS. Canonicalize the event
+    // path so both sides are like-for-like; fall back to the original path if it
+    // no longer exists (e.g. a delete event).
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let relative = canonical_path.strip_prefix(&sessions_root).ok()?;
     let parts: Vec<_> = relative.components().collect();
     if parts.len() != 3 {
         return None;
@@ -603,12 +610,18 @@ mod tests {
             result.0,
             format!(
                 "kimi://{}",
-                temp.path().join("sessions/project_hash").display()
+                temp.path()
+                    .canonicalize()
+                    .unwrap()
+                    .join("sessions/project_hash")
+                    .display()
             )
         );
         assert_eq!(
             result.1,
             temp.path()
+                .canonicalize()
+                .unwrap()
                 .join("sessions/project_hash/session_1")
                 .to_string_lossy()
         );
@@ -642,12 +655,18 @@ mod tests {
             result.0,
             format!(
                 "kimi://{}",
-                temp.path().join("sessions/project_hash").display()
+                temp.path()
+                    .canonicalize()
+                    .unwrap()
+                    .join("sessions/project_hash")
+                    .display()
             )
         );
         assert_eq!(
             result.1,
             temp.path()
+                .canonicalize()
+                .unwrap()
                 .join("sessions/project_hash/session_1")
                 .to_string_lossy()
         );
@@ -682,12 +701,18 @@ mod tests {
             result.0,
             format!(
                 "kimi://{}",
-                temp.path().join("sessions/project_hash").display()
+                temp.path()
+                    .canonicalize()
+                    .unwrap()
+                    .join("sessions/project_hash")
+                    .display()
             )
         );
         assert_eq!(
             result.1,
             temp.path()
+                .canonicalize()
+                .unwrap()
                 .join("sessions/project_hash/session_1")
                 .to_string_lossy()
         );


### PR DESCRIPTION
## Problem
`extract_kimi_paths` strips the watcher event path against `kimi::get_base_path()`, which **canonicalizes**. On macOS `/var` is a symlink to `/private/var`, so for a Kimi session under `$KIMI_HOME` (or any `/var`-rooted dir) the two sides resolve differently and `strip_prefix` misses:

- **Real bug:** the Kimi file-change event is silently dropped → **watcher auto-refresh never fires for Kimi sessions on macOS** (manual refresh still works).
- **Test symptom:** `test_extract_kimi_{context,state}_paths` and `test_extract_kimi_paths_from_custom_home` panic on `unwrap()` of `None` — but **only on macOS**. They passed on Linux CI because `/tmp` isn't a symlink, which is exactly why this slipped through (CI is Linux-only for the Rust suite).

The `load_sessions` side already emits canonicalized paths (`file_path` / `kimi://…` are built from the canonicalized base), so the watcher must emit the same form for the frontend to match.

## Fix
Canonicalize the event path before `strip_prefix` so both sides are like-for-like, falling back to the original path for delete events where the file is already gone. The emitted `kimi://` project/session paths stay canonical (unchanged), matching `load_sessions`. The three `test_extract_kimi_*` expectations are updated to the canonicalized form they were always meant to assert (a no-op on Linux, correct on macOS).

## Verification (local, macOS)
`cargo test --all-features -- --test-threads=1` → **675 lib pass** (was 672 + 3 failing) · `cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file watcher reliability to consistently detect session changes, particularly on systems with alternative file path configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->