### PR TITLE
feat(providers): add Open Interpreter, Qwen Code, Zed, OpenHands, and Trae

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -752,6 +752,8 @@ version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -923,6 +925,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "winreg",
+ "zstd",
 ]
 
 [[package]]
@@ -2929,6 +2932,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
 ]
 
 [[package]]
@@ -8106,6 +8119,34 @@ dependencies = [
  "crc32fast",
  "indexmap 2.14.0",
  "memchr",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ regex = "1.11"
 lazy_static = "1.5"
 once_cell = "1.19"
 rusqlite = { version = "0.32", features = ["bundled"] }
+zstd = "0.13"
 notify = { version = "7.0", default-features = false, features = ["macos_fsevent"] }
 notify-debouncer-mini = "0.5"
 

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -54,6 +54,7 @@ pub async fn scan_all_projects(
             "kiro".to_string(),
             "llm".to_string(),
             "zed".to_string(),
+            "openhands".to_string(),
         ]
     });
 
@@ -210,6 +211,16 @@ pub async fn scan_all_projects(
             Ok(projects) => all_projects.extend(projects),
             Err(e) => {
                 log::warn!("Zed scan failed: {e}");
+            }
+        }
+    }
+
+    // OpenHands (classic ~/.openhands/sessions event store)
+    if providers_to_scan.iter().any(|p| p == "openhands") {
+        match providers::openhands::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("OpenHands scan failed: {e}");
             }
         }
     }
@@ -488,6 +499,7 @@ pub async fn load_provider_sessions(
         "kiro" => providers::kiro::load_sessions(&project_path, exclude),
         "llm" => providers::llm::load_sessions(&project_path, exclude),
         "zed" => providers::zed::load_sessions(&project_path, exclude),
+        "openhands" => providers::openhands::load_sessions(&project_path, exclude),
         _ => Err(format!("Unknown provider: {provider}")),
     }
 }
@@ -531,6 +543,7 @@ pub async fn load_provider_messages(
         "kiro" => providers::kiro::load_messages(&session_path)?,
         "llm" => providers::llm::load_messages(&session_path)?,
         "zed" => providers::zed::load_messages(&session_path)?,
+        "openhands" => providers::openhands::load_messages(&session_path)?,
         _ => return Err(format!("Unknown provider: {provider}")),
     };
 
@@ -580,6 +593,7 @@ pub async fn search_all_providers(
             "kiro".to_string(),
             "llm".to_string(),
             "zed".to_string(),
+            "openhands".to_string(),
         ]
     });
 
@@ -847,6 +861,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Zed search failed: {e}");
+            }
+        }
+    }
+
+    // OpenHands
+    if providers_to_search.iter().any(|p| p == "openhands") {
+        match providers::openhands::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("OpenHands search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -53,6 +53,7 @@ pub async fn scan_all_projects(
             "codebuddy".to_string(),
             "kiro".to_string(),
             "llm".to_string(),
+            "zed".to_string(),
         ]
     });
 
@@ -199,6 +200,16 @@ pub async fn scan_all_projects(
             Ok(projects) => all_projects.extend(projects),
             Err(e) => {
                 log::warn!("Qwen scan failed: {e}");
+            }
+        }
+    }
+
+    // Zed (Agent Panel threads — SQLite + Zstd JSON)
+    if providers_to_scan.iter().any(|p| p == "zed") {
+        match providers::zed::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("Zed scan failed: {e}");
             }
         }
     }
@@ -476,6 +487,7 @@ pub async fn load_provider_sessions(
         "codebuddy" => providers::codebuddy::load_sessions(&project_path, exclude),
         "kiro" => providers::kiro::load_sessions(&project_path, exclude),
         "llm" => providers::llm::load_sessions(&project_path, exclude),
+        "zed" => providers::zed::load_sessions(&project_path, exclude),
         _ => Err(format!("Unknown provider: {provider}")),
     }
 }
@@ -518,6 +530,7 @@ pub async fn load_provider_messages(
         "codebuddy" => providers::codebuddy::load_messages(&session_path)?,
         "kiro" => providers::kiro::load_messages(&session_path)?,
         "llm" => providers::llm::load_messages(&session_path)?,
+        "zed" => providers::zed::load_messages(&session_path)?,
         _ => return Err(format!("Unknown provider: {provider}")),
     };
 
@@ -566,6 +579,7 @@ pub async fn search_all_providers(
             "codebuddy".to_string(),
             "kiro".to_string(),
             "llm".to_string(),
+            "zed".to_string(),
         ]
     });
 
@@ -823,6 +837,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("llm search failed: {e}");
+            }
+        }
+    }
+
+    // Zed
+    if providers_to_search.iter().any(|p| p == "zed") {
+        match providers::zed::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Zed search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -41,6 +41,7 @@ pub async fn scan_all_projects(
             "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
+            "openinterpreter".to_string(),
             "cline".to_string(),
             "crush".to_string(),
             "cursor".to_string(),
@@ -177,6 +178,16 @@ pub async fn scan_all_projects(
             Ok(projects) => all_projects.extend(projects),
             Err(e) => {
                 log::warn!("OpenCode scan failed: {e}");
+            }
+        }
+    }
+
+    // Open Interpreter (Codex-format rollouts under ~/.openinterpreter)
+    if providers_to_scan.iter().any(|p| p == "openinterpreter") {
+        match providers::openinterpreter::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("Open Interpreter scan failed: {e}");
             }
         }
     }
@@ -442,6 +453,7 @@ pub async fn load_provider_sessions(
         "kimi" => providers::kimi::load_sessions(&project_path, exclude),
         "forgecode" => providers::forgecode::load_sessions(&project_path, exclude),
         "opencode" => providers::opencode::load_sessions(&project_path, exclude),
+        "openinterpreter" => providers::openinterpreter::load_sessions(&project_path, exclude),
         "cline" => providers::cline::load_sessions(&project_path, exclude),
         "crush" => providers::crush::load_sessions(&project_path, exclude),
         "cursor" => providers::cursor::load_sessions(&project_path, exclude),
@@ -482,6 +494,7 @@ pub async fn load_provider_messages(
         "kimi" => providers::kimi::load_messages(&session_path)?,
         "forgecode" => providers::forgecode::load_messages(&session_path)?,
         "opencode" => providers::opencode::load_messages(&session_path)?,
+        "openinterpreter" => providers::openinterpreter::load_messages(&session_path)?,
         "cline" => providers::cline::load_messages(&session_path)?,
         "crush" => providers::crush::load_messages(&session_path)?,
         "cursor" => providers::cursor::load_messages(&session_path)?,
@@ -528,6 +541,7 @@ pub async fn search_all_providers(
             "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
+            "openinterpreter".to_string(),
             "cline".to_string(),
             "crush".to_string(),
             "cursor".to_string(),
@@ -676,6 +690,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("OpenCode search failed: {e}");
+            }
+        }
+    }
+
+    // Open Interpreter
+    if providers_to_search.iter().any(|p| p == "openinterpreter") {
+        match providers::openinterpreter::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Open Interpreter search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -42,6 +42,7 @@ pub async fn scan_all_projects(
             "forgecode".to_string(),
             "opencode".to_string(),
             "openinterpreter".to_string(),
+            "qwen".to_string(),
             "cline".to_string(),
             "crush".to_string(),
             "cursor".to_string(),
@@ -188,6 +189,16 @@ pub async fn scan_all_projects(
             Ok(projects) => all_projects.extend(projects),
             Err(e) => {
                 log::warn!("Open Interpreter scan failed: {e}");
+            }
+        }
+    }
+
+    // Qwen Code (JSONL transcripts under ~/.qwen/projects)
+    if providers_to_scan.iter().any(|p| p == "qwen") {
+        match providers::qwen::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("Qwen scan failed: {e}");
             }
         }
     }
@@ -454,6 +465,7 @@ pub async fn load_provider_sessions(
         "forgecode" => providers::forgecode::load_sessions(&project_path, exclude),
         "opencode" => providers::opencode::load_sessions(&project_path, exclude),
         "openinterpreter" => providers::openinterpreter::load_sessions(&project_path, exclude),
+        "qwen" => providers::qwen::load_sessions(&project_path, exclude),
         "cline" => providers::cline::load_sessions(&project_path, exclude),
         "crush" => providers::crush::load_sessions(&project_path, exclude),
         "cursor" => providers::cursor::load_sessions(&project_path, exclude),
@@ -495,6 +507,7 @@ pub async fn load_provider_messages(
         "forgecode" => providers::forgecode::load_messages(&session_path)?,
         "opencode" => providers::opencode::load_messages(&session_path)?,
         "openinterpreter" => providers::openinterpreter::load_messages(&session_path)?,
+        "qwen" => providers::qwen::load_messages(&session_path)?,
         "cline" => providers::cline::load_messages(&session_path)?,
         "crush" => providers::crush::load_messages(&session_path)?,
         "cursor" => providers::cursor::load_messages(&session_path)?,
@@ -542,6 +555,7 @@ pub async fn search_all_providers(
             "forgecode".to_string(),
             "opencode".to_string(),
             "openinterpreter".to_string(),
+            "qwen".to_string(),
             "cline".to_string(),
             "crush".to_string(),
             "cursor".to_string(),
@@ -700,6 +714,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Open Interpreter search failed: {e}");
+            }
+        }
+    }
+
+    // Qwen Code
+    if providers_to_search.iter().any(|p| p == "qwen") {
+        match providers::qwen::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Qwen search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -55,6 +55,7 @@ pub async fn scan_all_projects(
             "llm".to_string(),
             "zed".to_string(),
             "openhands".to_string(),
+            "trae".to_string(),
         ]
     });
 
@@ -221,6 +222,16 @@ pub async fn scan_all_projects(
             Ok(projects) => all_projects.extend(projects),
             Err(e) => {
                 log::warn!("OpenHands scan failed: {e}");
+            }
+        }
+    }
+
+    // Trae IDE (reverse-engineered icube chat in per-workspace state.vscdb)
+    if providers_to_scan.iter().any(|p| p == "trae") {
+        match providers::trae::scan_projects() {
+            Ok(projects) => all_projects.extend(projects),
+            Err(e) => {
+                log::warn!("Trae scan failed: {e}");
             }
         }
     }
@@ -500,6 +511,7 @@ pub async fn load_provider_sessions(
         "llm" => providers::llm::load_sessions(&project_path, exclude),
         "zed" => providers::zed::load_sessions(&project_path, exclude),
         "openhands" => providers::openhands::load_sessions(&project_path, exclude),
+        "trae" => providers::trae::load_sessions(&project_path, exclude),
         _ => Err(format!("Unknown provider: {provider}")),
     }
 }
@@ -544,6 +556,7 @@ pub async fn load_provider_messages(
         "llm" => providers::llm::load_messages(&session_path)?,
         "zed" => providers::zed::load_messages(&session_path)?,
         "openhands" => providers::openhands::load_messages(&session_path)?,
+        "trae" => providers::trae::load_messages(&session_path)?,
         _ => return Err(format!("Unknown provider: {provider}")),
     };
 
@@ -594,6 +607,7 @@ pub async fn search_all_providers(
             "llm".to_string(),
             "zed".to_string(),
             "openhands".to_string(),
+            "trae".to_string(),
         ]
     });
 
@@ -871,6 +885,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("OpenHands search failed: {e}");
+            }
+        }
+    }
+
+    // Trae IDE
+    if providers_to_search.iter().any(|p| p == "trae") {
+        match providers::trae::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Trae search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -75,6 +75,9 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
         allowed.push(PathBuf::from(&oi_base).join("sessions"));
         allowed.push(PathBuf::from(&oi_base).join("archived_sessions"));
     }
+    if let Some(qwen_base) = crate::providers::qwen::get_base_path() {
+        allowed.push(PathBuf::from(qwen_base));
+    }
 
     // Canonicalize each allowlist entry so the comparison below is like-for-like
     // with the canonicalized candidate. Without this, a symlinked provider root

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -71,6 +71,10 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(amazon_q_base) = crate::providers::amazon_q::get_base_path() {
         allowed.push(PathBuf::from(amazon_q_base));
     }
+    if let Some(oi_base) = crate::providers::openinterpreter::get_base_path() {
+        allowed.push(PathBuf::from(&oi_base).join("sessions"));
+        allowed.push(PathBuf::from(&oi_base).join("archived_sessions"));
+    }
 
     // Canonicalize each allowlist entry so the comparison below is like-for-like
     // with the canonicalized candidate. Without this, a symlinked provider root

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -84,6 +84,9 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(oh_base) = crate::providers::openhands::get_base_path() {
         allowed.push(PathBuf::from(oh_base));
     }
+    if let Some(trae_base) = crate::providers::trae::get_base_path() {
+        allowed.push(PathBuf::from(trae_base));
+    }
 
     // Canonicalize each allowlist entry so the comparison below is like-for-like
     // with the canonicalized candidate. Without this, a symlinked provider root

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -81,6 +81,9 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(zed_base) = crate::providers::zed::get_base_path() {
         allowed.push(PathBuf::from(zed_base));
     }
+    if let Some(oh_base) = crate::providers::openhands::get_base_path() {
+        allowed.push(PathBuf::from(oh_base));
+    }
 
     // Canonicalize each allowlist entry so the comparison below is like-for-like
     // with the canonicalized candidate. Without this, a symlinked provider root

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -78,6 +78,9 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(qwen_base) = crate::providers::qwen::get_base_path() {
         allowed.push(PathBuf::from(qwen_base));
     }
