### PR TITLE
feat(web): add global conversation refresh

### DIFF
--- a/src/i18n/locales/en/session.json
+++ b/src/i18n/locales/en/session.json
@@ -191,6 +191,7 @@
   "session.nativeRename.warningForgeCode": "This operation updates the ForgeCode conversation title stored in the Forge database.",
   "session.nativeRename.warningOpenCode": "This operation modifies the OpenCode session metadata file. The change is reversible.",
   "session.refresh": "Refresh Sessions",
+  "session.refreshAllConversations": "Refresh all conversations",
   "session.rename": "Rename session",
   "session.renameAction": "Rename session",
   "session.renameHint": "Double-click to rename",

--- a/src/i18n/locales/ja/session.json
+++ b/src/i18n/locales/ja/session.json
@@ -191,6 +191,7 @@
   "session.nativeRename.warningForgeCode": "この操作はForgeデータベースに保存されたForgeCode会話タイトルを更新します。",
   "session.nativeRename.warningOpenCode": "この操作はOpenCodeセッションのメタデータファイルを変更します。変更は元に戻せます。",
   "session.refresh": "セッションを更新",
+  "session.refreshAllConversations": "すべての会話を更新",
   "session.rename": "セッション名を変更",
   "session.renameAction": "セッション名を変更",
   "session.renameHint": "ダブルクリックで名前変更",

--- a/src/i18n/locales/ko/session.json
+++ b/src/i18n/locales/ko/session.json
@@ -191,6 +191,7 @@
   "session.nativeRename.warningForgeCode": "이 작업은 Forge 데이터베이스에 저장된 ForgeCode 대화 제목을 업데이트합니다.",
   "session.nativeRename.warningOpenCode": "이 작업은 OpenCode 세션 메타데이터 파일을 수정합니다. 변경은 되돌릴 수 있습니다.",
   "session.refresh": "세션 새로고침",
+  "session.refreshAllConversations": "모든 대화 새로고침",
   "session.rename": "세션 이름 변경",
   "session.renameAction": "세션 이름 변경",
   "session.renameHint": "더블클릭하여 이름 변경",

--- a/src/i18n/locales/zh-CN/session.json
+++ b/src/i18n/locales/zh-CN/session.json
@@ -191,6 +191,7 @@
   "session.nativeRename.warningForgeCode": "此操作会更新 Forge 数据库中存储的 ForgeCode 对话标题。",
   "session.nativeRename.warningOpenCode": "此操作会修改 OpenCode 会话元数据文件。更改可以撤销。",
   "session.refresh": "刷新会话",
+  "session.refreshAllConversations": "刷新所有对话",
   "session.rename": "重命名会话",
   "session.renameAction": "重命名会话",
   "session.renameHint": "双击重命名",

--- a/src/i18n/locales/zh-TW/session.json
+++ b/src/i18n/locales/zh-TW/session.json
@@ -191,6 +191,7 @@
   "session.nativeRename.warningForgeCode": "此操作會更新 Forge 資料庫中儲存的 ForgeCode 對話標題。",
   "session.nativeRename.warningOpenCode": "此操作會修改 OpenCode 會話中繼資料檔案。變更可以復原。",
   "session.refresh": "重新整理會話",
