### PR TITLE
fix(export): include subagent (sidechain) messages when exporting a subagent session

### DIFF
--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -208,6 +208,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
   const { isExporting, exportConversation } = useExport(
     displayMessages,
     selectedSession?.project_name ?? selectedSession?.session_id ?? "conversation",
+    { includeSidechain: isInSubagent },
   );
   const handleExport = useCallback((format: ExportFormat) => {
     if (isExporting || displayMessages.length === 0) return;

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -20,10 +20,15 @@ function sanitizeFilename(name: string): string {
   return safe.slice(0, 200) || "conversation";
 }
 
-export function useExport(messages: ClaudeMessage[], sessionName: string) {
+export function useExport(
+  messages: ClaudeMessage[],
+  sessionName: string,
+  options?: { includeSidechain?: boolean },
+) {
   const { t } = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
   const { messageFilter, isMessageFilterActive } = useAppStore();
+  const includeSidechain = options?.includeSidechain === true;
 
   const exportConversation = useCallback(
     async (format: ExportFormat) => {
@@ -38,25 +43,28 @@ export function useExport(messages: ClaudeMessage[], sessionName: string) {
 
         // Pass content type filter to exporters when filters are active
         const ctFilter = isMessageFilterActive() ? messageFilter.contentTypes : undefined;
+        // When exporting a subagent session directly, its messages are all
+        // sidechain — keep them instead of filtering them out (issue #433).
+        const exportOptions = { includeSidechain };
 
         switch (format) {
           case "markdown": {
             const { exportToMarkdown } = await import("@/services/export/markdownExporter");
-            content = exportToMarkdown(messages, sessionName, ctFilter);
+            content = exportToMarkdown(messages, sessionName, ctFilter, exportOptions);
             defaultPath = `${safeName}.md`;
             mimeType = "text/markdown";
             break;
           }
           case "json": {
             const { exportToJson } = await import("@/services/export/jsonExporter");
-            content = exportToJson(messages, sessionName, ctFilter);
+            content = exportToJson(messages, sessionName, ctFilter, exportOptions);
             defaultPath = `${safeName}.json`;
             mimeType = "application/json";
             break;
           }
           case "html": {
             const { exportToHtml } = await import("@/services/export/htmlExporter");
-            content = exportToHtml(messages, sessionName, ctFilter);
+            content = exportToHtml(messages, sessionName, ctFilter, exportOptions);
             defaultPath = `${safeName}.html`;
             mimeType = "text/html";
             break;
@@ -80,7 +88,7 @@ export function useExport(messages: ClaudeMessage[], sessionName: string) {
         setIsExporting(false);
       }
     },
-    [messages, sessionName, t, messageFilter, isMessageFilterActive],
+    [messages, sessionName, t, messageFilter, isMessageFilterActive, includeSidechain],
   );
 
   return { isExporting, exportConversation };

--- a/src/services/export/contentExtractor.ts
+++ b/src/services/export/contentExtractor.ts
@@ -217,9 +217,19 @@ export function extractBlocks(content: string | ContentItem[] | Record<string, u
 
 /**
  * Filter messages to only exportable types (shared across all exporters).
+ *
+ * Sidechain (subagent) messages are excluded by default so they don't bleed
+ * into a parent session export. When the user has navigated *into* a subagent
+ * session and exports it directly, every message carries `isSidechain: true`,
+ * so callers pass `{ includeSidechain: true }` to keep them. See issue #433.
  */
-export function isExportable(m: ClaudeMessage): boolean {
-  return !m.isSidechain
+export type ExportOptions = {
+  /** Keep sidechain (subagent) messages — set when exporting a subagent session directly. */
+  includeSidechain?: boolean;
+};
+
+export function isExportable(m: ClaudeMessage, options?: ExportOptions): boolean {
+  return (options?.includeSidechain === true || !m.isSidechain)
     && m.type !== "system"
     && m.type !== "summary"
     && m.type !== "progress"

--- a/src/services/export/htmlExporter.ts
+++ b/src/services/export/htmlExporter.ts
@@ -6,7 +6,7 @@
 
 import { Marked } from "marked";
 import type { ClaudeMessage } from "@/types";
-import { extractBlocks, filterBlocksByContentType, isExportable, type ExtractedBlock } from "./contentExtractor";
+import { extractBlocks, filterBlocksByContentType, isExportable, type ExtractedBlock, type ExportOptions } from "./contentExtractor";
 import type { MessageFilterContentTypes } from "@/store/slices/filterSlice";
 
 const CSS = `
@@ -125,8 +125,8 @@ function blockToHtml(block: ExtractedBlock): string {
   }
 }
 
-export function exportToHtml(messages: ClaudeMessage[], sessionName: string, contentTypeFilter?: MessageFilterContentTypes): string {
-  const filtered = messages.filter(isExportable);
+export function exportToHtml(messages: ClaudeMessage[], sessionName: string, contentTypeFilter?: MessageFilterContentTypes, options?: ExportOptions): string {
+  const filtered = messages.filter((m) => isExportable(m, options));
 
   const firstTimestamp = filtered[0]?.timestamp;
   const lastTimestamp = filtered[filtered.length - 1]?.timestamp;

--- a/src/services/export/jsonExporter.ts
+++ b/src/services/export/jsonExporter.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ClaudeMessage } from "@/types";
-import { extractBlocks, filterBlocksByContentType, blocksToPlainText, isExportable } from "./contentExtractor";
+import { extractBlocks, filterBlocksByContentType, blocksToPlainText, isExportable, type ExportOptions } from "./contentExtractor";
 import type { MessageFilterContentTypes } from "@/store/slices/filterSlice";
 
 interface ExportedMessage {
@@ -21,8 +21,8 @@ interface ExportedMessage {
 }
 
 
-export function exportToJson(messages: ClaudeMessage[], sessionName: string, contentTypeFilter?: MessageFilterContentTypes): string {
-  const filtered = messages.filter(isExportable);
+export function exportToJson(messages: ClaudeMessage[], sessionName: string, contentTypeFilter?: MessageFilterContentTypes, options?: ExportOptions): string {
+  const filtered = messages.filter((m) => isExportable(m, options));
 
   const exportedMessages: ExportedMessage[] = filtered.map((msg) => {
     const base: ExportedMessage = {

--- a/src/services/export/markdownExporter.ts
+++ b/src/services/export/markdownExporter.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ClaudeMessage } from "@/types";
-import { extractBlocks, filterBlocksByContentType, isExportable, type ExtractedBlock } from "./contentExtractor";
+import { extractBlocks, filterBlocksByContentType, isExportable, type ExtractedBlock, type ExportOptions } from "./contentExtractor";
 import type { MessageFilterContentTypes } from "@/store/slices/filterSlice";
 
 function formatTimestamp(timestamp: string): { date: string; time: string } {
@@ -39,8 +39,8 @@ function blockToMarkdown(block: ExtractedBlock): string {
   }
 }
 
-export function exportToMarkdown(messages: ClaudeMessage[], sessionName: string, contentTypeFilter?: MessageFilterContentTypes): string {
-  const filtered = messages.filter(isExportable);
+export function exportToMarkdown(messages: ClaudeMessage[], sessionName: string, contentTypeFilter?: MessageFilterContentTypes, options?: ExportOptions): string {
+  const filtered = messages.filter((m) => isExportable(m, options));
 
   const firstTimestamp = filtered[0]?.timestamp;
   const lastTimestamp = filtered[filtered.length - 1]?.timestamp;

--- a/src/test/export/contentExtractor.test.ts
+++ b/src/test/export/contentExtractor.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { extractBlocks, blocksToPlainText } from "@/services/export/contentExtractor";
+import { extractBlocks, blocksToPlainText, isExportable } from "@/services/export/contentExtractor";
+import type { ClaudeMessage } from "@/types";
+
+function msg(overrides: Partial<ClaudeMessage> & { type: ClaudeMessage["type"] }): ClaudeMessage {
+  return { uuid: "u", sessionId: "s", timestamp: "2026-03-13T10:30:15.000Z", content: "", ...overrides } as ClaudeMessage;
+}
 
 describe("contentExtractor", () => {
   it("should return empty array for null/undefined", () => {
@@ -201,5 +206,23 @@ describe("contentExtractor", () => {
     ];
     const text = blocksToPlainText(blocks);
     expect(text).toBe("Hello\n\nRead(file: test.ts)");
+  });
+});
+
+describe("isExportable", () => {
+  it("excludes sidechain messages by default", () => {
+    expect(isExportable(msg({ type: "user", isSidechain: true }))).toBe(false);
+    expect(isExportable(msg({ type: "user", isSidechain: false }))).toBe(true);
+  });
+
+  it("keeps sidechain messages when includeSidechain is set (issue #433)", () => {
+    expect(isExportable(msg({ type: "user", isSidechain: true }), { includeSidechain: true })).toBe(true);
+    expect(isExportable(msg({ type: "assistant", isSidechain: true }), { includeSidechain: true })).toBe(true);
+  });
+
+  it("still excludes non-message types even when includeSidechain is set", () => {
+    for (const type of ["system", "summary", "progress", "queue-operation", "file-history-snapshot"] as const) {
+      expect(isExportable(msg({ type, isSidechain: true }), { includeSidechain: true })).toBe(false);
+    }
   });
 });

--- a/src/test/export/markdownExporter.test.ts
+++ b/src/test/export/markdownExporter.test.ts
@@ -65,6 +65,23 @@ describe("markdownExporter", () => {
     expect(result).not.toContain("hidden");
   });
 
+  it("should include sidechain messages when includeSidechain is set (subagent export, issue #433)", () => {
+    // A subagent session: every message is a sidechain message.
+    const messages = [
+      makeMessage({ type: "user", content: "subagent question", isSidechain: true }),
+      makeMessage({ type: "assistant", content: "subagent answer", isSidechain: true }),
+    ];
+
+    const withoutOption = exportToMarkdown(messages, "test");
+    expect(withoutOption).toContain("0 user / 0 assistant");
+    expect(withoutOption).not.toContain("subagent question");
+
+    const withOption = exportToMarkdown(messages, "test", undefined, { includeSidechain: true });
+    expect(withOption).toContain("1 user / 1 assistant");
+    expect(withOption).toContain("subagent question");
+    expect(withOption).toContain("subagent answer");
+  });
+
   it("should exclude system and summary messages", () => {
     const messages = [
       makeMessage({ type: "user", content: "visible" }),


### PR DESCRIPTION
## Problem

Closes #433. Exporting a subagent session (any format — Markdown, JSON, HTML) produced an empty file with a stub header like `# Session: myproject / 0 user / 0 assistant`.

## Root cause

The shared `isExportable()` filter in `contentExtractor.ts` unconditionally dropped every message where `isSidechain === true`:

```ts
return !m.isSidechain && m.type !== "system" && ...
```

That guard is correct for a **parent** session export — it keeps subagent messages from bleeding in. But when the user navigates **into** a subagent session and exports it directly, *every* message carries `isSidechain: true`, so all of them were filtered out and the export came back empty.

## Fix

`isExportable()` now accepts an optional `{ includeSidechain }` flag (new `ExportOptions` type). `MessageViewer` already computes `isInSubagent = parentSessionStack.length > 0` and feeds the displayed messages into `useExport`; that flag is now threaded through `useExport` → the three exporters → `isExportable`. So:

- **Parent session export** → `includeSidechain: false` → unchanged behavior (sidechain still excluded).
- **Subagent session export** → `includeSidechain: true` → its messages are kept.

Non-message types (`system`/`summary`/`progress`/`queue-operation`/`file-history-snapshot`) are still excluded regardless.

## Files

- `src/services/export/contentExtractor.ts` — `ExportOptions` type + `includeSidechain` param on `isExportable`
- `src/services/export/{markdown,json,html}Exporter.ts` — accept + forward `ExportOptions`
- `src/hooks/useExport.ts` — accept `{ includeSidechain }`, pass to exporters
- `src/components/MessageViewer/MessageViewer.tsx` — pass `{ includeSidechain: isInSubagent }`
- tests: `src/test/export/contentExtractor.test.ts` (new `isExportable` block), `markdownExporter.test.ts` (subagent-export case)

## Verification

- `pnpm tsc --build .` — clean
- `pnpm lint` — clean
- `pnpm vitest run` — 868 passed (4 new)

## Out of scope / follow-up

The headless CLI export (`src-tauri/src/export.rs`) has the same `is_sidechain` guard, but it operates by session path with no navigation context to tell whether the target is a subagent session. Determining that headlessly (e.g. "all messages are sidechain") is a separate change; noting here for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exporting conversations now supports including sidechain/subagent messages when enabled.
  * Export output across markdown, JSON, HTML, and viewer-based exports can reflect this new option.

* **Bug Fixes**
  * Fixed exports so subagent-session content is included only when explicitly requested, while keeping the default export behavior unchanged.

* **Tests**
  * Added coverage for sidechain message filtering and inclusion in exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->