### PR TITLE
fix(session): fall back to permanent delete when system trash is unavailable (#256)

### DIFF
--- a/src-tauri/src/commands/session/delete.rs
+++ b/src-tauri/src/commands/session/delete.rs
@@ -2,11 +2,34 @@ use std::fs;
 use std::path::Path;
 use tauri::command;
 
+/// Removes a file or directory: tries the system trash first, falls back to permanent deletion.
+///
+/// `trash::delete` can fail on Windows when the Recycle Bin is disabled, on network drives,
+/// or when the file is locked. In those cases we permanently delete rather than surfacing an
+/// opaque "delete session failed" to the user (issue #256).
+fn remove_path(path: &Path) -> Result<(), String> {
+    if let Err(trash_err) = trash::delete(path) {
+        if path.is_dir() {
+            fs::remove_dir_all(path).map_err(|e| {
+                format!("Trash failed: {trash_err}; permanent delete also failed: {e}")
+            })?;
+        } else {
+            fs::remove_file(path).map_err(|e| {
+                format!("Trash failed: {trash_err}; permanent delete also failed: {e}")
+            })?;
+        }
+    }
+    Ok(())
+}
+
 /// Moves a session's JSONL file and its associated folder (subagents, tool-results) to the system trash.
 ///
 /// For a session at `<dir>/<uuid>.jsonl`, also trashes `<dir>/<uuid>/` if it exists.
 /// Validates that the target is an absolute, plain `.jsonl` file (not a symlink) with a
 /// well-formed session ID before moving anything.
+///
+/// If the system trash is unavailable (e.g. a disabled Recycle Bin on Windows), falls back
+/// to permanent deletion so the operation does not fail outright.
 #[command]
 pub async fn delete_session(file_path: String) -> Result<(), String> {
     if file_path.starts_with("forgecode://") || file_path.starts_with("forgecode-db://") {
@@ -55,15 +78,16 @@ pub async fn delete_session(file_path: String) -> Result<(), String> {
         }
     }
 
-    // Trash the .jsonl first (authoritative artifact), then the associated folder
-    trash::delete(path).map_err(|e| format!("Failed to move session file to trash: {e}"))?;
+    // Delete the .jsonl first (authoritative artifact), then the associated folder.
+    // Tries the system trash first, falls back to permanent deletion on failure.
+    remove_path(path).map_err(|e| format!("Failed to delete session file: {e}"))?;
 
-    // Best-effort trash of associated folder — don't fail if it can't be trashed
+    // Best-effort removal of associated folder — don't fail if it can't be removed
     // since the primary .jsonl file is already gone
     let associated_dir = path.with_extension("");
     if let Ok(dir_meta) = fs::symlink_metadata(&associated_dir) {
         if !dir_meta.file_type().is_symlink() && dir_meta.is_dir() {
-            let _ = trash::delete(&associated_dir);
+            let _ = remove_path(&associated_dir);
         }
     }
 
@@ -156,5 +180,26 @@ mod tests {
         delete_session(file.to_string_lossy().into()).await.unwrap();
         assert!(!file.exists());
         assert!(!assoc_dir.exists());
+    }
+
+    #[test]
+    fn remove_path_deletes_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "data").unwrap();
+
+        remove_path(&file).unwrap();
+        assert!(!file.exists());
+    }
+
+    #[test]
+    fn remove_path_deletes_directory() {
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("subdir");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("child.txt"), "data").unwrap();
+
+        remove_path(&sub).unwrap();
+        assert!(!sub.exists());
     }
 }

--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -102,7 +102,7 @@
   "session.copyFilePath": "Copy File Path",
   "session.showJsonlFile": "Show JSONL File",
   "session.revealError": "Could not reveal file",
-  "session.deleteConfirm": "This will move the session file and all associated data (subagents, tool results) to the trash.",
+  "session.deleteConfirm": "This will delete the session file and all associated data (subagents, tool results). The file is moved to the trash when possible, otherwise it is permanently deleted.",
   "session.deleteError": "Failed to delete session",
   "session.selectError": "Failed to open session",
   "session.deleteSession": "Delete Session",

--- a/src/i18n/locales/ja/session.json
+++ b/src/i18n/locales/ja/session.json
@@ -102,7 +102,7 @@
   "session.copyFilePath": "ファイルパスをコピー",
   "session.showJsonlFile": "JSONLファイルを表示",
   "session.revealError": "ファイルを表示できませんでした",