+    if let Some(zed_base) = crate::providers::zed::get_base_path() {
+        allowed.push(PathBuf::from(zed_base));
+    }
 
     // Canonicalize each allowlist entry so the comparison below is like-for-like
     // with the canonicalized candidate. Without this, a symlinked provider root

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1104,6 +1104,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(qwen_base) = providers::qwen::get_base_path() {
+        let qwen_projects = PathBuf::from(qwen_base);
+        if qwen_projects.is_dir() {
+            paths.push(qwen_projects);
+        }
+    }
+
     if let Some(copilot_base) = providers::copilot_cli::get_base_path() {
         let session_state = PathBuf::from(copilot_base).join("session-state");
         if session_state.is_dir() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1118,6 +1118,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(oh_base) = providers::openhands::get_base_path() {
+        let oh_dir = PathBuf::from(oh_base);
+        if oh_dir.is_dir() {
+            paths.push(oh_dir);
+        }
+    }
+
     if let Some(copilot_base) = providers::copilot_cli::get_base_path() {
         let session_state = PathBuf::from(copilot_base).join("session-state");
         if session_state.is_dir() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1111,6 +1111,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(zed_base) = providers::zed::get_base_path() {
+        let zed_dir = PathBuf::from(zed_base);
+        if zed_dir.is_dir() {
+            paths.push(zed_dir);
+        }
+    }
+
     if let Some(copilot_base) = providers::copilot_cli::get_base_path() {
         let session_state = PathBuf::from(copilot_base).join("session-state");
         if session_state.is_dir() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1095,6 +1095,15 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(oi_base) = providers::openinterpreter::get_base_path() {
+        for sub in ["sessions", "archived_sessions"] {
+            let dir = PathBuf::from(&oi_base).join(sub);
+            if dir.is_dir() {
+                paths.push(dir);
+            }
+        }
+    }
+
     if let Some(copilot_base) = providers::copilot_cli::get_base_path() {
         let session_state = PathBuf::from(copilot_base).join("session-state");
         if session_state.is_dir() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1125,6 +1125,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(trae_base) = providers::trae::get_base_path() {
+        let trae_dir = PathBuf::from(trae_base);
+        if trae_dir.is_dir() {
+            paths.push(trae_dir);
+        }
+    }
+
     if let Some(copilot_base) = providers::copilot_cli::get_base_path() {
         let session_state = PathBuf::from(copilot_base).join("session-state");
         if session_state.is_dir() {

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -74,7 +74,7 @@ fn get_existing_session_dirs() -> Result<Vec<PathBuf>, String> {
         .collect())
 }
 
-fn is_rollout_jsonl(path: &Path) -> bool {
+pub(crate) fn is_rollout_jsonl(path: &Path) -> bool {
     path.file_name()
         .map(|name| name.to_string_lossy().starts_with("rollout-"))
         .unwrap_or(false)
@@ -123,26 +123,28 @@ fn validate_session_path(session_path: &Path, raw_session_path: &str) -> Result<
     Ok(canonical_session)
 }
 
-/// Session metadata extracted from rollout files
-struct SessionInfo {
-    session_id: String,
-    cwd: Option<String>,
+/// Session metadata extracted from rollout files. `pub(crate)` so providers
+/// that share the Codex rollout format (e.g. Open Interpreter) can reuse the
+/// extractors below.
+pub(crate) struct SessionInfo {
+    pub(crate) session_id: String,
+    pub(crate) cwd: Option<String>,
     #[allow(dead_code)]
-    model: Option<String>,
-    message_count: usize,
-    first_message_time: String,
-    last_message_time: String,
-    last_modified: String,
-    file_path: String,
-    has_tool_use: bool,
-    summary: Option<String>,
+    pub(crate) model: Option<String>,
+    pub(crate) message_count: usize,
+    pub(crate) first_message_time: String,
+    pub(crate) last_message_time: String,
+    pub(crate) last_modified: String,
+    pub(crate) file_path: String,
+    pub(crate) has_tool_use: bool,
+    pub(crate) summary: Option<String>,
 }
 
 /// Lightweight metadata used by project-level scans.
-struct ProjectScanInfo {
-    cwd: Option<String>,
-    message_count: usize,
-    last_modified: String,
+pub(crate) struct ProjectScanInfo {
+    pub(crate) cwd: Option<String>,
+    pub(crate) message_count: usize,
+    pub(crate) last_modified: String,
 }
 
 /// Scan Codex projects from a specific base path.
@@ -300,15 +302,22 @@ pub fn load_sessions(
 }
 
 /// Load all messages from a Codex rollout file
-#[allow(unsafe_code)] // Required for mmap performance optimization
 pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
     let path = Path::new(session_path);
     if !path.exists() {
         return Err(format!("Session file not found: {session_path}"));
     }
     let canonical_path = validate_session_path(path, session_path)?;
+    parse_rollout_file(&canonical_path)
+}
 
-    let file = File::open(&canonical_path).map_err(|e| e.to_string())?;
+/// Parse an already-validated Codex rollout JSONL file into messages. Pure of
+/// base-path/scheme concerns so providers sharing the identical rollout format
+/// (e.g. Open Interpreter) can validate against their own root, call this, and
+/// re-tag the provider on the result.
+#[allow(unsafe_code)] // Required for mmap performance optimization
+pub(crate) fn parse_rollout_file(canonical_path: &Path) -> Result<Vec<ClaudeMessage>, String> {
+    let file = File::open(canonical_path).map_err(|e| e.to_string())?;
     // SAFETY: File is read-only and we only read from the mapping
     let mmap = unsafe { Mmap::map(&file) }.map_err(|e| e.to_string())?;
     let ranges = find_line_ranges(&mmap);
@@ -704,7 +713,7 @@ fn estimate_rollout_message_count(path: &Path) -> usize {
 }
 
 #[allow(unsafe_code)] // Required for mmap performance optimization
-fn extract_session_cwd(rollout_path: &Path) -> Result<Option<String>, String> {
+pub(crate) fn extract_session_cwd(rollout_path: &Path) -> Result<Option<String>, String> {
     let file = File::open(rollout_path).map_err(|e| e.to_string())?;
     // SAFETY: File is read-only and we only read from the mapping
     let mmap = unsafe { Mmap::map(&file) }.map_err(|e| e.to_string())?;
@@ -721,7 +730,7 @@ fn extract_session_cwd(rollout_path: &Path) -> Result<Option<String>, String> {
     Ok(cwd)
 }
 
-fn extract_project_scan_info(rollout_path: &Path) -> Result<ProjectScanInfo, String> {
+pub(crate) fn extract_project_scan_info(rollout_path: &Path) -> Result<ProjectScanInfo, String> {
     Ok(ProjectScanInfo {
         cwd: extract_session_cwd(rollout_path)?,
         // Project list scans stay lightweight; session-level message counts
@@ -793,7 +802,7 @@ fn load_native_title_index(base_path: &str) -> HashMap<String, String> {
 }
 
 #[allow(unsafe_code)] // Required for mmap performance optimization
-fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
+pub(crate) fn extract_session_info(rollout_path: &Path) -> Result<SessionInfo, String> {
     let file = File::open(rollout_path).map_err(|e| e.to_string())?;
     // SAFETY: File is read-only and we only read from the mapping
     let mmap = unsafe { Mmap::map(&file) }.map_err(|e| e.to_string())?;

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -26,6 +26,7 @@ pub mod pearai;
 pub mod q_conversation;
 pub mod qwen;
 pub mod vscode;
+pub mod zed;
 
 /// Provider identifier
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -65,6 +66,8 @@ pub enum ProviderId {
     /// Qwen Code (Gemini-CLI fork) — JSONL transcripts under `~/.qwen/projects`.
     Qwen,
     Antigravity,
+    /// Zed Agent Panel threads (`SQLite` + Zstd JSON at `…/Zed/threads/threads.db`).
+    Zed,
 }
 
 impl ProviderId {
@@ -92,6 +95,7 @@ impl ProviderId {
             Self::OpenInterpreter => "openinterpreter",
             Self::Qwen => "qwen",
             Self::Antigravity => "antigravity",
+            Self::Zed => "zed",
         }
     }
 
@@ -119,6 +123,7 @@ impl ProviderId {
             "openinterpreter" => Some(Self::OpenInterpreter),
             "qwen" => Some(Self::Qwen),
             "antigravity" => Some(Self::Antigravity),
+            "zed" => Some(Self::Zed),
             _ => None,
         }
     }
@@ -147,6 +152,7 @@ impl ProviderId {
             Self::OpenInterpreter => "Open Interpreter",
             Self::Qwen => "Qwen Code",
             Self::Antigravity => "Antigravity",
+            Self::Zed => "Zed",
         }
     }
 }
@@ -195,6 +201,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = qwen::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = zed::detect() {
         providers.push(info);
     }
     if let Some(info) = cline::detect() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -20,6 +20,7 @@ pub mod kimi;
 pub mod kiro;
 pub mod llm;
 pub mod opencode;
+pub mod openhands;
 pub mod openinterpreter;
 pub mod pearai;
 /// Shared `ConversationState` parsing for the Amazon Q CLI lineage (amazon_q + kiro).
@@ -63,6 +64,8 @@ pub enum ProviderId {
     OpenCode,
     /// Open Interpreter (Rust v1.0) — Codex-format rollouts under `~/.openinterpreter`.
     OpenInterpreter,
+    /// `OpenHands` (classic 0.x) — `~/.openhands/sessions/<id>/events/*.json`.
+    OpenHands,
     /// Qwen Code (Gemini-CLI fork) — JSONL transcripts under `~/.qwen/projects`.
     Qwen,
     Antigravity,
@@ -93,6 +96,7 @@ impl ProviderId {
             Self::Llm => "llm",
             Self::OpenCode => "opencode",
             Self::OpenInterpreter => "openinterpreter",
+            Self::OpenHands => "openhands",
             Self::Qwen => "qwen",
             Self::Antigravity => "antigravity",
             Self::Zed => "zed",
@@ -121,6 +125,7 @@ impl ProviderId {
             "llm" => Some(Self::Llm),
             "opencode" => Some(Self::OpenCode),
             "openinterpreter" => Some(Self::OpenInterpreter),
+            "openhands" => Some(Self::OpenHands),
             "qwen" => Some(Self::Qwen),
             "antigravity" => Some(Self::Antigravity),
             "zed" => Some(Self::Zed),
@@ -150,6 +155,7 @@ impl ProviderId {
             Self::Llm => "llm",
             Self::OpenCode => "OpenCode",
             Self::OpenInterpreter => "Open Interpreter",
+            Self::OpenHands => "OpenHands",
             Self::Qwen => "Qwen Code",
             Self::Antigravity => "Antigravity",
             Self::Zed => "Zed",
@@ -198,6 +204,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = openinterpreter::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = openhands::detect() {
         providers.push(info);
     }
     if let Some(info) = qwen::detect() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -24,6 +24,7 @@ pub mod openinterpreter;
 pub mod pearai;
 /// Shared `ConversationState` parsing for the Amazon Q CLI lineage (amazon_q + kiro).
 pub mod q_conversation;
+pub mod qwen;
 pub mod vscode;
 
 /// Provider identifier
@@ -61,6 +62,8 @@ pub enum ProviderId {
     OpenCode,
     /// Open Interpreter (Rust v1.0) — Codex-format rollouts under `~/.openinterpreter`.
     OpenInterpreter,
+    /// Qwen Code (Gemini-CLI fork) — JSONL transcripts under `~/.qwen/projects`.
+    Qwen,
     Antigravity,
 }
 
@@ -87,6 +90,7 @@ impl ProviderId {
             Self::Llm => "llm",
             Self::OpenCode => "opencode",
             Self::OpenInterpreter => "openinterpreter",
+            Self::Qwen => "qwen",
             Self::Antigravity => "antigravity",
         }
     }
@@ -113,6 +117,7 @@ impl ProviderId {
             "llm" => Some(Self::Llm),
             "opencode" => Some(Self::OpenCode),
             "openinterpreter" => Some(Self::OpenInterpreter),
+            "qwen" => Some(Self::Qwen),
             "antigravity" => Some(Self::Antigravity),
             _ => None,
         }
@@ -140,6 +145,7 @@ impl ProviderId {
             Self::Llm => "llm",
             Self::OpenCode => "OpenCode",
             Self::OpenInterpreter => "Open Interpreter",
+            Self::Qwen => "Qwen Code",
             Self::Antigravity => "Antigravity",
         }
     }
@@ -186,6 +192,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = openinterpreter::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = qwen::detect() {
         providers.push(info);
     }
     if let Some(info) = cline::detect() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -26,6 +26,7 @@ pub mod pearai;
 /// Shared `ConversationState` parsing for the Amazon Q CLI lineage (amazon_q + kiro).
 pub mod q_conversation;
 pub mod qwen;
+pub mod trae;
 pub mod vscode;
 pub mod zed;
 
@@ -71,6 +72,8 @@ pub enum ProviderId {
     Antigravity,
     /// Zed Agent Panel threads (`SQLite` + Zstd JSON at `…/Zed/threads/threads.db`).
     Zed,
+    /// Trae IDE chat (reverse-engineered icube JSON in per-workspace `state.vscdb`).
+    Trae,
 }
 
 impl ProviderId {
@@ -100,6 +103,7 @@ impl ProviderId {
             Self::Qwen => "qwen",
             Self::Antigravity => "antigravity",
             Self::Zed => "zed",
+            Self::Trae => "trae",
         }
     }
 
@@ -129,6 +133,7 @@ impl ProviderId {
             "qwen" => Some(Self::Qwen),
             "antigravity" => Some(Self::Antigravity),
             "zed" => Some(Self::Zed),
+            "trae" => Some(Self::Trae),
             _ => None,
         }
     }
@@ -159,6 +164,7 @@ impl ProviderId {
             Self::Qwen => "Qwen Code",
             Self::Antigravity => "Antigravity",
             Self::Zed => "Zed",
+            Self::Trae => "Trae",
         }
     }
 }
@@ -213,6 +219,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = zed::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = trae::detect() {
         providers.push(info);
     }
     if let Some(info) = cline::detect() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -20,6 +20,7 @@ pub mod kimi;
 pub mod kiro;
 pub mod llm;
 pub mod opencode;
+pub mod openinterpreter;
 pub mod pearai;
 /// Shared `ConversationState` parsing for the Amazon Q CLI lineage (amazon_q + kiro).
 pub mod q_conversation;
@@ -58,6 +59,8 @@ pub enum ProviderId {
     /// Simon Willison's `llm` CLI (`~/.../io.datasette.llm/logs.db`).
     Llm,
     OpenCode,
+    /// Open Interpreter (Rust v1.0) — Codex-format rollouts under `~/.openinterpreter`.
+    OpenInterpreter,
     Antigravity,
 }
 
@@ -83,6 +86,7 @@ impl ProviderId {
             Self::Kiro => "kiro",
             Self::Llm => "llm",
             Self::OpenCode => "opencode",
+            Self::OpenInterpreter => "openinterpreter",
             Self::Antigravity => "antigravity",
         }
     }
@@ -108,6 +112,7 @@ impl ProviderId {
             "kiro" => Some(Self::Kiro),
             "llm" => Some(Self::Llm),
             "opencode" => Some(Self::OpenCode),
+            "openinterpreter" => Some(Self::OpenInterpreter),
             "antigravity" => Some(Self::Antigravity),
             _ => None,
         }
@@ -134,6 +139,7 @@ impl ProviderId {
             Self::Kiro => "Kiro CLI",
             Self::Llm => "llm",
             Self::OpenCode => "OpenCode",
+            Self::OpenInterpreter => "Open Interpreter",
             Self::Antigravity => "Antigravity",
         }
     }
@@ -177,6 +183,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = opencode::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = openinterpreter::detect() {
         providers.push(info);
     }
     if let Some(info) = cline::detect() {

--- a/src-tauri/src/providers/openhands.rs
+++ b/src-tauri/src/providers/openhands.rs
@@ -1,0 +1,510 @@
+//! `OpenHands` provider (classic `All-Hands-AI` 0.x local session store).
+//!
+//! Reads `~/.openhands/sessions/<sid>/events/<N>.json` (N = integer event id,
+//! 0-based) plus `metadata.json`. Each event JSON is `event_to_dict()`:
+//! - top-level `action` (an `ActionType` string) OR `observation` (an
+//!   `ObservationType` string) is the discriminator;
+//! - `source` is `"user" | "agent" | "environment"`;
+//! - a chat turn is `action == "message"` (`source` "user"/"agent"); a tool call
+//!   is any other `action` (run/read/write/…); a tool result is an
+//!   `observation`, linked to its call via `cause` (= the action's `id`).
+//!
+//! Displayable text: `args.content` for messages, top-level `content` for
+//! observations, `args.{command,code,path,thought}` for tool calls. We map these
+//! to the viewer's Claude-style blocks. All sessions surface under one synthetic
+//! "`OpenHands`" project (the store has no project/cwd grouping).
+//!
+//! Scope: this targets classic `OpenHands` 0.x (`openhands/events`); the newer V1
+//! `software-agent-sdk` uses a different, cwd-relative layout and is not covered.
+
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::providers::ProviderInfo;
+use crate::utils::{build_provider_message, search_json_value_case_insensitive};
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+const PROVIDER: &str = "openhands";
+const SCHEME: &str = "openhands://";
+const PROJECT_KEY: &str = "__workspace__";
+const SUMMARY_MAX_CHARS: usize = 80;
+
+/// `~/.openhands/sessions` (the classic `file_store_path` default).
+fn sessions_dir() -> Option<PathBuf> {
+    let dir = dirs::home_dir()?.join(".openhands").join("sessions");
+    if dir.is_dir() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+/// Detect an `OpenHands` installation.
+pub fn detect() -> Option<ProviderInfo> {
+    let dir = sessions_dir()?;
+    Some(ProviderInfo {
+        id: PROVIDER.to_string(),
+        display_name: "OpenHands".to_string(),
+        is_available: !session_ids(&dir).is_empty(),
+        base_path: dir.to_string_lossy().to_string(),
+    })
+}
+
+/// Base path (`~/.openhands/sessions`), for the file watcher.
+pub fn get_base_path() -> Option<String> {
+    sessions_dir().map(|p| p.to_string_lossy().to_string())
+}
+
+/// Conversation ids = immediate subdirectories of `sessions/` that have an
+/// `events/` dir.
+fn session_ids(sessions: &Path) -> Vec<String> {
+    WalkDir::new(sessions)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_dir())
+        .filter(|e| e.path().join("events").is_dir())
+        .filter_map(|e| e.file_name().to_str().map(str::to_string))
+        .collect()
+}
+
+/// One synthetic project holding every `OpenHands` conversation.
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let Some(dir) = sessions_dir() else {
+        return Ok(vec![]);
+    };
+    let ids = session_ids(&dir);
+    if ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut message_count = 0usize;
+    let mut last_modified = String::new();
+    for sid in &ids {
+        let events = dir.join(sid).join("events");
+        message_count += event_files(&events).len();
+        let mtime = dir_mtime_rfc3339(&dir.join(sid));
+        if mtime > last_modified {
+            last_modified = mtime;
+        }
+    }
+    Ok(vec![ClaudeProject {
+        name: "OpenHands".to_string(),
+        path: format!("{SCHEME}{PROJECT_KEY}"),
+        actual_path: "OpenHands".to_string(),
+        session_count: ids.len(),
+        message_count,
+        last_modified,
+        git_info: None,
+        provider: Some(PROVIDER.to_string()),
+        storage_type: Some("json".to_string()),
+        custom_directory_label: None,
+    }])
+}
+
+/// Load the conversations (sessions) of the synthetic `OpenHands` project.
+pub fn load_sessions(
+    _project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let Some(dir) = sessions_dir() else {
+        return Ok(vec![]);
+    };
+    let mut sessions = Vec::new();
+    for sid in session_ids(&dir) {
+        let session_dir = dir.join(&sid);
+        let events = session_dir.join("events");
+        let files = event_files(&events);
+        if files.is_empty() {
+            continue;
+        }
+        let (summary, first_ts, last_ts, has_tool_use) = session_overview(&files);
+        let title = read_metadata_title(&session_dir);
+        let mtime = dir_mtime_rfc3339(&session_dir);
+        let first = first_ts.unwrap_or_else(|| mtime.clone());
+        let last = last_ts.unwrap_or(mtime);
+        sessions.push(ClaudeSession {
+            session_id: format!("{SCHEME}{sid}"),
+            actual_session_id: sid.clone(),
+            file_path: format!("{SCHEME}{sid}"),
+            project_name: "OpenHands".to_string(),
+            message_count: files.len(),
+            first_message_time: first,
+            last_message_time: last.clone(),
+            last_modified: last,
+            has_tool_use,
+            has_errors: false,
+            summary: title
+                .filter(|t| !t.trim().is_empty())
+                .or(summary)
+                .or_else(|| Some(sid.clone())),
+            is_renamed: false,
+            provider: Some(PROVIDER.to_string()),
+            storage_type: Some("json".to_string()),
+            entrypoint: None,
+        });
+    }
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+/// Load messages for one `OpenHands` conversation (`openhands://<sid>`).
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let sid = session_path.strip_prefix(SCHEME).unwrap_or(session_path);
+    let events = events_dir_for(sid)?;
+    let mut messages = Vec::new();
+    for (idx, path) in event_files(&events).into_iter().enumerate() {
+        let Ok(data) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(event) = serde_json::from_str::<Value>(&data) else {
+            continue;
+        };
+        if let Some(msg) = convert_event(&event, sid, idx) {
+            messages.push(msg);
+        }
+    }
+    Ok(messages)
+}
+
+/// Search across all `OpenHands` conversations.
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let Some(dir) = sessions_dir() else {
+        return Ok(vec![]);
+    };
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+    for sid in session_ids(&dir) {
+        let events = dir.join(&sid).join("events");
+        for (idx, path) in event_files(&events).into_iter().enumerate() {
+            if results.len() >= limit {
+                return Ok(results);
+            }
+            let Ok(data) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(event) = serde_json::from_str::<Value>(&data) else {
+                continue;
+            };
+            if let Some(mut msg) = convert_event(&event, &sid, idx) {
+                let matched = msg
+                    .content
+                    .as_ref()
+                    .map(|c| search_json_value_case_insensitive(c, &query_lower))
+                    .unwrap_or(false);
+                if matched {
+                    msg.project_name = Some("OpenHands".to_string());
+                    results.push(msg);
+                }
+            }
+        }
+    }
+    Ok(results)
+}
+
+// ============================================================================
+// Event handling
+// ============================================================================
+
+/// `events/<N>.json` files sorted by their integer id.
+fn event_files(events: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<(i64, PathBuf)> = WalkDir::new(events)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().and_then(|s| s.to_str()) != Some("json") {
+                return None;
+            }
+            let n: i64 = p.file_stem().and_then(|s| s.to_str())?.parse().ok()?;
+            Some((n, p.to_path_buf()))
+        })
+        .collect();
+    files.sort_by_key(|(n, _)| *n);
+    files.into_iter().map(|(_, p)| p).collect()
+}
+
+fn events_dir_for(sid: &str) -> Result<PathBuf, String> {
+    // sid must be a single safe path component (no traversal).
+    if sid.is_empty() || sid.contains('/') || sid.contains('\\') || sid.contains("..") {
+        return Err(format!("Invalid OpenHands session id: {sid}"));
+    }
+    let dir = sessions_dir().ok_or("OpenHands sessions path not found")?;
+    let events = dir.join(sid).join("events");
+    if events.is_dir() {
+        Ok(events)
+    } else {
+        Err(format!("OpenHands session not found: {sid}"))
+    }
+}
+
+/// Convert one classic-`OpenHands` event dict to a `ClaudeMessage`.
+fn convert_event(event: &Value, sid: &str, idx: usize) -> Option<ClaudeMessage> {
+    let source = event.get("source").and_then(Value::as_str).unwrap_or("");
+    let timestamp = event
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let event_id = event
+        .get("id")
+        .map(ToString::to_string)
+        .unwrap_or_else(|| idx.to_string());
+    let uuid = format!("{sid}-{event_id}");
+
+    if let Some(action) = event.get("action").and_then(Value::as_str) {
+        match action {
+            "system" | "null" | "change_agent_state" => None,
+            "message" => {
+                let text = event
+                    .get("args")
+                    .and_then(|a| a.get("content"))
+                    .and_then(Value::as_str)
+                    .or_else(|| event.get("message").and_then(Value::as_str))
+                    .unwrap_or("");
+                if text.is_empty() {
+                    return None;
+                }
+                let role = if source == "user" {
+                    "user"
+                } else {
+                    "assistant"
+                };
+                Some(make_msg(
+                    PROVIDER,
+                    uuid,
+                    sid,
+                    timestamp,
+                    role,
+                    vec![json!({ "type": "text", "text": text })],
+                ))
+            }
+            // Any other action is an agent tool call.
+            _ => {
+                let mut blocks = Vec::new();
+                if let Some(thought) = event
+                    .get("args")
+                    .and_then(|a| a.get("thought"))
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                {
+                    blocks.push(json!({ "type": "text", "text": thought }));
+                }
+                let input = event.get("args").cloned().unwrap_or_else(|| json!({}));
+                blocks.push(json!({
+                    "type": "tool_use",
+                    "id": event_id,
+                    "name": action,
+                    "input": input
+                }));
+                Some(make_msg(
+                    PROVIDER,
+                    uuid,
+                    sid,
+                    timestamp,
+                    "assistant",
+                    blocks,
+                ))
+            }
+        }
+    } else if let Some(_obs) = event.get("observation").and_then(Value::as_str) {
+        let content = event
+            .get("content")
+            .map(|c| match c {
+                Value::String(s) => s.clone(),
+                other => other.to_string(),
+            })
+            .unwrap_or_default();
+        let tool_use_id = event
+            .get("cause")
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let is_error = event.get("observation").and_then(Value::as_str) == Some("error");
+        Some(make_msg(
+            PROVIDER,
+            uuid,
+            sid,
+            timestamp,
+            "user",
+            vec![json!({
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content,
+                "is_error": is_error
+            })],
+        ))
+    } else {
+        None
+    }
+}
+
+fn make_msg(
+    provider: &str,
+    uuid: String,
+    sid: &str,
+    timestamp: String,
+    role: &str,
+    blocks: Vec<Value>,
+) -> ClaudeMessage {
+    build_provider_message(
+        provider,
+        uuid,
+        sid,
+        timestamp,
+        role,
+        Some(role),
+        Some(Value::Array(blocks)),
+        None,
+    )
+}
+
+/// `(summary, first_ts, last_ts, has_tool_use)` over a session's event files.
+fn session_overview(files: &[PathBuf]) -> (Option<String>, Option<String>, Option<String>, bool) {
+    let mut summary = None;
+    let mut first_ts = None;
+    let mut last_ts = None;
+    let mut has_tool_use = false;
+    for path in files {
+        let Ok(data) = fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(event) = serde_json::from_str::<Value>(&data) else {
+            continue;
+        };
+        if let Some(ts) = event.get("timestamp").and_then(Value::as_str) {
+            if first_ts.is_none() {
+                first_ts = Some(ts.to_string());
+            }
+            last_ts = Some(ts.to_string());
+        }
+        let action = event.get("action").and_then(Value::as_str);
+        if matches!(action, Some(a) if !matches!(a, "message" | "system" | "null" | "change_agent_state"))
+            || event.get("observation").is_some()
+        {
+            has_tool_use = true;
+        }
+        if summary.is_none()
+            && action == Some("message")
+            && event.get("source").and_then(Value::as_str) == Some("user")
+        {
+            summary = event
+                .get("args")
+                .and_then(|a| a.get("content"))
+                .and_then(Value::as_str)
+                .map(summarize);
+        }
+    }
+    (summary, first_ts, last_ts, has_tool_use)
+}
+
+fn read_metadata_title(session_dir: &Path) -> Option<String> {
+    let data = fs::read_to_string(session_dir.join("metadata.json")).ok()?;
+    let meta: Value = serde_json::from_str(&data).ok()?;
+    meta.get("title")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn summarize(text: &str) -> String {
+    let cleaned = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if cleaned.chars().count() > SUMMARY_MAX_CHARS {
+        format!(
+            "{}…",
+            cleaned.chars().take(SUMMARY_MAX_CHARS).collect::<String>()
+        )
+    } else {
+        cleaned
+    }
+}
+
+fn dir_mtime_rfc3339(path: &Path) -> String {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+        .map(|d| {
+            #[allow(clippy::cast_possible_wrap)]
+            DateTime::from_timestamp(d.as_secs() as i64, 0)
+                .unwrap_or_else(Utc::now)
+                .to_rfc3339()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user_event() -> Value {
+        json!({ "id": 1, "timestamp": "2026-06-20T10:00:00", "source": "user",
+            "message": "run ls", "action": "message",
+            "args": { "content": "run ls" } })
+    }
+    fn assistant_event() -> Value {
+        json!({ "id": 7, "timestamp": "2026-06-20T10:00:05", "source": "agent",
+            "message": "Sure", "action": "message", "args": { "content": "Sure, listing." } })
+    }
+    fn toolcall_event() -> Value {
+        json!({ "id": 8, "timestamp": "2026-06-20T10:00:06", "source": "agent",
+            "message": "Running command: ls -la", "action": "run",
+            "args": { "command": "ls -la", "thought": "let me list" } })
+    }
+    fn observation_event() -> Value {
+        json!({ "id": 9, "timestamp": "2026-06-20T10:00:07", "source": "agent",
+            "cause": 8, "observation": "run", "content": "total 8\nfile.rs",
+            "extras": { "metadata": { "exit_code": 0 } } })
+    }
+    fn system_event() -> Value {
+        json!({ "id": 0, "source": "agent", "action": "system", "args": { "content": "sys prompt" } })
+    }
+
+    #[test]
+    fn convert_user_and_assistant_messages() {
+        let u = convert_event(&user_event(), "s1", 0).unwrap();
+        assert_eq!(u.role.as_deref(), Some("user"));
+        assert_eq!(u.uuid, "s1-1");
+        assert_eq!(u.provider.as_deref(), Some("openhands"));
+        assert_eq!(u.content.as_ref().unwrap()[0]["text"], "run ls");
+
+        let a = convert_event(&assistant_event(), "s1", 1).unwrap();
+        assert_eq!(a.role.as_deref(), Some("assistant"));
+        assert_eq!(a.content.as_ref().unwrap()[0]["text"], "Sure, listing.");
+    }
+
+    #[test]
+    fn convert_tool_call_and_observation_link_by_cause() {
+        let call = convert_event(&toolcall_event(), "s1", 2).unwrap();
+        assert_eq!(call.role.as_deref(), Some("assistant"));
+        let cb = call.content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(cb[0]["type"], "text"); // thought
+        assert_eq!(cb[1]["type"], "tool_use");
+        assert_eq!(cb[1]["id"], "8");
+        assert_eq!(cb[1]["name"], "run");
+        assert_eq!(cb[1]["input"]["command"], "ls -la");
+
+        let obs = convert_event(&observation_event(), "s1", 3).unwrap();
+        assert_eq!(obs.role.as_deref(), Some("user"));
+        let ob = obs.content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(ob[0]["type"], "tool_result");
+        assert_eq!(ob[0]["tool_use_id"], "8"); // == toolcall id (cause)
+        assert!(ob[0]["content"].as_str().unwrap().contains("file.rs"));
+    }
+
+    #[test]
+    fn system_and_unknown_records_are_skipped() {
+        assert!(convert_event(&system_event(), "s1", 0).is_none());
+        assert!(convert_event(&json!({ "id": 1, "source": "agent" }), "s1", 0).is_none());
+    }
+
+    #[test]
+    fn events_dir_rejects_traversal() {
+        assert!(events_dir_for("../../etc").is_err());
+        assert!(events_dir_for("a/b").is_err());
+        assert!(events_dir_for("").is_err());
+    }
+}

--- a/src-tauri/src/providers/openhands.rs
+++ b/src-tauri/src/providers/openhands.rs
@@ -65,6 +65,7 @@ fn session_ids(sessions: &Path) -> Vec<String> {
         .max_depth(1)
         .into_iter()
         .filter_map(Result::ok)
+        .filter(|e| !e.path_is_symlink())
         .filter(|e| e.file_type().is_dir())
         .filter(|e| e.path().join("events").is_dir())
         .filter_map(|e| e.file_name().to_str().map(str::to_string))
@@ -215,6 +216,7 @@ fn event_files(events: &Path) -> Vec<PathBuf> {
         .max_depth(1)
         .into_iter()
         .filter_map(Result::ok)
+        .filter(|e| !e.path_is_symlink())
         .filter(|e| e.file_type().is_file())
         .filter_map(|e| {
             let p = e.path();

--- a/src-tauri/src/providers/openinterpreter.rs
+++ b/src-tauri/src/providers/openinterpreter.rs
@@ -1,0 +1,359 @@
+//! Open Interpreter provider (Rust v1.0).
+//!
+//! Open Interpreter v1.0 is a re-rooted fork of `OpenAI` Codex and writes the
+//! IDENTICAL rollout JSONL format, under `~/.openinterpreter/sessions/**` (+
+//! `archived_sessions/`). The home dir is overridable via `INTERPRETER_HOME`
+//! (`CODEX_HOME` is deliberately ignored by Open Interpreter).
+//!
+//! Because the on-disk format is byte-compatible with Codex, this module reuses
+//! the Codex rollout parser ([`super::codex::parse_rollout_file`]) and metadata
+//! extractors, validating paths against the Open Interpreter root and re-tagging
+//! the provider on the result. Projects group rollouts by `cwd`, like Codex.
+
+use super::codex;
+use super::ProviderInfo;
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+const PROVIDER: &str = "openinterpreter";
+const SCHEME: &str = "openinterpreter://";
+
+/// Open Interpreter home: `$INTERPRETER_HOME` (if set + exists) else
+/// `~/.openinterpreter`. Returns `None` unless the directory exists.
+fn home_dir() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("INTERPRETER_HOME") {
+        let home = home.trim();
+        if !home.is_empty() {
+            let p = PathBuf::from(home);
+            return if p.exists() { Some(p) } else { None };
+        }
+    }
+    let p = dirs::home_dir()?.join(".openinterpreter");
+    if p.exists() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Detect an Open Interpreter installation.
+pub fn detect() -> Option<ProviderInfo> {
+    let base = home_dir()?;
+    Some(ProviderInfo {
+        id: PROVIDER.to_string(),
+        display_name: "Open Interpreter".to_string(),
+        is_available: !session_dirs().is_empty(),
+        base_path: base.to_string_lossy().to_string(),
+    })
+}
+
+/// Base path (the Open Interpreter home), for the file watcher.
+pub fn get_base_path() -> Option<String> {
+    home_dir().map(|p| p.to_string_lossy().to_string())
+}
+
+/// The existing `sessions/` and `archived_sessions/` roots under the OI home.
+fn session_dirs() -> Vec<PathBuf> {
+    let Some(base) = home_dir() else {
+        return Vec::new();
+    };
+    [base.join("sessions"), base.join("archived_sessions")]
+        .into_iter()
+        .filter(|p| p.is_dir())
+        .collect()
+}
+
+/// All `rollout-*.jsonl` files under the OI session roots.
+fn rollout_files() -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for dir in session_dirs() {
+        for entry in WalkDir::new(dir)
+            .min_depth(1)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_file())
+            .filter(|e| codex::is_rollout_jsonl(e.path()))
+        {
+            files.push(entry.path().to_path_buf());
+        }
+    }
+    files
+}
+
+/// Scan Open Interpreter projects (rollouts grouped by `cwd`).
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    struct Agg {
+        session_count: usize,
+        message_count: usize,
+        last_modified: String,
+    }
+    let mut by_cwd: HashMap<String, Agg> = HashMap::new();
+
+    for path in rollout_files() {
+        if let Ok(info) = codex::extract_project_scan_info(&path) {
+            let cwd = info.cwd.clone().unwrap_or_else(|| "unknown".to_string());
+            let e = by_cwd.entry(cwd).or_insert_with(|| Agg {
+                session_count: 0,
+                message_count: 0,
+                last_modified: String::new(),
+            });
+            e.session_count += 1;
+            e.message_count += info.message_count;
+            if info.last_modified > e.last_modified {
+                e.last_modified = info.last_modified;
+            }
+        }
+    }
+
+    let mut projects: Vec<ClaudeProject> = by_cwd
+        .into_iter()
+        .map(|(cwd, agg)| {
+            let name = Path::new(&cwd)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| cwd.clone());
+            ClaudeProject {
+                name,
+                path: format!("{SCHEME}{cwd}"),
+                actual_path: cwd,
+                session_count: agg.session_count,
+                message_count: agg.message_count,
+                last_modified: agg.last_modified,
+                git_info: None,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: None,
+                custom_directory_label: None,
+            }
+        })
+        .collect();
+
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+/// Load the sessions for one Open Interpreter project (filtered by `cwd`).
+pub fn load_sessions(
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let target_cwd = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
+    let mut sessions = Vec::new();
+
+    for path in rollout_files() {
+        if let Ok(Some(cwd)) = codex::extract_session_cwd(&path) {
+            if cwd != target_cwd {
+                continue;
+            }
+        }
+        if let Ok(info) = codex::extract_session_info(&path) {
+            if info.cwd.as_deref().unwrap_or("unknown") != target_cwd {
+                continue;
+            }
+            sessions.push(ClaudeSession {
+                session_id: info.file_path.clone(),
+                actual_session_id: info.session_id,
+                file_path: info.file_path,
+                project_name: Path::new(target_cwd)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default(),
+                message_count: info.message_count,
+                first_message_time: info.first_message_time,
+                last_message_time: info.last_message_time,
+                last_modified: info.last_modified,
+                has_tool_use: info.has_tool_use,
+                has_errors: false,
+                summary: info.summary,
+                is_renamed: false,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: None,
+                entrypoint: None,
+            });
+        }
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+/// Load all messages from one Open Interpreter rollout file.
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let path = Path::new(session_path);
+    if !path.exists() {
+        return Err(format!("Session file not found: {session_path}"));
+    }
+    let canonical = validate_under_base(path)?;
+    let mut messages = codex::parse_rollout_file(&canonical)?;
+    // The Codex parser tags messages "codex"; re-tag for this provider.
+    for msg in &mut messages {
+        msg.provider = Some(PROVIDER.to_string());
+    }
+    Ok(messages)
+}
+
+/// Search across all Open Interpreter rollouts.
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    if query.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for path in rollout_files() {
+        let Ok(messages) = load_messages(&path.to_string_lossy()) else {
+            continue;
+        };
+        for msg in messages {
+            if results.len() >= limit {
+                return Ok(results);
+            }
+            if let Some(content) = &msg.content {
+                if crate::utils::search_json_value_case_insensitive(content, &query_lower) {
+                    results.push(msg);
+                }
+            }
+        }
+    }
+    Ok(results)
+}
+
+/// Confine `session_path` to the Open Interpreter session roots and confirm it
+/// is a rollout file. Canonicalizes both sides.
+fn validate_under_base(path: &Path) -> Result<PathBuf, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve session path: {e}"))?;
+    if !codex::is_rollout_jsonl(&canonical) {
+        return Err(format!(
+            "Not an Open Interpreter rollout file: {}",
+            path.display()
+        ));
+    }
+    let allowed: Vec<PathBuf> = session_dirs()
+        .into_iter()
+        .filter_map(|d| d.canonicalize().ok())
+        .collect();
+    if allowed.is_empty() {
+        return Err("Open Interpreter session directories not found".to_string());
+    }
+    if allowed.iter().any(|d| canonical.starts_with(d)) {
+        Ok(canonical)
+    } else {
+        Err(format!(
+            "Session path is outside Open Interpreter session directories: {}",
+            path.display()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+    use serial_test::serial;
+    use std::fs;
+    use tempfile::TempDir;
+
+    struct HomeGuard {
+        original: Option<String>,
+    }
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let original = std::env::var("INTERPRETER_HOME").ok();
+            std::env::set_var("INTERPRETER_HOME", path);
+            Self { original }
+        }
+    }
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match self.original.as_ref() {
+                Some(v) => std::env::set_var("INTERPRETER_HOME", v),
+                None => std::env::remove_var("INTERPRETER_HOME"),
+            }
+        }
+    }
+
+    fn write_rollout(
+        sessions_dir: &Path,
+        filename: &str,
+        id: &str,
+        cwd: &str,
+        prompt: &str,
+    ) -> PathBuf {
+        let path = sessions_dir.join(filename);
+        let lines = [
+            json!({ "type": "session_meta", "payload": { "id": id, "cwd": cwd } }),
+            json!({
+                "timestamp": "2026-02-21T10:00:00Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message", "role": "user", "created_at": "2026-02-21T10:00:00Z",
+                    "content": [{ "type": "input_text", "text": prompt }]
+                }
+            }),
+        ];
+        let body = lines
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&path, format!("{body}\n")).unwrap();
+        path
+    }
+
+    #[test]
+    #[serial]
+    fn scan_load_and_retag_via_interpreter_home() {
+        let tmp = TempDir::new().unwrap();
+        let sessions = tmp.path().join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        write_rollout(
+            &sessions,
+            "rollout-2026-02-21T10-00-00-uuid1.jsonl",
+            "uuid1",
+            "/Users/jack/proj",
+            "why does LOGIN fail?",
+        );
+        let _guard = HomeGuard::set(tmp.path());
+
+        // detect + base path
+        let info = detect().unwrap();
+        assert_eq!(info.id, "openinterpreter");
+        assert!(info.is_available);
+
+        // scan groups by cwd
+        let projects = scan_projects().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].provider.as_deref(), Some("openinterpreter"));
+        assert_eq!(projects[0].path, "openinterpreter:///Users/jack/proj");
+        assert_eq!(projects[0].actual_path, "/Users/jack/proj");
+
+        // load_sessions
+        let sess = load_sessions("openinterpreter:///Users/jack/proj", false).unwrap();
+        assert_eq!(sess.len(), 1);
+        assert_eq!(sess[0].provider.as_deref(), Some("openinterpreter"));
+        let file_path = sess[0].file_path.clone();
+
+        // load_messages reuses the Codex parser but re-tags provider
+        let msgs = load_messages(&file_path).unwrap();
+        assert!(!msgs.is_empty());
+        assert!(msgs
+            .iter()
+            .all(|m| m.provider.as_deref() == Some("openinterpreter")));
+    }
+
+    #[test]
+    #[serial]
+    fn load_messages_rejects_path_outside_base() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("sessions")).unwrap();
+        let _guard = HomeGuard::set(tmp.path());
+
+        // A rollout file outside the OI session roots must be rejected.
+        let outside = TempDir::new().unwrap();
+        let stray = write_rollout(outside.path(), "rollout-x.jsonl", "x", "/c", "hi");
+        assert!(load_messages(&stray.to_string_lossy()).is_err());
+    }
+}

--- a/src-tauri/src/providers/qwen.rs
+++ b/src-tauri/src/providers/qwen.rs
@@ -1,0 +1,626 @@
+//! Qwen Code provider (Alibaba's Gemini-CLI-derived terminal agent).
+//!
+//! Qwen Code auto-saves the full transcript (user + assistant + tool results)
+//! as per-session JSONL at
+//! `<runtime-base>/projects/<sanitizedCwd>/chats/<sessionId>.jsonl`, where the
+//! runtime base is `$QWEN_RUNTIME_DIR` / `$QWEN_HOME` / `~/.qwen` and
+//! `sanitizedCwd` is the project path with every non-alphanumeric char replaced
+//! by `-`. Each line is a `ChatRecord`:
+//! ```json
+//! { "uuid": "...", "parentUuid": null, "sessionId": "...", "timestamp": "...",
+//!   "type": "user"|"assistant"|"tool_result"|"system", "cwd": "/abs/path",
+//!   "model": "qwen3-coder-plus", "usageMetadata": {...},
+//!   "message": { "role": "user"|"model", "parts": [Part, ...] } }
+//! ```
+//! `Part` is the `@google/genai` shape: `{text}` / `{text,thought:true}` /
+//! `{functionCall:{name,args,id}}` / `{functionResponse:{name,response,id}}`.
+//! We map these to the viewer's Claude-style content blocks. Projects group by
+//! the real `cwd` carried on each record.
+
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
+use crate::providers::ProviderInfo;
+use crate::utils::{build_provider_message, search_json_value_case_insensitive};
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+const PROVIDER: &str = "qwen";
+const SCHEME: &str = "qwen://";
+const SUMMARY_MAX_CHARS: usize = 80;
+
+/// Runtime base dir: `$QWEN_RUNTIME_DIR` / `$QWEN_HOME` / `~/.qwen`.
+fn runtime_base() -> Option<PathBuf> {
+    for env in ["QWEN_RUNTIME_DIR", "QWEN_HOME"] {
+        if let Ok(v) = std::env::var(env) {
+            let v = v.trim();
+            if !v.is_empty() {
+                return Some(PathBuf::from(v));
+            }
+        }
+    }
+    Some(dirs::home_dir()?.join(".qwen"))
+}
+
+fn projects_dir() -> Option<PathBuf> {
+    let dir = runtime_base()?.join("projects");
+    if dir.is_dir() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+/// Detect a Qwen Code installation.
+pub fn detect() -> Option<ProviderInfo> {
+    let base = projects_dir()?;
+    Some(ProviderInfo {
+        id: PROVIDER.to_string(),
+        display_name: "Qwen Code".to_string(),
+        is_available: !session_files(&base).is_empty(),
+        base_path: base.to_string_lossy().to_string(),
+    })
+}
+
+/// Base path (`<runtime-base>/projects`), for the file watcher.
+pub fn get_base_path() -> Option<String> {
+    projects_dir().map(|p| p.to_string_lossy().to_string())
+}
+
+/// All `<projects>/<dir>/chats/*.jsonl` session files.
+fn session_files(projects: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for project in WalkDir::new(projects)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_dir())
+    {
+        let chats = project.path().join("chats");
+        if !chats.is_dir() {
+            continue;
+        }
+        for entry in WalkDir::new(&chats)
+            .min_depth(1)
+            .max_depth(1)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_file())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("jsonl"))
+            .filter(|e| !is_symlink(e.path()))
+        {
+            files.push(entry.path().to_path_buf());
+        }
+    }
+    files
+}
+
+/// Scan Qwen projects (sessions grouped by the real `cwd`).
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let Some(base) = projects_dir() else {
+        return Ok(vec![]);
+    };
+    struct Agg {
+        session_count: usize,
+        message_count: usize,
+        last_modified: String,
+    }
+    let mut by_cwd: HashMap<String, Agg> = HashMap::new();
+
+    for file in session_files(&base) {
+        let Ok(data) = fs::read_to_string(&file) else {
+            continue;
+        };
+        let Some(meta) = session_meta(&data) else {
+            continue;
+        };
+        if meta.message_count == 0 {
+            continue;
+        }
+        let cwd = meta.cwd.unwrap_or_else(|| "unknown".to_string());
+        let mtime = file_mtime_rfc3339(&file);
+        let entry = by_cwd.entry(cwd).or_insert_with(|| Agg {
+            session_count: 0,
+            message_count: 0,
+            last_modified: String::new(),
+        });
+        entry.session_count += 1;
+        entry.message_count += meta.message_count;
+        let last = meta.last_ts.clone().unwrap_or(mtime);
+        if last > entry.last_modified {
+            entry.last_modified = last;
+        }
+    }
+
+    let mut projects: Vec<ClaudeProject> = by_cwd
+        .into_iter()
+        .map(|(cwd, agg)| {
+            let name = Path::new(&cwd)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| cwd.clone());
+            ClaudeProject {
+                name,
+                path: format!("{SCHEME}{cwd}"),
+                actual_path: cwd,
+                session_count: agg.session_count,
+                message_count: agg.message_count,
+                last_modified: agg.last_modified,
+                git_info: None,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: None,
+                custom_directory_label: None,
+            }
+        })
+        .collect();
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+/// Load the sessions for one Qwen project (filtered by `cwd`).
+pub fn load_sessions(
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let Some(base) = projects_dir() else {
+        return Ok(vec![]);
+    };
+    let target_cwd = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
+    let mut sessions = Vec::new();
+
+    for file in session_files(&base) {
+        let Ok(data) = fs::read_to_string(&file) else {
+            continue;
+        };
+        let Some(meta) = session_meta(&data) else {
+            continue;
+        };
+        if meta.message_count == 0 {
+            continue;
+        }
+        if meta.cwd.as_deref().unwrap_or("unknown") != target_cwd {
+            continue;
+        }
+        let mtime = file_mtime_rfc3339(&file);
+        let first = meta.first_ts.clone().unwrap_or_else(|| mtime.clone());
+        let last = meta.last_ts.clone().unwrap_or(mtime);
+        sessions.push(ClaudeSession {
+            session_id: file.to_string_lossy().to_string(),
+            actual_session_id: meta.session_id,
+            file_path: file.to_string_lossy().to_string(),
+            project_name: Path::new(target_cwd)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            message_count: meta.message_count,
+            first_message_time: first,
+            last_message_time: last.clone(),
+            last_modified: last,
+            has_tool_use: meta.has_tool_use,
+            has_errors: false,
+            summary: meta.summary,
+            is_renamed: false,
+            provider: Some(PROVIDER.to_string()),
+            storage_type: None,
+            entrypoint: None,
+        });
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+/// Load all messages from one Qwen session file.
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let path = Path::new(session_path);
+    if !path.exists() {
+        return Err(format!("Session file not found: {session_path}"));
+    }
+    validate_under_base(path)?;
+    if is_symlink(path) {
+        return Err("Session file must not be a symlink".to_string());
+    }
+    let data = fs::read_to_string(path).map_err(|e| format!("Failed to read session file: {e}"))?;
+    Ok(parse_messages(&data))
+}
+
+/// Search across all Qwen sessions.
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let Some(base) = projects_dir() else {
+        return Ok(vec![]);
+    };
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+    for file in session_files(&base) {
+        let Ok(data) = fs::read_to_string(&file) else {
+            continue;
+        };
+        let cwd = session_meta(&data).and_then(|m| m.cwd);
+        let project_name = cwd
+            .as_deref()
+            .map(|c| {
+                Path::new(c)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| c.to_string())
+            })
+            .unwrap_or_default();
+        for mut msg in parse_messages(&data) {
+            if results.len() >= limit {
+                return Ok(results);
+            }
+            let matched = msg
+                .content
+                .as_ref()
+                .map(|c| search_json_value_case_insensitive(c, &query_lower))
+                .unwrap_or(false);
+            if matched {
+                msg.project_name = Some(project_name.clone());
+                results.push(msg);
+            }
+        }
+    }
+    Ok(results)
+}
+
+// ============================================================================
+// Pure parsing (unit-testable)
+// ============================================================================
+
+struct SessionMeta {
+    session_id: String,
+    cwd: Option<String>,
+    message_count: usize,
+    summary: Option<String>,
+    first_ts: Option<String>,
+    last_ts: Option<String>,
+    has_tool_use: bool,
+}
+
+/// Lightweight per-session metadata from a chat JSONL (one parse).
+fn session_meta(data: &str) -> Option<SessionMeta> {
+    let mut session_id = String::new();
+    let mut cwd = None;
+    let mut message_count = 0usize;
+    let mut summary = None;
+    let mut first_ts = None;
+    let mut last_ts = None;
+    let mut has_tool_use = false;
+
+    for line in data.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(rec) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if session_id.is_empty() {
+            if let Some(s) = rec.get("sessionId").and_then(Value::as_str) {
+                session_id = s.to_string();
+            }
+        }
+        if cwd.is_none() {
+            cwd = rec.get("cwd").and_then(Value::as_str).map(str::to_string);
+        }
+        let rec_type = rec.get("type").and_then(Value::as_str).unwrap_or("");
+        if !matches!(rec_type, "user" | "assistant" | "tool_result") {
+            continue;
+        }
+        message_count += 1;
+        if let Some(ts) = rec.get("timestamp").and_then(Value::as_str) {
+            if first_ts.is_none() {
+                first_ts = Some(ts.to_string());
+            }
+            last_ts = Some(ts.to_string());
+        }
+        if summary.is_none() && rec_type == "user" {
+            summary = first_text(&rec).map(|t| summarize(&t));
+        }
+        if rec_type == "tool_result" || record_has_function_call(&rec) {
+            has_tool_use = true;
+        }
+    }
+
+    if session_id.is_empty() && cwd.is_none() && message_count == 0 {
+        return None;
+    }
+    Some(SessionMeta {
+        session_id,
+        cwd,
+        message_count,
+        summary,
+        first_ts,
+        last_ts,
+        has_tool_use,
+    })
+}
+
+/// Parse a chat JSONL into messages.
+fn parse_messages(data: &str) -> Vec<ClaudeMessage> {
+    let mut messages = Vec::new();
+    for line in data.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(rec) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(msg) = convert_record(&rec) {
+            messages.push(msg);
+        }
+    }
+    messages
+}
+
+fn convert_record(rec: &Value) -> Option<ClaudeMessage> {
+    let rec_type = rec.get("type").and_then(Value::as_str)?;
+    // tool_result records carry role 'user' in genai but are their own record
+    // type; surface them in the user lane like Claude tool results.
+    let (message_type, role) = match rec_type {
+        "user" | "tool_result" => ("user", "user"),
+        "assistant" => ("assistant", "assistant"),
+        _ => return None, // skip system / UI records
+    };
+
+    let parts = rec
+        .get("message")
+        .and_then(|m| m.get("parts"))
+        .and_then(Value::as_array);
+    let blocks: Vec<Value> = parts
+        .map(|ps| ps.iter().filter_map(convert_part).collect())
+        .unwrap_or_default();
+    if blocks.is_empty() {
+        return None;
+    }
+
+    let session_id = rec.get("sessionId").and_then(Value::as_str).unwrap_or("");
+    let uuid = rec
+        .get("uuid")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(session_id)
+        .to_string();
+    let timestamp = rec
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let model = rec.get("model").and_then(Value::as_str).map(str::to_string);
+
+    let mut msg = build_provider_message(
+        PROVIDER,
+        uuid,
+        session_id,
+        timestamp,
+        message_type,
+        Some(role),
+        Some(Value::Array(blocks)),
+        model,
+    );
+    msg.parent_uuid = rec
+        .get("parentUuid")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if let Some(usage) = rec.get("usageMetadata") {
+        msg.usage = Some(convert_usage(usage));
+    }
+    Some(msg)
+}
+
+/// Map a `@google/genai` `Part` to a Claude-style content block.
+fn convert_part(part: &Value) -> Option<Value> {
+    if let Some(call) = part.get("functionCall") {
+        let name = call
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let id = call.get("id").and_then(Value::as_str).unwrap_or("");
+        let input = call.get("args").cloned().unwrap_or_else(|| json!({}));
+        return Some(json!({ "type": "tool_use", "id": id, "name": name, "input": input }));
+    }
+    if let Some(resp) = part.get("functionResponse") {
+        let id = resp.get("id").and_then(Value::as_str).unwrap_or("");
+        // response is usually { output: <string|object> }.
+        let content = resp
+            .get("response")
+            .and_then(|r| r.get("output"))
+            .map(stringify_value)
+            .or_else(|| resp.get("response").map(stringify_value))
+            .unwrap_or_default();
+        return Some(json!({ "type": "tool_result", "tool_use_id": id, "content": content }));
+    }
+    if let Some(text) = part.get("text").and_then(Value::as_str) {
+        if text.is_empty() {
+            return None;
+        }
+        // A part flagged thought:true is reasoning, not user-visible text.
+        if part
+            .get("thought")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return Some(json!({ "type": "thinking", "thinking": text, "signature": "" }));
+        }
+        return Some(json!({ "type": "text", "text": text }));
+    }
+    // inlineData / fileData / executableCode / codeExecutionResult: not rendered
+    // in this MVP.
+    None
+}
+
+fn convert_usage(usage: &Value) -> TokenUsage {
+    let g = |k: &str| usage.get(k).and_then(Value::as_u64).map(|n| n as u32);
+    TokenUsage {
+        input_tokens: g("promptTokenCount"),
+        output_tokens: g("candidatesTokenCount"),
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: g("cachedContentTokenCount"),
+        service_tier: None,
+    }
+}
+
+fn record_has_function_call(rec: &Value) -> bool {
+    rec.get("message")
+        .and_then(|m| m.get("parts"))
+        .and_then(Value::as_array)
+        .is_some_and(|ps| ps.iter().any(|p| p.get("functionCall").is_some()))
+}
+
+/// First non-thought text of a record's message (for the session summary).
+fn first_text(rec: &Value) -> Option<String> {
+    let parts = rec
+        .get("message")
+        .and_then(|m| m.get("parts"))
+        .and_then(Value::as_array)?;
+    parts.iter().find_map(|p| {
+        if p.get("thought").and_then(Value::as_bool).unwrap_or(false) {
+            return None;
+        }
+        p.get("text")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn stringify_value(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn summarize(text: &str) -> String {
+    let cleaned = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if cleaned.chars().count() > SUMMARY_MAX_CHARS {
+        format!(
+            "{}…",
+            cleaned.chars().take(SUMMARY_MAX_CHARS).collect::<String>()
+        )
+    } else {
+        cleaned
+    }
+}
+
+fn is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+fn validate_under_base(path: &Path) -> Result<(), String> {
+    let base = projects_dir().ok_or("Qwen projects path not found")?;
+    let canon_base = base
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve Qwen base: {e}"))?;
+    let canon_path = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve session path: {e}"))?;
+    if canon_path.starts_with(&canon_base) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Path is outside the Qwen projects root: {}",
+            path.display()
+        ))
+    }
+}
+
+fn file_mtime_rfc3339(path: &Path) -> String {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+        .map(|d| {
+            #[allow(clippy::cast_possible_wrap)]
+            DateTime::from_timestamp(d.as_secs() as i64, 0)
+                .unwrap_or_else(Utc::now)
+                .to_rfc3339()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SESSION: &str = concat!(
+        r#"{"uuid":"u1","parentUuid":null,"sessionId":"sess-1","timestamp":"2026-06-20T10:00:00Z","type":"user","cwd":"/Users/jack/proj","message":{"role":"user","parts":[{"text":"why does LOGIN fail?"}]}}"#,
+        "\n",
+        r#"{"uuid":"u2","parentUuid":"u1","sessionId":"sess-1","timestamp":"2026-06-20T10:00:01Z","type":"assistant","model":"qwen3-coder-plus","usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":34,"cachedContentTokenCount":5},"message":{"role":"model","parts":[{"text":"let me reason","thought":true},{"text":"Checking auth"},{"functionCall":{"id":"c1","name":"run_shell_command","args":{"command":"grep -r login"}}}]}}"#,
+        "\n",
+        r#"{"uuid":"u3","parentUuid":"u2","sessionId":"sess-1","timestamp":"2026-06-20T10:00:02Z","type":"tool_result","cwd":"/Users/jack/proj","message":{"role":"user","parts":[{"functionResponse":{"id":"c1","name":"run_shell_command","response":{"output":"login.rs:42"}}}]}}"#,
+        "\n",
+        r#"{"uuid":"s1","sessionId":"sess-1","timestamp":"2026-06-20T10:00:03Z","type":"system","subtype":"custom_title","message":{"role":"user","parts":[{"text":"ignored"}]}}"#,
+        "\n",
+    );
+
+    #[test]
+    fn session_meta_extracts_cwd_count_summary() {
+        let m = session_meta(SESSION).unwrap();
+        assert_eq!(m.session_id, "sess-1");
+        assert_eq!(m.cwd.as_deref(), Some("/Users/jack/proj"));
+        // user + assistant + tool_result (system excluded) = 3
+        assert_eq!(m.message_count, 3);
+        assert_eq!(m.summary.as_deref(), Some("why does LOGIN fail?"));
+        assert!(m.has_tool_use);
+        assert_eq!(m.first_ts.as_deref(), Some("2026-06-20T10:00:00Z"));
+        assert_eq!(m.last_ts.as_deref(), Some("2026-06-20T10:00:02Z"));
+    }
+
+    #[test]
+    fn parse_messages_maps_parts_to_blocks() {
+        let msgs = parse_messages(SESSION);
+        // system record is skipped.
+        assert_eq!(msgs.len(), 3);
+
+        // user
+        assert_eq!(msgs[0].role.as_deref(), Some("user"));
+        assert_eq!(msgs[0].uuid, "u1");
+        assert_eq!(msgs[0].provider.as_deref(), Some("qwen"));
+
+        // assistant: thinking + text + tool_use, with usage + model + parent
+        let a = &msgs[1];
+        assert_eq!(a.role.as_deref(), Some("assistant"));
+        assert_eq!(a.parent_uuid.as_deref(), Some("u1"));
+        assert_eq!(a.model.as_deref(), Some("qwen3-coder-plus"));
+        assert_eq!(a.usage.as_ref().unwrap().input_tokens, Some(12));
+        assert_eq!(a.usage.as_ref().unwrap().output_tokens, Some(34));
+        assert_eq!(a.usage.as_ref().unwrap().cache_read_input_tokens, Some(5));
+        let ab = a.content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(ab[0]["type"], "thinking");
+        assert_eq!(ab[1]["type"], "text");
+        assert_eq!(ab[2]["type"], "tool_use");
+        assert_eq!(ab[2]["name"], "run_shell_command");
+        assert_eq!(ab[2]["id"], "c1");
+
+        // tool_result -> user lane, tool_result block with extracted output
+        assert_eq!(msgs[2].role.as_deref(), Some("user"));
+        let tr = msgs[2].content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(tr[0]["type"], "tool_result");
+        assert_eq!(tr[0]["tool_use_id"], "c1");
+        assert_eq!(tr[0]["content"], "login.rs:42");
+    }
+
+    #[test]
+    fn convert_part_kinds() {
+        assert!(convert_part(&json!({"text":""})).is_none());
+        assert_eq!(convert_part(&json!({"text":"hi"})).unwrap()["type"], "text");
+        assert_eq!(
+            convert_part(&json!({"text":"r","thought":true})).unwrap()["type"],
+            "thinking"
+        );
+        // functionResponse with object output is stringified.
+        let tr =
+            convert_part(&json!({"functionResponse":{"id":"x","response":{"output":{"k":1}}}}))
+                .unwrap();
+        assert_eq!(tr["type"], "tool_result");
+        assert!(tr["content"].as_str().unwrap().contains("\"k\""));
+    }
+}

--- a/src-tauri/src/providers/qwen.rs
+++ b/src-tauri/src/providers/qwen.rs
@@ -77,6 +77,7 @@ fn session_files(projects: &Path) -> Vec<PathBuf> {
         .max_depth(1)
         .into_iter()
         .filter_map(Result::ok)
+        .filter(|e| !e.path_is_symlink())
         .filter(|e| e.file_type().is_dir())
     {
         let chats = project.path().join("chats");

--- a/src-tauri/src/providers/trae.rs
+++ b/src-tauri/src/providers/trae.rs
@@ -1,0 +1,579 @@
+//! Trae IDE provider (`ByteDance` VS Code fork) — BEST-EFFORT / reverse-engineered.
+//!
+//! Trae stores chat/agent history in the per-workspace VS Code key-value DB
+//! `<UserData>/Trae/User/workspaceStorage/<hash>/state.vscdb` (`SQLite`,
+//! `ItemTable(key, value)`). The conversation lives under `ByteDance` "icube"
+//! keys; we query (in precedence order):
+//!   `memento/icube-ai-agent-storage` (primary; value = `{ "list": [Session] }`),
+//!   `ChatStore`, `chat.ChatSessionStore.index`, and the install-suffixed
+//!   `memento/icube-ai-chat-storage-<n>` / `memento/icube-ai-ng-chat-storage-<n>`
+//!   (matched by prefix since `<n>` is account-specific).
+//!
+//! ⚠️ Unlike the other providers, this schema is NOT from official source — it is
+//! reverse-engineered from the `trae-chats-exporter` community tool, the keys are
+//! install-specific, and the Agent/SOLO-mode content is deeply nested. It has not
+//! been verified against a real Trae install. Parsing is therefore defensive
+//! (multiple field-name fallbacks) and renders text content; structured tool
+//! calls in Agent mode are flattened to text. Treat as provisional.
+
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::providers::ProviderInfo;
+use crate::utils::{build_provider_message, search_json_value_case_insensitive};
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+const PROVIDER: &str = "trae";
+const SCHEME: &str = "trae://";
+const SESSION_SEP: char = '#';
+const SUMMARY_MAX_CHARS: usize = 80;
+
+/// Exact icube keys to try, in precedence order.
+const EXACT_KEYS: &[&str] = &[
+    "memento/icube-ai-agent-storage",
+    "ChatStore",
+    "chat.ChatSessionStore.index",
+];
+/// Prefixes for the install-suffixed icube chat-storage keys.
+const KEY_PREFIXES: &[&str] = &[
+    "memento/icube-ai-ng-chat-storage-",
+    "memento/icube-ai-chat-storage-",
+];
+
+/// `<UserData>/Trae/User/workspaceStorage` (`dirs::config_dir()` resolves to
+/// `~/Library/Application Support` on macOS, `~/.config` on Linux, `%APPDATA%`
+/// on Windows — matching VS Code-family layout).
+fn workspace_storage() -> Option<PathBuf> {
+    let dir = dirs::config_dir()?
+        .join("Trae")
+        .join("User")
+        .join("workspaceStorage");
+    if dir.is_dir() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+/// Detect a Trae installation (any workspace with a `state.vscdb`).
+pub fn detect() -> Option<ProviderInfo> {
+    let storage = workspace_storage()?;
+    Some(ProviderInfo {
+        id: PROVIDER.to_string(),
+        display_name: "Trae".to_string(),
+        is_available: !workspace_dbs(&storage).is_empty(),
+        base_path: storage.to_string_lossy().to_string(),
+    })
+}
+
+/// Base path (`…/Trae/User/workspaceStorage`), for the file watcher.
+pub fn get_base_path() -> Option<String> {
+    workspace_storage().map(|p| p.to_string_lossy().to_string())
+}
+
+/// `(hash, state.vscdb path)` for each workspace that has a DB.
+fn workspace_dbs(storage: &Path) -> Vec<(String, PathBuf)> {
+    WalkDir::new(storage)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_dir())
+        .filter_map(|e| {
+            let db = e.path().join("state.vscdb");
+            if db.is_file() {
+                Some((e.file_name().to_string_lossy().to_string(), db))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn open_db(path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Trae DB: {e}"))?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(|e| format!("Failed to set busy timeout: {e}"))?;
+    Ok(conn)
+}
+
+/// Read the first present icube conversation value from a workspace DB.
+fn read_icube_value(conn: &Connection) -> Option<Value> {
+    for key in EXACT_KEYS {
+        if let Ok(raw) = conn.query_row("SELECT value FROM ItemTable WHERE key = ?1", [key], |r| {
+            r.get::<_, String>(0)
+        }) {
+            if let Ok(v) = serde_json::from_str::<Value>(&raw) {
+                if !extract_sessions(&v).is_empty() {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    for prefix in KEY_PREFIXES {
+        let like = format!("{prefix}%");
+        if let Ok(raw) = conn.query_row(
+            "SELECT value FROM ItemTable WHERE key LIKE ?1 ORDER BY key DESC LIMIT 1",
+            [&like],
+            |r| r.get::<_, String>(0),
+        ) {
+            if let Ok(v) = serde_json::from_str::<Value>(&raw) {
+                if !extract_sessions(&v).is_empty() {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// The workspace folder path from `workspace.json` (folder URI), for display.
+fn workspace_folder(db_path: &Path) -> Option<String> {
+    let ws_json = db_path.parent()?.join("workspace.json");
+    let data = std::fs::read_to_string(ws_json).ok()?;
+    let v: Value = serde_json::from_str(&data).ok()?;
+    let folder = v.get("folder").and_then(Value::as_str)?;
+    // folder is a file:// URI.
+    Some(folder.strip_prefix("file://").unwrap_or(folder).to_string())
+}
+
+/// Scan Trae projects — one per workspace that has parseable chat sessions.
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let Some(storage) = workspace_storage() else {
+        return Ok(vec![]);
+    };
+    let mut projects = Vec::new();
+    for (hash, db_path) in workspace_dbs(&storage) {
+        let Ok(conn) = open_db(&db_path) else {
+            continue;
+        };
+        let Some(value) = read_icube_value(&conn) else {
+            continue;
+        };
+        let sessions = extract_sessions(&value);
+        if sessions.is_empty() {
+            continue;
+        }
+        let folder = workspace_folder(&db_path).unwrap_or_else(|| hash.clone());
+        let name = Path::new(&folder)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| folder.clone());
+        let message_count: usize = sessions.iter().map(|s| s.messages.len()).sum();
+        projects.push(ClaudeProject {
+            name,
+            path: format!("{SCHEME}{hash}"),
+            actual_path: folder,
+            session_count: sessions.len(),
+            message_count,
+            last_modified: String::new(),
+            git_info: None,
+            provider: Some(PROVIDER.to_string()),
+            storage_type: Some("sqlite".to_string()),
+            custom_directory_label: None,
+        });
+    }
+    Ok(projects)
+}
+
+/// Load the chat sessions for one Trae workspace (`trae://<hash>`).
+pub fn load_sessions(
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let hash = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
+    let Some(storage) = workspace_storage() else {
+        return Ok(vec![]);
+    };
+    let db_path = storage.join(hash).join("state.vscdb");
+    if !db_path.is_file() {
+        return Ok(vec![]);
+    }
+    let conn = open_db(&db_path)?;
+    let Some(value) = read_icube_value(&conn) else {
+        return Ok(vec![]);
+    };
+    let folder = workspace_folder(&db_path).unwrap_or_else(|| hash.to_string());
+    let project_name = Path::new(&folder)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let sessions = extract_sessions(&value)
+        .into_iter()
+        .map(|s| {
+            let summary = s
+                .title
+                .clone()
+                .filter(|t| !t.trim().is_empty())
+                .or_else(|| s.first_user_text().map(|t| summarize(&t)))
+                .or_else(|| Some(s.id.clone()));
+            ClaudeSession {
+                session_id: format!("{SCHEME}{hash}{SESSION_SEP}{}", s.id),
+                actual_session_id: s.id.clone(),
+                file_path: format!("{SCHEME}{hash}{SESSION_SEP}{}", s.id),
+                project_name: project_name.clone(),
+                message_count: s.messages.len(),
+                first_message_time: String::new(),
+                last_message_time: String::new(),
+                last_modified: String::new(),
+                has_tool_use: false,
+                has_errors: false,
+                summary,
+                is_renamed: false,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: Some("sqlite".to_string()),
+                entrypoint: None,
+            }
+        })
+        .collect();
+    Ok(sessions)
+}
+
+/// Load messages for one Trae session (`trae://<hash>#<sessionId>`).
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let (hash, session_id) = parse_session_path(session_path)?;
+    let Some(storage) = workspace_storage() else {
+        return Ok(vec![]);
+    };
+    let db_path = storage.join(&hash).join("state.vscdb");
+    if !db_path.is_file() {
+        return Ok(vec![]);
+    }
+    let conn = open_db(&db_path)?;
+    let Some(value) = read_icube_value(&conn) else {
+        return Ok(vec![]);
+    };
+    let Some(session) = extract_sessions(&value)
+        .into_iter()
+        .find(|s| s.id == session_id)
+    else {
+        return Ok(vec![]);
+    };
+    Ok(session.to_messages())
+}
+
+/// Search across all Trae sessions.
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let Some(storage) = workspace_storage() else {
+        return Ok(vec![]);
+    };
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+    for (_hash, db_path) in workspace_dbs(&storage) {
+        let project_name = workspace_folder(&db_path)
+            .map(|f| {
+                Path::new(&f)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or(f)
+            })
+            .unwrap_or_default();
+        let Ok(conn) = open_db(&db_path) else {
+            continue;
+        };
+        let Some(value) = read_icube_value(&conn) else {
+            continue;
+        };
+        for session in extract_sessions(&value) {
+            for mut msg in session.to_messages() {
+                if results.len() >= limit {
+                    return Ok(results);
+                }
+                let matched = msg
+                    .content
+                    .as_ref()
+                    .map(|c| search_json_value_case_insensitive(c, &query_lower))
+                    .unwrap_or(false);
+                if matched {
+                    msg.project_name = Some(project_name.clone());
+                    results.push(msg);
+                }
+            }
+        }
+    }
+    Ok(results)
+}
+
+// ============================================================================
+// Pure extraction (unit-testable)
+// ============================================================================
+
+struct TraeSession {
+    id: String,
+    title: Option<String>,
+    messages: Vec<Value>,
+}
+
+impl TraeSession {
+    fn first_user_text(&self) -> Option<String> {
+        self.messages.iter().find_map(|m| {
+            if role_of(m) == Some("user") {
+                message_text(m)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn to_messages(&self) -> Vec<ClaudeMessage> {
+        let mut out = Vec::new();
+        for (idx, m) in self.messages.iter().enumerate() {
+            let Some(role) = role_of(m) else {
+                continue;
+            };
+            let Some(text) = message_text(m) else {
+                continue;
+            };
+            if text.is_empty() {
+                continue;
+            }
+            out.push(build_provider_message(
+                PROVIDER,
+                format!("{}-{idx}", self.id),
+                &self.id,
+                String::new(),
+                role,
+                Some(role),
+                Some(json!([{ "type": "text", "text": text }])),
+                None,
+            ));
+        }
+        out
+    }
+}
+
+/// Pull the session list out of an icube value (defensive across the known
+/// container shapes: `{list:[]}` / `{sessions:{}}` / `{conversations}` /
+/// `{entries}` / bare array).
+fn extract_sessions(value: &Value) -> Vec<TraeSession> {
+    let containers = ["list", "sessions", "conversations", "entries"];
+    let raw: Vec<Value> = if let Some(arr) = value.as_array() {
+        arr.clone()
+    } else if let Some(obj) = value.as_object() {
+        let mut found = None;
+        for key in containers {
+            match obj.get(key) {
+                Some(Value::Array(a)) => {
+                    found = Some(a.clone());
+                    break;
+                }
+                Some(Value::Object(m)) => {
+                    found = Some(m.values().cloned().collect());
+                    break;
+                }
+                _ => {}
+            }
+        }
+        found.unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    raw.iter()
+        .filter_map(|s| {
+            let id = s
+                .get("id")
+                .or_else(|| s.get("sessionId"))
+                .or_else(|| s.get("key"))
+                .and_then(Value::as_str)
+                .map(str::to_string)?;
+            let title = s
+                .get("title")
+                .or_else(|| s.get("name"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let messages = ["messages", "conversation", "history", "list", "bubbles"]
+                .iter()
+                .find_map(|k| s.get(*k).and_then(Value::as_array).cloned())
+                .unwrap_or_default();
+            if messages.is_empty() {
+                return None;
+            }
+            Some(TraeSession {
+                id,
+                title,
+                messages,
+            })
+        })
+        .collect()
+}
+
+/// Normalized message role ("user"/"assistant"), mapping Trae's "ai".
+fn role_of(msg: &Value) -> Option<&'static str> {
+    match msg.get("role").and_then(Value::as_str) {
+        Some("user") => Some("user"),
+        Some("assistant" | "ai" | "model") => Some("assistant"),
+        _ => None,
+    }
+}
+
+/// Best-effort displayable text for a Trae message: plain-chat fields, plus
+/// Agent/SOLO `agentTaskContent.guideline.planItems[]` flattened to text.
+fn message_text(msg: &Value) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+
+    for field in ["content", "text", "message", "body", "prompt", "response"] {
+        if let Some(v) = msg.get(field) {
+            if let Some(s) = clean_content(v) {
+                if !s.is_empty() {
+                    parts.push(s);
+                    break;
+                }
+            }
+        }
+    }
+
+    // Agent/SOLO mode: flatten plan items (thought / toolName / result).
+    if let Some(items) = msg
+        .get("agentTaskContent")
+        .and_then(|a| a.get("guideline"))
+        .and_then(|g| g.get("planItems"))
+        .and_then(Value::as_array)
+    {
+        for item in items {
+            for f in ["thought", "toolName", "result", "content", "text"] {
+                if let Some(s) = item.get(f).and_then(clean_content) {
+                    if !s.is_empty() {
+                        parts.push(s);
+                    }
+                }
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
+}
+
+/// Reduce a content value to a string (mirrors the exporter's cleanContent).
+fn clean_content(v: &Value) -> Option<String> {
+    match v {
+        Value::String(s) => Some(s.clone()),
+        Value::Object(_) => {
+            for path in [
+                v.get("data").and_then(|d| d.get("summary")),
+                v.get("summary"),
+                v.get("content"),
+                v.get("text"),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                if let Some(s) = path.as_str() {
+                    return Some(s.to_string());
+                }
+            }
+            Some(v.to_string())
+        }
+        Value::Null => None,
+        other => Some(other.to_string()),
+    }
+}
+
+fn parse_session_path(session_path: &str) -> Result<(String, String), String> {
+    let rest = session_path.strip_prefix(SCHEME).unwrap_or(session_path);
+    rest.split_once(SESSION_SEP)
+        .map(|(h, id)| (h.to_string(), id.to_string()))
+        .ok_or_else(|| format!("Invalid Trae session path: {session_path}"))
+}
+
+fn summarize(text: &str) -> String {
+    let cleaned = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if cleaned.chars().count() > SUMMARY_MAX_CHARS {
+        format!(
+            "{}…",
+            cleaned.chars().take(SUMMARY_MAX_CHARS).collect::<String>()
+        )
+    } else {
+        cleaned
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_sessions_from_list_container() {
+        let value = json!({
+            "list": [
+                {
+                    "id": "sess-a", "title": "Fix LOGIN",
+                    "messages": [
+                        { "role": "user", "content": "why does LOGIN fail?" },
+                        { "role": "assistant", "content": "Checking" }
+                    ]
+                },
+                { "id": "empty", "messages": [] }
+            ]
+        });
+        let sessions = extract_sessions(&value);
+        assert_eq!(sessions.len(), 1); // empty skipped
+        assert_eq!(sessions[0].id, "sess-a");
+        assert_eq!(sessions[0].title.as_deref(), Some("Fix LOGIN"));
+        let msgs = sessions[0].to_messages();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role.as_deref(), Some("user"));
+        assert_eq!(msgs[0].provider.as_deref(), Some("trae"));
+        assert_eq!(
+            msgs[0].content.as_ref().unwrap()[0]["text"],
+            "why does LOGIN fail?"
+        );
+    }
+
+    #[test]
+    fn extract_sessions_from_object_map_and_ai_role() {
+        let value = json!({
+            "sessions": {
+                "k1": { "sessionId": "s1", "name": "chat", "conversation": [
+                    { "role": "ai", "text": "hello" }
+                ] }
+            }
+        });
+        let sessions = extract_sessions(&value);
+        assert_eq!(sessions.len(), 1);
+        let msgs = sessions[0].to_messages();
+        assert_eq!(msgs[0].role.as_deref(), Some("assistant")); // ai -> assistant
+        assert_eq!(msgs[0].content.as_ref().unwrap()[0]["text"], "hello");
+    }
+
+    #[test]
+    fn message_text_agent_mode_flattens_plan_items() {
+        let msg = json!({
+            "role": "assistant",
+            "agentTaskContent": { "guideline": { "planItems": [
+                { "thought": "I'll search", "toolName": "grep", "result": "found in auth.rs" }
+            ] } }
+        });
+        let text = message_text(&msg).unwrap();
+        assert!(text.contains("I'll search"));
+        assert!(text.contains("grep"));
+        assert!(text.contains("auth.rs"));
+    }
+
+    #[test]
+    fn clean_content_object_summary() {
+        assert_eq!(clean_content(&json!("hi")).as_deref(), Some("hi"));
+        assert_eq!(
+            clean_content(&json!({ "data": { "summary": "S" } })).as_deref(),
+            Some("S")
+        );
+        assert_eq!(clean_content(&json!({ "text": "T" })).as_deref(), Some("T"));
+        assert!(clean_content(&Value::Null).is_none());
+    }
+
+    #[test]
+    fn parse_session_path_splits() {
+        let (h, id) = parse_session_path("trae://abc123#sess-1").unwrap();
+        assert_eq!(h, "abc123");
+        assert_eq!(id, "sess-1");
+        assert!(parse_session_path("trae://no-sep").is_err());
+    }
+}

--- a/src-tauri/src/providers/trae.rs
+++ b/src-tauri/src/providers/trae.rs
@@ -79,6 +79,7 @@ fn workspace_dbs(storage: &Path) -> Vec<(String, PathBuf)> {
         .max_depth(1)
         .into_iter()
         .filter_map(Result::ok)
+        .filter(|e| !e.path_is_symlink())
         .filter(|e| e.file_type().is_dir())
         .filter_map(|e| {
             let db = e.path().join("state.vscdb");
@@ -89,6 +90,13 @@ fn workspace_dbs(storage: &Path) -> Vec<(String, PathBuf)> {
             }
         })
         .collect()
+}
+
+/// A workspaceStorage `<hash>` must be a single safe path component (the hash
+/// can arrive from untrusted `WebUI` input), guarding `storage.join(hash)` against
+/// traversal.
+fn valid_hash(hash: &str) -> bool {
+    !hash.is_empty() && !hash.contains('/') && !hash.contains('\\') && !hash.contains("..")
 }
 
 fn open_db(path: &Path) -> Result<Connection, String> {
@@ -185,6 +193,9 @@ pub fn load_sessions(
     _exclude_sidechain: bool,
 ) -> Result<Vec<ClaudeSession>, String> {
     let hash = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
+    if !valid_hash(hash) {
+        return Ok(vec![]);
+    }
     let Some(storage) = workspace_storage() else {
         return Ok(vec![]);
     };
@@ -236,6 +247,9 @@ pub fn load_sessions(
 /// Load messages for one Trae session (`trae://<hash>#<sessionId>`).
 pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
     let (hash, session_id) = parse_session_path(session_path)?;
+    if !valid_hash(&hash) {
+        return Ok(vec![]);
+    }
     let Some(storage) = workspace_storage() else {
         return Ok(vec![]);
     };
@@ -575,5 +589,14 @@ mod tests {
         assert_eq!(h, "abc123");
         assert_eq!(id, "sess-1");
         assert!(parse_session_path("trae://no-sep").is_err());
+    }
+
+    #[test]
+    fn valid_hash_rejects_traversal() {
+        assert!(valid_hash("3b1c9f0a2e"));
+        assert!(!valid_hash("../../etc"));
+        assert!(!valid_hash("a/b"));
+        assert!(!valid_hash("a\\b"));
+        assert!(!valid_hash(""));
     }
 }

--- a/src-tauri/src/providers/zed.rs
+++ b/src-tauri/src/providers/zed.rs
@@ -1,0 +1,555 @@
+//! Zed provider (Agent Panel thread history).
+//!
+//! Zed stores agent threads in a single `SQLite` DB at
+//! `dirs::data_dir()/Zed/threads/threads.db` (macOS
+//! `~/Library/Application Support/Zed/...`, Linux `~/.local/share/Zed/...`,
+//! Windows `%APPDATA%\Zed\...`). The `threads` table holds metadata plus a
+//! `data` BLOB that is the serialized `DbThread` JSON — stored either plain
+//! (`data_type = "json"`) or Zstd-compressed (`data_type = "zstd"`).
+//!
+//! `DbThread.messages` is an array of externally-tagged `Message` values:
+//! `{"User":{content:[{Text}|{Mention}|{Image}]}}` /
+//! `{"Agent":{content:[{Text}|{Thinking}|{RedactedThinking}|{ToolUse}],
+//!  tool_results:{<id>:{...}}}}` / `"Resume"` / `{"Compaction":...}`. A legacy
+//! `SerializedThread` shape (internally-tagged segments) is handled as a
+//! fallback. Tool results live in a sibling `tool_results` map keyed by
+//! tool-use id and are surfaced as a following user turn (Claude convention).
+//!
+//! Projects group by the thread's first workspace folder (`folder_paths`).
+//! Schema is undocumented/unstable across Zed releases (see the `zed-chat-export`
+//! reference tool); tool inputs/results are treated as opaque JSON.
+
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::providers::ProviderInfo;
+use crate::utils::{build_provider_message, search_json_value_case_insensitive};
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+const PROVIDER: &str = "zed";
+const SCHEME: &str = "zed://";
+const UNKNOWN_WORKSPACE: &str = "unknown";
+
+fn get_db_path() -> Option<PathBuf> {
+    Some(
+        dirs::data_dir()?
+            .join("Zed")
+            .join("threads")
+            .join("threads.db"),
+    )
+}
+
+/// Detect a Zed installation.
+pub fn detect() -> Option<ProviderInfo> {
+    let db = get_db_path()?;
+    Some(ProviderInfo {
+        id: PROVIDER.to_string(),
+        display_name: "Zed".to_string(),
+        base_path: db
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+        is_available: db.is_file(),
+    })
+}
+
+/// Base path (the `threads` dir holding `threads.db`), for the file watcher.
+pub fn get_base_path() -> Option<String> {
+    get_db_path()?
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+}
+
+fn open_db() -> Result<Connection, String> {
+    let path = get_db_path().ok_or("Zed threads DB not found")?;
+    if !path.is_file() {
+        return Err("Zed threads database not found".to_string());
+    }
+    let conn = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Zed DB: {e}"))?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(|e| format!("Failed to set busy timeout: {e}"))?;
+    Ok(conn)
+}
+
+/// First workspace folder of a thread (from the `folder_paths` JSON array),
+/// used as the project grouping key.
+fn workspace_of(folder_paths: Option<&str>) -> String {
+    folder_paths
+        .and_then(|fp| serde_json::from_str::<Value>(fp).ok())
+        .and_then(|v| {
+            v.as_array()
+                .and_then(|a| a.first())
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| UNKNOWN_WORKSPACE.to_string())
+}
+
+/// Scan Zed projects (threads grouped by first workspace folder).
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let conn = open_db()?;
+    let mut stmt = conn
+        .prepare("SELECT folder_paths, updated_at FROM threads")
+        .map_err(|e| e.to_string())?;
+
+    struct Agg {
+        session_count: usize,
+        last_modified: String,
+    }
+    let mut by_ws: HashMap<String, Agg> = HashMap::new();
+
+    let rows = stmt
+        .query_map([], |row| {
+            let folder_paths: Option<String> = row.get(0)?;
+            let updated_at: Option<String> = row.get(1)?;
+            Ok((folder_paths, updated_at))
+        })
+        .map_err(|e| e.to_string())?;
+    for (folder_paths, updated_at) in rows.flatten() {
+        let ws = workspace_of(folder_paths.as_deref());
+        let entry = by_ws.entry(ws).or_insert_with(|| Agg {
+            session_count: 0,
+            last_modified: String::new(),
+        });
+        entry.session_count += 1;
+        let last = updated_at.unwrap_or_default();
+        if last > entry.last_modified {
+            entry.last_modified = last;
+        }
+    }
+
+    let mut projects: Vec<ClaudeProject> = by_ws
+        .into_iter()
+        .map(|(ws, agg)| {
+            let name = PathBuf::from(&ws)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| ws.clone());
+            ClaudeProject {
+                name,
+                path: format!("{SCHEME}{ws}"),
+                actual_path: ws,
+                session_count: agg.session_count,
+                message_count: 0,
+                last_modified: agg.last_modified,
+                git_info: None,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: Some("sqlite".to_string()),
+                custom_directory_label: None,
+            }
+        })
+        .collect();
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+/// Load the threads (sessions) for one Zed project (workspace folder).
+pub fn load_sessions(
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let target_ws = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
+    let conn = open_db()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, summary, folder_paths, created_at, updated_at FROM threads \
+             ORDER BY updated_at DESC",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let project_name = PathBuf::from(target_ws)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let sessions = stmt
+        .query_map([], |row| {
+            let id: String = row.get(0)?;
+            let summary: Option<String> = row.get(1)?;
+            let folder_paths: Option<String> = row.get(2)?;
+            let created_at: Option<String> = row.get(3)?;
+            let updated_at: Option<String> = row.get(4)?;
+            Ok((id, summary, folder_paths, created_at, updated_at))
+        })
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .filter(|(_, _, folder_paths, _, _)| workspace_of(folder_paths.as_deref()) == target_ws)
+        .map(|(id, summary, _, created_at, updated_at)| {
+            let created = created_at.unwrap_or_default();
+            let updated = updated_at.unwrap_or_default();
+            ClaudeSession {
+                session_id: format!("{SCHEME}{id}"),
+                actual_session_id: id.clone(),
+                file_path: format!("{SCHEME}{id}"),
+                project_name: project_name.clone(),
+                message_count: 0,
+                first_message_time: created.clone(),
+                last_message_time: updated.clone(),
+                last_modified: updated,
+                has_tool_use: false,
+                has_errors: false,
+                summary: summary.filter(|s| !s.trim().is_empty()).or(Some(id)),
+                is_renamed: false,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: Some("sqlite".to_string()),
+                entrypoint: None,
+            }
+        })
+        .collect();
+
+    Ok(sessions)
+}
+
+/// Load messages for one Zed thread (`zed://<thread_id>`).
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let id = session_path.strip_prefix(SCHEME).unwrap_or(session_path);
+    let conn = open_db()?;
+    let (data_type, data, updated_at): (String, Vec<u8>, Option<String>) = conn
+        .query_row(
+            "SELECT data_type, data, updated_at FROM threads WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .map_err(|e| format!("Thread not found: {e}"))?;
+
+    let json = decode_thread_data(&data_type, &data)?;
+    Ok(parse_thread(&json, id, updated_at.as_deref().unwrap_or("")))
+}
+
+/// Search across all Zed threads.
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    if query.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+    let conn = open_db()?;
+    let query_lower = query.to_lowercase();
+    let mut stmt = conn
+        .prepare("SELECT id, data_type, data, updated_at FROM threads")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Vec<u8>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut results = Vec::new();
+    for (id, data_type, data, updated_at) in rows.flatten() {
+        let Ok(json) = decode_thread_data(&data_type, &data) else {
+            continue;
+        };
+        for msg in parse_thread(&json, &id, updated_at.as_deref().unwrap_or("")) {
+            if results.len() >= limit {
+                return Ok(results);
+            }
+            let matched = msg
+                .content
+                .as_ref()
+                .map(|c| search_json_value_case_insensitive(c, &query_lower))
+                .unwrap_or(false);
+            if matched {
+                results.push(msg);
+            }
+        }
+    }
+    Ok(results)
+}
+
+// ============================================================================
+// Decoding + parsing (pure where possible)
+// ============================================================================
+
+/// Decode a `threads.data` BLOB to its `DbThread` JSON string.
+fn decode_thread_data(data_type: &str, data: &[u8]) -> Result<Value, String> {
+    let bytes = if data_type == "zstd" {
+        zstd::decode_all(data).map_err(|e| format!("Failed to zstd-decode Zed thread: {e}"))?
+    } else {
+        data.to_vec()
+    };
+    serde_json::from_slice(&bytes).map_err(|e| format!("Failed to parse Zed thread JSON: {e}"))
+}
+
+/// Parse a decoded `DbThread` (or legacy `SerializedThread`) JSON into messages.
+fn parse_thread(thread: &Value, thread_id: &str, ts: &str) -> Vec<ClaudeMessage> {
+    let Some(messages) = thread.get("messages").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (idx, msg) in messages.iter().enumerate() {
+        convert_message(msg, thread_id, idx, ts, &mut out);
+    }
+    out
+}
+
+/// Convert one `Message` (current `DbThread` shape, or legacy `SerializedMessage`)
+/// and push the resulting message(s).
+fn convert_message(
+    msg: &Value,
+    thread_id: &str,
+    idx: usize,
+    ts: &str,
+    out: &mut Vec<ClaudeMessage>,
+) {
+    // Current externally-tagged shape: {"User":{...}} / {"Agent":{...}}.
+    if let Some(user) = msg.get("User") {
+        let blocks = user_blocks(user.get("content"));
+        if !blocks.is_empty() {
+            out.push(make_msg(thread_id, idx, "user", ts, blocks, None));
+        }
+        return;
+    }
+    if let Some(agent) = msg.get("Agent") {
+        let blocks = agent_blocks(agent.get("content"));
+        if !blocks.is_empty() {
+            out.push(make_msg(thread_id, idx, "assistant", ts, blocks, None));
+        }
+        // Tool results live in a sibling map keyed by tool-use id -> surface as a
+        // following user turn (Claude convention).
+        if let Some(results) = agent.get("tool_results").and_then(Value::as_object) {
+            let tr_blocks: Vec<Value> = results
+                .iter()
+                .map(|(tool_use_id, res)| {
+                    let is_error = res.get("is_error").and_then(Value::as_bool).unwrap_or(false);
+                    let content = res
+                        .get("content")
+                        .map(stringify)
+                        .unwrap_or_default();
+                    json!({ "type": "tool_result", "tool_use_id": tool_use_id, "content": content, "is_error": is_error })
+                })
+                .collect();
+            if !tr_blocks.is_empty() {
+                out.push(make_msg(thread_id, idx, "user", ts, tr_blocks, Some("-tr")));
+            }
+        }
+        return;
+    }
+    // Legacy SerializedMessage: {"role":"user"|"assistant"|"system","segments":[{"type":"text",...}],...}
+    if let Some(role) = msg.get("role").and_then(Value::as_str) {
+        let blocks = legacy_segments(msg.get("segments"));
+        if !blocks.is_empty() {
+            let mapped = if role == "assistant" {
+                "assistant"
+            } else {
+                "user"
+            };
+            out.push(make_msg(thread_id, idx, mapped, ts, blocks, None));
+        }
+    }
+    // "Resume" / {"Compaction":...} -> ignored.
+}
+
+fn user_blocks(content: Option<&Value>) -> Vec<Value> {
+    let Some(items) = content.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut blocks = Vec::new();
+    for item in items {
+        if let Some(text) = item.get("Text").and_then(Value::as_str) {
+            if !text.is_empty() {
+                blocks.push(json!({ "type": "text", "text": text }));
+            }
+        } else if let Some(mention) = item.get("Mention") {
+            if let Some(text) = mention.get("content").and_then(Value::as_str) {
+                if !text.is_empty() {
+                    blocks.push(json!({ "type": "text", "text": text }));
+                }
+            }
+        }
+        // Image -> skipped in this MVP.
+    }
+    blocks
+}
+
+fn agent_blocks(content: Option<&Value>) -> Vec<Value> {
+    let Some(items) = content.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut blocks = Vec::new();
+    for item in items {
+        if let Some(text) = item.get("Text").and_then(Value::as_str) {
+            if !text.is_empty() {
+                blocks.push(json!({ "type": "text", "text": text }));
+            }
+        } else if let Some(thinking) = item.get("Thinking") {
+            let text = thinking.get("text").and_then(Value::as_str).unwrap_or("");
+            blocks.push(json!({
+                "type": "thinking",
+                "thinking": text,
+                "signature": thinking.get("signature").and_then(Value::as_str).unwrap_or("")
+            }));
+        } else if let Some(rt) = item.get("RedactedThinking").and_then(Value::as_str) {
+            blocks.push(json!({ "type": "redacted_thinking", "data": rt }));
+        } else if let Some(tool) = item.get("ToolUse") {
+            let id = tool.get("id").and_then(Value::as_str).unwrap_or("");
+            let name = tool
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let input = tool
+                .get("input")
+                .or_else(|| tool.get("raw_input"))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            blocks.push(json!({ "type": "tool_use", "id": id, "name": name, "input": input }));
+        }
+    }
+    blocks
+}
+
+fn legacy_segments(segments: Option<&Value>) -> Vec<Value> {
+    let Some(items) = segments.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut blocks = Vec::new();
+    for seg in items {
+        match seg.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(t) = seg.get("text").and_then(Value::as_str) {
+                    if !t.is_empty() {
+                        blocks.push(json!({ "type": "text", "text": t }));
+                    }
+                }
+            }
+            Some("thinking") => {
+                let t = seg.get("text").and_then(Value::as_str).unwrap_or("");
+                blocks.push(json!({
+                    "type": "thinking",
+                    "thinking": t,
+                    "signature": seg.get("signature").and_then(Value::as_str).unwrap_or("")
+                }));
+            }
+            _ => {}
+        }
+    }
+    blocks
+}
+
+fn make_msg(
+    thread_id: &str,
+    idx: usize,
+    role: &str,
+    ts: &str,
+    blocks: Vec<Value>,
+    suffix: Option<&str>,
+) -> ClaudeMessage {
+    let uuid = format!("{thread_id}-{idx}{}", suffix.unwrap_or(""));
+    build_provider_message(
+        PROVIDER,
+        uuid,
+        thread_id,
+        ts.to_string(),
+        role,
+        Some(role),
+        Some(Value::Array(blocks)),
+        None,
+    )
+}
+
+fn stringify(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db_thread() -> Value {
+        json!({
+            "title": "Fix LOGIN",
+            "messages": [
+                { "User": { "id": "u1", "content": [{ "Text": "why does LOGIN fail?" }, { "Mention": { "uri": "x", "content": "see auth.rs" } }] } },
+                { "Agent": {
+                    "content": [
+                        { "Text": "Let me look" },
+                        { "Thinking": { "text": "reasoning", "signature": "sig" } },
+                        { "ToolUse": { "id": "t1", "name": "grep", "input": { "q": "login" } } }
+                    ],
+                    "tool_results": { "t1": { "content": "auth.rs:42", "is_error": false } }
+                } },
+                "Resume"
+            ]
+        })
+    }
+
+    #[test]
+    fn parse_thread_user_agent_and_tool_results() {
+        let msgs = parse_thread(&db_thread(), "thread-1", "2026-06-20T10:00:00Z");
+        // user, assistant, tool-result(user) ; "Resume" ignored
+        assert_eq!(msgs.len(), 3);
+
+        assert_eq!(msgs[0].role.as_deref(), Some("user"));
+        assert_eq!(msgs[0].provider.as_deref(), Some("zed"));
+        let u = msgs[0].content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(u[0]["text"], "why does LOGIN fail?");
+        assert_eq!(u[1]["text"], "see auth.rs"); // Mention -> text
+
+        let a = msgs[1].content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(a[0]["type"], "text");
+        assert_eq!(a[1]["type"], "thinking");
+        assert_eq!(a[2]["type"], "tool_use");
+        assert_eq!(a[2]["id"], "t1");
+
+        // tool_results -> following user turn with tool_result block joined by id
+        assert_eq!(msgs[2].role.as_deref(), Some("user"));
+        let tr = msgs[2].content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(tr[0]["type"], "tool_result");
+        assert_eq!(tr[0]["tool_use_id"], "t1");
+        assert_eq!(tr[0]["content"], "auth.rs:42");
+    }
+
+    #[test]
+    fn parse_legacy_serialized_thread() {
+        let legacy = json!({
+            "version": "0.1.0",
+            "summary": "old",
+            "messages": [
+                { "id": 1, "role": "user", "segments": [{ "type": "text", "text": "hi" }] },
+                { "id": 2, "role": "assistant", "segments": [
+                    { "type": "thinking", "text": "hmm", "signature": "s" },
+                    { "type": "text", "text": "hello" }
+                ] }
+            ]
+        });
+        let msgs = parse_thread(&legacy, "t", "");
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role.as_deref(), Some("user"));
+        assert_eq!(msgs[1].role.as_deref(), Some("assistant"));
+        let a = msgs[1].content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(a[0]["type"], "thinking");
+        assert_eq!(a[1]["type"], "text");
+    }
+
+    #[test]
+    fn workspace_grouping_from_folder_paths() {
+        assert_eq!(
+            workspace_of(Some(r#"["/Users/jack/proj","/other"]"#)),
+            "/Users/jack/proj"
+        );
+        assert_eq!(workspace_of(Some("[]")), "unknown");
+        assert_eq!(workspace_of(None), "unknown");
+    }
+
+    #[test]
+    fn decode_plain_and_zstd() {
+        let value = json!({ "messages": [] });
+        let json_bytes = serde_json::to_vec(&value).unwrap();
+        // plain
+        let got = decode_thread_data("json", &json_bytes).unwrap();
+        assert!(got.get("messages").is_some());
+        // zstd
+        let compressed = zstd::encode_all(&json_bytes[..], 3).unwrap();
+        let got = decode_thread_data("zstd", &compressed).unwrap();
+        assert!(got.get("messages").is_some());
+    }
+}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -123,6 +123,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       openinterpreter: 0,
       pearai: 0,
       qwen: 0,
+      zed: 0,
     };
 
     for (const project of projects) {

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -122,6 +122,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       opencode: 0,
       openinterpreter: 0,
       pearai: 0,
+      qwen: 0,
     };
 
     for (const project of projects) {

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -124,6 +124,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       openinterpreter: 0,
       pearai: 0,
       qwen: 0,
+      trae: 0,
       zed: 0,
     };
 

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -120,6 +120,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       kiro: 0,
       llm: 0,
       opencode: 0,
+      openhands: 0,
       openinterpreter: 0,
       pearai: 0,
       qwen: 0,

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -120,6 +120,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       kiro: 0,
       llm: 0,
       opencode: 0,
+      openinterpreter: 0,
       pearai: 0,
     };
 

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -138,6 +138,7 @@
   "common.provider.opencode": "OpenCode",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
+  "common.provider.qwen": "Qwen Code",
   "common.view": "View",
   "common.watcher.autoRefresh": "Auto-refresh",
   "common.watcher.disabled": "Auto-refresh disabled",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.view": "View",
   "common.watcher.autoRefresh": "Auto-refresh",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -140,6 +140,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.trae": "Trae",
   "common.provider.zed": "Zed",
   "common.view": "View",
   "common.watcher.autoRefresh": "Auto-refresh",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openhands": "OpenHands",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -139,6 +139,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.zed": "Zed",
   "common.view": "View",
   "common.watcher.autoRefresh": "Auto-refresh",
   "common.watcher.disabled": "Auto-refresh disabled",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -140,6 +140,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.trae": "Trae",
   "common.provider.zed": "Zed",
   "common.view": "表示",
   "common.watcher.autoRefresh": "自動更新",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openhands": "OpenHands",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -139,6 +139,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.zed": "Zed",
   "common.view": "表示",
   "common.watcher.autoRefresh": "自動更新",
   "common.watcher.disabled": "自動更新が無効です",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -138,6 +138,7 @@
   "common.provider.opencode": "OpenCode",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
+  "common.provider.qwen": "Qwen Code",
   "common.view": "表示",
   "common.watcher.autoRefresh": "自動更新",
   "common.watcher.disabled": "自動更新が無効です",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.view": "表示",
   "common.watcher.autoRefresh": "自動更新",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -140,6 +140,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.trae": "Trae",
   "common.provider.zed": "Zed",
   "common.view": "보기",
   "common.watcher.autoRefresh": "자동 새로고침",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openhands": "OpenHands",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -138,6 +138,7 @@
   "common.provider.opencode": "OpenCode",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
+  "common.provider.qwen": "Qwen Code",
   "common.view": "보기",
   "common.watcher.autoRefresh": "자동 새로고침",
   "common.watcher.disabled": "자동 새로고침 비활성화됨",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.view": "보기",
   "common.watcher.autoRefresh": "자동 새로고침",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -139,6 +139,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.zed": "Zed",
   "common.view": "보기",
   "common.watcher.autoRefresh": "자동 새로고침",
   "common.watcher.disabled": "자동 새로고침 비활성화됨",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openhands": "OpenHands",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -139,6 +139,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.zed": "Zed",
   "common.view": "查看",
   "common.watcher.autoRefresh": "自动刷新",
   "common.watcher.disabled": "自动刷新已禁用",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -140,6 +140,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.trae": "Trae",
   "common.provider.zed": "Zed",
   "common.view": "查看",
   "common.watcher.autoRefresh": "自动刷新",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.view": "查看",
   "common.watcher.autoRefresh": "自动刷新",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -138,6 +138,7 @@
   "common.provider.opencode": "OpenCode",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
+  "common.provider.qwen": "Qwen Code",
   "common.view": "查看",
   "common.watcher.autoRefresh": "自动刷新",
   "common.watcher.disabled": "自动刷新已禁用",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -140,6 +140,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.trae": "Trae",
   "common.provider.zed": "Zed",
   "common.view": "檢視",
   "common.watcher.autoRefresh": "自動重新整理",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openhands": "OpenHands",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -138,6 +138,7 @@
   "common.provider.opencode": "OpenCode",
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
+  "common.provider.qwen": "Qwen Code",
   "common.view": "檢視",
   "common.watcher.autoRefresh": "自動重新整理",
   "common.watcher.disabled": "自動重新整理已停用",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -139,6 +139,7 @@
   "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.provider.qwen": "Qwen Code",
+  "common.provider.zed": "Zed",
   "common.view": "檢視",
   "common.watcher.autoRefresh": "自動重新整理",
   "common.watcher.disabled": "自動重新整理已停用",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -136,6 +136,7 @@
   "common.provider.kiro": "Kiro CLI",
   "common.provider.llm": "llm",
   "common.provider.opencode": "OpenCode",
+  "common.provider.openinterpreter": "Open Interpreter",
   "common.provider.pearai": "PearAI",
   "common.view": "檢視",
   "common.watcher.autoRefresh": "自動重新整理",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-06-21T16:43:52.546Z
- * 총 키 개수: 1818
+ * 생성 시간: 2026-06-21T16:53:08.783Z
+ * 총 키 개수: 1819
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (173개)
+ * common namespace의 번역 키 (174개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -129,6 +129,7 @@ export type CommonKeys =
   | 'common.provider.opencode'
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
+  | 'common.provider.qwen'
   | 'common.refresh'
   | 'common.remove'
   | 'common.restartApp'
@@ -2315,6 +2316,7 @@ export type TranslationKey =
   | 'common.provider.opencode'
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
+  | 'common.provider.qwen'
   | 'common.refresh'
   | 'common.remove'
   | 'common.restartApp'

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-06-21T17:00:26.025Z
- * 총 키 개수: 1820
+ * 생성 시간: 2026-06-21T17:15:50.668Z
+ * 총 키 개수: 1821
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (175개)
+ * common namespace의 번역 키 (176개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -127,6 +127,7 @@ export type CommonKeys =
   | 'common.provider.kiro'
   | 'common.provider.llm'
   | 'common.provider.opencode'
+  | 'common.provider.openhands'
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.provider.qwen'
@@ -2315,6 +2316,7 @@ export type TranslationKey =
   | 'common.provider.kiro'
   | 'common.provider.llm'
   | 'common.provider.opencode'
+  | 'common.provider.openhands'
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.provider.qwen'

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-06-21T16:53:08.783Z
- * 총 키 개수: 1819
+ * 생성 시간: 2026-06-21T17:00:26.025Z
+ * 총 키 개수: 1820
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (174개)
+ * common namespace의 번역 키 (175개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -130,6 +130,7 @@ export type CommonKeys =
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.provider.qwen'
+  | 'common.provider.zed'
   | 'common.refresh'
   | 'common.remove'
   | 'common.restartApp'
@@ -2317,6 +2318,7 @@ export type TranslationKey =
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.provider.qwen'
+  | 'common.provider.zed'
   | 'common.refresh'
   | 'common.remove'
   | 'common.restartApp'

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-06-21T17:15:50.668Z
- * 총 키 개수: 1821
+ * 생성 시간: 2026-06-21T17:22:55.325Z
+ * 총 키 개수: 1822
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (176개)
+ * common namespace의 번역 키 (177개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -131,6 +131,7 @@ export type CommonKeys =
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.provider.qwen'
+  | 'common.provider.trae'
   | 'common.provider.zed'
   | 'common.refresh'
   | 'common.remove'
@@ -2320,6 +2321,7 @@ export type TranslationKey =
   | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.provider.qwen'
+  | 'common.provider.trae'
   | 'common.provider.zed'
   | 'common.refresh'
   | 'common.remove'

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-06-21T16:03:29.095Z
- * 총 키 개수: 1817
+ * 생성 시간: 2026-06-21T16:43:52.546Z
+ * 총 키 개수: 1818
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (172개)
+ * common namespace의 번역 키 (173개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -127,6 +127,7 @@ export type CommonKeys =
   | 'common.provider.kiro'
   | 'common.provider.llm'
   | 'common.provider.opencode'
+  | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.refresh'
   | 'common.remove'
@@ -2312,6 +2313,7 @@ export type TranslationKey =
   | 'common.provider.kiro'
   | 'common.provider.llm'
   | 'common.provider.opencode'
+  | 'common.provider.openinterpreter'
   | 'common.provider.pearai'
   | 'common.refresh'
   | 'common.remove'

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -58,6 +58,7 @@ describe("providers utils", () => {
       "kiro",
       "llm",
       "opencode",
+      "openhands",
       "openinterpreter",
       "pearai",
       "qwen",

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -62,6 +62,7 @@ describe("providers utils", () => {
       "openinterpreter",
       "pearai",
       "qwen",
+      "trae",
       "zed",
     ]);
   });

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -61,6 +61,7 @@ describe("providers utils", () => {
       "openinterpreter",
       "pearai",
       "qwen",
+      "zed",
     ]);
   });
 

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -58,6 +58,7 @@ describe("providers utils", () => {
       "kiro",
       "llm",
       "opencode",
+      "openinterpreter",
       "pearai",
     ]);
   });

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -60,6 +60,7 @@ describe("providers utils", () => {
       "opencode",
       "openinterpreter",
       "pearai",
+      "qwen",
     ]);
   });
 

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openinterpreter" | "pearai" | "qwen";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openinterpreter" | "pearai" | "qwen" | "zed";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openinterpreter" | "pearai";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openinterpreter" | "pearai" | "qwen";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "pearai";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openinterpreter" | "pearai";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "qwen" | "zed";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "qwen" | "trae" | "zed";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openinterpreter" | "pearai" | "qwen" | "zed";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "qwen" | "zed";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openhands", "openinterpreter", "pearai", "qwen", "zed"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openhands", "openinterpreter", "pearai", "qwen", "trae", "zed"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -30,6 +30,7 @@ const PROVIDER_TRANSLATIONS: Record<
   openinterpreter: { key: "common.provider.openinterpreter", fallback: "Open Interpreter" },
   pearai: { key: "common.provider.pearai", fallback: "PearAI" },
   qwen: { key: "common.provider.qwen", fallback: "Qwen Code" },
+  trae: { key: "common.provider.trae", fallback: "Trae" },
   zed: { key: "common.provider.zed", fallback: "Zed" },
 };
 
@@ -208,6 +209,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  trae: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   zed: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
@@ -253,6 +261,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "openinterpreter":
     case "pearai":
     case "qwen":
+    case "trae":
     case "zed":
     case "claude":
       return provider;
@@ -411,6 +420,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   openhands: "bg-gray-500/15 text-gray-600 dark:text-gray-300",
   pearai: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
   qwen: "bg-violet-600/15 text-violet-700 dark:text-violet-300",
+  trae: "bg-blue-600/15 text-blue-700 dark:text-blue-300",
   zed: "bg-neutral-500/15 text-neutral-600 dark:text-neutral-400",
   aider: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
   amazonq: "bg-zinc-500/15 text-zinc-600 dark:text-zinc-400",

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openinterpreter", "pearai", "qwen", "zed"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openhands", "openinterpreter", "pearai", "qwen", "zed"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -26,6 +26,7 @@ const PROVIDER_TRANSLATIONS: Record<
   kiro: { key: "common.provider.kiro", fallback: "Kiro CLI" },
   llm: { key: "common.provider.llm", fallback: "llm" },
   opencode: { key: "common.provider.opencode", fallback: "OpenCode" },
+  openhands: { key: "common.provider.openhands", fallback: "OpenHands" },
   openinterpreter: { key: "common.provider.openinterpreter", fallback: "Open Interpreter" },
   pearai: { key: "common.provider.pearai", fallback: "PearAI" },
   qwen: { key: "common.provider.qwen", fallback: "Qwen Code" },
@@ -179,6 +180,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  openhands: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   openinterpreter: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
@@ -241,6 +249,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "kiro":
     case "llm":
     case "opencode":
+    case "openhands":
     case "openinterpreter":
     case "pearai":
     case "qwen":
@@ -399,6 +408,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   llm: "bg-slate-500/15 text-slate-600 dark:text-slate-400",
   opencode: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
   openinterpreter: "bg-stone-500/15 text-stone-600 dark:text-stone-400",
+  openhands: "bg-gray-500/15 text-gray-600 dark:text-gray-300",
   pearai: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
   qwen: "bg-violet-600/15 text-violet-700 dark:text-violet-300",
   zed: "bg-neutral-500/15 text-neutral-600 dark:text-neutral-400",

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "pearai"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openinterpreter", "pearai"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -26,6 +26,7 @@ const PROVIDER_TRANSLATIONS: Record<
   kiro: { key: "common.provider.kiro", fallback: "Kiro CLI" },
   llm: { key: "common.provider.llm", fallback: "llm" },
   opencode: { key: "common.provider.opencode", fallback: "OpenCode" },
+  openinterpreter: { key: "common.provider.openinterpreter", fallback: "Open Interpreter" },
   pearai: { key: "common.provider.pearai", fallback: "PearAI" },
 };
 
@@ -176,6 +177,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  openinterpreter: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   pearai: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
@@ -217,6 +225,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "kiro":
     case "llm":
     case "opencode":
+    case "openinterpreter":
     case "pearai":
     case "claude":
       return provider;
@@ -371,6 +380,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   kiro: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
   llm: "bg-slate-500/15 text-slate-600 dark:text-slate-400",
   opencode: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+  openinterpreter: "bg-stone-500/15 text-stone-600 dark:text-stone-400",
   pearai: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
   aider: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
   amazonq: "bg-zinc-500/15 text-zinc-600 dark:text-zinc-400",

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openinterpreter", "pearai", "qwen"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openinterpreter", "pearai", "qwen", "zed"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -29,6 +29,7 @@ const PROVIDER_TRANSLATIONS: Record<
   openinterpreter: { key: "common.provider.openinterpreter", fallback: "Open Interpreter" },
   pearai: { key: "common.provider.pearai", fallback: "PearAI" },
   qwen: { key: "common.provider.qwen", fallback: "Qwen Code" },
+  zed: { key: "common.provider.zed", fallback: "Zed" },
 };
 
 type TranslateFn = (key: string, defaultValue: string) => string;
@@ -199,6 +200,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  zed: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
 };
 
 export interface ProviderTokenStatsLike {
@@ -236,6 +244,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "openinterpreter":
     case "pearai":
     case "qwen":
+    case "zed":
     case "claude":
       return provider;
     default:
@@ -392,6 +401,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   openinterpreter: "bg-stone-500/15 text-stone-600 dark:text-stone-400",
   pearai: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
   qwen: "bg-violet-600/15 text-violet-700 dark:text-violet-300",
+  zed: "bg-neutral-500/15 text-neutral-600 dark:text-neutral-400",
   aider: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
   amazonq: "bg-zinc-500/15 text-zinc-600 dark:text-zinc-400",
   antigravity: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openinterpreter", "pearai"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "opencode", "openinterpreter", "pearai", "qwen"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -28,6 +28,7 @@ const PROVIDER_TRANSLATIONS: Record<
   opencode: { key: "common.provider.opencode", fallback: "OpenCode" },
   openinterpreter: { key: "common.provider.openinterpreter", fallback: "Open Interpreter" },
   pearai: { key: "common.provider.pearai", fallback: "PearAI" },
+  qwen: { key: "common.provider.qwen", fallback: "Qwen Code" },
 };
 
 type TranslateFn = (key: string, defaultValue: string) => string;
@@ -191,6 +192,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  qwen: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
 };
 
 export interface ProviderTokenStatsLike {
@@ -227,6 +235,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "opencode":
     case "openinterpreter":
     case "pearai":
+    case "qwen":
     case "claude":
       return provider;
     default:
@@ -382,6 +391,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   opencode: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
   openinterpreter: "bg-stone-500/15 text-stone-600 dark:text-stone-400",
   pearai: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
+  qwen: "bg-violet-600/15 text-violet-700 dark:text-violet-300",
   aider: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
   amazonq: "bg-zinc-500/15 text-zinc-600 dark:text-zinc-400",
   antigravity: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",


### PR DESCRIPTION
## Summary

Completes the platform-coverage backlog with **5 more providers** (the previously deferred wave). Each was built from a **source-verified** on-disk schema (except Trae — see note), with the standard ~14-site registration + i18n (5 locales) + unit tests.

| Provider | Storage | Notes |
|---|---|---|
| **Open Interpreter** | `~/.openinterpreter/sessions/**/rollout-*.jsonl` | Codex-identical format → reuses the Codex rollout parser. `codex.rs` changed **additively only** (extract `pub(crate) parse_rollout_file` + expose extractors); its 36 tests are unchanged. |
| **Qwen Code** | `~/.qwen/projects/<cwd>/chats/*.jsonl` | Full ChatRecord transcripts (genai `Content` parts → text/thinking/tool_use/tool_result + token usage + parent tree). |
| **Zed** | `…/Zed/threads/threads.db` (SQLite + **Zstd** JSON) | Adds the `zstd` crate. Externally-tagged User/Agent messages; `tool_results` joined by id; legacy `SerializedThread` fallback. |
| **OpenHands** | `~/.openhands/sessions/<sid>/events/<N>.json` | Classic 0.x `event_to_dict` (action/observation + source); tool call↔result linked by `cause`. Single synthetic project. |
| **Trae** | `…/Trae/User/workspaceStorage/<hash>/state.vscdb` | ⚠️ **Reverse-engineered** (see note). |

Brings supported provider IDs to **~25**.

## Verification

- OI / Qwen / Zed / OpenHands schemas confirmed from upstream source (codex-rs, QwenLM/qwen-code, zed db.rs/thread.rs + zed-chat-export, OpenHands 0.62.0 events/serialization).
- Gates: `tsc` ✅ · `vitest` 864 ✅ · `eslint` ✅ · `i18n:validate` ✅ · `cargo test` **745** ✅ · `clippy -D warnings` ✅ · `fmt` ✅.

## Notes / limitations

- ⚠️ **Trae is reverse-engineered** from the `trae-chats-exporter` community tool (no official schema), uses install-specific keys, flattens Agent-mode tool steps to text, and is **not verified against a real Trae install** — parsing is defensive and treated as provisional.
- ⚠️ None of the five are runtime-verified against real installs yet (built from source schemas + synthetic-fixture tests). A real-file sanity check per tool is recommended before release.
- New dependency: `zstd` (for Zed); `Cargo.lock` updated.
- OpenHands V1 `software-agent-sdk` (cwd-relative `workspace/conversations`) is out of scope; this covers classic 0.x. Trae structured tool calls render as text in Agent mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for five new AI providers: OpenHands, Open Interpreter, Qwen, Zed, and Trae. The app can now detect installations, scan projects, load session history, and search across conversations from these tools.
* **Improvements**
  * Expanded session/path safety checks and file-watcher coverage so imported provider data is more reliably found and constrained.
* **Chores**
  * Updated provider labels in the UI translations across multiple languages for the newly supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->