+  "session.refreshAllConversations": "重新整理所有對話",
   "session.rename": "重新命名會話",
   "session.renameAction": "重新命名會話",
   "session.renameHint": "雙擊重新命名",

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -43,12 +43,21 @@ export const Header = ({ analyticsActions, analyticsComputed, updater }: HeaderP
   const {
     selectedProject,
     selectedSession,
+    isLoadingProjects,
+    isLoadingSessions,
     isLoadingMessages,
+    isRefreshingAllConversations,
+    refreshAllConversations,
     refreshCurrentSession,
   } = useAppStore();
 
   const computed = analyticsComputed;
   const isClaudeProject = (selectedProject?.provider ?? "claude") === "claude";
+  const isRefreshingConversations =
+    isRefreshingAllConversations ||
+    isLoadingProjects ||
+    isLoadingSessions ||
+    isLoadingMessages;
 
   const handleLoadTokenStats = async () => {
     if (!selectedProject) return;
@@ -172,6 +181,27 @@ export const Header = ({ analyticsActions, analyticsComputed, updater }: HeaderP
         >
           <Search className="w-5 h-5" />
         </button>
+
+        {/* Global refresh */}
+        <TooltipButton
+          onClick={() => {
+            void refreshAllConversations();
+          }}
+          disabled={isRefreshingConversations}
+          className={cn(
+            "p-2 rounded-md transition-colors",
+            "text-muted-foreground hover:text-foreground hover:bg-muted",
+            isRefreshingConversations && "opacity-70 cursor-not-allowed"
+          )}
+          content={t(
+            "session.refreshAllConversations",
+            "Refresh all conversations"
+          )}
+        >
+          <RefreshCw
+            className={cn("w-4 h-4", isRefreshingConversations && "animate-spin")}
+          />
+        </TooltipButton>
 
         {/* Desktop nav buttons */}
         <div className="hidden md:flex items-center gap-1">

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -9,6 +9,7 @@ import { storageAdapter } from "@/services/storage";
 import type { ClaudeProject, ClaudeSession, AppError, ProviderId, UserSettings } from "../../types";
 import { AppErrorType } from "../../types";
 import type { StateCreator } from "zustand";
+import { toast } from "sonner";
 import type { FullAppStore } from "./types";
 import {
   detectWorktreeGroupsHybrid,
@@ -34,12 +35,14 @@ export interface ProjectSliceState {
   isLoading: boolean;
   isLoadingProjects: boolean;
   isLoadingSessions: boolean;
+  isRefreshingAllConversations: boolean;
   error: AppError | null;
 }
 
 export interface ProjectSliceActions {
   initializeApp: () => Promise<void>;
   scanProjects: () => Promise<void>;
+  refreshAllConversations: () => Promise<void>;
   selectProject: (project: ClaudeProject) => Promise<void>;
   clearProjectSelection: () => void;
   setClaudePath: (path: string) => Promise<void>;
@@ -66,6 +69,7 @@ const initialProjectState: ProjectSliceState = {
   isLoading: false,
   isLoadingProjects: false,
   isLoadingSessions: false,
+  isRefreshingAllConversations: false,
   error: null,
 };
 
@@ -110,6 +114,21 @@ const withProvider = (
     ...project,
     provider: project.provider ?? provider,
   }));
+
+const isSameProject = (
+  project: ClaudeProject,
+  selectedProject: ClaudeProject,
+): boolean =>
+  project.path === selectedProject.path &&
+  getProviderId(project.provider) === getProviderId(selectedProject.provider);
+
+const isSameSession = (
+  session: ClaudeSession,
+  selectedSession: ClaudeSession,
+): boolean =>
+  session.file_path === selectedSession.file_path ||
+  session.session_id === selectedSession.session_id ||
+  session.actual_session_id === selectedSession.actual_session_id;
 
 const scanProviderProjects = async ({
   provider,
@@ -411,6 +430,110 @@ export const createProjectSlice: StateCreator<
       if (requestId === getRequestId("scanProjects")) {
         set({ isLoadingProjects: false });
       }
+    }
+  },
+
+  refreshAllConversations: async () => {
+    if (get().isRefreshingAllConversations) {
+      return;
+    }
+
+    const previouslySelectedProject = get().selectedProject;
+    const previouslySelectedSession = get().selectedSession;
+
+    set({ isRefreshingAllConversations: true, error: null });
+
+    try {
+      await get().scanProjects();
+
+      const stateAfterScan = get();
+      if (!previouslySelectedProject) {
+        if (stateAfterScan.analytics.currentView === "analytics") {
+          await stateAfterScan.loadGlobalStats();
+        }
+        return;
+      }
+
+      const refreshedProject = stateAfterScan.projects.find((project) =>
+        isSameProject(project, previouslySelectedProject)
+      );
+
+      if (!refreshedProject) {
+        get().clearProjectSelection();
+        return;
+      }
+
+      await get().selectProject(refreshedProject);
+
+      let refreshedSession: ClaudeSession | null = null;
+      if (previouslySelectedSession) {
+        refreshedSession = get().sessions.find((session) =>
+          isSameSession(session, previouslySelectedSession)
+        ) ?? null;
+
+        if (refreshedSession) {
+          await get().selectSession(refreshedSession);
+        } else {
+          set({
+            selectedSession: null,
+            messages: [],
+            pagination: { ...INITIAL_PAGINATION },
+            isLoadingMessages: false,
+            subagentSessions: [],
+            parentSessionStack: [],
+          });
+          get().clearSessionSearch();
+          get().clearTokenStats();
+          get().clearTargetMessage();
+        }
+      }
+
+      const refreshedState = get();
+      if (refreshedState.analytics.currentView === "tokenStats") {
+        await refreshedState.loadProjectTokenStats(refreshedProject.path);
+        if (refreshedSession) {
+          await refreshedState.loadSessionTokenStats(refreshedSession.file_path);
+        }
+      } else if (refreshedState.analytics.currentView === "analytics") {
+        const projectSummary = await refreshedState.loadProjectStatsSummary(
+          refreshedProject.path
+        );
+        refreshedState.setAnalyticsProjectSummary(projectSummary);
+        if (refreshedSession) {
+          const sessionComparison = await refreshedState.loadSessionComparison(
+            refreshedSession.actual_session_id,
+            refreshedProject.path
+          );
+          refreshedState.setAnalyticsSessionComparison(sessionComparison);
+        } else {
+          refreshedState.setAnalyticsSessionComparison(null);
+        }
+      } else if (refreshedState.analytics.currentView === "recentEdits") {
+        const recentEdits = await refreshedState.loadRecentEdits(
+          refreshedProject.path
+        );
+        refreshedState.setAnalyticsRecentEdits({
+          files: recentEdits.files,
+          total_edits_count: recentEdits.total_edits_count,
+          unique_files_count: recentEdits.unique_files_count,
+          project_cwd: recentEdits.project_cwd,
+        });
+      } else if (refreshedState.analytics.currentView === "board") {
+        refreshedState.clearBoard();
+        await refreshedState.loadBoardSessions(get().sessions);
+      } else if (refreshedState.analytics.currentView === "archive") {
+        await refreshedState.loadArchives();
+      }
+    } catch (error) {
+      console.error("Failed to refresh all conversations:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to refresh conversations: ${message}`);
+      get().setError({
+        type: AppErrorType.UNKNOWN,
+        message,
+      });
+    } finally {
+      set({ isRefreshingAllConversations: false });
     }
   },
 

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -103,6 +103,7 @@ export interface AppStoreState {
   isLoading: boolean;
   isLoadingProjects: boolean;
   isLoadingSessions: boolean;
+  isRefreshingAllConversations: boolean;
   error: AppError | null;
 
   // Message state
@@ -212,6 +213,7 @@ export interface AppStoreActions {
   // Project actions
   initializeApp: () => Promise<void>;
   scanProjects: () => Promise<void>;
+  refreshAllConversations: () => Promise<void>;
   selectProject: (project: ClaudeProject) => Promise<void>;
   clearProjectSelection: () => void;
   setClaudePath: (path: string) => Promise<void>;

--- a/src/test/projectSlice.scanProjects.test.ts
+++ b/src/test/projectSlice.scanProjects.test.ts
@@ -9,6 +9,7 @@ import {
   AppErrorType,
   DEFAULT_USER_METADATA,
   type ClaudeProject,
+  type ClaudeSession,
   type ProviderInfo,
   type UserMetadata,
 } from "../types";
@@ -40,6 +41,28 @@ type TestStore = ProjectSlice & {
   userMetadata: UserMetadata;
   updateUserSettings: ReturnType<typeof vi.fn>;
   excludeSidechain: boolean;
+  analytics: { currentView: "messages" | "analytics" | "tokenStats" | "recentEdits" | "board" | "archive" };
+  messages: unknown[];
+  activeProviders: ProviderInfo["id"][];
+  detectProviders: ReturnType<typeof vi.fn>;
+  selectSession: ReturnType<typeof vi.fn>;
+  loadGlobalStats: ReturnType<typeof vi.fn>;
+  loadProjectTokenStats: ReturnType<typeof vi.fn>;
+  loadSessionTokenStats: ReturnType<typeof vi.fn>;
+  loadProjectStatsSummary: ReturnType<typeof vi.fn>;
+  setAnalyticsProjectSummary: ReturnType<typeof vi.fn>;
+  loadSessionComparison: ReturnType<typeof vi.fn>;
+  setAnalyticsSessionComparison: ReturnType<typeof vi.fn>;
+  loadRecentEdits: ReturnType<typeof vi.fn>;
+  setAnalyticsRecentEdits: ReturnType<typeof vi.fn>;
+  loadBoardSessions: ReturnType<typeof vi.fn>;
+  loadArchives: ReturnType<typeof vi.fn>;
+  clearSessionSearch: ReturnType<typeof vi.fn>;
+  clearTokenStats: ReturnType<typeof vi.fn>;
+  clearTargetMessage: ReturnType<typeof vi.fn>;
+  resetAnalytics: ReturnType<typeof vi.fn>;
+  clearBoard: ReturnType<typeof vi.fn>;
+  setDateFilter: ReturnType<typeof vi.fn>;
 };
 
 const createMockProject = (
@@ -57,12 +80,58 @@ const createMockProject = (
   ...(provider ? { provider } : {}),
 });
 
+const createMockSession = (
+  id: string,
+  project: ClaudeProject,
+): ClaudeSession => ({
+  session_id: id,
+  actual_session_id: `actual-${id}`,
+  file_path: `${project.path}/${id}.jsonl`,
+  project_name: project.name,
+  message_count: 1,
+  first_message_time: "2026-01-01T00:00:00.000Z",
+  last_message_time: "2026-01-01T00:00:00.000Z",
+  last_modified: "2026-01-01T00:00:00.000Z",
+  has_tool_use: false,
+  has_errors: false,
+  provider: project.provider,
+});
+
 const createTestStore = () =>
   create<TestStore>()((set, get) => ({
     providers: [],
     userMetadata: DEFAULT_USER_METADATA,
     updateUserSettings: vi.fn().mockResolvedValue(undefined),
     excludeSidechain: true,
+    analytics: { currentView: "messages" },
+    messages: [],
+    activeProviders: ["claude"],
+    detectProviders: vi.fn().mockResolvedValue(undefined),
+    selectSession: vi.fn().mockImplementation(async (session: ClaudeSession) => {
+      set({ selectedSession: session });
+    }),
+    loadGlobalStats: vi.fn().mockResolvedValue(undefined),
+    loadProjectTokenStats: vi.fn().mockResolvedValue(undefined),
+    loadSessionTokenStats: vi.fn().mockResolvedValue(undefined),
+    loadProjectStatsSummary: vi.fn().mockResolvedValue({}),
+    setAnalyticsProjectSummary: vi.fn(),
+    loadSessionComparison: vi.fn().mockResolvedValue({}),
+    setAnalyticsSessionComparison: vi.fn(),
+    loadRecentEdits: vi.fn().mockResolvedValue({
+      files: [],
+      total_edits_count: 0,
+      unique_files_count: 0,
+      project_cwd: "/workspace",
+    }),
+    setAnalyticsRecentEdits: vi.fn(),
+    loadBoardSessions: vi.fn().mockResolvedValue(undefined),
+    loadArchives: vi.fn().mockResolvedValue(undefined),
+    clearSessionSearch: vi.fn(),
+    clearTokenStats: vi.fn(),
+    clearTargetMessage: vi.fn(),
+    resetAnalytics: vi.fn(),
+    clearBoard: vi.fn(),
+    setDateFilter: vi.fn(),
     ...createProjectSlice(
       set as Parameters<typeof createProjectSlice>[0],
       get as Parameters<typeof createProjectSlice>[1],
@@ -203,5 +272,176 @@ describe("projectSlice scanProjects", () => {
       type: AppErrorType.UNKNOWN,
       message: "gemini: scan failed",
     });
+  });
+
+  it("refreshes all conversations and reopens the selected session", async () => {
+    const store = createTestStore();
+    const project = createMockProject("current", "claude");
+    const refreshedProject = {
+      ...project,
+      session_count: 2,
+      last_modified: "2026-01-02T00:00:00.000Z",
+    };
+    const selectedSession = createMockSession("session-1", project);
+    const refreshedSession = {
+      ...selectedSession,
+      message_count: 3,
+      summary: "fresh session",
+    };
+
+    store.setState({
+      claudePath: "/root/.claude",
+      providers: [
+        {
+          id: "claude",
+          display_name: "Claude Code",
+          base_path: "/root/.claude",
+          is_available: true,
+        },
+      ],
+      selectedProject: project,
+      selectedSession,
+      activeProviders: ["claude"],
+    });
+
+    vi.mocked(api).mockImplementation((command) => {
+      if (command === "scan_projects") {
+        return Promise.resolve([refreshedProject]);
+      }
+      if (command === "load_project_sessions") {
+        return Promise.resolve([refreshedSession]);
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    await store.getState().refreshAllConversations();
+
+    expect(store.getState().detectProviders).not.toHaveBeenCalled();
+    expect(store.getState().activeProviders).toEqual(["claude"]);
+    expect(store.getState().selectedProject).toEqual(refreshedProject);
+    expect(store.getState().sessions).toEqual([refreshedSession]);
+    expect(store.getState().selectSession).toHaveBeenCalledWith(refreshedSession);
+    expect(store.getState().isRefreshingAllConversations).toBe(false);
+  });
+
+  it("clears stale selection when the selected project no longer exists", async () => {
+    const store = createTestStore();
+    const project = createMockProject("deleted", "claude");
+    const selectedSession = createMockSession("session-1", project);
+
+    store.setState({
+      claudePath: "/root/.claude",
+      providers: [
+        {
+          id: "claude",
+          display_name: "Claude Code",
+          base_path: "/root/.claude",
+          is_available: true,
+        },
+      ],
+      selectedProject: project,
+      selectedSession,
+      sessions: [selectedSession],
+      messages: [{ uuid: "stale" }],
+    });
+
+    vi.mocked(api).mockImplementation((command) => {
+      if (command === "scan_projects") {
+        return Promise.resolve([]);
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    await store.getState().refreshAllConversations();
+
+    expect(store.getState().selectedProject).toBeNull();
+    expect(store.getState().selectedSession).toBeNull();
+    expect(store.getState().sessions).toEqual([]);
+    expect(store.getState().messages).toEqual([]);
+    expect(store.getState().isRefreshingAllConversations).toBe(false);
+  });
+
+  it("clears stale session when the selected session no longer exists", async () => {
+    const store = createTestStore();
+    const project = createMockProject("current", "claude");
+    const selectedSession = createMockSession("session-1", project);
+
+    store.setState({
+      claudePath: "/root/.claude",
+      providers: [
+        {
+          id: "claude",
+          display_name: "Claude Code",
+          base_path: "/root/.claude",
+          is_available: true,
+        },
+      ],
+      selectedProject: project,
+      selectedSession,
+      sessions: [selectedSession],
+      messages: [{ uuid: "stale" }],
+    });
+
+    vi.mocked(api).mockImplementation((command) => {
+      if (command === "scan_projects") {
+        return Promise.resolve([project]);
+      }
+      if (command === "load_project_sessions") {
+        return Promise.resolve([]);
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    await store.getState().refreshAllConversations();
+
+    expect(store.getState().selectedProject).toEqual(project);
+    expect(store.getState().selectedSession).toBeNull();
+    expect(store.getState().messages).toEqual([]);
+    expect(store.getState().clearSessionSearch).toHaveBeenCalled();
+    expect(store.getState().clearTokenStats).toHaveBeenCalled();
+  });
+
+  it("refreshes project-level analytics when no session is selected", async () => {
+    const store = createTestStore();
+    const project = createMockProject("analytics", "claude");
+    const projectSummary = { total_tokens: 123 };
+
+    store.setState({
+      claudePath: "/root/.claude",
+      analytics: { currentView: "analytics" },
+      providers: [
+        {
+          id: "claude",
+          display_name: "Claude Code",
+          base_path: "/root/.claude",
+          is_available: true,
+        },
+      ],
+      selectedProject: project,
+      selectedSession: null,
+    });
+    store.getState().loadProjectStatsSummary.mockResolvedValue(projectSummary);
+
+    vi.mocked(api).mockImplementation((command) => {
+      if (command === "scan_projects") {
+        return Promise.resolve([project]);
+      }
+      if (command === "load_project_sessions") {
+        return Promise.resolve([]);
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+
+    await store.getState().refreshAllConversations();
+
+    expect(store.getState().loadProjectStatsSummary).toHaveBeenCalledWith(
+      project.path
+    );
+    expect(store.getState().setAnalyticsProjectSummary).toHaveBeenCalledWith(
+      projectSummary
+    );
+    expect(store.getState().setAnalyticsSessionComparison).toHaveBeenCalledWith(
+      null
+    );
   });
 });


### PR DESCRIPTION
﻿## What & why

Adds a global conversation refresh action in the header so users can manually rescan all conversation projects, reload the current project/session when still present, and clear stale selections when projects or sessions disappear.

This complements the existing current-session refresh and file watcher behavior with an explicit whole-app refresh path.

Closes #

## Type

- [ ] Bug fix
- [x] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: any new user-facing string is `t()`-wrapped and the key exists in **all 5 languages** (`en, ko, ja, zh-CN, zh-TW`) — verified with `pnpm run i18n:validate`

## If this adds a frontend-callable backend command

- [x] N/A — no frontend-callable backend command added

## If this adds a new provider

- [x] N/A — no new provider added
