### PR TITLE
fix(dev): prevent Vite server from watching `src-tauri/target/` directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,172 +13,180 @@ export default defineConfig(async () => {
     : null;
 
   return {
-  base: "./",
-  plugins: [
-    react(),
-    tailwindcss(),
-    // Mock API plugin for browser testing (VITE_MOCK=1 pnpm dev)
-    mockPlugin,
-    // Bundle analyzer disabled - uncomment to enable
-    // visualizer({
-    //   open: true,
-    //   filename: "dist/bundle-stats.html",
-    //   gzipSize: true,
-    //   brotliSize: true,
-    // }),
-  ].filter(Boolean),
+    base: "./",
+    plugins: [
+      react(),
+      tailwindcss(),
+      // Mock API plugin for browser testing (VITE_MOCK=1 pnpm dev)
+      mockPlugin,
+      // Bundle analyzer disabled - uncomment to enable
+      // visualizer({
+      //   open: true,
+      //   filename: "dist/bundle-stats.html",
+      //   gzipSize: true,
+      //   brotliSize: true,
+      // }),
+    ].filter(Boolean),
 
-  build: {
-    // Increase chunk size warning limit (default is 500KB)
-    chunkSizeWarningLimit: 1000,
+    build: {
+      // Increase chunk size warning limit (default is 500KB)
+      chunkSizeWarningLimit: 1000,
 
-    rollupOptions: {
-      output: {
-        manualChunks: (id: string) => {
-          // === i18n locale data (split by language to avoid one mega-chunk) ===
-          if (id.includes("i18n/locales/en/")) return "i18n-en";
-          if (id.includes("i18n/locales/ko/")) return "i18n-ko";
-          if (id.includes("i18n/locales/ja/")) return "i18n-ja";
-          if (id.includes("i18n/locales/zh-CN/")) return "i18n-zh-cn";
-          if (id.includes("i18n/locales/zh-TW/")) return "i18n-zh-tw";
+      rollupOptions: {
+        output: {
+          manualChunks: (id: string) => {
+            // === i18n locale data (split by language to avoid one mega-chunk) ===
+            if (id.includes("i18n/locales/en/")) return "i18n-en";
+            if (id.includes("i18n/locales/ko/")) return "i18n-ko";
+            if (id.includes("i18n/locales/ja/")) return "i18n-ja";
+            if (id.includes("i18n/locales/zh-CN/")) return "i18n-zh-cn";
+            if (id.includes("i18n/locales/zh-TW/")) return "i18n-zh-tw";
 
-          // i18n runtime libraries
-          if (
-            id.includes("i18next") ||
-            id.includes("react-i18next") ||
-            id.includes("i18next-browser-languagedetector")
-          ) {
-            return "i18n-vendor";
-          }
+            // i18n runtime libraries
+            if (
+              id.includes("i18next") ||
+              id.includes("react-i18next") ||
+              id.includes("i18next-browser-languagedetector")
+            ) {
+              return "i18n-vendor";
+            }
 
-          // Core React bundle
-          if (id.includes("react") || id.includes("react-dom")) {
-            return "react-vendor";
-          }
+            // Core React bundle
+            if (id.includes("react") || id.includes("react-dom")) {
+              return "react-vendor";
+            }
 
-          // UI libraries bundle
-          if (
-            id.includes("@headlessui") ||
-            id.includes("@radix-ui") ||
-            id.includes("tailwind-merge") ||
-            id.includes("clsx") ||
-            id.includes("class-variance-authority") ||
-            id.includes("cmdk") ||
-            id.includes("sonner")
-          ) {
-            return "ui-vendor";
-          }
+            // UI libraries bundle
+            if (
+              id.includes("@headlessui") ||
+              id.includes("@radix-ui") ||
+              id.includes("tailwind-merge") ||
+              id.includes("clsx") ||
+              id.includes("class-variance-authority") ||
+              id.includes("cmdk") ||
+              id.includes("sonner")
+            ) {
+              return "ui-vendor";
+            }
 
-          // Icons bundle (separate lucide and heroicons)
-          if (id.includes("lucide-react")) {
-            return "lucide-icons";
-          }
-          if (id.includes("@heroicons")) {
-            return "hero-icons";
-          }
+            // Icons bundle (separate lucide and heroicons)
+            if (id.includes("lucide-react")) {
+              return "lucide-icons";
+            }
+            if (id.includes("@heroicons")) {
+              return "hero-icons";
+            }
 
-          // Syntax highlighting bundle (heavy)
-          if (
-            id.includes("prismjs") ||
-            id.includes("refractor") ||
-            id.includes("prism-react-renderer")
-          ) {
-            return "syntax-highlighting";
-          }
+            // Syntax highlighting bundle (heavy)
+            if (
+              id.includes("prismjs") ||
+              id.includes("refractor") ||
+              id.includes("prism-react-renderer")
+            ) {
+              return "syntax-highlighting";
+            }
 
-          // Diff viewer bundle
-          if (id.includes("react-diff-viewer") || id.includes("node_modules/diff/")) {
-            return "diff-viewer";
-          }
+            // Diff viewer bundle
+            if (id.includes("react-diff-viewer") || id.includes("node_modules/diff/")) {
+              return "diff-viewer";
+            }
 
-          // Markdown bundle
-          if (
-            id.includes("react-markdown") ||
-            id.includes("remark") ||
-            id.includes("mdast") ||
-            id.includes("micromark") ||
-            id.includes("unist")
-          ) {
-            return "markdown";
-          }
+            // Markdown bundle
+            if (
+              id.includes("react-markdown") ||
+              id.includes("remark") ||
+              id.includes("mdast") ||
+              id.includes("micromark") ||
+              id.includes("unist")
+            ) {
+              return "markdown";
+            }
 
-          // Search library
-          if (id.includes("flexsearch")) {
-            return "search-vendor";
-          }
+            // Search library
+            if (id.includes("flexsearch")) {
+              return "search-vendor";
+            }
 
-          // Data/state management bundle
-          if (
-            id.includes("zustand") ||
-            id.includes("@tanstack/react-query") ||
-            id.includes("dexie") ||
-            id.includes("minisearch")
-          ) {
-            return "data-vendor";
-          }
+            // Data/state management bundle
+            if (
+              id.includes("zustand") ||
+              id.includes("@tanstack/react-query") ||
+              id.includes("dexie") ||
+              id.includes("minisearch")
+            ) {
+              return "data-vendor";
+            }
 
-          // Tauri specific bundle
-          if (id.includes("@tauri-apps")) {
-            return "tauri";
-          }
+            // Tauri specific bundle
+            if (id.includes("@tauri-apps")) {
+              return "tauri";
+            }
 
-          // Virtual scrolling bundle
-          if (
-            id.includes("react-window") ||
-            id.includes("@tanstack/react-virtual")
-          ) {
-            return "virtual-scroll";
-          }
+            // Virtual scrolling bundle
+            if (
+              id.includes("react-window") ||
+              id.includes("@tanstack/react-virtual")
+            ) {
+              return "virtual-scroll";
+            }
 
-          // Scrollbar + misc vendor
-          if (id.includes("overlayscrollbars")) {
-            return "scrollbar-vendor";
-          }
+            // Scrollbar + misc vendor
+            if (id.includes("overlayscrollbars")) {
+              return "scrollbar-vendor";
+            }
 
-          // ANSI terminal rendering
-          if (id.includes("ansi-to-html")) {
-            return "ansi-vendor";
-          }
+            // ANSI terminal rendering
+            if (id.includes("ansi-to-html")) {
+              return "ansi-vendor";
+            }
+          },
         },
       },
     },
-  },
 
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
 
-  // Optimize dependencies pre-bundling
-  optimizeDeps: {
-    include: [
-      "react",
-      "react-dom",
-      "react-markdown",
-      "lucide-react",
-    ],
-    exclude: [
-      "@tauri-apps/api",
-      "@tauri-apps/plugin-dialog",
-      "@tauri-apps/plugin-store",
-    ],
-  },
+    // Optimize dependencies pre-bundling
+    optimizeDeps: {
+      include: [
+        "react",
+        "react-dom",
+        "react-markdown",
+        "lucide-react",
+      ],
+      exclude: [
+        "@tauri-apps/api",
+        "@tauri-apps/plugin-dialog",
+        "@tauri-apps/plugin-store",
+      ],
+    },
 
-  // Test configuration
-  test: {
-    environment: "jsdom",
-    globals: true,
-    setupFiles: "./src/test/setup.ts",
-    include: [
-      "src/**/*.test.ts",
-      "src/**/*.test.tsx",
-      "src-tauri/tests/**/*.test.ts",
-    ],
-    environmentMatchGlobs: [
-      // Node environment for file system tests
-      ["src-tauri/tests/**", "node"],
-    ],
-  },
-};
+    // Test configuration
+    test: {
+      environment: "jsdom",
+      globals: true,
+      setupFiles: "./src/test/setup.ts",
+      include: [
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+        "src-tauri/tests/**/*.test.ts",
+      ],
+      environmentMatchGlobs: [
+        // Node environment for file system tests
+        ["src-tauri/tests/**", "node"],
+      ],
+    },
+
+    // Prevent Vite from watching Tauri src directory
+    // Ref: https://tauri.app/start/create-project/
+    server: {
+      watch: {
+        ignored: ["**/src-tauri/target/**"],
+      },
+    },
+  };
 });


### PR DESCRIPTION
## What & why

On Windows, Vite's `chokidar` watcher recursively watches the entire project directory by default. This causes an `EBUSY: resource busy or locked` crash when it tries to watch compiled `.exe` files inside `src-tauri/target/` that the OS has locked (e.g. `build_script_build-*.exe`).

Added `server.watch.ignored: ["**/src-tauri/target/**"]` to `vite.config.ts` to skip the Rust build output directory. Vite has no reason to watch it anyway; Tauri's own watcher handles Rust rebuilds independently.

Related documentation: https://tauri.app/start/create-project/#manual-setup-tauri-cli

## Type

- [x] Bug fix

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
  - No tests needed: config-only change
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: any new user-facing string is `t()`-wrapped and the key exists in all 5 languages
  - No user-facing strings added