### PR TITLE
improve(names): prefer verifiable folder name over stale cwd for project identity

### DIFF
--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -270,17 +270,25 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
             continue;
         }
 
-        // Prefer the exact cwd Claude wrote into JSONL. Claude's storage
-        // directory names are lossy (`_` and path separators can both become
-        // `-`), so decoding the folder name can produce a non-existent cwd.
-        // Project-level identity should come from top-level session files.
-        // Subagent JSONL files can run in narrower cwd values (for example
-        // `/home/cym/paseo`) while the parent Claude project directory remains
-        // `/home/cym`; using nested files here would rename the whole project
-        // based on whichever subagent was modified most recently.
-        let actual_path = direct_cwd_candidate
-            .or(nested_cwd_candidate)
-            .map(|(_, cwd)| cwd)
+        // Resolve the project's real path, in priority order:
+        // 1. The folder name, when it verifiably resolves to an existing
+        //    directory. This is authoritative even when a session's embedded
+        //    `cwd` is stale (e.g. JSONL files moved between project folders).
+        // 2. The exact cwd Claude wrote into the JSONL. Claude's storage
+        //    directory names are lossy (`_` and path separators can both become
+        //    `-`), so when (1) fails the decoded folder name may be a
+        //    non-existent path and the real `cwd` is the better signal (#369).
+        //    Project-level identity should come from top-level session files;
+        //    subagent JSONL files can run in narrower cwd values (for example
+        //    `/home/cym/paseo`) while the parent project remains `/home/cym`,
+        //    so nested files are only a secondary fallback here.
+        // 3. A lossy heuristic decode of the folder name, as a last resort.
+        let actual_path = crate::utils::decode_project_path_verified(&project_path)
+            .or_else(|| {
+                direct_cwd_candidate
+                    .or(nested_cwd_candidate)
+                    .map(|(_, cwd)| cwd)
+            })
             .unwrap_or_else(|| crate::utils::decode_project_path(&project_path));
         let project_name = project_display_name_from_path(&actual_path)
             .unwrap_or_else(|| extract_project_name(&raw_project_name));
@@ -579,6 +587,40 @@ mod tests {
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].actual_path, actual_cwd);
         assert_eq!(projects[0].name, "claude_prompt_design");
