### PR TITLE
fix(ui): make tool/thinking box and markdown font sizes respect the app font-size setting

### DIFF
--- a/src/components/EnhancedDiffViewer.tsx
+++ b/src/components/EnhancedDiffViewer.tsx
@@ -242,7 +242,7 @@ export const EnhancedDiffViewer = ({
             renderContent={language !== "text" ? highlightSyntax : undefined}
             styles={{
               contentText: {
-                fontSize: "13px",
+                fontSize: "calc(13px * var(--app-font-scale))",
               },
             }}
           />

--- a/src/components/FileContent.tsx
+++ b/src/components/FileContent.tsx
@@ -287,7 +287,7 @@ export const FileContent = ({
                     <pre
                       className={className}
                       style={getPreStyles(isDarkMode, style, {
-                        fontSize: "0.6875rem",
+                        fontSize: "calc(0.6875rem * var(--app-font-scale))",
                         lineHeight: "1.2rem",
                         maxHeight: "24rem",
                         overflow: "auto",

--- a/src/components/RecentEditsViewer/FileEditItem.tsx
+++ b/src/components/RecentEditsViewer/FileEditItem.tsx
@@ -299,7 +299,7 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({ edit, isDarkMode }) 
                   <pre
                     className={className}
                     style={getPreStyles(isDarkMode, style, {
-                      fontSize: "0.8125rem",
+                      fontSize: "calc(0.8125rem * var(--app-font-scale))",
                       lineHeight: "1.25rem",
                       padding: "0.75rem",
                     })}

--- a/src/components/contentRenderer/ClaudeContentArrayRenderer.tsx
+++ b/src/components/contentRenderer/ClaudeContentArrayRenderer.tsx
@@ -161,7 +161,7 @@ export const ClaudeContentArrayRenderer = memo(({
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 text-px12">
       {normalizedContent.map((entry) => {
         if (entry.kind === "toolExecution") {
           if (skipToolCalls) return null;

--- a/src/components/messageRenderer/ClaudeToolUseDisplay.tsx
+++ b/src/components/messageRenderer/ClaudeToolUseDisplay.tsx
@@ -25,7 +25,7 @@ export const ClaudeToolUseDisplay: React.FC<ClaudeToolUseDisplayProps> = ({
           toolName={toolName as string}
           className="text-muted-foreground"
         />
-        <span className="font-medium text-foreground">
+        <span className={cn(layout.titleText, "text-foreground")}>
           {String(toolName)}{" "}
           {typeof toolUse.description === "string" &&
             `- ${toolUse.description}`}

--- a/src/components/messageRenderer/ClaudeToolUseDisplay.tsx
+++ b/src/components/messageRenderer/ClaudeToolUseDisplay.tsx
@@ -41,7 +41,7 @@ export const ClaudeToolUseDisplay: React.FC<ClaudeToolUseDisplayProps> = ({
             <pre
               className={className}
               style={getPreStyles(isDarkMode, style, {
-                fontSize: "0.8125rem",
+                fontSize: "calc(0.8125rem * var(--app-font-scale))",
                 padding: "0.5rem",
                 overflowX: "auto",
               })}

--- a/src/components/messageRenderer/CommandOutputDisplay.tsx
+++ b/src/components/messageRenderer/CommandOutputDisplay.tsx
@@ -83,7 +83,7 @@ export const CommandOutputDisplay: React.FC<CommandOutputDisplayProps> = ({
               <pre
                 className={className}
                 style={getPreStyles(isDarkMode, style, {
-                  fontSize: "0.6875rem",
+                  fontSize: "calc(0.6875rem * var(--app-font-scale))",
                   padding: "0.75rem",
                 })}
               >

--- a/src/components/renderers/styles.ts
+++ b/src/components/renderers/styles.ts
@@ -303,7 +303,7 @@ export const commonStyles = {
  * Prism theme configuration (shared across all code renderers)
  */
 export const codeTheme = {
-  fontSize: "0.8125rem",
+  fontSize: "calc(0.8125rem * var(--app-font-scale))",
   lineHeight: "1.25rem",
   padding: "0.5rem",
 } as const;

--- a/src/components/toolResultRenderer/ClaudeToolResultItem.tsx
+++ b/src/components/toolResultRenderer/ClaudeToolResultItem.tsx
@@ -194,7 +194,7 @@ export const ClaudeToolResultItem = memo(function ClaudeToolResultItem({
                 <pre
                   className={className}
                   style={getPreStyles(isDarkMode, style, {
-                    fontSize: "0.9375rem",
+                    fontSize: "calc(0.9375rem * var(--app-font-scale))",
                     lineHeight: codeTheme.lineHeight,
                     maxHeight: "32rem",
                     overflow: "auto",

--- a/src/components/toolResultRenderer/FallbackRenderer.tsx
+++ b/src/components/toolResultRenderer/FallbackRenderer.tsx
@@ -31,7 +31,7 @@ export const FallbackRenderer = ({ toolResult }: Props) => {
               <pre
                 className={className}
                 style={getPreStyles(isDarkMode, style, {
-                  fontSize: "0.8125rem",
+                  fontSize: "calc(0.8125rem * var(--app-font-scale))",
                   padding: "0.5rem",
                 })}
               >

--- a/src/index.css
+++ b/src/index.css
@@ -1669,44 +1669,6 @@
     line-height: 1.15;
   }
 
-  /* Meta/Label text: uppercase with wide tracking */
-  .text-label {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-  }
-
-  .text-label-sm {
-    font-size: 0.625rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-  }
-
-  /* Caption text */
-  .text-caption {
-    font-size: 0.75rem;
-    line-height: 1.4;
-    color: var(--muted-foreground);
-  }
-
-  /* Monospace data display */
-  .text-data {
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 0.8125rem;
-    font-feature-settings: 'tnum' on, 'zero' on;
-    letter-spacing: -0.01em;
-  }
-
-  .text-data-lg {
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 1.3125rem;
-    font-weight: 500;
-    font-feature-settings: 'tnum' on, 'zero' on;
-    letter-spacing: -0.02em;
-  }
-
   /* === Text Gradients === */
   .text-gradient {
     background: var(--gradient-accent);

--- a/src/index.css
+++ b/src/index.css
@@ -539,7 +539,7 @@
 
   /* Prose typography overrides for compact display */
   .prose {
-    font-size: 0.75rem !important;
+    font-size: calc(0.75rem * var(--app-font-scale)) !important;
     line-height: 1.5 !important;
   }
 
@@ -549,19 +549,19 @@
   }
 
   .prose h1 {
-    font-size: 0.9375rem !important;
+    font-size: calc(0.9375rem * var(--app-font-scale)) !important;
     margin-top: 0 !important;
     margin-bottom: 0.375em !important;
   }
 
   .prose h2 {
-    font-size: 0.875rem !important;
+    font-size: calc(0.875rem * var(--app-font-scale)) !important;
     margin-top: 0.75em !important;
     margin-bottom: 0.375em !important;
   }
 
   .prose h3 {
-    font-size: 0.8125rem !important;
+    font-size: calc(0.8125rem * var(--app-font-scale)) !important;
     margin-top: 0.75em !important;
     margin-bottom: 0.375em !important;
   }
@@ -569,7 +569,7 @@
   .prose h4,
   .prose h5,
   .prose h6 {
-    font-size: 0.75rem !important;
+    font-size: calc(0.75rem * var(--app-font-scale)) !important;
     margin-top: 0.75em !important;
     margin-bottom: 0.375em !important;
   }
@@ -607,7 +607,7 @@
   }
 
   .prose pre {
-    font-size: 0.6875rem !important;
+    font-size: calc(0.6875rem * var(--app-font-scale)) !important;
     line-height: 1.4 !important;
     margin-top: 0.5em !important;
     margin-bottom: 0.5em !important;
@@ -615,7 +615,7 @@
   }
 
   .prose code {
-    font-size: 0.6875rem !important;
+    font-size: calc(0.6875rem * var(--app-font-scale)) !important;
     padding: 0.0625em 0.1875em !important;
   }
 
@@ -626,7 +626,7 @@
   }
 
   .prose table {
-    font-size: 0.6875rem !important;
+    font-size: calc(0.6875rem * var(--app-font-scale)) !important;
     margin-top: 0.75em !important;
     margin-bottom: 0.75em !important;
     width: 100% !important;
@@ -722,7 +722,7 @@
   }
 
   .prose kbd {
-    font-size: 0.625rem !important;
+    font-size: calc(0.625rem * var(--app-font-scale)) !important;
     font-family: var(--font-mono, ui-monospace, monospace) !important;
     background-color: var(--muted) !important;
     border: 1px solid var(--border) !important;


### PR DESCRIPTION
## What & why

Issues #440 and #441 report that the app's font-size setting doesn't consistently scale the UI: the AI tool-invocation/thinking boxes render oversized and ignore the setting (#440), and assistant text boxes stay at their default size (#441).

`#412` (commit `c81e9a8`) made most hardcoded `text-[Npx]` values reactive to `--app-font-scale` via new `.text-pxN` utilities and a reactive `prose-xs`, but missed two categories:

1. **A `!important` override was silently beating that fix.** `.prose { font-size: 0.75rem !important; ... }` in `src/index.css` (added January 2026, months before `#412`) also `!important`-sets `.prose h1-h6/pre/code/table/kbd`. Every markdown block applies `prose` and `prose-xs` together, and `!important` always wins over a non-`!important` declaration regardless of layer or source order — so this rule silently overrode `#412`'s reactive `prose-xs` everywhere markdown renders (assistant bubbles, `AgentCard` prompt/result, etc.). Root cause of #441.
2. **Hardcoded inline `fontSize` styles on code/diff blocks.** Several tool-result renderers pass a literal `fontSize` (via a shared `codeTheme` constant, or ad-hoc per-file values) into `prism-react-renderer`/`react-diff-viewer-continued`'s inline `style` props. Inline styles always beat CSS classes, so no class-level fix could reach these. Part of #440.

## Changes

- `d1c2ba0` — `text-px12` on `ClaudeContentArrayRenderer`'s wrapper div. **Confirmed by manual testing to fix #440**, though the causation isn't fully explained — see "Open question" below.
- `4cee877` — made the `.prose` block reactive (`calc(rem * var(--app-font-scale))`), keeping `!important` so the default scale (1x) is pixel-identical. **Confirmed by manual testing to fix #441.**
- `bef0b11` — made the ~8 hardcoded inline `fontSize` call sites reactive via the same `calc()` pattern (`codeTheme.fontSize`, `ClaudeToolUseDisplay`, `ClaudeToolResultItem`, `CommandOutputDisplay`, `FileContent`, `FileEditItem`, `FallbackRenderer`, `EnhancedDiffViewer`).
- `60e3867` — removed `.text-label`, `.text-label-sm`, `.text-caption`, `.text-data`, `.text-data-lg`: dead, non-reactive utility classes found during the audit.
- `ea96726` — `ClaudeToolUseDisplay`'s title span had no font-size class anywhere in its ancestor chain — a genuinely orphaned element on a separate legacy render path (top-level `message.toolUse`, a sibling of `ClaudeContentArrayRenderer`, so `d1c2ba0` never reached it). Fixed with `layout.titleText`. Didn't change anything visible in local testing (that path likely wasn't exercised), but it's a real bug worth merging regardless.

## Open question

**#440's root cause isn't conclusively identified.** `d1c2ba0`'s wrapper class empirically fixes the symptom, but nothing in the traced component tree explains why: every element we checked (`unifiedCards/*`, `RendererHeader`, `ThinkingRenderer`, `ContentArrayRenderer`) already sets its own explicit reactive font-size class, so that wrapper shouldn't matter. Treat #440 as empirically fixed, not root-caused, and re-open this question before assuming it's fully understood.

## Suggested follow-up (not included in this PR)

- Reactive fallback `font-size` on a high-level container (e.g. `body`), so any other undiscovered orphaned element — like the one found here — scales correctly by default instead of silently falling back to the browser default.
- Consolidate the ~15 duplicated `calc(Xrem * var(--app-font-scale))` literals (`.text-pxN`, `.prose` overrides, `codeTheme`, inline styles) into shared CSS custom properties — one source of truth per size step.

Closes #440
Closes #441

## Type

- [x] Bug fix

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] `pnpm tsc --build .`, `pnpm lint`, and `pnpm vitest run` (871 tests) pass
- [x] No new user-facing strings; no i18n changes needed
- [x] No visual change at the default font-size scale (1x)
- [x] Manually verified #440 and #441 at non-default scales (#440 empirically, not root-caused — see "Open question")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app-wide font scaling support for rendered text, including prose content, code blocks, diffs, and tool output.
  * Improved typography consistency across message and content views so text now follows the app’s font scale setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->