-  "session.deleteConfirm": "セッションファイルと関連するすべてのデータ（サブエージェント、ツール結果）がゴミ箱に移動されます。",
+  "session.deleteConfirm": "セッションファイルと関連するすべてのデータ（サブエージェント、ツール結果）が削除されます。可能な場合はゴミ箱に移動し、それ以外は完全に削除されます。",
   "session.deleteError": "セッションの削除に失敗しました",
   "session.selectError": "セッションを開けませんでした",
   "session.deleteSession": "セッションを削除",

--- a/src/i18n/locales/ko/session.json
+++ b/src/i18n/locales/ko/session.json
@@ -102,7 +102,7 @@
   "session.copyFilePath": "파일 경로 복사",
   "session.showJsonlFile": "JSONL 파일 보기",
   "session.revealError": "파일을 열 수 없습니다",
-  "session.deleteConfirm": "세션 파일과 관련된 모든 데이터(서브에이전트, 도구 결과)가 휴지통으로 이동됩니다.",
+  "session.deleteConfirm": "세션 파일과 관련된 모든 데이터(서브에이전트, 도구 결과)가 삭제됩니다. 가능하면 휴지통으로 이동되며, 그렇지 않으면 영구 삭제됩니다.",
   "session.deleteError": "세션 삭제에 실패했습니다",
   "session.selectError": "세션을 열 수 없습니다",
   "session.deleteSession": "세션 삭제",

--- a/src/i18n/locales/zh-CN/session.json
+++ b/src/i18n/locales/zh-CN/session.json
@@ -102,7 +102,7 @@
   "session.copyFilePath": "复制文件路径",
   "session.showJsonlFile": "显示 JSONL 文件",
   "session.revealError": "无法显示文件",
-  "session.deleteConfirm": "这将把会话文件及所有相关数据（子代理、工具结果）移至回收站。",
+  "session.deleteConfirm": "这将删除会话文件及所有相关数据（子代理、工具结果）。如果可能，文件将移至回收站，否则将永久删除。",
   "session.deleteError": "删除会话失败",
   "session.selectError": "打开会话失败",
   "session.deleteSession": "删除会话",

--- a/src/i18n/locales/zh-TW/session.json
+++ b/src/i18n/locales/zh-TW/session.json
@@ -102,7 +102,7 @@
   "session.copyFilePath": "複製檔案路徑",
   "session.showJsonlFile": "顯示 JSONL 檔案",
   "session.revealError": "無法顯示檔案",
-  "session.deleteConfirm": "這將把會話檔案及所有相關資料（子代理、工具結果）移至垃圾桶。",
+  "session.deleteConfirm": "這將刪除會話檔案及所有相關資料（子代理、工具結果）。如果可能，檔案將移至垃圾桶，否則將永久刪除。",
   "session.deleteError": "刪除會話失敗",
   "session.selectError": "開啟會話失敗",
   "session.deleteSession": "刪除會話",


### PR DESCRIPTION
## Summary

Fixes #256 — session deletion fails on Windows with an opaque "delete session failed" when the Recycle Bin is disabled (also affects network drives and locked files).

`delete_session` called `trash::delete` directly, with no recovery path when the OS trash is unavailable. This adds a `remove_path` helper that:
1. tries the system trash first (unchanged default behavior), and
2. falls back to `fs::remove_file` / `fs::remove_dir_all` on failure, with a combined error message if both fail.

Applied to both the `.jsonl` file and its associated `<uuid>/` folder. The confirmation copy in all 5 locales now notes deletion may be permanent.

### Scope note
The **error-surfacing** half of #256 already shipped on `develop` (the delete toast shows the real backend error via its `description`). This PR adds only the missing **functional fallback**. It deliberately threads the helper into the *current* `delete.rs` rather than cherry-picking the old `ab63a30`, so the ForgeCode dispatch guard and the Codex `state_5.sqlite` cleanup that landed since are preserved.

## Testing
- `cargo test commands::session::delete -- --test-threads=1` → 10/10 pass (2 new: `remove_path_deletes_file`, `remove_path_deletes_directory`)
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --check`, `pnpm tsc --build`, `pnpm run i18n:validate` → all green

> Note: the trash→permanent fallback path is only exercised when the OS trash is genuinely unavailable, which can't be reproduced on the macOS CI/dev box. The Windows reporters (@Skyerhw, @Leeiio, @yeafel666) would confirm against a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session deletion reliability with graceful fallback to permanent deletion when trash removal fails.

* **Localization**
  * Updated deletion confirmation messages in English, Japanese, Korean, and Chinese (Simplified & Traditional) to accurately reflect the new deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->