### PR TITLE
fix(search): index tool_use.input so in-session search matches tool arguments

### DIFF
--- a/src/utils/searchIndex.test.ts
+++ b/src/utils/searchIndex.test.ts
@@ -132,6 +132,53 @@ describe("linearSearchMessages", () => {
   });
 });
 
+describe("tool_use input indexing (#429)", () => {
+  it("finds text inside tool_use.input (file_path, command, etc.)", () => {
+    const msg = createMessage({
+      uuid: "tu-1",
+      type: "assistant",
+      content: [
+        { type: "tool_use", id: "t1", name: "Read", input: { file_path: "/src/reflectance.ts" } },
+      ],
+    });
+    // Searching for the tool name still works...
+    expect(linearSearchMessages([msg], "Read").length).toBe(1);
+    // ...and now the input value is searchable too (previously missed).
+    const byInput = linearSearchMessages([msg], "reflectance");
+    expect(byInput.length).toBe(1);
+    expect(byInput[0].messageUuid).toBe("tu-1");
+  });
+
+  it("finds nested string values in tool_use.input", () => {
+    const msg = createMessage({
+      uuid: "tu-2",
+      type: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "t2",
+          name: "AskUserQuestion",
+          input: { questions: [{ question: "What reflectance model should we use?" }] },
+        },
+      ],
+    });
+    const results = linearSearchMessages([msg], "reflectance model");
+    expect(results.length).toBe(1);
+    expect(results[0].messageUuid).toBe("tu-2");
+  });
+
+  it("indexes mcp_tool_use input values", () => {
+    const msg = createMessage({
+      uuid: "tu-3",
+      type: "assistant",
+      content: [
+        { type: "mcp_tool_use", server_name: "fs", tool_name: "grep", input: { pattern: "needle-token" } },
+      ],
+    });
+    expect(linearSearchMessages([msg], "needle-token").length).toBe(1);
+  });
+});
+
 describe("isSearchIndexReady / clearSearchIndex", () => {
   beforeEach(() => {
     clearSearchIndex();

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -18,6 +18,36 @@ const hasStringProperty = (obj: Record<string, unknown>, key: string): boolean =
 
 // 검색 가능한 텍스트 추출 (content 검색용)
 const MAX_TEXT_LENGTH = 10000; // 최대 10KB만 인덱싱 (텍스트용)
+const MAX_INPUT_LENGTH = 5000; // tool_use.input 값 인덱싱 상한 (도구당)
+
+// tool_use.input(객체)의 문자열/숫자 값을 재귀적으로 수집한다.
+// 키가 아니라 값만 인덱싱해 글로벌(rust) 검색과 동작을 맞추고,
+// budget으로 총 길이를 제한해 거대한 input이 인덱스를 부풀리지 않게 한다. (#429)
+const collectInputValues = (
+  value: unknown,
+  parts: string[],
+  budget: { remaining: number },
+): void => {
+  if (budget.remaining <= 0) return;
+  if (typeof value === "string") {
+    const s = value.slice(0, budget.remaining);
+    parts.push(s);
+    budget.remaining -= s.length;
+  } else if (typeof value === "number" || typeof value === "boolean") {
+    parts.push(String(value));
+    budget.remaining -= String(value).length;
+  } else if (Array.isArray(value)) {
+    for (const v of value) {
+      if (budget.remaining <= 0) break;
+      collectInputValues(v, parts, budget);
+    }
+  } else if (isRecord(value)) {
+    for (const v of Object.values(value)) {
+      if (budget.remaining <= 0) break;
+      collectInputValues(v, parts, budget);
+    }
+  }
+};
 
 const extractSearchableText = (message: ClaudeMessage): string => {
   const parts: string[] = [];
@@ -47,17 +77,19 @@ const extractSearchableText = (message: ClaudeMessage): string => {
             if (hasStringProperty(item, "thinking")) {
               parts.push((item.thinking as string).slice(0, MAX_TEXT_LENGTH));
             }
-            // tool_use: name
-            if (itemType === "tool_use" && hasStringProperty(item, "name")) {
-              parts.push(item.name as string);
+            // tool_use: name + input values (file_path, command, query 등) (#429)
+            if (itemType === "tool_use") {
+              if (hasStringProperty(item, "name")) parts.push(item.name as string);
+              if (isRecord(item.input)) collectInputValues(item.input, parts, { remaining: MAX_INPUT_LENGTH });
             }
             // tool_result: content
             if (itemType === "tool_result" && hasStringProperty(item, "content")) {
               parts.push(item.content as string);
             }
-            // server_tool_use: name
-            if (itemType === "server_tool_use" && hasStringProperty(item, "name")) {
-              parts.push(item.name as string);
+            // server_tool_use: name + input values (#429)
+            if (itemType === "server_tool_use") {
+              if (hasStringProperty(item, "name")) parts.push(item.name as string);
+              if (isRecord(item.input)) collectInputValues(item.input, parts, { remaining: MAX_INPUT_LENGTH });
             }
             // web_search_tool_result: titles and urls
             if (itemType === "web_search_tool_result" && isRecord(item.content)) {
@@ -92,10 +124,11 @@ const extractSearchableText = (message: ClaudeMessage): string => {
                 }
               }
             }
-            // mcp_tool_use: server_name, tool_name
+            // mcp_tool_use: server_name, tool_name + input values (#429)
             if (itemType === "mcp_tool_use") {
               if (hasStringProperty(item, "server_name")) parts.push(item.server_name as string);
               if (hasStringProperty(item, "tool_name")) parts.push(item.tool_name as string);
+              if (isRecord(item.input)) collectInputValues(item.input, parts, { remaining: MAX_INPUT_LENGTH });
             }
             // mcp_tool_result: text content
             if (itemType === "mcp_tool_result") {

--- a/src/utils/searchWorker.ts
+++ b/src/utils/searchWorker.ts
@@ -74,6 +74,35 @@ const hasStringProperty = (obj: Record<string, unknown>, key: string): boolean =
 };
 
 const MAX_TEXT_LENGTH = 10000;
+const MAX_INPUT_LENGTH = 5000;
+
+// tool_use.input 값 인덱싱 — 키가 아닌 값만 수집, budget으로 길이 제한 (#429)
+// (main thread searchIndex.ts의 collectInputValues와 동일 로직)
+const collectInputValues = (
+  value: unknown,
+  parts: string[],
+  budget: { remaining: number },
+): void => {
+  if (budget.remaining <= 0) return;
+  if (typeof value === "string") {
+    const s = value.slice(0, budget.remaining);
+    parts.push(s);
+    budget.remaining -= s.length;
+  } else if (typeof value === "number" || typeof value === "boolean") {
+    parts.push(String(value));
+    budget.remaining -= String(value).length;
+  } else if (Array.isArray(value)) {
+    for (const v of value) {
+      if (budget.remaining <= 0) break;
+      collectInputValues(v, parts, budget);
+    }
+  } else if (isRecord(value)) {
+    for (const v of Object.values(value)) {
+      if (budget.remaining <= 0) break;
+      collectInputValues(v, parts, budget);
+    }
+  }
+};
 
 const extractSearchableText = (message: ClaudeMessageMinimal): string => {
   const parts: string[] = [];
@@ -89,9 +118,15 @@ const extractSearchableText = (message: ClaudeMessageMinimal): string => {
             if (item.type === "image") continue;
             if (hasStringProperty(item, "text")) parts.push((item.text as string).slice(0, MAX_TEXT_LENGTH));
             if (hasStringProperty(item, "thinking")) parts.push((item.thinking as string).slice(0, MAX_TEXT_LENGTH));
-            if (item.type === "tool_use" && hasStringProperty(item, "name")) parts.push(item.name as string);
+            if (item.type === "tool_use") {
+              if (hasStringProperty(item, "name")) parts.push(item.name as string);
+              if (isRecord(item.input)) collectInputValues(item.input, parts, { remaining: MAX_INPUT_LENGTH });
+            }
             if (item.type === "tool_result" && hasStringProperty(item, "content")) parts.push(item.content as string);
-            if (item.type === "server_tool_use" && hasStringProperty(item, "name")) parts.push(item.name as string);
+            if (item.type === "server_tool_use") {
+              if (hasStringProperty(item, "name")) parts.push(item.name as string);
+              if (isRecord(item.input)) collectInputValues(item.input, parts, { remaining: MAX_INPUT_LENGTH });
+            }
             // Keep coverage in sync with src/utils/searchIndex.ts (#352): the
             // worker must index the same content types as the main path, or
             // search silently misses them.
@@ -128,6 +163,7 @@ const extractSearchableText = (message: ClaudeMessageMinimal): string => {
             if (itemType === "mcp_tool_use") {
               if (hasStringProperty(item, "server_name")) parts.push(item.server_name as string);
               if (hasStringProperty(item, "tool_name")) parts.push(item.tool_name as string);
+              if (isRecord(item.input)) collectInputValues(item.input, parts, { remaining: MAX_INPUT_LENGTH });
             }
             if (itemType === "mcp_tool_result") {
               const c = item.content;


### PR DESCRIPTION
## Problem

Addresses #429. The in-session search bar fails to find content that is clearly in the conversation — e.g. a path, a command, or the text of a model question — while the global search (Ctrl/Cmd+K) finds the same text.

## Root cause

`extractSearchableText` in `src/utils/searchIndex.ts` indexed a `tool_use` block only by its **`name`** (e.g. "Read", "Bash"). The **`input`** object (`file_path`, `command`, `query`, `AskUserQuestion` prompts, etc.) was never added to the index. The linear-search fallback uses the same function, so it had the identical gap.

By contrast the Rust global search (`search_in_value` in `commands/session/search.rs`) recursively descends every JSON value including `input`, so it matches that text. That asymmetry is exactly the "can't find all relevant information" the reporter saw.

## Fix

`extractSearchableText` now collects the string/number **values** inside `input` for `tool_use`, `server_tool_use`, and `mcp_tool_use`:
- **Values only, not keys** — matches the global search's value-only semantics (the Rust side ignores object keys), so searching for `string` doesn't spuriously match the key `old_string`.
- **Bounded** — a 5KB-per-tool budget (`MAX_INPUT_LENGTH`) walks nested objects/arrays so a huge input can't bloat the index.

The same logic is mirrored in `src/utils/searchWorker.ts`, which intentionally duplicates `extractSearchableText` because web workers can't import main-thread modules (the file already carries a "keep in sync" note).

## Scope note

This fixes the **search-coverage** half of #429. The reporter also raised (a) whether the Up/Down buttons scroll to matches and (b) a request for a dedicated "question tool" renderer — both pending their clarification and tracked separately on the issue; not in this PR.

## Verification

- `pnpm tsc --build .` — clean
- `pnpm lint` — clean
- `pnpm vitest run` — 871 passed (3 new in `searchIndex.test.ts` covering tool_use.input, nested values, and mcp_tool_use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search now finds text inside tool input content, including nested values, for tool-use and MCP tool-use entries.
  * Tool names still remain searchable, with input matching added alongside existing behavior.

* **Tests**
  * Added coverage for searching within tool inputs and nested input fields to verify the updated search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->