### PR TITLE
feat(providers): add Amazon Q Developer CLI provider

### DIFF
--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -46,6 +46,7 @@ pub async fn scan_all_projects(
             "cursor".to_string(),
             "cursor-agent".to_string(),
             "aider".to_string(),
+            "amazonq".to_string(),
             "antigravity".to_string(),
             "codebuddy".to_string(),
             "kiro".to_string(),
@@ -226,6 +227,16 @@ pub async fn scan_all_projects(
             Ok(projects) => all_projects.extend(projects),
             Err(e) => {
                 log::warn!("Aider scan failed: {e}");
+            }
+        }
+    }
+
+    // Amazon Q Developer CLI — amazon-q/data.sqlite3 (conversations table)
+    if providers_to_scan.iter().any(|p| p == "amazonq") {
+        match providers::amazon_q::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("Amazon Q scan failed: {e}");
             }
         }
     }
@@ -436,6 +447,7 @@ pub async fn load_provider_sessions(
         "cursor" => providers::cursor::load_sessions(&project_path, exclude),
         "cursor-agent" => providers::cursor_agent::load_sessions(&project_path, exclude),
         "aider" => providers::aider::load_sessions(&project_path, exclude),
+        "amazonq" => providers::amazon_q::load_sessions(&project_path, exclude),
         "antigravity" => providers::antigravity::load_sessions(&project_path, exclude),
         "codebuddy" => providers::codebuddy::load_sessions(&project_path, exclude),
         "kiro" => providers::kiro::load_sessions(&project_path, exclude),
@@ -475,6 +487,7 @@ pub async fn load_provider_messages(
         "cursor" => providers::cursor::load_messages(&session_path)?,
         "cursor-agent" => providers::cursor_agent::load_messages(&session_path)?,
         "aider" => providers::aider::load_messages(&session_path)?,
+        "amazonq" => providers::amazon_q::load_messages(&session_path)?,
         "antigravity" => providers::antigravity::load_messages(&session_path)?,
         "codebuddy" => providers::codebuddy::load_messages(&session_path)?,
         "kiro" => providers::kiro::load_messages(&session_path)?,
@@ -520,6 +533,7 @@ pub async fn search_all_providers(
             "cursor".to_string(),
             "cursor-agent".to_string(),
             "aider".to_string(),
+            "amazonq".to_string(),
             "antigravity".to_string(),
             "codebuddy".to_string(),
             "kiro".to_string(),
@@ -712,6 +726,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Aider search failed: {e}");
+            }
+        }
+    }
+
+    // Amazon Q Developer CLI
+    if providers_to_search.iter().any(|p| p == "amazonq") {
+        match providers::amazon_q::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Amazon Q search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -68,6 +68,9 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(llm_base) = crate::providers::llm::get_base_path() {
         allowed.push(PathBuf::from(llm_base));
     }
+    if let Some(amazon_q_base) = crate::providers::amazon_q::get_base_path() {
+        allowed.push(PathBuf::from(amazon_q_base));
+    }
 
     // Canonicalize each allowlist entry so the comparison below is like-for-like
     // with the canonicalized candidate. Without this, a symlinked provider root

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1088,6 +1088,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(amazon_q_base) = providers::amazon_q::get_base_path() {
+        let amazon_q_dir = PathBuf::from(amazon_q_base);
+        if amazon_q_dir.is_dir() {
+            paths.push(amazon_q_dir);
+        }
+    }
+
     if let Some(copilot_base) = providers::copilot_cli::get_base_path() {
         let session_state = PathBuf::from(copilot_base).join("session-state");
         if session_state.is_dir() {

--- a/src-tauri/src/providers/amazon_q.rs
+++ b/src-tauri/src/providers/amazon_q.rs
@@ -10,7 +10,7 @@
 
 use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
 use crate::providers::{q_conversation, ProviderInfo};
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
 use std::path::{Path, PathBuf};
 
 const PROVIDER: &str = "amazonq";
@@ -130,13 +130,16 @@ pub fn load_sessions(
     let key = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
     let conn = open_db()?;
 
+    // .optional(): "no row" -> Ok(None) (stale project path -> empty), but a real
+    // DB error propagates instead of being silently swallowed as an empty list.
     let value: Option<String> = conn
         .query_row(
             "SELECT value FROM conversations WHERE key = ?1",
             [key],
             |r| r.get(0),
         )
-        .ok();
+        .optional()
+        .map_err(|e| format!("Failed to load Amazon Q conversation: {e}"))?;
     let Some(value) = value else {
         return Ok(vec![]);
     };

--- a/src-tauri/src/providers/amazon_q.rs
+++ b/src-tauri/src/providers/amazon_q.rs
@@ -1,0 +1,336 @@
+//! Amazon Q Developer CLI provider (`q chat`).
+//!
+//! Reads `dirs::data_local_dir()/amazon-q/data.sqlite3`, table
+//! `conversations (key TEXT PRIMARY KEY, value TEXT)` where `key` is the working
+//! directory and `value` is a serialized `ConversationState` — i.e. exactly ONE
+//! conversation per cwd (the `q chat --resume` state). This is the v1 schema;
+//! the rebranded Kiro CLI uses a richer `conversations_v2` table handled by the
+//! [`super::kiro`] provider. Both share the same `value` shape, so message
+//! conversion is delegated to [`super::q_conversation`].
+
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::providers::{q_conversation, ProviderInfo};
+use rusqlite::{Connection, OpenFlags};
+use std::path::{Path, PathBuf};
+
+const PROVIDER: &str = "amazonq";
+const SCHEME: &str = "amazonq://";
+const SUMMARY_MAX_CHARS: usize = 100;
+
+fn get_db_path() -> Option<PathBuf> {
+    Some(
+        dirs::data_local_dir()?
+            .join("amazon-q")
+            .join("data.sqlite3"),
+    )
+}
+
+/// Detect an Amazon Q CLI installation.
+pub fn detect() -> Option<ProviderInfo> {
+    let db = get_db_path()?;
+    Some(ProviderInfo {
+        id: PROVIDER.to_string(),
+        display_name: "Amazon Q CLI".to_string(),
+        base_path: db
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+        is_available: db.is_file(),
+    })
+}
+
+/// Base path (the `amazon-q` dir holding `data.sqlite3`), for the file watcher.
+pub fn get_base_path() -> Option<String> {
+    get_db_path()?
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+}
+
+fn open_db() -> Result<Connection, String> {
+    let path = get_db_path().ok_or("Amazon Q CLI not found")?;
+    if !path.is_file() {
+        return Err("Amazon Q CLI database not found".to_string());
+    }
+    let conn = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Amazon Q DB: {e}"))?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(|e| format!("Failed to set busy timeout: {e}"))?;
+    Ok(conn)
+}
+
+/// `data.sqlite3` mtime as an RFC3339 string, for conversations that carry no
+/// in-history timestamps.
+fn db_mtime_iso() -> String {
+    get_db_path()
+        .and_then(|p| std::fs::metadata(p).ok())
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+        .map(|d| ms_to_iso_secs(d.as_secs()))
+        .unwrap_or_default()
+}
+
+#[allow(clippy::cast_possible_wrap)]
+fn ms_to_iso_secs(secs: u64) -> String {
+    use chrono::{DateTime, Utc};
+    DateTime::from_timestamp(secs as i64, 0)
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339()
+}
+
+/// Scan Amazon Q projects — one per `conversations.key` (cwd).
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let conn = open_db()?;
+    let fallback = db_mtime_iso();
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM conversations")
+        .map_err(|e| e.to_string())?;
+
+    let projects = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .filter_map(|(key, value)| {
+            let msg_count = q_conversation::message_count(&value);
+            if msg_count == 0 {
+                return None;
+            }
+            let (_, last) = q_conversation::history_time_bounds(&value);
+            let name = Path::new(&key)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| key.clone());
+            Some(ClaudeProject {
+                name,
+                path: format!("{SCHEME}{key}"),
+                actual_path: key,
+                session_count: 1,
+                message_count: msg_count,
+                last_modified: last.unwrap_or_else(|| fallback.clone()),
+                git_info: None,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: Some("sqlite".to_string()),
+                custom_directory_label: None,
+            })
+        })
+        .collect();
+
+    Ok(projects)
+}
+
+/// Load the (single) session for one Amazon Q project (`amazonq://<cwd>`).
+pub fn load_sessions(
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let key = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
+    let conn = open_db()?;
+
+    let value: Option<String> = conn
+        .query_row(
+            "SELECT value FROM conversations WHERE key = ?1",
+            [key],
+            |r| r.get(0),
+        )
+        .ok();
+    let Some(value) = value else {
+        return Ok(vec![]);
+    };
+    let msg_count = q_conversation::message_count(&value);
+    if msg_count == 0 {
+        return Ok(vec![]);
+    }
+
+    let project_name = Path::new(key)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let (first, last) = q_conversation::history_time_bounds(&value);
+    let fallback = db_mtime_iso();
+    let first = first.unwrap_or_else(|| fallback.clone());
+    let last = last.unwrap_or(fallback);
+    let summary = q_conversation::first_prompt_summary(&value, SUMMARY_MAX_CHARS);
+
+    Ok(vec![ClaudeSession {
+        // One conversation per cwd → the session is addressed by the cwd key.
+        session_id: format!("{SCHEME}{key}"),
+        actual_session_id: key.to_string(),
+        file_path: format!("{SCHEME}{key}"),
+        project_name,
+        message_count: msg_count,
+        first_message_time: first,
+        last_message_time: last.clone(),
+        last_modified: last,
+        has_tool_use: false,
+        has_errors: false,
+        summary,
+        is_renamed: false,
+        provider: Some(PROVIDER.to_string()),
+        storage_type: Some("sqlite".to_string()),
+        entrypoint: None,
+    }])
+}
+
+/// Load messages for one Amazon Q conversation (`amazonq://<cwd>`).
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let key = session_path.strip_prefix(SCHEME).unwrap_or(session_path);
+    let conn = open_db()?;
+    let value: String = conn
+        .query_row(
+            "SELECT value FROM conversations WHERE key = ?1",
+            [key],
+            |r| r.get(0),
+        )
+        .map_err(|e| format!("Conversation not found: {e}"))?;
+    Ok(q_conversation::parse_history(PROVIDER, &value, key))
+}
+
+/// Search across all Amazon Q conversations.
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    if query.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+    let conn = open_db()?;
+    let pattern = format!("%{query}%");
+    let query_lower = query.to_lowercase();
+
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM conversations WHERE value LIKE ?1")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([&pattern], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut results = Vec::new();
+    for (key, value) in rows.flatten() {
+        let project_name = Path::new(&key)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        for mut msg in q_conversation::parse_history(PROVIDER, &value, &key) {
+            let matched = msg
+                .content
+                .as_ref()
+                .map(|c| crate::utils::search_json_value_case_insensitive(c, &query_lower))
+                .unwrap_or(false);
+            if !matched {
+                continue;
+            }
+            msg.project_name = Some(project_name.clone());
+            results.push(msg);
+            if results.len() >= limit {
+                return Ok(results);
+            }
+        }
+    }
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE conversations (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        let value = serde_json::json!({
+            "history": [
+                {
+                    "user": {"content": {"Prompt": {"prompt": "why does LOGIN fail?"}}, "timestamp": "2026-06-20T10:00:00Z"},
+                    "assistant": {"Response": {"message_id": "a1", "content": "Checking auth"}}
+                },
+                {
+                    "user": {"content": {"ToolUseResults": {"tool_use_results": [{"tool_use_id": "t1", "content": [{"Text": "ok"}]}]}}, "timestamp": "2026-06-20T10:01:00Z"},
+                    "assistant": {"ToolUse": {"message_id": "a2", "content": "running", "tool_uses": [{"id": "t1", "name": "execute_bash", "args": {"command": "ls"}}]}}
+                }
+            ]
+        })
+        .to_string();
+        conn.execute(
+            "INSERT INTO conversations VALUES ('/Users/jack/proj', ?1)",
+            [value],
+        )
+        .unwrap();
+        // An empty conversation (no history) must be skipped by scan/load.
+        conn.execute(
+            "INSERT INTO conversations VALUES ('/Users/jack/empty', '{\"history\":[]}')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    // The DB-backed public fns resolve the real ~/.../amazon-q path, so the
+    // tests drive the SQL inline against an in-memory DB to stay isolated.
+    fn scan_rows(conn: &Connection) -> Vec<(String, String)> {
+        let mut stmt = conn
+            .prepare("SELECT key, value FROM conversations")
+            .unwrap();
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .flatten()
+            .collect()
+    }
+
+    #[test]
+    fn parse_history_maps_amazon_q_conversation() {
+        let conn = fixture_db();
+        let (_, value) = scan_rows(&conn)
+            .into_iter()
+            .find(|(k, _)| k == "/Users/jack/proj")
+            .unwrap();
+        let msgs = q_conversation::parse_history(PROVIDER, &value, "/Users/jack/proj");
+        // 2 user + 2 assistant.
+        assert_eq!(msgs.len(), 4);
+        assert_eq!(msgs[0].role.as_deref(), Some("user"));
+        assert_eq!(msgs[0].provider.as_deref(), Some("amazonq"));
+        // tool_use mapped through map_tool_name.
+        let tu = msgs[3].content.as_ref().unwrap().as_array().unwrap();
+        assert!(tu
+            .iter()
+            .any(|b| b["type"] == "tool_use" && b["name"] == "Bash"));
+    }
+
+    #[test]
+    fn project_metadata_skips_empty_and_counts() {
+        let conn = fixture_db();
+        let rows = scan_rows(&conn);
+        let non_empty: Vec<_> = rows
+            .iter()
+            .filter(|(_, v)| q_conversation::message_count(v) > 0)
+            .collect();
+        assert_eq!(non_empty.len(), 1, "empty conversation is skipped");
+        let (key, value) = non_empty[0];
+        assert_eq!(key, "/Users/jack/proj");
+        assert_eq!(q_conversation::message_count(value), 4);
+        let (first, last) = q_conversation::history_time_bounds(value);
+        assert_eq!(first.as_deref(), Some("2026-06-20T10:00:00Z"));
+        assert_eq!(last.as_deref(), Some("2026-06-20T10:01:00Z"));
+        assert_eq!(
+            q_conversation::first_prompt_summary(value, SUMMARY_MAX_CHARS).as_deref(),
+            Some("why does LOGIN fail?")
+        );
+    }
+
+    #[test]
+    fn db_path_uses_amazon_q_under_data_local_dir() {
+        // Sanity: path ends with the expected segments (don't assert the root,
+        // which is host-specific).
+        if let Some(p) = get_db_path() {
+            let s = p.to_string_lossy();
+            assert!(s.ends_with("amazon-q/data.sqlite3") || s.ends_with("amazon-q\\data.sqlite3"));
+        }
+    }
+}

--- a/src-tauri/src/providers/kiro.rs
+++ b/src-tauri/src/providers/kiro.rs
@@ -1,6 +1,7 @@
 use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::providers::q_conversation;
 use crate::providers::ProviderInfo;
-use crate::utils::{build_provider_message, ms_to_iso, search_json_value_case_insensitive};
+use crate::utils::{ms_to_iso, search_json_value_case_insensitive};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -19,18 +20,14 @@ pub fn detect() -> Option<ProviderInfo> {
 }
 
 fn get_db_path() -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-
-    #[cfg(target_os = "macos")]
-    let path = home.join("Library/Application Support/kiro-cli/data.sqlite3");
-
-    #[cfg(target_os = "linux")]
-    let path = home.join(".local/share/kiro-cli/data.sqlite3");
-
-    #[cfg(target_os = "windows")]
-    let path = home.join("AppData/Roaming/kiro-cli/data.sqlite3");
-
-    Some(path)
+    // data_local_dir(): macOS ~/Library/Application Support, Linux ~/.local/share,
+    // Windows %LOCALAPPDATA% — matches upstream kiro-cli (dirs::data_local_dir).
+    // (Previously hardcoded Windows to AppData/Roaming, which was wrong.)
+    Some(
+        dirs::data_local_dir()?
+            .join("kiro-cli")
+            .join("data.sqlite3"),
+    )
 }
 
 fn open_db() -> Result<Connection, String> {
@@ -173,30 +170,7 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
         )
         .map_err(|e| format!("Conversation not found: {e}"))?;
 
-    let json: Value = serde_json::from_str(&value).map_err(|e| e.to_string())?;
-    let history = json
-        .get("history")
-        .and_then(Value::as_array)
-        .ok_or("No history found")?;
-
-    let mut messages = Vec::new();
-
-    for (i, entry) in history.iter().enumerate() {
-        // User message
-        if let Some(user) = entry.get("user") {
-            if let Some(msg) = convert_user_message(user, conv_id, i) {
-                messages.push(msg);
-            }
-        }
-        // Assistant message
-        if let Some(assistant) = entry.get("assistant") {
-            if let Some(msg) = convert_assistant_message(assistant, conv_id, i) {
-                messages.push(msg);
-            }
-        }
-    }
-
-    Ok(messages)
+    Ok(q_conversation::parse_history(PROVIDER, &value, conv_id))
 }
 
 /// Search across all Kiro conversations
