### PR TITLE
feat(vscode): wire VS Code Copilot Chat provider into all dispatch ta…

### DIFF
--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -56,6 +56,7 @@ pub async fn scan_all_projects(
             "zed".to_string(),
             "openhands".to_string(),
             "trae".to_string(),
+            "vscode".to_string(),
         ]
     });
 
@@ -141,6 +142,7 @@ pub async fn scan_all_projects(
         ("kiro", providers::kiro::scan_projects),
         ("llm", providers::llm::scan_projects),
         ("copilot", providers::copilot::scan_projects),
+        ("vscode", providers::vscode::scan_projects),
     ];
 
     // Spawn every enabled scanner up front so they run concurrently on the
@@ -331,6 +333,7 @@ pub async fn load_provider_sessions(
         "zed" => providers::zed::load_sessions(&project_path, exclude),
         "openhands" => providers::openhands::load_sessions(&project_path, exclude),
         "trae" => providers::trae::load_sessions(&project_path, exclude),
+        "vscode" => providers::vscode::load_sessions(&project_path, exclude),
         _ => Err(format!("Unknown provider: {provider}")),
     }
 }
@@ -376,6 +379,7 @@ pub async fn load_provider_messages(
         "zed" => providers::zed::load_messages(&session_path)?,
         "openhands" => providers::openhands::load_messages(&session_path)?,
         "trae" => providers::trae::load_messages(&session_path)?,
+        "vscode" => providers::vscode::load_messages(&session_path)?,
         _ => return Err(format!("Unknown provider: {provider}")),
     };
 
@@ -427,6 +431,7 @@ pub async fn search_all_providers(
             "zed".to_string(),
             "openhands".to_string(),
             "trae".to_string(),
+            "vscode".to_string(),
         ]
     });
 
@@ -714,6 +719,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Trae search failed: {e}");
+            }
+        }
+    }
+
+    // VS Code Copilot Chat
+    if providers_to_search.iter().any(|p| p == "vscode") {
+        match providers::vscode::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("VS Code Copilot Chat search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -257,6 +257,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
     if let Some(info) = copilot::detect() {
         providers.push(info);
     }
+    if let Some(info) = vscode::detect() {
+        providers.push(info);
+    }
 
     providers
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -175,5 +175,6 @@
   "time.secondShort": "s",
   "time.today": "Today",
   "time.yesterday": "Yesterday",
-  "common.provider.copilot": "Copilot"
+  "common.provider.copilot": "Copilot",
+  "common.provider.vscode": "VS Code Copilot Chat"
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -175,5 +175,6 @@
   "time.secondShort": "秒",
   "time.today": "今日",
   "time.yesterday": "昨日",
-  "common.provider.copilot": "Copilot"
+  "common.provider.copilot": "Copilot",
+  "common.provider.vscode": "VS Code Copilot Chat"
 }

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -175,5 +175,6 @@
   "time.secondShort": "초",
   "time.today": "오늘",
   "time.yesterday": "어제",
-  "common.provider.copilot": "Copilot"
+  "common.provider.copilot": "Copilot",
+  "common.provider.vscode": "VS Code Copilot Chat"
 }

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -175,5 +175,6 @@
   "time.secondShort": "秒",
   "time.today": "今天",
   "time.yesterday": "昨天",
-  "common.provider.copilot": "Copilot"
+  "common.provider.copilot": "Copilot",
+  "common.provider.vscode": "VS Code Copilot Chat"
 }

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -175,5 +175,6 @@
   "time.secondShort": "秒",
   "time.today": "今天",
   "time.yesterday": "昨天",
-  "common.provider.copilot": "Copilot"
+  "common.provider.copilot": "Copilot",
+  "common.provider.vscode": "VS Code Copilot Chat"
 }


### PR DESCRIPTION
## Summary

Fixes #444 — VS Code Copilot Chat sessions are never shown despite a complete provider implementation existing in `src-tauri/src/providers/vscode.rs`.

The `vscode` module is declared as `pub mod vscode` in `providers/mod.rs` and contains full scan, load, search, and patch-log replay logic — but it was never registered in any dispatch table. Users with VS Code Copilot Chat history see nothing in the viewer. This PR wires the existing implementation into all the right places.

## What changed

**`src-tauri/src/providers/mod.rs`**
- Added `vscode::detect()` call inside `detect_providers()` so VS Code shows up in the provider detection list alongside all other providers.

**`src-tauri/src/commands/multi_provider.rs`**
- Added `"vscode"` to the `providers_to_scan` default list in `scan_all_projects`
- Added `("vscode", providers::vscode::scan_projects)` to `sync_scanners` (runs concurrently with other providers, not serially)
- Added `"vscode" => providers::vscode::load_sessions(...)` arm to `load_provider_sessions`
- Added `"vscode" => providers::vscode::load_messages(...)` arm to `load_provider_messages`
- Added `"vscode"` to the `providers_to_search` default list
- Added VS Code Copilot Chat search block in `search_all_providers`

**`src/i18n/locales/{en,ko,ja,zh-CN,zh-TW}/common.json`**
- Added `"common.provider.vscode": "VS Code Copilot Chat"` to all 5 locale files so the provider badge renders a human-readable label.

## Notes
- No schema changes, no new dependencies, no server changes
- The `vscode` provider was already fully implemented and tested (26 unit tests in `vscode.rs`) — this PR only adds the missing dispatch registrations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VS Code Copilot Chat as a supported provider.
  * VS Code Copilot Chat sessions, messages, projects, and search results are now included across provider views.
  * Added provider detection for VS Code Copilot Chat.

* **Localization**
  * Added VS Code Copilot Chat labels in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->