### PR TITLE
feat(search): show which conversation each global-search result belongs to

### DIFF
--- a/src/components/modals/globalSearch/GlobalSearchModal.tsx
+++ b/src/components/modals/globalSearch/GlobalSearchModal.tsx
@@ -86,9 +86,13 @@ export const GlobalSearchModal = ({
 
     // Get session display name for a search result
     const getSessionName = useCallback((result: GlobalSearchResult): string | undefined => {
-        if (!result.sessionId) return undefined;
-        return getSessionDisplayName(result.sessionId);
-    }, [getSessionDisplayName]);
+        if (!result.sessionId || result.sessionId === "unknown-session") return undefined;
+        const name = getSessionDisplayName(result.sessionId);
+        if (name) return name;
+        // No custom/known name: show a short, stable conversation handle so results
+        // from different conversations are still distinguishable (#420).
+        return t("globalSearch.conversationId", { id: result.sessionId.slice(0, 8) });
+    }, [getSessionDisplayName, t]);
 
     // Debounced search
     const performSearch = useCallback(
@@ -594,8 +598,9 @@ export const GlobalSearchModal = ({
                                                             {(() => {
                                                                 const sessionName = getSessionName(result);
                                                                 return sessionName ? (
-                                                                    <p className="text-xs text-muted-foreground/70 truncate mb-0.5">
-                                                                        {sessionName}
+                                                                    <p className="flex items-center gap-1 text-xs text-muted-foreground/70 mb-0.5">
+                                                                        <MessageSquare className="w-3 h-3 shrink-0" />
+                                                                        <span className="truncate">{sessionName}</span>
                                                                     </p>
                                                                 ) : null;
                                                             })()}

--- a/src/i18n/locales/en/renderers.json
+++ b/src/i18n/locales/en/renderers.json
@@ -211,6 +211,7 @@
   "globalSearch.tips.filters": "Use filters to narrow results by message type or project",
   "globalSearch.tips.navigate": "Use ↑↓ to navigate results, Enter to select",
   "globalSearch.unknownProject": "Unknown Project",
+  "globalSearch.conversationId": "Conversation {{id}}",
   "imageRenderer.cannotLoadImage": "Cannot load image",
   "imageRenderer.close": "Close",
   "imageRenderer.downloadImage": "Download image",

--- a/src/i18n/locales/ja/renderers.json
+++ b/src/i18n/locales/ja/renderers.json
@@ -211,6 +211,7 @@
   "globalSearch.tips.filters": "フィルターでメッセージの種類やプロジェクトを絞り込めます",
   "globalSearch.tips.navigate": "↑↓で結果を選択、Enterで確定",
   "globalSearch.unknownProject": "不明なプロジェクト",
+  "globalSearch.conversationId": "会話 {{id}}",
   "imageRenderer.cannotLoadImage": "画像を読み込めません",
   "imageRenderer.close": "閉じる",
   "imageRenderer.downloadImage": "画像をダウンロード",

--- a/src/i18n/locales/ko/renderers.json
+++ b/src/i18n/locales/ko/renderers.json
@@ -211,6 +211,7 @@
   "globalSearch.tips.filters": "필터를 사용하여 메시지 유형이나 프로젝트별로 검색 범위를 좁힐 수 있습니다",
   "globalSearch.tips.navigate": "↑↓로 결과를 탐색하고, Enter로 선택할 수 있습니다",
   "globalSearch.unknownProject": "알 수 없는 프로젝트",
+  "globalSearch.conversationId": "대화 {{id}}",
   "imageRenderer.cannotLoadImage": "이미지를 로드할 수 없습니다",
   "imageRenderer.close": "닫기",
   "imageRenderer.downloadImage": "이미지 다운로드",

--- a/src/i18n/locales/zh-CN/renderers.json
+++ b/src/i18n/locales/zh-CN/renderers.json
@@ -211,6 +211,7 @@
   "globalSearch.tips.filters": "使用筛选器按消息类型或项目缩小搜索范围",
   "globalSearch.tips.navigate": "使用 ↑↓ 浏览结果，Enter 选择",
   "globalSearch.unknownProject": "未知项目",
+  "globalSearch.conversationId": "会话 {{id}}",
   "imageRenderer.cannotLoadImage": "无法加载图像",
   "imageRenderer.close": "关闭",
   "imageRenderer.downloadImage": "下载图像",

--- a/src/i18n/locales/zh-TW/renderers.json
+++ b/src/i18n/locales/zh-TW/renderers.json
@@ -211,6 +211,7 @@
   "globalSearch.tips.filters": "使用篩選器按訊息類型或專案縮小搜尋範圍",
   "globalSearch.tips.navigate": "使用 ↑↓ 瀏覽結果，Enter 選擇",
   "globalSearch.unknownProject": "未知專案",
+  "globalSearch.conversationId": "對話 {{id}}",
   "imageRenderer.cannotLoadImage": "無法載入圖像",
   "imageRenderer.close": "關閉",
   "imageRenderer.downloadImage": "下載圖像",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-06-21T17:22:55.325Z
- * 총 키 개수: 1822
+ * 생성 시간: 2026-06-22T16:33:13.422Z
+ * 총 키 개수: 1823
  * Namespace 수: 11
  */
 
@@ -1395,7 +1395,7 @@ export type MessageKeys =
   | 'navigator.userOnly';
 
 /**
- * renderers namespace의 번역 키 (384개)
+ * renderers namespace의 번역 키 (385개)
  * 파일: locales/{lang}/renderers.json
  */
 export type RenderersKeys =
@@ -1582,6 +1582,7 @@ export type RenderersKeys =
   | 'globalSearch.allProjects'
   | 'globalSearch.clearSearch'
   | 'globalSearch.close'
+  | 'globalSearch.conversationId'
   | 'globalSearch.description'
   | 'globalSearch.filterType.all'
   | 'globalSearch.filterType.assistant'
@@ -2558,6 +2559,7 @@ export type TranslationKey =
   | 'globalSearch.allProjects'
   | 'globalSearch.clearSearch'
   | 'globalSearch.close'
+  | 'globalSearch.conversationId'
   | 'globalSearch.description'
   | 'globalSearch.filterType.all'
   | 'globalSearch.filterType.assistant'


### PR DESCRIPTION
Fixes #420.

## Problem

When a keyword appears across many conversations, the global search result list gives no per-result hint of **which conversation** a hit came from. Results are grouped by project (header), but the per-row session line only showed something if the user had manually *renamed* that session — otherwise it was blank. So the reporter couldn't tell whether a given result was the conversation they were looking for.

## Change (frontend-only)

Each result row now **always** shows a conversation handle next to a `MessageSquare` icon:
- the session's custom name when the user has renamed it, otherwise
- a short, stable id — `Conversation <first 8 chars>` — so results from different conversations are still distinguishable.

Combined with the existing project group header, every hit now shows **both** its project and its conversation.

Deliberately frontend-only: surfacing real auto-titles for never-renamed sessions would require threading the session summary through the search backend, which constructs `ClaudeMessage` at 44 sites — out of proportion for this UX fix. The short-id handle solves the "tell results apart" need with zero backend risk. (Real-title enrichment can be a follow-up if desired.)

## i18n
Adds `globalSearch.conversationId` to all 5 locales (en/ko/ja/zh-CN/zh-TW); `i18n:validate` passes, types regenerated.

## Verification
`tsc --build`, `eslint`, and `i18n:validate` all pass. This is a small render-only addition (one guarded line + icon, standard flex/truncate pattern); visual spot-check recommended on a populated search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced global search results with improved session information display, now featuring a visual icon and refined styling for better clarity.
  * Added multi-language localization support for conversation ID labels across English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->