@@ -240,7 +214,9 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
                 return Ok(results);
             }
             if let Some(user) = entry.get("user") {
-                if let Some(mut msg) = convert_user_message(user, &conv_id, i) {
+                if let Some(mut msg) =
+                    q_conversation::convert_user_message(PROVIDER, user, &conv_id, i)
+                {
                     if let Some(ref c) = msg.content {
                         if search_json_value_case_insensitive(c, &query_lower) {
                             msg.project_name = Some("Kiro CLI".to_string());
@@ -253,7 +229,9 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
                 return Ok(results);
             }
             if let Some(assistant) = entry.get("assistant") {
-                if let Some(mut msg) = convert_assistant_message(assistant, &conv_id, i) {
+                if let Some(mut msg) =
+                    q_conversation::convert_assistant_message(PROVIDER, assistant, &conv_id, i)
+                {
                     if let Some(ref c) = msg.content {
                         if search_json_value_case_insensitive(c, &query_lower) {
                             msg.project_name = Some("Kiro CLI".to_string());
@@ -266,207 +244,4 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
     }
 
     Ok(results)
-}
-
-// ============================================================================
-// Private helpers
-// ============================================================================
-
-fn convert_user_message(user: &Value, session_id: &str, idx: usize) -> Option<ClaudeMessage> {
-    let timestamp = user
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-
-    let content_obj = user.get("content")?;
-    let mut blocks: Vec<Value> = Vec::new();
-
-    if let Some(prompt) = content_obj.get("Prompt") {
-        let text = prompt.get("prompt").and_then(Value::as_str).unwrap_or("");
-        if !text.is_empty() {
-            blocks.push(serde_json::json!({"type": "text", "text": text}));
-        }
-    } else if let Some(tool_results) = content_obj.get("ToolUseResults") {
-        if let Some(results) = tool_results
-            .get("tool_use_results")
-            .and_then(Value::as_array)
-        {
-            for tr in results {
-                let tool_use_id = tr.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
-                let content_arr = tr.get("content").and_then(Value::as_array);
-                let text = content_arr
-                    .and_then(|arr| arr.first())
-                    .and_then(|c| c.get("Text").and_then(Value::as_str))
-                    .unwrap_or("");
-                blocks.push(serde_json::json!({
-                    "type": "tool_result",
-                    "tool_use_id": tool_use_id,
-                    "content": text
-                }));
-            }
-        }
-    }
-
-    if blocks.is_empty() {
-        return None;
-    }
-
-    Some(build_provider_message(
-        PROVIDER,
-        format!("{session_id}-user-{idx}"),
-        session_id,
-        timestamp,
-        "user",
-        Some("user"),
-        Some(Value::Array(blocks)),
-        None,
-    ))
-}
-
-fn convert_assistant_message(
-    assistant: &Value,
-    session_id: &str,
-    idx: usize,
-) -> Option<ClaudeMessage> {
-    let mut blocks: Vec<Value> = Vec::new();
-
-    if let Some(response) = assistant.get("Response") {
-        let text = response
-            .get("content")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        if !text.is_empty() {
-            blocks.push(serde_json::json!({"type": "text", "text": text}));
-        }
-    } else if let Some(tool_use) = assistant.get("ToolUse") {
-        let text = tool_use
-            .get("content")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        if !text.is_empty() {
-            blocks.push(serde_json::json!({"type": "text", "text": text}));
-        }
-        if let Some(tools) = tool_use.get("tool_uses").and_then(Value::as_array) {
-            for tool in tools {
-                let id = tool.get("id").and_then(Value::as_str).unwrap_or("");
-                let name = tool
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .unwrap_or("unknown");
-                let args = tool
-                    .get("args")
-                    .cloned()
-                    .unwrap_or(Value::Object(serde_json::Map::default()));
-                blocks.push(serde_json::json!({
-                    "type": "tool_use",
-                    "id": id,
-                    "name": map_tool_name(name),
-                    "input": args
-                }));
-            }
-        }
-    }
-
-    if blocks.is_empty() {
-        return None;
-    }
-
-    let msg_id = assistant
-        .get("Response")
-        .or_else(|| assistant.get("ToolUse"))
-        .and_then(|v| v.get("message_id"))
-        .and_then(Value::as_str)
-        .unwrap_or("");
-
-    Some(build_provider_message(
-        PROVIDER,
-        if msg_id.is_empty() {
-            format!("{session_id}-asst-{idx}")
-        } else {
-            msg_id.to_string()
-        },
-        session_id,
-        String::new(),
-        "assistant",
-        Some("assistant"),
-        Some(Value::Array(blocks)),
-        None,
-    ))
-}
-
-fn map_tool_name(name: &str) -> &str {
-    match name {
-        "execute_bash" => "Bash",
-        "read_file" | "file_read" => "Read",
-        "write_file" | "file_write" | "create_file" => "Write",
-        "list_directory" => "Glob",
-        "search_files" | "grep" => "Grep",
-        "web_search" => "WebSearch",
-        "web_fetch" => "WebFetch",
-        _ => name,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_convert_user_prompt() {
-        let user = json!({
-            "content": {"Prompt": {"prompt": "hello world"}},
-            "timestamp": "2025-10-08T10:50:49.220865-07:00"
-        });
-        let msg = convert_user_message(&user, "sess-1", 0).unwrap();
-        assert_eq!(msg.message_type, "user");
-        assert_eq!(msg.provider, Some("kiro".to_string()));
-    }
-
-    #[test]
-    fn test_convert_assistant_response() {
-        let asst = json!({"Response": {"message_id": "abc", "content": "Hello!"}});
-        let msg = convert_assistant_message(&asst, "sess-1", 0).unwrap();
-        assert_eq!(msg.message_type, "assistant");
-        let arr = msg.content.unwrap();
-        assert_eq!(arr[0]["text"], "Hello!");
-    }
-
-    #[test]
-    fn test_convert_assistant_tool_use() {
-        let asst = json!({
-            "ToolUse": {
-                "message_id": "xyz",
-                "content": "Let me run that",
-                "tool_uses": [{"id": "t1", "name": "execute_bash", "args": {"command": "ls"}, "orig_name": "", "orig_args": {}}]
-            }
-        });
-        let msg = convert_assistant_message(&asst, "sess-1", 1).unwrap();
-        let arr = msg.content.unwrap().as_array().unwrap().clone();
-        assert_eq!(arr[0]["type"], "text");
-        assert_eq!(arr[1]["type"], "tool_use");
-        assert_eq!(arr[1]["name"], "Bash");
-    }
-
-    #[test]
-    fn test_convert_user_tool_results() {
-        let user = json!({
-            "content": {"ToolUseResults": {"tool_use_results": [
-                {"tool_use_id": "t1", "content": [{"Text": "output here"}]}
-            ]}},
-            "timestamp": "2025-10-08T10:51:00-07:00"
-        });
-        let msg = convert_user_message(&user, "sess-1", 1).unwrap();
-        let arr = msg.content.unwrap().as_array().unwrap().clone();
-        assert_eq!(arr[0]["type"], "tool_result");
-        assert_eq!(arr[0]["tool_use_id"], "t1");
-    }
-
-    #[test]
-    fn test_map_tool_names() {
-        assert_eq!(map_tool_name("execute_bash"), "Bash");
-        assert_eq!(map_tool_name("read_file"), "Read");
-        assert_eq!(map_tool_name("unknown_thing"), "unknown_thing");
-    }
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod aider;
+pub mod amazon_q;
 pub mod antigravity;
 pub mod claude;
 pub mod cline;
@@ -20,6 +21,8 @@ pub mod kiro;
 pub mod llm;
 pub mod opencode;
 pub mod pearai;
+/// Shared `ConversationState` parsing for the Amazon Q CLI lineage (amazon_q + kiro).
+pub mod q_conversation;
 pub mod vscode;
 
 /// Provider identifier
@@ -27,6 +30,8 @@ pub mod vscode;
 #[serde(rename_all = "lowercase")]
 pub enum ProviderId {
     Aider,
+    /// Amazon Q Developer CLI (`amazon-q/data.sqlite3`).
+    AmazonQ,
     Claude,
     Cline,
     Codebuddy,
@@ -60,6 +65,7 @@ impl ProviderId {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Aider => "aider",
+            Self::AmazonQ => "amazonq",
             Self::Claude => "claude",
             Self::Cline => "cline",
             Self::Codebuddy => "codebuddy",
@@ -84,6 +90,7 @@ impl ProviderId {
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "aider" => Some(Self::Aider),
+            "amazonq" => Some(Self::AmazonQ),
             "claude" => Some(Self::Claude),
             "cline" => Some(Self::Cline),
             "codebuddy" => Some(Self::Codebuddy),
@@ -109,6 +116,7 @@ impl ProviderId {
     pub fn display_name(&self) -> &'static str {
         match self {
             Self::Aider => "Aider",
+            Self::AmazonQ => "Amazon Q CLI",
             Self::Claude => "Claude Code",
             Self::Cline => "Cline",
             Self::Codebuddy => "CodeBuddy Code",
@@ -184,6 +192,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = aider::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = amazon_q::detect() {
         providers.push(info);
     }
     if let Some(info) = antigravity::detect() {

--- a/src-tauri/src/providers/q_conversation.rs
+++ b/src-tauri/src/providers/q_conversation.rs
@@ -1,0 +1,356 @@
+//! Shared `ConversationState` → message conversion for the Amazon Q CLI lineage.
+//!
+//! Amazon Q CLI (`amazon-q/data.sqlite3`, table `conversations`) and its
+//! rebrand Kiro CLI (`kiro-cli/data.sqlite3`, table `conversations_v2`) store
+//! the **same** serialized `ConversationState` in their `value` column — only
+//! the surrounding table/row layout differs. This module owns the value→message
+//! conversion both providers share; it's parameterized by `provider` so each
+//! tags its own id.
+//!
+//! `value` JSON: `{ "history": [ { "user": {...}, "assistant": {...} }, ... ] }`
+//! with externally-tagged enums:
+//! - `user.content`: `Prompt{prompt}` | `ToolUseResults{tool_use_results}` |
+//!   `CancelledToolUses{prompt?, tool_use_results}`
+//! - `assistant`: `Response{message_id?, content}` |
+//!   `ToolUse{message_id?, content, tool_uses[]{id,name,args}}`
+
+use crate::models::ClaudeMessage;
+use crate::utils::build_provider_message;
+use serde_json::{json, Value};
+
+/// Parse a `ConversationState` `value` JSON string into messages, in order.
+pub(crate) fn parse_history(
+    provider: &str,
+    value_json: &str,
+    session_id: &str,
+) -> Vec<ClaudeMessage> {
+    let Ok(json) = serde_json::from_str::<Value>(value_json) else {
+        return Vec::new();
+    };
+    let Some(history) = json.get("history").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut messages = Vec::new();
+    for (i, entry) in history.iter().enumerate() {
+        if let Some(user) = entry.get("user") {
+            if let Some(msg) = convert_user_message(provider, user, session_id, i) {
+                messages.push(msg);
+            }
+        }
+        if let Some(assistant) = entry.get("assistant") {
+            if let Some(msg) = convert_assistant_message(provider, assistant, session_id, i) {
+                messages.push(msg);
+            }
+        }
+    }
+    messages
+}
+
+/// The (first, last) user-turn ISO timestamps in a history, if any. Amazon Q's
+/// v1 `conversations` table has no `created_at`/`updated_at` columns, so session
+/// times are derived from these. `last` falls back to `first` for single-turn
+/// conversations.
+pub(crate) fn history_time_bounds(value_json: &str) -> (Option<String>, Option<String>) {
+    let Ok(json) = serde_json::from_str::<Value>(value_json) else {
+        return (None, None);
+    };
+    let Some(history) = json.get("history").and_then(Value::as_array) else {
+        return (None, None);
+    };
+    let mut times = history
+        .iter()
+        .filter_map(|e| {
+            e.get("user")
+                .and_then(|u| u.get("timestamp"))
+                .and_then(Value::as_str)
+        })
+        .filter(|s| !s.is_empty());
+    let first = times.next().map(str::to_string);
+    // next_back() (not last()) avoids re-walking the whole iterator; gives the
+    // last remaining timestamp, falling back to `first` for single-turn chats.
+    let last = times
+        .next_back()
+        .map(str::to_string)
+        .or_else(|| first.clone());
+    (first, last)
+}
+
+/// Build a short session summary from the first user prompt in the history.
+pub(crate) fn first_prompt_summary(value_json: &str, max_chars: usize) -> Option<String> {
+    let json = serde_json::from_str::<Value>(value_json).ok()?;
+    let history = json.get("history").and_then(Value::as_array)?;
+    history.iter().find_map(|e| {
+        e.get("user")?
+            .get("content")?
+            .get("Prompt")?
+            .get("prompt")?
+            .as_str()
+            .map(|s| s.chars().take(max_chars).collect::<String>())
+    })
+}
+
+/// Number of renderable messages a history would produce (user + assistant).
+pub(crate) fn message_count(value_json: &str) -> usize {
+    parse_history("", value_json, "count").len()
+}
+
+pub(crate) fn convert_user_message(
+    provider: &str,
+    user: &Value,
+    session_id: &str,
+    idx: usize,
+) -> Option<ClaudeMessage> {
+    let timestamp = user
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    let content_obj = user.get("content")?;
+    let mut blocks: Vec<Value> = Vec::new();
+
+    if let Some(prompt) = content_obj.get("Prompt") {
+        if let Some(text) = prompt.get("prompt").and_then(Value::as_str) {
+            if !text.is_empty() {
+                blocks.push(json!({"type": "text", "text": text}));
+            }
+        }
+    } else if let Some(tool_results) = content_obj.get("ToolUseResults") {
+        push_tool_results(&mut blocks, tool_results);
+    } else if let Some(cancelled) = content_obj.get("CancelledToolUses") {
+        // A cancelled turn may carry a prompt plus the partial tool results.
+        if let Some(text) = cancelled.get("prompt").and_then(Value::as_str) {
+            if !text.is_empty() {
+                blocks.push(json!({"type": "text", "text": text}));
+            }
+        }
+        push_tool_results(&mut blocks, cancelled);
+    }
+
+    if blocks.is_empty() {
+        return None;
+    }
+
+    Some(build_provider_message(
+        provider,
+        format!("{session_id}-user-{idx}"),
+        session_id,
+        timestamp,
+        "user",
+        Some("user"),
+        Some(Value::Array(blocks)),
+        None,
+    ))
+}
+
+/// Append `tool_result` blocks from an object holding `tool_use_results[]`.
+fn push_tool_results(blocks: &mut Vec<Value>, holder: &Value) {
+    let Some(results) = holder.get("tool_use_results").and_then(Value::as_array) else {
+        return;
+    };
+    for tr in results {
+        let tool_use_id = tr.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
+        let text = tr
+            .get("content")
+            .and_then(Value::as_array)
+            .and_then(|arr| arr.first())
+            .and_then(|c| c.get("Text").and_then(Value::as_str))
+            .unwrap_or("");
+        blocks.push(json!({
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": text
+        }));
+    }
+}
+
+pub(crate) fn convert_assistant_message(
+    provider: &str,
+    assistant: &Value,
+    session_id: &str,
+    idx: usize,
+) -> Option<ClaudeMessage> {
+    let mut blocks: Vec<Value> = Vec::new();
+
+    if let Some(response) = assistant.get("Response") {
+        let text = response
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !text.is_empty() {
+            blocks.push(json!({"type": "text", "text": text}));
+        }
+    } else if let Some(tool_use) = assistant.get("ToolUse") {
+        let text = tool_use
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !text.is_empty() {
+            blocks.push(json!({"type": "text", "text": text}));
+        }
+        if let Some(tools) = tool_use.get("tool_uses").and_then(Value::as_array) {
+            for tool in tools {
+                let id = tool.get("id").and_then(Value::as_str).unwrap_or("");
+                let name = tool
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                let args = tool
+                    .get("args")
+                    .cloned()
+                    .unwrap_or(Value::Object(serde_json::Map::default()));
+                blocks.push(json!({
+                    "type": "tool_use",
+                    "id": id,
+                    "name": map_tool_name(name),
+                    "input": args
+                }));
+            }
+        }
+    }
+
+    if blocks.is_empty() {
+        return None;
+    }
+
+    let msg_id = assistant
+        .get("Response")
+        .or_else(|| assistant.get("ToolUse"))
+        .and_then(|v| v.get("message_id"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    Some(build_provider_message(
+        provider,
+        if msg_id.is_empty() {
+            format!("{session_id}-asst-{idx}")
+        } else {
+            msg_id.to_string()
+        },
+        session_id,
+        String::new(),
+        "assistant",
+        Some("assistant"),
+        Some(Value::Array(blocks)),
+        None,
+    ))
+}
+
+/// Map Amazon Q / Kiro tool names to the canonical names the viewer renders.
+fn map_tool_name(name: &str) -> &str {
+    match name {
+        "execute_bash" => "Bash",
+        "read_file" | "file_read" => "Read",
+        "write_file" | "file_write" | "create_file" => "Write",
+        "list_directory" => "Glob",
+        "search_files" | "grep" => "Grep",
+        "web_search" => "WebSearch",
+        "web_fetch" => "WebFetch",
+        _ => name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convert_user_prompt() {
+        let user = json!({
+            "content": {"Prompt": {"prompt": "hello world"}},
+            "timestamp": "2025-10-08T10:50:49.220865-07:00"
+        });
+        let msg = convert_user_message("amazonq", &user, "sess-1", 0).unwrap();
+        assert_eq!(msg.message_type, "user");
+        assert_eq!(msg.provider.as_deref(), Some("amazonq"));
+        assert_eq!(msg.uuid, "sess-1-user-0");
+    }
+
+    #[test]
+    fn convert_assistant_response() {
+        let asst = json!({"Response": {"message_id": "abc", "content": "Hello!"}});
+        let msg = convert_assistant_message("kiro", &asst, "sess-1", 0).unwrap();
+        assert_eq!(msg.message_type, "assistant");
+        assert_eq!(msg.provider.as_deref(), Some("kiro"));
+        assert_eq!(msg.uuid, "abc"); // message_id wins over the synthetic id
+        let arr = msg.content.unwrap();
+        assert_eq!(arr[0]["text"], "Hello!");
+    }
+
+    #[test]
+    fn convert_assistant_tool_use_maps_name() {
+        let asst = json!({
+            "ToolUse": {
+                "message_id": "xyz",
+                "content": "Let me run that",
+                "tool_uses": [{"id": "t1", "name": "execute_bash", "args": {"command": "ls"}}]
+            }
+        });
+        let msg = convert_assistant_message("amazonq", &asst, "sess-1", 1).unwrap();
+        let arr = msg.content.unwrap().as_array().unwrap().clone();
+        assert_eq!(arr[0]["type"], "text");
+        assert_eq!(arr[1]["type"], "tool_use");
+        assert_eq!(arr[1]["name"], "Bash");
+    }
+
+    #[test]
+    fn convert_user_tool_results() {
+        let user = json!({
+            "content": {"ToolUseResults": {"tool_use_results": [
+                {"tool_use_id": "t1", "content": [{"Text": "output here"}]}
+            ]}},
+            "timestamp": "2025-10-08T10:51:00-07:00"
+        });
+        let msg = convert_user_message("amazonq", &user, "sess-1", 1).unwrap();
+        let arr = msg.content.unwrap().as_array().unwrap().clone();
+        assert_eq!(arr[0]["type"], "tool_result");
+        assert_eq!(arr[0]["tool_use_id"], "t1");
+        assert_eq!(arr[0]["content"], "output here");
+    }
+
+    #[test]
+    fn convert_cancelled_tool_uses_prompt_and_results() {
+        let user = json!({
+            "content": {"CancelledToolUses": {
+                "prompt": "stop",
+                "tool_use_results": [{"tool_use_id": "t9", "content": [{"Text": "partial"}]}]
+            }},
+            "timestamp": ""
+        });
+        let msg = convert_user_message("amazonq", &user, "s", 0).unwrap();
+        let arr = msg.content.unwrap().as_array().unwrap().clone();
+        assert_eq!(arr[0]["type"], "text");
+        assert_eq!(arr[0]["text"], "stop");
+        assert_eq!(arr[1]["type"], "tool_result");
+        assert_eq!(arr[1]["tool_use_id"], "t9");
+    }
+
+    #[test]
+    fn parse_history_walks_user_and_assistant() {
+        let value = json!({
+            "history": [
+                {
+                    "user": {"content": {"Prompt": {"prompt": "hi"}}, "timestamp": "2025-10-08T10:00:00Z"},
+                    "assistant": {"Response": {"message_id": "m1", "content": "hello"}}
+                }
+            ]
+        })
+        .to_string();
+        let msgs = parse_history("amazonq", &value, "sess-1");
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role.as_deref(), Some("user"));
+        assert_eq!(msgs[1].role.as_deref(), Some("assistant"));
+        assert_eq!(message_count(&value), 2);
+        let (first, last) = history_time_bounds(&value);
+        assert_eq!(first.as_deref(), Some("2025-10-08T10:00:00Z"));
+        assert_eq!(last.as_deref(), Some("2025-10-08T10:00:00Z")); // single turn -> last = first
+        assert_eq!(first_prompt_summary(&value, 80).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn map_tool_names() {
+        assert_eq!(map_tool_name("execute_bash"), "Bash");
+        assert_eq!(map_tool_name("read_file"), "Read");
+        assert_eq!(map_tool_name("unknown_thing"), "unknown_thing");
+    }
+}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -102,6 +102,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     const counts: Record<ProviderTabId, number> = {
       all: projects.length,
       aider: 0,
+      amazonq: 0,
       antigravity: 0,
       claude: 0,
       cline: 0,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -118,6 +118,7 @@
   "common.update.skip": "Skip This Version",
   "common.update.upToDate": "You have the latest version",
   "common.provider.aider": "Aider",
+  "common.provider.amazonq": "Amazon Q CLI",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
   "common.provider.codebuddy": "CodeBuddy Code",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -118,6 +118,7 @@
   "common.update.skip": "このバージョンをスキップ",
   "common.update.upToDate": "最新バージョンです",
   "common.provider.aider": "Aider",
+  "common.provider.amazonq": "Amazon Q CLI",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
   "common.provider.codebuddy": "CodeBuddy Code",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -118,6 +118,7 @@
   "common.update.skip": "이 버전 건너뛰기",
   "common.update.upToDate": "최신 버전입니다",
   "common.provider.aider": "Aider",
+  "common.provider.amazonq": "Amazon Q CLI",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
   "common.provider.codebuddy": "CodeBuddy Code",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -118,6 +118,7 @@
   "common.update.skip": "跳过此版本",
   "common.update.upToDate": "已是最新版本",
   "common.provider.aider": "Aider",
+  "common.provider.amazonq": "Amazon Q CLI",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
   "common.provider.codebuddy": "CodeBuddy Code",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -118,6 +118,7 @@
   "common.update.skip": "略過此版本",
   "common.update.upToDate": "已是最新版本",
   "common.provider.aider": "Aider",
+  "common.provider.amazonq": "Amazon Q CLI",
   "common.provider.claude": "Claude Code",
   "common.provider.cline": "Cline",
   "common.provider.codebuddy": "CodeBuddy Code",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-06-21T14:25:42.009Z
- * 총 키 개수: 1816
+ * 생성 시간: 2026-06-21T16:03:29.095Z
+ * 총 키 개수: 1817
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (171개)
+ * common namespace의 번역 키 (172개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -108,6 +108,7 @@ export type CommonKeys =
   | 'common.ok'
   | 'common.pending'
   | 'common.provider.aider'
+  | 'common.provider.amazonq'
   | 'common.provider.antigravity'
   | 'common.provider.claude'
   | 'common.provider.cline'
@@ -2292,6 +2293,7 @@ export type TranslationKey =
   | 'common.ok'
   | 'common.pending'
   | 'common.provider.aider'
+  | 'common.provider.amazonq'
   | 'common.provider.antigravity'
   | 'common.provider.claude'
   | 'common.provider.cline'

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -40,6 +40,7 @@ describe("providers utils", () => {
   it("keeps provider id list stable for all known providers", () => {
     expect(PROVIDER_IDS).toEqual([
       "aider",
+      "amazonq",
       "antigravity",
       "claude",
       "cline",

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "pearai";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "pearai";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "pearai"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "pearai"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -8,6 +8,7 @@ const PROVIDER_TRANSLATIONS: Record<
   { key: string; fallback: string }
 > = {
   aider: { key: "common.provider.aider", fallback: "Aider" },
+  amazonq: { key: "common.provider.amazonq", fallback: "Amazon Q CLI" },
   antigravity: { key: "common.provider.antigravity", fallback: "Antigravity" },
   claude: { key: "common.provider.claude", fallback: "Claude Code" },
   cline: { key: "common.provider.cline", fallback: "Cline" },
@@ -40,6 +41,13 @@ export interface ProviderSessionCapability {
 
 const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapability> = {
   aider: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
+  amazonq: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
     supportsResumeCommand: false,
@@ -192,6 +200,7 @@ export interface ConversationBreakdownCoverage {
 export function getProviderId(provider?: ProviderId | string): ProviderId {
   switch (provider) {
     case "aider":
+    case "amazonq":
     case "antigravity":
     case "cline":
     case "codebuddy":
@@ -364,6 +373,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   opencode: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
   pearai: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
   aider: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
+  amazonq: "bg-zinc-500/15 text-zinc-600 dark:text-zinc-400",
   antigravity: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",
 };
 


### PR DESCRIPTION
## Summary

Adds the **Amazon Q Developer CLI** (`q chat`) as a provider, reading its local SQLite chat store. Brings supported provider IDs to **20**.

- **`amazon_q.rs`** — reads `dirs::data_local_dir()/amazon-q/data.sqlite3`, table `conversations(key, value)` where `key` = cwd and `value` = serialized `ConversationState`. v1 schema stores **one conversation per cwd**, so each `key` is a project with a single session; session times are derived from the history's user timestamps (v1 has no `created_at`/`updated_at`).
- **`q_conversation.rs`** (new shared module) — the Amazon Q CLI `conversations` table and Kiro CLI's `conversations_v2` store the **identical** `value` shape (verified from `aws/amazon-q-developer-cli` source: same `ConversationState`, same externally-tagged `Prompt`/`ToolUseResults`/`CancelledToolUses`/`Response`/`ToolUse`). The value→message conversion now lives here, parameterized by provider id.
- **`kiro.rs`** refactored to use the shared converter (drops ~120 duplicated lines) and now resolves its DB via `dirs::data_local_dir()` — **fixing a latent bug**: the old code hardcoded the Windows path to `AppData\Roaming\kiro-cli`, but upstream uses `data_local_dir()` (`%LOCALAPPDATA%`, i.e. **Local**).

## Verification

- Table + `value` schema and the v1↔v2 difference confirmed from upstream Rust source (migration `007_conversations_table.sql`, `ConversationState`/`message.rs`). v1↔v2 differ only at the row/column layer; the `value` JSON is the same type → converter reuse is safe.
- New providers tested with in-memory SQLite DBs; the shared converter has unit tests (incl. `CancelledToolUses`, tool-name mapping, time bounds).
- Gates: `tsc` ✅ · `vitest` 864 ✅ · `eslint` ✅ · `i18n:validate` ✅ · `cargo test` 727 ✅ · `clippy -D warnings` ✅ · `fmt` ✅

## Notes

- ⚠️ Not yet runtime-verified against a real Amazon Q install — a real-file sanity check is recommended before release.
- The post-rebrand **Kiro CLI** (`kiro-cli/data.sqlite3`, `conversations_v2`) is already covered by the existing `kiro` provider; this adds the legacy/standalone **`amazon-q`** store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Amazon Q CLI as a selectable provider, including project/session browsing and cross-provider search.
  * Updated provider name/badge display with new translations (English, Japanese, Korean, Simplified Chinese, Traditional Chinese).
  * Amazon Q provider sessions now participate in real-time session updates and show up in provider project counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->