+    }
+
+    #[tokio::test]
+    async fn test_scan_projects_prefers_verified_folder_over_stale_cwd() {
+        let temp_dir = TempDir::new().unwrap();
+        let claude_dir = temp_dir.path().join(".claude");
+        let projects_dir = claude_dir.join("projects");
+        // Folder name decodes to an existing directory (/usr/lib).
+        let project_dir = projects_dir.join("-usr-lib");
+        fs::create_dir_all(&project_dir).unwrap();
+
+        // The session's embedded cwd is stale (points elsewhere), simulating a
+        // JSONL file moved into this folder by hand.
+        create_test_jsonl_file(
+            &project_dir,
+            "session.jsonl",
+            &jsonl_lines(vec![serde_json::json!({
+                "uuid": "uuid-1",
+                "sessionId": "session-1",
+                "timestamp": "2025-06-26T10:00:00Z",
+                "type": "user",
+                "cwd": "/some/stale/Dev",
+                "message": { "role": "user", "content": "Hello" },
+            })]),
+        );
+
+        let projects = scan_projects(claude_dir.to_string_lossy().to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(projects.len(), 1);
+        // Verified folder name wins over the stale cwd.
+        assert_eq!(projects[0].actual_path, "/usr/lib");
+        assert_eq!(projects[0].name, "lib");
     }
 
     #[test]

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -58,7 +58,10 @@ struct SessionMetadataCache {
 // Bumped 9 -> 10: rename_name is now also extracted from `/branch` custom-title
 // events (not just `/rename`), AND Claude project names are derived from the
 // JSONL `cwd` when available; stale caches must be invalidated to pick both up.
-const CACHE_VERSION: u32 = 10;
+// Bumped 10 -> 11: a verifiable folder name now takes priority over the JSONL
+// `cwd` for the project name (handles sessions moved between project folders);
+// stale caches must be invalidated to recompute project_name.
+const CACHE_VERSION: u32 = 11;
 
 /// Get the cache file path for a project
 fn get_cache_path(project_path: &str) -> PathBuf {
@@ -588,9 +591,21 @@ fn extract_session_metadata_internal(
         .unwrap_or("Unknown")
         .to_string();
 
-    let project_name = session_cwd
+    // A verifiable folder name is authoritative (handles sessions moved between
+    // project folders, whose embedded `cwd` is stale); otherwise fall back to
+    // the JSONL `cwd`, then the cached value, then a lossy folder-name decode.
+    let verified_project_name = file_path
+        .parent()
+        .and_then(|p| p.to_str())
+        .and_then(crate::utils::decode_project_path_verified)
         .as_deref()
-        .and_then(project_display_name_from_path)
+        .and_then(project_display_name_from_path);
+    let project_name = verified_project_name
+        .or_else(|| {
+            session_cwd
+                .as_deref()
+                .and_then(project_display_name_from_path)
+        })
         .or(incremental_project_name)
         .unwrap_or_else(|| extract_project_name(&raw_project_name));
     // Rename name takes highest priority, then existing summary fallback chain
@@ -2113,6 +2128,38 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].project_name, "claude_prompt_design");
+    }
+
+    #[tokio::test]
+    async fn test_load_project_sessions_prefers_verified_folder_over_stale_cwd() {
+        let temp_dir = TempDir::new().unwrap();
+        // Folder name decodes to an existing directory (/usr/lib); the
+        // `.claude/projects/` marker must be present for verified decoding.
+        let project_dir = temp_dir
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-usr-lib");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        // Stale embedded cwd simulates a session moved into this folder by hand.
+        let content = concat!(
+            r#"{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","#,
+            r#""type":"user","cwd":"/some/stale/Dev","#,
+            r#""message":{"role":"user","content":"Hello world"}}"#,
+            "\n"
+        );
+        let file_path = project_dir.join("test.jsonl");
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+
+        let result = load_project_sessions(project_dir.to_string_lossy().to_string(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        // Verified folder name wins over the stale cwd.
+        assert_eq!(result[0].project_name, "lib");
     }
 
     #[tokio::test]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -241,7 +241,13 @@ pub fn decode_project_path_verified(session_storage_path: &str) -> Option<String
             if let Some(original) = parsed.get("originalPath").and_then(|v| v.as_str()) {
                 let original = original.trim();
                 let candidate = Path::new(original);
-                if candidate.is_absolute() && candidate.is_dir() {
+                // Use symlink_metadata (not is_dir, which follows symlinks) so a
+                // symlinked directory is rejected here too, matching the
+                // symlink-blocking policy in decode_with_filesystem_check.
+                let is_real_dir = std::fs::symlink_metadata(candidate)
+                    .map(|m| m.file_type().is_dir())
+                    .unwrap_or(false);
+                if candidate.is_absolute() && is_real_dir {
                     return Some(original.to_string());
                 }
             }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -220,6 +220,43 @@ pub fn decode_project_path(session_storage_path: &str) -> String {
     session_storage_path.to_string()
 }
 
+/// Resolve a session storage folder to a real on-disk project path, returning
+/// `None` when the folder name cannot be verified against the filesystem.
+///
+/// Unlike [`decode_project_path`], this never falls back to a lossy heuristic
+/// guess: it only ever returns a path that actually exists on disk. Callers can
+/// therefore treat a successful result as the folder's authoritative identity.
+///
+/// This complements the `cwd`-from-JSONL resolution introduced in #369: that
+/// handles the case where the *folder name* is lossy/unresolvable (so the real
+/// `cwd` is the better signal), while this handles the opposite case where the
+/// embedded `cwd` is stale — e.g. a session manually moved between project
+/// folders keeps its original `cwd`, but its containing folder is authoritative.
+pub fn decode_project_path_verified(session_storage_path: &str) -> Option<String> {
+    // 1. Prefer originalPath from sessions-index.json, but only if it still
+    //    points at an existing directory.
+    let index_path = Path::new(session_storage_path).join("sessions-index.json");
+    if let Ok(content) = std::fs::read_to_string(&index_path) {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Some(original) = parsed.get("originalPath").and_then(|v| v.as_str()) {
+                let original = original.trim();
+                let candidate = Path::new(original);
+                if candidate.is_absolute() && candidate.is_dir() {
+                    return Some(original.to_string());
+                }
+            }
+        }
+    }
+
+    // 2. Decode the encoded folder name, verifying each segment against the
+    //    filesystem. Returns `None` if the decoded path does not exist.
+    const MARKER: &str = ".claude/projects/";
+    let marker_pos = session_storage_path.find(MARKER)?;
+    let encoded = &session_storage_path[marker_pos + MARKER.len()..];
+    let stripped = encoded.strip_prefix('-')?;
+    decode_with_filesystem_check(stripped)
+}
+
 /// Decode path by checking filesystem existence at each possible split point
 ///
 /// For `-Users-jack-client-claude-code-history-viewer`:
@@ -745,6 +782,34 @@ mod tests {
     #[test]
     fn test_decode_project_path_regular() {
         assert_eq!(decode_project_path("/some/other/path"), "/some/other/path");
+    }
+
+    #[test]
+    fn test_decode_project_path_verified_resolves_existing_folder() {
+        // `/usr/lib` exists on macOS and Linux and contains no dashes, so the
+        // dash-decoder can resolve it against the real filesystem.
+        assert_eq!(
+            decode_project_path_verified("/Users/whoever/.claude/projects/-usr-lib"),
+            Some("/usr/lib".to_string())
+        );
+    }
+
+    #[test]
+    fn test_decode_project_path_verified_none_for_nonexistent() {
+        // This encoded folder name does not resolve to any real directory, so
+        // there is no verified result (callers fall back to the JSONL `cwd`).
+        assert_eq!(
+            decode_project_path_verified(
+                "/Users/whoever/.claude/projects/-this-does-not-exist-anywhere-xyzzy"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_decode_project_path_verified_none_without_marker() {
+        // Paths outside the `.claude/projects/` layout cannot be decoded.
+        assert_eq!(decode_project_path_verified("/some/other/path"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #369. That PR resolved a project's `actual_path` + display name from the `cwd` recorded inside the session JSONL, with a clear and valid rationale: Claude's storage directory names are lossy (`_` and `/` both collapse to `-`), so decoding the folder name can produce a non-existent path. 👍 That's the right call **when the folder name is the unreliable signal.**

I hit the mirror-image case, where the `cwd` is the unreliable one. I share some sessions across machines/accounts and reorganize them by **moving `.jsonl` files by hand between `~/.claude/projects/<folder>/` directories**. A moved file keeps the `cwd` from where it originally ran, so after moving it into another project's folder, CCHV labels that folder with the *moved* session's old project name. Worse, because the name is taken from the most-recently-modified top-level session, one moved file can rename the entire destination project.

## Approach — unify both cases, don't revert #369

There's already a robust decoder, `decode_with_filesystem_check`, that walks the encoded folder name and **only returns a path that actually exists on disk** (and uses `symlink_metadata`, so it won't follow symlinks). Building on it, a new `decode_project_path_verified` returns the folder's path *only when it verifiably resolves*, never the lossy heuristic guess.

Project identity is then resolved in priority order:

1. **Verified folder name** — authoritative even when a session's `cwd` is stale (the moved-files case).
2. **JSONL `cwd`** — the #369 behavior; used whenever (1) can't be verified (the lossy/renamed/deleted-dir case).
3. **Lossy heuristic decode** — unchanged last resort.

This is strictly additive to #369:
- Lossy folder name (e.g. a real `my_project` stored as `my-project`) → verified decode fails → falls back to `cwd`. **#369 preserved.** ✅
- Hand-moved session → folder resolves on disk → correct label. **New case fixed.** ✅
- Deleted/missing project dir → verified decode fails → `cwd`. No regression.

Applied to both sites #369 touched: `scan_projects` (project tree) and the per-session name in `load.rs`. `CACHE_VERSION` 10 → 11 to recompute cached names.

## Test plan

- [x] New unit tests: `decode_project_path_verified` (resolves / non-existent / no-marker), and end-to-end "verified folder wins over stale cwd" at both the `scan_projects` and `load_project_sessions` levels.
- [x] Existing `*_prefers_jsonl_cwd_*` tests still pass (their folder names don't resolve on disk, so `cwd` still wins — confirming #369's path is intact).
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -- --test-threads=1` (731 passing; the lone `get_git_log` failure is a local-env git-author override, green in CI).
- [x] Verified in a locally built `.app`: hand-moved sessions now appear under their actual destination folder (and it also corrected some pre-existing stale/duplicated folder entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project and session metadata resolution by prioritizing verified project folder names over stale embedded session paths.
  * Updated session metadata caching so outdated cache entries are invalidated and project naming is recomputed correctly.

* **Tests**
  * Added coverage to ensure verified folder decoding is preferred when embedded CWD data is stale.
  * Added unit tests for strict folder-name verification (valid directory returns a value; missing or non-matching inputs return none).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->