### PR TITLE
perf(messages): real chat-style message pagination across all providers

### DIFF
--- a/specs/20260712-real-message-pagination/context.md
+++ b/specs/20260712-real-message-pagination/context.md
@@ -1,0 +1,17 @@
+# Context: real-message-pagination
+
+## 0. Resume here
+<!-- The live working-set state, so a fresh session (or a post-compaction self)
+     can resume without re-narration. Write it with `/harness-kit:handoff` at a
+     stopping point; a fresh session continues from it with `/harness-kit:pickup`. -->
+<!-- resume:start -->
+- **Original ask (verbatim):**
+- **Phase / N of M:**
+- **Files touched:**
+- **Next command:**
+- **In-flight decisions:**
+<!-- resume:end -->
+
+## Working notes
+<!-- Grounding: the real files/data you examined, decisions made, dead ends hit.
+     This is what keeps the work from drifting off the original ask. -->

--- a/specs/20260712-real-message-pagination/spec.md
+++ b/specs/20260712-real-message-pagination/spec.md
@@ -1,0 +1,96 @@
+# Spec: real-message-pagination
+
+- Status: In progress
+- Created: 2026-07-12
+
+## Problem / goal
+
+Original ask (verbatim):
+
+> 현재 해당 서비스의 기능들을 전부 나열하고 데이터가 많아짐에 따라 UIUX적으로 문제가 되거나 최적화가 필요한 부분 찾아줘
+> 우선순위대로 나열해서 견고하게 진행
+
+Priority item P1 (of 5): opening a session must no longer load the ENTIRE
+message set into memory / over IPC. `messageSlice.selectSession` currently
+calls `load_provider_messages` (full load) and fakes `pagination`
+(`messageSlice.ts:242-293`). Backend `load_session_messages_paginated`
+(chat-style: offset 0 = newest) exists for Claude but is unused by the unified
+provider entry point.
+
+## What "done" looks like
+
+Opening a session issues a paginated request (newest window, ~200 messages).
+Scrolling up loads earlier pages without a scroll jump. Export, session search,
+and deep-link jumps still operate on the complete session. All quality gates
+green.
+
+## Scope
+
+- **In:**
+  - Backend: `load_provider_messages_paginated` (claude → existing paginated
+    loader; other providers → load + merge + chat-style slice, bounding IPC and
+    frontend memory) and `get_provider_message_offset` (uuid → offset-from-newest,
+    powers deep links). Wire both in lib.rs AND WebUI server (routes +
+    READ_ONLY_ALLOWED_API_PATHS + handlers — tauri-axum parity).
+  - Frontend: messageSlice real pagination (initial page, loadMoreMessages
+    prepend, in-place reload preserving window size, stale/concurrent guards);
+    MessageViewer load-earlier UI + auto-load near top + scroll anchoring on
+    prepend; counts show loaded-vs-total; navigateToMessage extends the window
+    to cover an off-window uuid; export fetches full session at export time;
+    session search builds its index from a one-shot full fetch on first search.
+- **Out:**
+  - True streaming pagination inside non-Claude provider parsers (still
+    parse-then-slice server-side).
+  - P2 stats caching, P3 project-list virtualization, P4 select-all semantics,
+    P5 renderer size guards (separate tasks).
+
+## Verified constraints (code-read 2026-07-12)
+
+- Both Claude loaders (full + paginated) apply IDENTICAL filtering
+  (`EXCLUDED_MESSAGE_TYPES` 6 types + `HIDDEN_SYSTEM_SUBTYPES`, load.rs:665-694)
+  → no message-set change for Claude.
+- Paginated loader supports `exclude_sidechain` at classification.
+- Frontend `MessagePage` type exists unused (`message.types.ts:277`);
+  `PaginationState` is `@deprecated` but is the live shape.
+- Orphan i18n keys `messageViewer.loadMoreMessages` / `message.loadMore` exist
+  in all 5 locales — reuse.
+- `loadSubagents` progress back-compat scan is already dead for Claude (backend
+  excludes `progress`); meta.json primary path unaffected by windowing.
+- `flattenMessageTree` has an orphan fallback (<90% DFS → timestamp append) —
+  a partial window renders; grouping degrades gracefully at boundaries.
+- `useScrollNavigation.ts:338-354` auto-scrolls on length growth — prepend
+  needs explicit anchoring.
+- Consumers assuming full `messages`: export (`useExport` ← displayMessages),
+  session search (searchSlice over in-memory array), `navigateToMessage`
+  (findIndex → silent no-op), counts (AppLayout:643, FilterToolbar,
+  `allMessagesLoaded` header), navigator outline, SessionLane count.
+
+## Acceptance
+
+- Open a large session → network/IPC request is `load_provider_messages_paginated`
+  with limit ≤ default page size; store holds only the window.
+- "Load earlier" (button + near-top auto-load) prepends without viewport jump.
+- Global-search jump to an off-window message loads the containing window and
+  scrolls to it.
+- Export emits the complete session while only a window is loaded.
+- Session search finds matches outside the loaded window.
+- UI counts distinguish loaded vs total when `hasMore`.
+- New Rust tests: chat-style slice helper + offset lookup + claude/non-claude
+  paginated command behavior. Vitest: messageSlice pagination actions.
+- Gates: `pnpm tsc --build .`, `pnpm vitest run`, `pnpm lint`,
+  `pnpm run i18n:validate`, `cargo test -- --test-threads=1`, clippy, fmt.
+
+## Risks / open questions
+
+- RESOLVED: `merge_tool_execution_messages` is NOT a no-op for claude — it folds
+  user `tool_result` blocks into the preceding assistant `tool_use` message.
+  Decision: claude paginated path slices in PRE-merge index space (stable,
+  matches `get_session_message_count`), then merges WITHIN the page. At a page
+  boundary a tool_result whose assistant lives in an older page stays unmerged —
+  it renders via the existing standalone tool_result renderers (accepted,
+  boundary-only artifact). Non-claude: load → merge → slice in post-merge space
+  (those providers fully parse today anyway). The 27-arm provider match is
+  extracted into a shared helper so full + paginated entry points stay in sync.
+- Scroll anchoring with @tanstack/react-virtual dynamic heights on prepend —
+  verify with real run (WebUI --serve + playwright).
+- Watcher-driven in-place reload must not shrink the user's loaded window.

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -1,4 +1,4 @@
-use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, MessagePage};
 use crate::providers;
 use crate::utils::parse_rfc3339_utc;
 use serde::{Deserialize, Serialize};
@@ -413,54 +413,170 @@ pub async fn load_provider_sessions_page(
     })
 }
 
+/// Default / maximum page size for `load_provider_messages_paginated`.
+const DEFAULT_MESSAGE_PAGE_SIZE: usize = 200;
+const MAX_MESSAGE_PAGE_LIMIT: usize = 500;
+
+/// Load raw (pre-merge) messages for a non-Claude provider.
+/// Single source of truth for the provider dispatch — used by both the full
+/// and the paginated entry points so they cannot drift.
+fn load_non_claude_messages(
+    provider: &str,
+    session_path: &str,
+) -> Result<Vec<ClaudeMessage>, String> {
+    match provider {
+        "codex" => providers::codex::load_messages(session_path),
+        "continue" => providers::continue_dev::load_messages(session_path),
+        "pearai" => providers::pearai::load_messages(session_path),
+        "copilot" => providers::copilot::load_messages(session_path),
+        "gemini" => providers::gemini::load_messages(session_path),
+        "goose" => providers::goose::load_messages(session_path),
+        "kimi" => providers::kimi::load_messages(session_path),
+        "forgecode" => providers::forgecode::load_messages(session_path),
+        "opencode" => providers::opencode::load_messages(session_path),
+        "openinterpreter" => providers::openinterpreter::load_messages(session_path),
+        "pi" => providers::pi::load_messages(session_path),
+        "ompi" => providers::ompi::load_messages(session_path),
+        "qwen" => providers::qwen::load_messages(session_path),
+        "cline" => providers::cline::load_messages(session_path),
+        "crush" => providers::crush::load_messages(session_path),
+        "cursor" => providers::cursor::load_messages(session_path),
+        "cursor-agent" => providers::cursor_agent::load_messages(session_path),
+        "aider" => providers::aider::load_messages(session_path),
+        "amazonq" => providers::amazon_q::load_messages(session_path),
+        "antigravity" => providers::antigravity::load_messages(session_path),
+        "codebuddy" => providers::codebuddy::load_messages(session_path),
+        "kiro" => providers::kiro::load_messages(session_path),
+        "llm" => providers::llm::load_messages(session_path),
+        "zed" => providers::zed::load_messages(session_path),
+        "openhands" => providers::openhands::load_messages(session_path),
+        "trae" => providers::trae::load_messages(session_path),
+        "vibe" => providers::vibe::load_messages(session_path),
+        _ => Err(format!("Unknown provider: {provider}")),
+    }
+}
+
 /// Load messages from a specific provider's session
 #[tauri::command]
 pub async fn load_provider_messages(
     provider: String,
     session_path: String,
 ) -> Result<Vec<ClaudeMessage>, String> {
-    let messages = match provider.as_str() {
-        "claude" => {
-            let mut messages =
-                crate::commands::session::load_session_messages(session_path).await?;
-            for m in &mut messages {
-                if m.provider.is_none() {
-                    m.provider = Some("claude".to_string());
-                }
+    let messages = if provider == "claude" {
+        let mut messages = crate::commands::session::load_session_messages(session_path).await?;
+        for m in &mut messages {
+            if m.provider.is_none() {
+                m.provider = Some("claude".to_string());
             }
-            messages
         }
-        "codex" => providers::codex::load_messages(&session_path)?,
-        "continue" => providers::continue_dev::load_messages(&session_path)?,
-        "pearai" => providers::pearai::load_messages(&session_path)?,
-        "copilot" => providers::copilot::load_messages(&session_path)?,
-        "gemini" => providers::gemini::load_messages(&session_path)?,
-        "goose" => providers::goose::load_messages(&session_path)?,
-        "kimi" => providers::kimi::load_messages(&session_path)?,
-        "forgecode" => providers::forgecode::load_messages(&session_path)?,
-        "opencode" => providers::opencode::load_messages(&session_path)?,
-        "openinterpreter" => providers::openinterpreter::load_messages(&session_path)?,
-        "pi" => providers::pi::load_messages(&session_path)?,
-        "ompi" => providers::ompi::load_messages(&session_path)?,
-        "qwen" => providers::qwen::load_messages(&session_path)?,
-        "cline" => providers::cline::load_messages(&session_path)?,
-        "crush" => providers::crush::load_messages(&session_path)?,
-        "cursor" => providers::cursor::load_messages(&session_path)?,
-        "cursor-agent" => providers::cursor_agent::load_messages(&session_path)?,
-        "aider" => providers::aider::load_messages(&session_path)?,
-        "amazonq" => providers::amazon_q::load_messages(&session_path)?,
-        "antigravity" => providers::antigravity::load_messages(&session_path)?,
-        "codebuddy" => providers::codebuddy::load_messages(&session_path)?,
-        "kiro" => providers::kiro::load_messages(&session_path)?,
-        "llm" => providers::llm::load_messages(&session_path)?,
-        "zed" => providers::zed::load_messages(&session_path)?,
-        "openhands" => providers::openhands::load_messages(&session_path)?,
-        "trae" => providers::trae::load_messages(&session_path)?,
-        "vibe" => providers::vibe::load_messages(&session_path)?,
-        _ => return Err(format!("Unknown provider: {provider}")),
+        messages
+    } else {
+        load_non_claude_messages(&provider, &session_path)?
     };
 
     Ok(merge_tool_execution_messages(messages))
+}
+
+/// Chat-style slice over an already-materialized, chronologically ordered
+/// message list: `offset` counts messages already loaded from the NEWEST end,
+/// so offset 0 returns the newest `limit` messages and increasing offsets walk
+/// toward the beginning of the session.
+fn paginate_messages_chat_style(
+    mut messages: Vec<ClaudeMessage>,
+    offset: usize,
+    limit: usize,
+) -> MessagePage {
+    let total_count = messages.len();
+    let remaining = total_count.saturating_sub(offset);
+    let to_load = limit.min(remaining);
+    let start = remaining - to_load;
+    let page: Vec<ClaudeMessage> = messages.drain(start..remaining).collect();
+
+    MessagePage {
+        messages: page,
+        total_count,
+        has_more: start > 0,
+        next_offset: offset + to_load,
+    }
+}
+
+/// Paginated variant of `load_provider_messages` (chat-style: offset 0 = newest).
+///
+/// - `claude` uses the mmap fast path (`load_session_messages_paginated`):
+///   offsets are in PRE-merge index space (stable across pages, consistent with
+///   `get_session_message_count`), and tool-result merging is applied WITHIN
+///   the returned window. A `tool_result` whose matching `tool_use` lives in an
+///   older, unloaded page stays unmerged and renders via the standalone
+///   `tool_result` renderers — a boundary-only artifact.
+/// - Other providers materialize the full session server-side (as they always
+///   have), merge, then slice — bounding the IPC payload and frontend memory.
+#[tauri::command]
+pub async fn load_provider_messages_paginated(
+    provider: String,
+    session_path: String,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    exclude_sidechain: Option<bool>,
+) -> Result<MessagePage, String> {
+    let offset = offset.unwrap_or(0);
+    let limit = limit
+        .unwrap_or(DEFAULT_MESSAGE_PAGE_SIZE)
+        .clamp(1, MAX_MESSAGE_PAGE_LIMIT);
+
+    if provider == "claude" {
+        let mut page = crate::commands::session::load_session_messages_paginated(
+            session_path,
+            offset,
+            limit,
+            exclude_sidechain,
+        )
+        .await?;
+        for m in &mut page.messages {
+            if m.provider.is_none() {
+                m.provider = Some("claude".to_string());
+            }
+        }
+        page.messages = merge_tool_execution_messages(page.messages);
+        return Ok(page);
+    }
+
+    let messages = load_non_claude_messages(&provider, &session_path)?;
+    let mut merged = merge_tool_execution_messages(messages);
+    if exclude_sidechain.unwrap_or(false) {
+        merged.retain(|m| !m.is_sidechain.unwrap_or(false));
+    }
+    Ok(paginate_messages_chat_style(merged, offset, limit))
+}
+
+/// Find how far from the NEWEST visible message a uuid sits (0 = newest).
+/// Returns `None` when the uuid is not present. Loading a chat-style window
+/// with `offset = 0, limit = result + 1` guarantees the message is included —
+/// this powers deep links (global search jumps) into unloaded regions without
+/// falling back to a full-session load.
+///
+/// Offsets are in the same index space as `load_provider_messages_paginated`
+/// for the given provider (pre-merge for claude, post-merge otherwise).
+#[tauri::command]
+pub async fn get_provider_message_offset(
+    provider: String,
+    session_path: String,
+    message_uuid: String,
+    exclude_sidechain: Option<bool>,
+) -> Result<Option<usize>, String> {
+    if provider == "claude" {
+        return crate::commands::session::get_session_message_offset(
+            session_path,
+            message_uuid,
+            exclude_sidechain,
+        );
+    }
+
+    let messages = load_non_claude_messages(&provider, &session_path)?;
+    let mut merged = merge_tool_execution_messages(messages);
+    if exclude_sidechain.unwrap_or(false) {
+        merged.retain(|m| !m.is_sidechain.unwrap_or(false));
+    }
+    Ok(merged.iter().rev().position(|m| m.uuid == message_uuid))
 }
 
 /// Search across all (or selected) providers
@@ -1115,6 +1231,164 @@ mod tests {
             microcompact_metadata: None,
             provider: Some("claude".to_string()),
         }
+    }
+
+    fn make_message_with_uuid(uuid: &str, message_type: &str, content: Value) -> ClaudeMessage {
+        let mut msg = make_message(message_type, content);
+        msg.uuid = uuid.to_string();
+        msg
+    }
+
+    #[test]
+    fn paginate_chat_style_returns_newest_window_first() {
+        let messages: Vec<ClaudeMessage> = (1..=5)
+            .map(|i| {
+                make_message_with_uuid(
+                    &format!("uuid-{i}"),
+                    "user",
+                    serde_json::json!(format!("Message {i}")),
+                )
+            })
+            .collect();
+
+        // offset 0 → newest two, chronological order preserved
+        let page = paginate_messages_chat_style(messages.clone(), 0, 2);
+        assert_eq!(page.total_count, 5);
+        assert_eq!(
+            page.messages
+                .iter()
+                .map(|m| m.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["uuid-4", "uuid-5"]
+        );
+        assert!(page.has_more);
+        assert_eq!(page.next_offset, 2);
+
+        // walking backwards with next_offset
+        let page2 = paginate_messages_chat_style(messages.clone(), page.next_offset, 2);
+        assert_eq!(
+            page2
+                .messages
+                .iter()
+                .map(|m| m.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["uuid-2", "uuid-3"]
+        );
+        assert!(page2.has_more);
+
+        // final partial page
+        let page3 = paginate_messages_chat_style(messages.clone(), page2.next_offset, 2);
+        assert_eq!(
+            page3
+                .messages
+                .iter()
+                .map(|m| m.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["uuid-1"]
+        );
+        assert!(!page3.has_more);
+        assert_eq!(page3.next_offset, 5);
+
+        // offset beyond the end → empty, no more
+        let past_end = paginate_messages_chat_style(messages, 10, 2);
+        assert!(past_end.messages.is_empty());
+        assert!(!past_end.has_more);
+        assert_eq!(past_end.total_count, 5);
+    }
+
+    #[test]
+    fn paginate_chat_style_empty_input() {
+        let page = paginate_messages_chat_style(vec![], 0, 100);
+        assert!(page.messages.is_empty());
+        assert_eq!(page.total_count, 0);
+        assert!(!page.has_more);
+        assert_eq!(page.next_offset, 0);
+    }
+
+    #[tokio::test]
+    async fn load_provider_messages_paginated_claude_merges_within_window() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("session.jsonl");
+        let content = concat!(
+            r#"{"uuid":"uuid-a","sessionId":"s1","timestamp":"2025-06-26T10:00:00Z","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"Bash","input":{"command":"pwd"}}]}}"#,
+            "\n",
+            r#"{"uuid":"uuid-b","sessionId":"s1","timestamp":"2025-06-26T10:00:01Z","type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"ok"}]}}"#,
+            "\n",
+            r#"{"uuid":"uuid-c","sessionId":"s1","timestamp":"2025-06-26T10:00:02Z","type":"user","message":{"role":"user","content":"trailing question"}}"#,
+            "\n",
+        );
+        std::fs::write(&file_path, content).unwrap();
+        let path = file_path.to_string_lossy().to_string();
+
+        // Full window: tool_result folds into the assistant message.
+        let full =
+            load_provider_messages_paginated("claude".into(), path.clone(), None, None, None)
+                .await
+                .unwrap();
+        assert_eq!(full.total_count, 3); // pre-merge space
+        assert_eq!(full.messages.len(), 2); // merged for display
+        assert_eq!(full.messages[0].uuid, "uuid-a");
+        assert!(full.messages[0]
+            .content
+            .as_ref()
+            .and_then(Value::as_array)
+            .is_some_and(|arr| arr
+                .iter()
+                .any(|b| b.get("type").and_then(Value::as_str) == Some("tool_result"))));
+        assert!(full
+            .messages
+            .iter()
+            .all(|m| m.provider.as_deref() == Some("claude")));
+
+        // Window that cuts between tool_use and tool_result: the orphan
+        // tool_result stays a standalone message (boundary artifact).
+        let window =
+            load_provider_messages_paginated("claude".into(), path, Some(0), Some(2), None)
+                .await
+                .unwrap();
+        assert_eq!(window.total_count, 3);
+        assert_eq!(window.messages.len(), 2);
+        assert_eq!(window.messages[0].uuid, "uuid-b");
+        assert!(window.has_more);
+        assert_eq!(window.next_offset, 2);
+    }
+
+    #[tokio::test]
+    async fn get_provider_message_offset_claude_matches_pagination_space() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("session.jsonl");
+        let mut content = String::new();
+        for i in 1..=4 {
+            content.push_str(&format!(
+                r#"{{"uuid":"uuid-{i}","sessionId":"s1","timestamp":"2025-06-26T10:00:0{i}Z","type":"user","message":{{"role":"user","content":"m{i}"}}}}{}"#,
+                "\n"
+            ));
+        }
+        std::fs::write(&file_path, &content).unwrap();
+        let path = file_path.to_string_lossy().to_string();
+
+        let offset =
+            get_provider_message_offset("claude".into(), path.clone(), "uuid-2".into(), None)
+                .await
+                .unwrap();
+        assert_eq!(offset, Some(2));
+
+        // limit = offset + 1 loads a window containing the target
+        let page = load_provider_messages_paginated(
+            "claude".into(),
+            path.clone(),
+            Some(0),
+            Some(offset.unwrap() + 1),
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(page.messages.iter().any(|m| m.uuid == "uuid-2"));
+
+        let missing = get_provider_message_offset("claude".into(), path, "nope".into(), None)
+            .await
+            .unwrap();
+        assert_eq!(missing, None);
     }
 
     #[test]

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -2062,6 +2062,33 @@ fn extract_subagent_metadata(
     (line_count, first_time, last_time, summary)
 }
 
+/// Shared viewer-visibility rules for a classified JSONL line.
+/// Must stay in sync with the filtering in `load_session_messages`.
+fn is_viewer_visible_line(
+    message_type: &str,
+    subtype: Option<&str>,
+    is_sidechain: Option<bool>,
+    is_meta: Option<bool>,
+    exclude_sidechain: bool,
+) -> bool {
+    if message_type == "summary" {
+        return false;
+    }
+    if is_system_message_type(message_type) {
+        return false;
+    }
+    if message_type == "system" && is_hidden_system_subtype(subtype) {
+        return false;
+    }
+    if is_meta.unwrap_or(false) {
+        return false;
+    }
+    if exclude_sidechain && is_sidechain.unwrap_or(false) {
+        return false;
+    }
+    true
+}
+
 /// Fast line classifier for simd-json (mutable slice)
 fn classify_line_fast(line: &[u8], exclude_sidechain: bool) -> bool {
     if line
@@ -2074,26 +2101,90 @@ fn classify_line_fast(line: &[u8], exclude_sidechain: bool) -> bool {
     // Try fast simd-json parsing with minimal struct
     let mut line_copy = line.to_vec();
     if let Ok(classifier) = simd_json::serde::from_slice::<LineClassifier>(&mut line_copy) {
-        if classifier.message_type == "summary" {
-            return false;
-        }
-        if is_system_message_type(&classifier.message_type) {
-            return false;
-        }
-        if classifier.message_type == "system"
-            && is_hidden_system_subtype(classifier.subtype.as_deref())
-        {
-            return false;
-        }
-        if classifier.is_meta.unwrap_or(false) {
-            return false;
-        }
-        if exclude_sidechain && classifier.is_sidechain.unwrap_or(false) {
-            return false;
-        }
-        return true;
+        return is_viewer_visible_line(
+            &classifier.message_type,
+            classifier.subtype.as_deref(),
+            classifier.is_sidechain,
+            classifier.is_meta,
+            exclude_sidechain,
+        );
     }
     false
+}
+
+/// Minimal classifier that also captures the message uuid.
+/// Used only by `get_session_message_offset` — keeping it separate from
+/// `LineClassifier` avoids a per-line String allocation on the hot
+/// classification path of the paginated loader.
+#[derive(serde::Deserialize)]
+struct LineUuidClassifier {
+    #[serde(rename = "type")]
+    message_type: String,
+    subtype: Option<String>,
+    #[serde(rename = "isSidechain")]
+    is_sidechain: Option<bool>,
+    #[serde(rename = "isMeta")]
+    is_meta: Option<bool>,
+    uuid: Option<String>,
+}
+
+/// Find how far from the NEWEST viewer-visible message a uuid sits.
+/// Returns `Some(0)` for the newest visible message, `Some(n)` when `n`
+/// visible messages are newer than it, and `None` when the uuid is absent.
+/// Loading a chat-style window with `offset = 0, limit = n + 1` therefore
+/// guarantees the message is inside the window.
+///
+/// Iterates newest → oldest so deep links to recent messages exit early.
+#[allow(unsafe_code)] // Required for mmap performance optimization
+pub fn get_session_message_offset(
+    session_path: String,
+    message_uuid: String,
+    exclude_sidechain: Option<bool>,
+) -> Result<Option<usize>, String> {
+    let file =
+        fs::File::open(&session_path).map_err(|e| format!("Failed to open session file: {e}"))?;
+
+    // SAFETY: We're only reading the file, and the file handle is kept open
+    // for the duration of the mmap's lifetime. No concurrent modifications expected
+    // as session files are append-only by Claude.
+    let mmap = unsafe { Mmap::map(&file) }
+        .map_err(|e| format!("Failed to memory-map session file: {e}"))?;
+
+    let exclude = exclude_sidechain.unwrap_or(false);
+    let line_ranges = find_line_ranges(&mmap);
+
+    let mut newer_visible = 0usize;
+    for &(start, end) in line_ranges.iter().rev() {
+        let line = &mmap[start..end];
+        if line
+            .iter()
+            .all(|&b| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r')
+        {
+            continue;
+        }
+
+        let mut line_copy = line.to_vec();
+        let Ok(classifier) = simd_json::serde::from_slice::<LineUuidClassifier>(&mut line_copy)
+        else {
+            continue;
+        };
+        if !is_viewer_visible_line(
+            &classifier.message_type,
+            classifier.subtype.as_deref(),
+            classifier.is_sidechain,
+            classifier.is_meta,
+            exclude,
+        ) {
+            continue;
+        }
+
+        if classifier.uuid.as_deref() == Some(message_uuid.as_str()) {
+            return Ok(Some(newer_visible));
+        }
+        newer_visible += 1;
+    }
+
+    Ok(None)
 }
 
 #[tauri::command]
@@ -2504,6 +2595,72 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(count_filtered, 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_offset_basic() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let mut content = String::new();
+        for i in 1..=5 {
+            content.push_str(&format!(
+                "{}\n",
+                create_sample_user_message(
+                    &format!("uuid-{i}"),
+                    "session-1",
+                    &format!("Message {i}")
+                )
+            ));
+        }
+        let file_path = create_test_jsonl_file(&temp_dir, "test.jsonl", &content);
+        let path = file_path.to_string_lossy().to_string();
+
+        // Newest message → offset 0
+        let newest = get_session_message_offset(path.clone(), "uuid-5".to_string(), None).unwrap();
+        assert_eq!(newest, Some(0));
+
+        // Oldest message → offset 4 (4 visible messages are newer)
+        let oldest = get_session_message_offset(path.clone(), "uuid-1".to_string(), None).unwrap();
+        assert_eq!(oldest, Some(4));
+
+        // Loading offset=0, limit=offset+1 must include the target uuid.
+        let needed = oldest.unwrap() + 1;
+        let page = load_session_messages_paginated(path.clone(), 0, needed, None)
+            .await
+            .unwrap();
+        assert!(page.messages.iter().any(|m| m.uuid == "uuid-1"));
+
+        // Unknown uuid → None
+        let missing = get_session_message_offset(path, "no-such-uuid".to_string(), None).unwrap();
+        assert_eq!(missing, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_session_message_offset_skips_invisible_lines() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // sidechain + summary lines must not shift the offset when excluded
+        let content = r#"{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","message":{"role":"user","content":"Hello"},"isSidechain":false}
+{"uuid":"uuid-2","sessionId":"session-1","timestamp":"2025-06-26T10:01:00Z","type":"user","message":{"role":"user","content":"Sidechain"},"isSidechain":true}
+{"type":"summary","summary":"A summary","leafUuid":"uuid-3"}
+{"uuid":"uuid-4","sessionId":"session-1","timestamp":"2025-06-26T10:02:00Z","type":"user","message":{"role":"user","content":"World"},"isSidechain":false}
+"#;
+        let file_path = create_test_jsonl_file(&temp_dir, "test.jsonl", content);
+        let path = file_path.to_string_lossy().to_string();
+
+        // With sidechain excluded: visible = [uuid-1, uuid-4]
+        let offset =
+            get_session_message_offset(path.clone(), "uuid-1".to_string(), Some(true)).unwrap();
+        assert_eq!(offset, Some(1));
+
+        // Without exclusion: visible = [uuid-1, uuid-2, uuid-4]
+        let offset_all =
+            get_session_message_offset(path.clone(), "uuid-1".to_string(), None).unwrap();
+        assert_eq!(offset_all, Some(2));
+
+        // Sidechain uuid itself is findable when not excluded
+        let sidechain = get_session_message_offset(path, "uuid-2".to_string(), None).unwrap();
+        assert_eq!(sidechain, Some(1));
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,8 +53,9 @@ use crate::commands::{
         MetadataState,
     },
     multi_provider::{
-        detect_providers, load_provider_messages, load_provider_sessions,
-        load_provider_sessions_page, scan_all_projects, search_all_providers,
+        detect_providers, get_provider_message_offset, load_provider_messages,
+        load_provider_messages_paginated, load_provider_sessions, load_provider_sessions_page,
+        scan_all_projects, search_all_providers,
     },
     project::{
         detect_claude_config_dir, get_claude_folder_path, get_git_log, scan_projects,
@@ -260,6 +261,8 @@ fn run_tauri() {
             load_provider_sessions,
             load_provider_sessions_page,
             load_provider_messages,
+            load_provider_messages_paginated,
+            get_provider_message_offset,
             search_all_providers,
             // Archive commands
             get_archive_base_path,

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -347,6 +347,29 @@ pub struct ProviderMessagesParams {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ProviderMessagesPaginatedParams {
+    pub provider: String,
+    pub session_path: String,
+    #[serde(default)]
+    pub offset: Option<usize>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub exclude_sidechain: Option<bool>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderMessageOffsetParams {
+    pub provider: String,
+    pub session_path: String,
+    pub message_uuid: String,
+    #[serde(default)]
+    pub exclude_sidechain: Option<bool>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SearchAllProvidersParams {
     #[serde(default)]
     pub claude_path: Option<String>,
@@ -865,6 +888,35 @@ handler_json!(
     ProviderMessagesParams,
     |p: ProviderMessagesParams| async move {
         commands::multi_provider::load_provider_messages(p.provider, p.session_path).await
+    }
+);
+
+handler_json!(
+    load_provider_messages_paginated,
+    ProviderMessagesPaginatedParams,
+    |p: ProviderMessagesPaginatedParams| async move {
+        commands::multi_provider::load_provider_messages_paginated(
+            p.provider,
+            p.session_path,
+            p.offset,
+            p.limit,
+            p.exclude_sidechain,
+        )
+        .await
+    }
+);
+
+handler_json!(
+    get_provider_message_offset,
+    ProviderMessageOffsetParams,
+    |p: ProviderMessageOffsetParams| async move {
+        commands::multi_provider::get_provider_message_offset(
+            p.provider,
+            p.session_path,
+            p.message_uuid,
+            p.exclude_sidechain,
+        )
+        .await
     }
 );
 

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -66,6 +66,7 @@ const READ_ONLY_ALLOWED_API_PATHS: &[&str] = &[
     "/get_preset",
     "/get_project_stats_summary",
     "/get_project_token_stats",
+    "/get_provider_message_offset",
     "/get_recent_edits",
     "/get_server_config",
     "/get_session_comparison",
@@ -84,6 +85,7 @@ const READ_ONLY_ALLOWED_API_PATHS: &[&str] = &[
     "/load_project_sessions",
     "/load_project_sessions_page",
     "/load_provider_messages",
+    "/load_provider_messages_paginated",
     "/load_provider_sessions",
     "/load_provider_sessions_page",
     "/load_session_messages",
@@ -298,6 +300,14 @@ pub fn build_router(
             post(h::load_provider_sessions_page),
         )
         .route("/load_provider_messages", post(h::load_provider_messages))
+        .route(
+            "/load_provider_messages_paginated",
+            post(h::load_provider_messages_paginated),
+        )
+        .route(
+            "/get_provider_message_offset",
+            post(h::get_provider_message_offset),
+        )
         .route("/search_all_providers", post(h::search_all_providers))
         // Archive commands
         .route("/get_archive_base_path", post(h::get_archive_base_path))

--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -5,7 +5,7 @@
  * Uses @tanstack/react-virtual for efficient rendering of large message lists.
  */
 
-import { useRef, useCallback, useMemo, useState, useEffect, memo } from "react";
+import { useRef, useCallback, useMemo, useState, useEffect, useLayoutEffect, memo } from "react";
 import { OverlayScrollbarsComponent, type OverlayScrollbarsComponentRef } from "overlayscrollbars-react";
 import { MessageCircle, ChevronDown, ChevronUp, Search, X, Camera, Download, ArrowLeft, Bot, ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -27,13 +27,12 @@ import { useCapturePreview } from "../../hooks/useCapturePreview";
 import { MAX_CAPTURE_MESSAGES } from "../../hooks/useCaptureScreenshot";
 import {
   groupAgentTasks,
-  filterMessagesByCategory,
   getMessageUuidsByCategory,
   groupAgentProgressMessages,
   groupTaskOperations,
+  applyMessageDisplayFilter,
 } from "./helpers";
 import { useAppStore } from "../../store/useAppStore";
-import { extractClaudeMessageContent } from "../../utils/messageUtils";
 import { useExpandRegistry } from "../../store/expandRegistryStore";
 import { useExport } from "../../hooks/useExport";
 import {
@@ -173,53 +172,30 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
   );
 
   // Apply role + content type filters
-  const displayMessages = useMemo(() => {
-    const { roles, contentTypes } = messageFilter;
-    const allRoles = roles.user && roles.assistant;
-    const allContent = contentTypes.text && contentTypes.thinking && contentTypes.toolCalls && contentTypes.commands;
-    const parallelTaskFilteredMessages = filterMessagesByCategory(
-      messages,
-      "parallel-task",
-      contentTypes.parallelTasks,
-    );
-    if (allRoles && allContent) return parallelTaskFilteredMessages;
+  const displayMessages = useMemo(
+    () => applyMessageDisplayFilter(messages, messageFilter),
+    [messages, messageFilter],
+  );
 
-    return parallelTaskFilteredMessages.filter((msg) => {
-      // Role filter
-      if (msg.type === "user") return roles.user;
-      if (msg.type === "assistant") {
-        if (!roles.assistant) return false;
-        // Content type filter — check if assistant message has any visible content left
-        if (!allContent) {
-          const hasText = contentTypes.text && !!extractClaudeMessageContent(msg);
-          const hasContentArray = Array.isArray(msg.content) && msg.content.some((item: unknown) => {
-            if (!item || typeof item !== "object") return false;
-            const typed = item as Record<string, unknown>;
-            const t = typed.type as string;
-            if (t === "text") return contentTypes.text;
-            if (t === "thinking" || t === "redacted_thinking") return contentTypes.thinking;
-            if (t === "tool_use" || t === "tool_result" || t === "server_tool_use"
-              || t === "web_search_tool_result" || t === "mcp_tool_use" || t === "mcp_tool_result"
-              || t === "web_fetch_tool_result" || t === "code_execution_tool_result"
-              || t === "bash_code_execution_tool_result" || t === "text_editor_code_execution_tool_result"
-              || t === "tool_search_tool_result") return contentTypes.toolCalls;
-            if (t === "command") return contentTypes.commands;
-            return true; // image, document, search_result — always show
-          });
-          const hasLegacyTool = contentTypes.toolCalls && !!(msg.toolUse || msg.toolUseResult);
-          if (!hasText && !hasContentArray && !hasLegacyTool) return false;
-        }
-        return true;
-      }
-      return true; // system/summary/other
-    });
-  }, [messages, messageFilter]);
+  // Message pagination state + actions (store holds a chat-style window)
+  const pagination = useAppStore((s) => s.pagination);
+  const loadMoreMessages = useAppStore((s) => s.loadMoreMessages);
+  const ensureMessageLoaded = useAppStore((s) => s.ensureMessageLoaded);
+  const fetchFullSessionMessages = useAppStore((s) => s.fetchFullSessionMessages);
+
+  // Export must cover the COMPLETE session even when only a window is
+  // loaded — fetch the full message list and apply the same display filter.
+  const resolveExportMessages = useCallback(async () => {
+    if (!useAppStore.getState().pagination.hasMore) return displayMessages;
+    const fullMessages = await fetchFullSessionMessages();
+    return applyMessageDisplayFilter(fullMessages, messageFilter);
+  }, [displayMessages, fetchFullSessionMessages, messageFilter]);
 
   // Export hook — uses role-filtered displayMessages
   const { isExporting, exportConversation } = useExport(
     displayMessages,
     selectedSession?.project_name ?? selectedSession?.session_id ?? "conversation",
-    { includeSidechain: isInSubagent },
+    { includeSidechain: isInSubagent, resolveMessages: resolveExportMessages },
   );
   const handleExport = useCallback((format: ExportFormat) => {
     if (isExporting || displayMessages.length === 0) return;
@@ -407,6 +383,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
   const {
     virtualizer,
     flattenedMessages,
+    uuidToIndexMap,
     virtualRows,
     totalSize,
     getScrollIndex,
@@ -600,7 +577,71 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     scrollElementReady,
     targetMessageUuid,
     onNearBottomChange: setActiveSessionNearBottom,
+    firstItemKey: messages[0]?.uuid ?? null,
   });
+
+  // ─── Load-earlier (chat-style message pagination) ──────────────────────
+  // The store holds only a window of the session; older pages are prepended
+  // on demand. The anchor keeps the currently visible rows stationary by
+  // compensating scrollTop for the height added above them.
+  const prependAnchorRef = useRef<{ totalSize: number; scrollTop: number } | null>(null);
+  // uuid currently being ensured into the window (deep link / search match)
+  const ensureInFlightRef = useRef<string | null>(null);
+
+  const handleLoadEarlier = useCallback(() => {
+    if (pagination.isLoadingMore || !pagination.hasMore) return;
+    const viewport = getScrollElement();
+    prependAnchorRef.current = {
+      totalSize: virtualizer.getTotalSize(),
+      scrollTop: viewport?.scrollTop ?? 0,
+    };
+    void loadMoreMessages();
+  }, [pagination.isLoadingMore, pagination.hasMore, getScrollElement, virtualizer, loadMoreMessages]);
+
+  useLayoutEffect(() => {
+    const anchor = prependAnchorRef.current;
+    if (!anchor || pagination.isLoadingMore) return;
+    prependAnchorRef.current = null;
+    const viewport = getScrollElement();
+    if (!viewport) return;
+    const delta = virtualizer.getTotalSize() - anchor.totalSize;
+    if (delta > 0) {
+      viewport.scrollTop = anchor.scrollTop + delta;
+    }
+  }, [flattenedMessages, pagination.isLoadingMore, getScrollElement, virtualizer]);
+
+  // Auto-load the previous page when the user scrolls near the top.
+  // Guarded on scrollReadyForSessionId so the initial scroll-to-bottom pass
+  // of a freshly opened session cannot trigger a spurious page load.
+  useEffect(() => {
+    if (!scrollElementReady) return;
+    if (scrollReadyForSessionId !== selectedSession?.session_id) return;
+    const viewport = getScrollElement();
+    if (!viewport) return;
+
+    const NEAR_TOP_AUTOLOAD_PX = 300;
+    const handleScroll = () => {
+      if (viewport.scrollTop >= NEAR_TOP_AUTOLOAD_PX) return;
+      const { pagination: p } = useAppStore.getState();
+      if (!p.hasMore || p.isLoadingMore) return;
+      handleLoadEarlier();
+    };
+    viewport.addEventListener("scroll", handleScroll, { passive: true });
+    return () => viewport.removeEventListener("scroll", handleScroll);
+  }, [scrollElementReady, scrollReadyForSessionId, selectedSession?.session_id, getScrollElement, handleLoadEarlier]);
+
+  // Search-match navigation into an unloaded region: extend the window until
+  // the match is present (scrollToHighlight re-fires via getScrollIndex once
+  // the uuid map includes it).
+  useEffect(() => {
+    if (!currentMatchUuid || uuidToIndexMap.has(currentMatchUuid)) return;
+    const p = useAppStore.getState().pagination;
+    if (!p.hasMore || ensureInFlightRef.current) return;
+    ensureInFlightRef.current = currentMatchUuid;
+    void ensureMessageLoaded(currentMatchUuid).finally(() => {
+      ensureInFlightRef.current = null;
+    });
+  }, [currentMatchUuid, uuidToIndexMap, ensureMessageLoaded]);
 
   // Handle Deep Linking / Scrolling to Target
   useEffect(() => {
@@ -609,6 +650,21 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
       const index = flattenedMessages.findIndex(
         (item) => item.type === "message" && item.message.uuid === targetMessageUuid
       );
+
+      if (index === -1) {
+        // Target may live in an unloaded older page — extend the window.
+        // The effect re-runs when flattenedMessages grows and then scrolls.
+        const p = useAppStore.getState().pagination;
+        if (p.hasMore && !ensureInFlightRef.current) {
+          const uuid = targetMessageUuid;
+          ensureInFlightRef.current = uuid;
+          void ensureMessageLoaded(uuid).then((found) => {
+            ensureInFlightRef.current = null;
+            if (!found) clearTargetMessage();
+          });
+        }
+        return;
+      }
 
       if (index !== -1) {
         // Multi-pass scroll to correct for height-estimate inaccuracy (#269).
@@ -644,7 +700,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
         };
       }
     }
-  }, [targetMessageUuid, scrollElementReady, flattenedMessages, virtualizer, clearTargetMessage]);
+  }, [targetMessageUuid, scrollElementReady, flattenedMessages, virtualizer, clearTargetMessage, ensureMessageLoaded]);
 
   // 검색어 초기화 핸들러
   const handleClearSearch = useCallback(() => {
@@ -1047,17 +1103,50 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
           </div>
         )}
 
-        {/* 메시지 목록 헤더 */}
+        {/* 메시지 목록 헤더 — 이전 페이지 로드 버튼 또는 완료 안내 */}
         {hasMessageListHeader && (
           <div
             ref={virtualHeaderRef}
             className="max-w-4xl mx-auto flex items-center justify-center py-4"
           >
-            <div className="text-sm text-muted-foreground">
-              {t("messageViewer.allMessagesLoaded", {
-                count: messages.length,
-              })}
-            </div>
+            {pagination.hasMore ? (
+              <button
+                type="button"
+                onClick={handleLoadEarlier}
+                disabled={pagination.isLoadingMore}
+                className={cn(
+                  "inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-md",
+                  "text-muted-foreground bg-muted/50 hover:bg-muted transition-colors",
+                  "disabled:opacity-60 disabled:cursor-default",
+                )}
+                aria-label={t("messageViewer.loadMoreMessages", {
+                  count: Math.min(
+                    pagination.pageSize || messages.length,
+                    Math.max(pagination.totalCount - pagination.currentOffset, 0),
+                  ),
+                  current: messages.length,
+                  total: pagination.totalCount,
+                })}
+              >
+                {pagination.isLoadingMore && (
+                  <LoadingSpinner size="sm" variant="muted" />
+                )}
+                {t("messageViewer.loadMoreMessages", {
+                  count: Math.min(
+                    pagination.pageSize || messages.length,
+                    Math.max(pagination.totalCount - pagination.currentOffset, 0),
+                  ),
+                  current: messages.length,
+                  total: pagination.totalCount,
+                })}
+              </button>
+            ) : (
+              <div className="text-sm text-muted-foreground">
+                {t("messageViewer.allMessagesLoaded", {
+                  count: messages.length,
+                })}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/MessageViewer/MessageViewer.tsx
+++ b/src/components/MessageViewer/MessageViewer.tsx
@@ -582,21 +582,39 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
 
   // ─── Load-earlier (chat-style message pagination) ──────────────────────
   // The store holds only a window of the session; older pages are prepended
-  // on demand. The anchor keeps the currently visible rows stationary by
-  // compensating scrollTop for the height added above them.
-  const prependAnchorRef = useRef<{ totalSize: number; scrollTop: number } | null>(null);
+  // on demand. The anchor pins the first visible MESSAGE row: its uuid and
+  // its on-screen offset are recorded before the load, and after the prepend
+  // the viewport is scrolled so the same row sits at the same place. This is
+  // robust against the virtualizer's estimate-vs-measured drift, which makes
+  // a naive totalSize-delta compensation land far off.
+  const prependAnchorRef = useRef<{ uuid: string; screenOffset: number } | null>(null);
+  // True while a prepend restore is converging — suppresses the near-top
+  // autoload so restore-induced scroll events cannot cascade page loads.
+  const anchorRestoringRef = useRef(false);
   // uuid currently being ensured into the window (deep link / search match)
   const ensureInFlightRef = useRef<string | null>(null);
 
   const handleLoadEarlier = useCallback(() => {
     if (pagination.isLoadingMore || !pagination.hasMore) return;
     const viewport = getScrollElement();
-    prependAnchorRef.current = {
-      totalSize: virtualizer.getTotalSize(),
-      scrollTop: viewport?.scrollTop ?? 0,
-    };
+    const scrollTop = viewport?.scrollTop ?? 0;
+    const firstVisible = virtualizer
+      .getVirtualItems()
+      .find(
+        (row) =>
+          row.start + row.size > scrollTop &&
+          flattenedMessages[row.index]?.type === "message",
+      );
+    const item = firstVisible ? flattenedMessages[firstVisible.index] : undefined;
+    prependAnchorRef.current =
+      firstVisible && item?.type === "message"
+        ? {
+            uuid: item.message.uuid,
+            screenOffset: firstVisible.start - scrollTop,
+          }
+        : null;
     void loadMoreMessages();
-  }, [pagination.isLoadingMore, pagination.hasMore, getScrollElement, virtualizer, loadMoreMessages]);
+  }, [pagination.isLoadingMore, pagination.hasMore, getScrollElement, virtualizer, flattenedMessages, loadMoreMessages]);
 
   useLayoutEffect(() => {
     const anchor = prependAnchorRef.current;
@@ -604,11 +622,34 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     prependAnchorRef.current = null;
     const viewport = getScrollElement();
     if (!viewport) return;
-    const delta = virtualizer.getTotalSize() - anchor.totalSize;
-    if (delta > 0) {
-      viewport.scrollTop = anchor.scrollTop + delta;
-    }
-  }, [flattenedMessages, pagination.isLoadingMore, getScrollElement, virtualizer]);
+
+    // Multi-pass restore (same technique as the deep-link scroll): the rows
+    // prepended above the anchor render with estimated heights first, so a
+    // single-pass restore lands off once they measure. Re-anchoring after
+    // each render pass converges on the true offset.
+    const restore = () => {
+      const newIndex = uuidToIndexMap.get(anchor.uuid);
+      if (newIndex === undefined) return;
+      const [newStart] = virtualizer.getOffsetForIndex(newIndex, "start") ?? [];
+      if (typeof newStart !== "number") return;
+      viewport.scrollTop = newStart - anchor.screenOffset;
+    };
+
+    anchorRestoringRef.current = true;
+    restore();
+    const passes = [
+      setTimeout(restore, 50),
+      setTimeout(restore, 200),
+      setTimeout(() => {
+        restore();
+        anchorRestoringRef.current = false;
+      }, 450),
+    ];
+    return () => {
+      passes.forEach(clearTimeout);
+      anchorRestoringRef.current = false;
+    };
+  }, [flattenedMessages, uuidToIndexMap, pagination.isLoadingMore, getScrollElement, virtualizer]);
 
   // Auto-load the previous page when the user scrolls near the top.
   // Guarded on scrollReadyForSessionId so the initial scroll-to-bottom pass
@@ -621,6 +662,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
 
     const NEAR_TOP_AUTOLOAD_PX = 300;
     const handleScroll = () => {
+      if (anchorRestoringRef.current) return;
       if (viewport.scrollTop >= NEAR_TOP_AUTOLOAD_PX) return;
       const { pagination: p } = useAppStore.getState();
       if (!p.hasMore || p.isLoadingMore) return;

--- a/src/components/MessageViewer/helpers/index.ts
+++ b/src/components/MessageViewer/helpers/index.ts
@@ -8,4 +8,5 @@
 export { groupAgentTasks } from "./agentTaskHelpers";
 export { groupAgentProgressMessages } from "./agentProgressHelpers";
 export { filterMessagesByCategory, getMessageUuidsByCategory } from "./messageCategories";
+export { applyMessageDisplayFilter } from "./messageDisplayFilter";
 export { groupTaskOperations } from "./taskOperationHelpers";

--- a/src/components/MessageViewer/helpers/messageDisplayFilter.ts
+++ b/src/components/MessageViewer/helpers/messageDisplayFilter.ts
@@ -1,0 +1,57 @@
+/**
+ * Role / content-type display filter shared by the message list and export.
+ *
+ * Extracted from the MessageViewer `displayMessages` memo so that export can
+ * apply the exact same filtering to a freshly fetched FULL session (the store
+ * may only hold a paginated window of it).
+ */
+
+import type { ClaudeMessage } from "../../../types";
+import type { MessageFilter } from "../../../store/slices/filterSlice";
+import { extractClaudeMessageContent } from "../../../utils/messageUtils";
+import { filterMessagesByCategory } from "./messageCategories";
+
+export function applyMessageDisplayFilter(
+  messages: ClaudeMessage[],
+  messageFilter: MessageFilter,
+): ClaudeMessage[] {
+  const { roles, contentTypes } = messageFilter;
+  const allRoles = roles.user && roles.assistant;
+  const allContent = contentTypes.text && contentTypes.thinking && contentTypes.toolCalls && contentTypes.commands;
+  const parallelTaskFilteredMessages = filterMessagesByCategory(
+    messages,
+    "parallel-task",
+    contentTypes.parallelTasks,
+  );
+  if (allRoles && allContent) return parallelTaskFilteredMessages;
+
+  return parallelTaskFilteredMessages.filter((msg) => {
+    // Role filter
+    if (msg.type === "user") return roles.user;
+    if (msg.type === "assistant") {
+      if (!roles.assistant) return false;
+      // Content type filter — check if assistant message has any visible content left
+      if (!allContent) {
+        const hasText = contentTypes.text && !!extractClaudeMessageContent(msg);
+        const hasContentArray = Array.isArray(msg.content) && msg.content.some((item: unknown) => {
+          if (!item || typeof item !== "object") return false;
+          const typed = item as Record<string, unknown>;
+          const t = typed.type as string;
+          if (t === "text") return contentTypes.text;
+          if (t === "thinking" || t === "redacted_thinking") return contentTypes.thinking;
+          if (t === "tool_use" || t === "tool_result" || t === "server_tool_use"
+            || t === "web_search_tool_result" || t === "mcp_tool_use" || t === "mcp_tool_result"
+            || t === "web_fetch_tool_result" || t === "code_execution_tool_result"
+            || t === "bash_code_execution_tool_result" || t === "text_editor_code_execution_tool_result"
+            || t === "tool_search_tool_result") return contentTypes.toolCalls;
+          if (t === "command") return contentTypes.commands;
+          return true; // image, document, search_result — always show
+        });
+        const hasLegacyTool = contentTypes.toolCalls && !!(msg.toolUse || msg.toolUseResult);
+        if (!hasText && !hasContentArray && !hasLegacyTool) return false;
+      }
+      return true;
+    }
+    return true; // system/summary/other
+  });
+}

--- a/src/components/MessageViewer/hooks/useScrollNavigation.ts
+++ b/src/components/MessageViewer/hooks/useScrollNavigation.ts
@@ -36,6 +36,12 @@ interface UseScrollNavigationOptions {
   targetMessageUuid?: string | null;
   /** Reports whether the message viewport is close enough to live-follow new writes. */
   onNearBottomChange?: (nearBottom: boolean) => void;
+  /**
+   * Key of the FIRST list item. When the list grows while this key changes,
+   * older messages were PREPENDED (chat-style pagination) — auto-scroll to
+   * bottom must not fire in that case.
+   */
+  firstItemKey?: string | null;
 }
 
 interface UseScrollNavigationReturn {
@@ -60,6 +66,7 @@ export const useScrollNavigation = ({
   scrollElementReady = false,
   targetMessageUuid,
   onNearBottomChange,
+  firstItemKey = null,
 }: UseScrollNavigationOptions): UseScrollNavigationReturn => {
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
@@ -70,6 +77,7 @@ export const useScrollNavigation = ({
   const isNearBottomRef = useRef(true);
   const lastReportedNearBottomRef = useRef<boolean | null>(null);
   const prevMessagesLengthRef = useRef(0);
+  const prevFirstItemKeyRef = useRef<string | null>(null);
 
   // Helper to get the scroll viewport element
   const getScrollViewport = useCallback(() => {
@@ -330,6 +338,7 @@ export const useScrollNavigation = ({
   // Reset prevMessagesLength on session switch
   useEffect(() => {
     prevMessagesLengthRef.current = 0;
+    prevFirstItemKeyRef.current = null;
     lastReportedNearBottomRef.current = null;
     reportNearBottom(true);
   }, [selectedSessionId, reportNearBottom]);
@@ -339,9 +348,17 @@ export const useScrollNavigation = ({
     const prevLength = prevMessagesLengthRef.current;
     prevMessagesLengthRef.current = messagesLength;
 
+    // Growth with a changed head = older page PREPENDED — keep the viewport
+    // where it is (the prepend anchor in MessageViewer handles compensation).
+    const prevFirstKey = prevFirstItemKeyRef.current;
+    prevFirstItemKeyRef.current = firstItemKey;
+    const isPrepend =
+      prevLength > 0 && messagesLength > prevLength && prevFirstKey !== firstItemKey;
+
     if (
       prevLength > 0 &&
       messagesLength > prevLength &&
+      !isPrepend &&
       isNearBottomRef.current &&
       !targetMessageUuid &&
       scrollReadyForSessionId === selectedSessionId
@@ -351,7 +368,7 @@ export const useScrollNavigation = ({
       });
       return () => cancelAnimationFrame(rafId);
     }
-  }, [messagesLength, scrollToBottom, scrollReadyForSessionId, selectedSessionId, targetMessageUuid]);
+  }, [messagesLength, firstItemKey, scrollToBottom, scrollReadyForSessionId, selectedSessionId, targetMessageUuid]);
 
   return {
     showScrollToTop,

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -23,12 +23,21 @@ function sanitizeFilename(name: string): string {
 export function useExport(
   messages: ClaudeMessage[],
   sessionName: string,
-  options?: { includeSidechain?: boolean },
+  options?: {
+    includeSidechain?: boolean;
+    /**
+     * Resolves the messages to export. Used when the store only holds a
+     * paginated window of the session — export must cover the COMPLETE
+     * conversation, not just what has been scrolled into memory.
+     */
+    resolveMessages?: () => Promise<ClaudeMessage[]>;
+  },
 ) {
   const { t } = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
   const { messageFilter, isMessageFilterActive } = useAppStore();
   const includeSidechain = options?.includeSidechain === true;
+  const resolveMessages = options?.resolveMessages;
 
   const exportConversation = useCallback(
     async (format: ExportFormat) => {
@@ -36,6 +45,10 @@ export function useExport(
       setIsExporting(true);
 
       try {
+        const exportMessages = resolveMessages
+          ? await resolveMessages()
+          : messages;
+        if (exportMessages.length === 0) return;
         const safeName = sanitizeFilename(sessionName);
         let content: string;
         let defaultPath: string;
@@ -50,21 +63,21 @@ export function useExport(
         switch (format) {
           case "markdown": {
             const { exportToMarkdown } = await import("@/services/export/markdownExporter");
-            content = exportToMarkdown(messages, sessionName, ctFilter, exportOptions);
+            content = exportToMarkdown(exportMessages, sessionName, ctFilter, exportOptions);
             defaultPath = `${safeName}.md`;
             mimeType = "text/markdown";
             break;
           }
           case "json": {
             const { exportToJson } = await import("@/services/export/jsonExporter");
-            content = exportToJson(messages, sessionName, ctFilter, exportOptions);
+            content = exportToJson(exportMessages, sessionName, ctFilter, exportOptions);
             defaultPath = `${safeName}.json`;
             mimeType = "application/json";
             break;
           }
           case "html": {
             const { exportToHtml } = await import("@/services/export/htmlExporter");
-            content = exportToHtml(messages, sessionName, ctFilter, exportOptions);
+            content = exportToHtml(exportMessages, sessionName, ctFilter, exportOptions);
             defaultPath = `${safeName}.html`;
             mimeType = "text/html";
             break;
@@ -88,7 +101,7 @@ export function useExport(
         setIsExporting(false);
       }
     },
-    [messages, sessionName, t, messageFilter, isMessageFilterActive, includeSidechain],
+    [messages, sessionName, t, messageFilter, isMessageFilterActive, includeSidechain, resolveMessages],
   );
 
   return { isExporting, exportConversation };

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -12,6 +12,7 @@ import {
   Archive,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useAppStore } from "@/store/useAppStore";
 import { LoadingSpinner } from "@/components/ui/loading";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
@@ -139,6 +140,9 @@ export interface AppLayoutProps {
 
 export const AppLayout: React.FC<AppLayoutProps> = (props) => {
   const { t } = useTranslation();
+  // Loaded window may be partial under message pagination — used to render
+  // the "+" suffix on the message count.
+  const hasMoreMessages = useAppStore((s) => s.pagination.hasMore);
   const {
     projects,
     sessions,
@@ -641,6 +645,7 @@ export const AppLayout: React.FC<AppLayoutProps> = (props) => {
                 <span className="text-border">&bull;</span>
                 <span>
                   {t("message.count", { count: messages.length })}
+                  {hasMoreMessages ? "+" : ""}
                 </span>
               </>
             )}

--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import type {
   ClaudeMessage,
   ClaudeSession,
+  MessagePage,
   PaginationState,
   SessionTokenStats,
   ProjectStatsSummary,
@@ -64,6 +65,21 @@ export interface MessageSliceState {
 
 export interface MessageSliceActions {
   selectSession: (session: ClaudeSession) => Promise<void>;
+  /** Load the next (older) page of the current session and prepend it. */
+  loadMoreMessages: () => Promise<void>;
+  /**
+   * Make sure the message with `uuid` is inside the loaded window, extending
+   * it backwards if needed. Resolves to whether the message is now present.
+   */
+  ensureMessageLoaded: (uuid: string) => Promise<boolean>;
+  /**
+   * Fetch the COMPLETE message list of the current session (same sidechain /
+   * system-message filtering as the loaded window). Used by consumers that
+   * must operate on the full session (export, in-session search) while the
+   * store only holds a window. Result is cached per session until the next
+   * selectSession call.
+   */
+  fetchFullSessionMessages: () => Promise<ClaudeMessage[]>;
   refreshCurrentSession: () => Promise<void>;
   loadSessionTokenStats: (sessionPath: string) => Promise<void>;
   loadProjectTokenStats: (projectPath: string) => Promise<void>;
@@ -89,6 +105,16 @@ export type MessageSlice = MessageSliceState & MessageSliceActions;
 // ============================================================================
 
 const TOKENS_STATS_PAGE_SIZE = 20;
+
+/** Messages fetched per page (backend clamps individual requests at 500). */
+export const MESSAGE_PAGE_SIZE = 200;
+
+/** Message types hidden by the "show system messages" toggle (client-side). */
+const SYSTEM_MESSAGE_TYPES = [
+  "queue-operation",
+  "progress",
+  "file-history-snapshot",
+] as const;
 
 /** Initial pagination state — shared with `clearProjectSelection` to avoid duplication. */
 export const INITIAL_PAGINATION = {
@@ -196,6 +222,153 @@ export const createMessageSlice: StateCreator<
     return supportsConversationBreakdown(provider);
   };
 
+  // ============================================================================
+  // Pagination internals
+  // ============================================================================
+
+  // Full-session fetch cache for export / in-session search. Keyed so a
+  // filter-relevant state change misses the cache; cleared on selectSession.
+  let fullSessionCache: {
+    key: string;
+    promise: Promise<ClaudeMessage[]>;
+  } | null = null;
+
+  // Serializes older-page loads (button, near-top autoload, ensureMessageLoaded)
+  // so concurrent callers can't fetch the same offset twice.
+  let loadOlderChain: Promise<void> = Promise.resolve();
+
+  const applySystemMessageFilter = (
+    messages: ClaudeMessage[]
+  ): ClaudeMessage[] => {
+    if (get().showSystemMessages) return messages;
+    return messages.filter(
+      (m) =>
+        !(SYSTEM_MESSAGE_TYPES as readonly string[]).includes(m.type)
+    );
+  };
+
+  /** Whether sidechain messages should be excluded server-side right now. */
+  const shouldExcludeSidechain = (treatAsSubagent: boolean): boolean =>
+    get().excludeSidechain && !treatAsSubagent;
+
+  const fetchMessagePage = (
+    provider: string,
+    sessionPath: string,
+    offset: number,
+    limit: number,
+    excludeSidechain: boolean
+  ): Promise<MessagePage> =>
+    api<MessagePage>("load_provider_messages_paginated", {
+      provider,
+      sessionPath,
+      offset,
+      limit,
+      excludeSidechain,
+    });
+
+  /**
+   * Fetch a window of at least `span` messages from the newest end, issuing
+   * as many page requests as needed (the backend clamps a single request at
+   * 500). Returns messages in chronological order.
+   */
+  const fetchWindow = async (
+    provider: string,
+    sessionPath: string,
+    span: number,
+    excludeSidechain: boolean
+  ): Promise<{ messages: ClaudeMessage[]; page: Omit<MessagePage, "messages"> }> => {
+    const accumulated: ClaudeMessage[] = [];
+    let offset = 0;
+    let totalCount = 0;
+    let hasMore = false;
+
+    for (;;) {
+      const remaining = span - offset;
+      if (remaining <= 0) break;
+      const page = await fetchMessagePage(
+        provider,
+        sessionPath,
+        offset,
+        Math.min(remaining, 500),
+        excludeSidechain
+      );
+      accumulated.unshift(...page.messages);
+      totalCount = page.total_count;
+      hasMore = page.has_more;
+      if (!page.has_more || page.next_offset === offset) {
+        offset = page.next_offset;
+        break;
+      }
+      offset = page.next_offset;
+    }
+
+    return {
+      messages: accumulated,
+      page: { total_count: totalCount, has_more: hasMore, next_offset: offset },
+    };
+  };
+
+  /**
+   * Load one older page (chat-style prepend) for the current session.
+   * Serialized through `loadOlderChain`; stale responses are dropped when the
+   * user navigated away mid-flight. Duplicate uuids (window overlap after the
+   * live session file grew) are dropped on prepend.
+   */
+  const loadOlderPage = (limit: number): Promise<void> => {
+    const run = async (): Promise<void> => {
+      const session = get().selectedSession;
+      const { pagination } = get();
+      if (!session || !pagination.hasMore || pagination.isLoadingMore) return;
+
+      const sessionPath = session.file_path;
+      const provider = session.provider ?? "claude";
+      const inSubagent = get().parentSessionStack.length > 0;
+
+      set({ pagination: { ...pagination, isLoadingMore: true } });
+      try {
+        const page = await fetchMessagePage(
+          provider,
+          sessionPath,
+          pagination.currentOffset,
+          limit,
+          shouldExcludeSidechain(inSubagent)
+        );
+
+        // Stale guard: user switched sessions while this page was in flight.
+        if (get().selectedSession?.file_path !== sessionPath) return;
+
+        const existing = get().messages;
+        const known = new Set(existing.map((m) => m.uuid));
+        const fresh = applySystemMessageFilter(
+          page.messages.filter((m) => !known.has(m.uuid))
+        );
+
+        set({
+          messages: fresh.length > 0 ? [...fresh, ...existing] : existing,
+          pagination: {
+            currentOffset: page.next_offset,
+            pageSize: MESSAGE_PAGE_SIZE,
+            totalCount: page.total_count,
+            hasMore: page.has_more,
+            isLoadingMore: false,
+          },
+        });
+      } catch (error) {
+        if (get().selectedSession?.file_path !== sessionPath) return;
+        console.error("Failed to load earlier messages:", error);
+        const message = error instanceof Error ? error.message : String(error);
+        toast.error(`Failed to load earlier messages: ${message}`);
+        set({
+          pagination: { ...get().pagination, isLoadingMore: false },
+        });
+      }
+    };
+
+    const next = loadOlderChain.then(run, run);
+    loadOlderChain = next.catch(() => undefined);
+    return next;
+  };
+
   return {
     ...initialMessageState,
 
@@ -234,67 +407,69 @@ export const createMessageSlice: StateCreator<
     get().setSelectedSession(session);
     // Note: sessionSearch state reset is handled by searchSlice
 
+    // The session file may have changed (or the session did) — the cached
+    // full-session fetch is no longer trustworthy either way.
+    fullSessionCache = null;
+
     try {
       const sessionPath = session.file_path;
       const start = performance.now();
 
       const provider = session.provider ?? "claude";
-      const allMessages = await api<ClaudeMessage[]>("load_provider_messages", {
+
+      // Window span: initial open loads the newest page; an in-place reload
+      // (filter toggle, watcher refresh) preserves the window the user has
+      // already paged in so their scroll position's content doesn't vanish.
+      const span = isInPlaceReload
+        ? Math.max(MESSAGE_PAGE_SIZE, get().pagination.currentOffset)
+        : MESSAGE_PAGE_SIZE;
+
+      // Sidechain filtering happens server-side at classification stage —
+      // subagent 세션은 모든 메시지가 isSidechain=true이므로 필터 우회.
+      const { messages: windowMessages, page } = await fetchWindow(
         provider,
         sessionPath,
-      });
+        span,
+        shouldExcludeSidechain(shouldTreatAsSubagent)
+      );
 
       // Stale response guard: await 중 다른 세션으로 이동했으면 중단.
       // (in-place reload는 selectedSession이 동일하므로 여기서 걸리지 않음)
       if (get().selectedSession?.file_path !== session.file_path) return;
 
-      // Apply sidechain filter — shouldTreatAsSubagent(pre-await 캡처값)를 사용.
-      // subagent 세션은 모든 메시지가 isSidechain=true이므로 필터 우회.
-      let filteredMessages =
-        get().excludeSidechain && !shouldTreatAsSubagent
-          ? allMessages.filter((m) => !m.isSidechain)
-          : allMessages;
-
-      // Apply system message filter
-      const systemMessageTypes = [
-        "queue-operation",
-        "progress",
-        "file-history-snapshot",
-      ];
-      if (!get().showSystemMessages) {
-        filteredMessages = filteredMessages.filter(
-          (m) => !systemMessageTypes.includes(m.type)
-        );
-      }
+      // Apply system message filter (client-side; window-local)
+      const filteredMessages = applySystemMessageFilter(windowMessages);
 
       const duration = performance.now() - start;
       if (import.meta.env.DEV) {
         console.log(
-          `[Frontend] selectSession: ${filteredMessages.length}개 메시지 로드, ${duration.toFixed(1)}ms`
+          `[Frontend] selectSession: ${filteredMessages.length}/${page.total_count}개 메시지 로드 (window), ${duration.toFixed(1)}ms`
         );
       }
 
+      const nextPagination: PaginationState = {
+        currentOffset: page.next_offset,
+        pageSize: MESSAGE_PAGE_SIZE,
+        totalCount: page.total_count,
+        hasMore: page.has_more,
+        isLoadingMore: false,
+      };
+
       if (isInPlaceReload && areMessagesEquivalent(get().messages, filteredMessages)) {
-        set({ isLoadingMessages: false });
+        set({ isLoadingMessages: false, pagination: nextPagination });
         return;
       }
 
       // Update state first to allow UI to render immediately
       set({
         messages: filteredMessages,
-        pagination: {
-          currentOffset: filteredMessages.length,
-          pageSize: filteredMessages.length,
-          totalCount: filteredMessages.length,
-          hasMore: false,
-          isLoadingMore: false,
-        },
+        pagination: nextPagination,
         isLoadingMessages: false,
       });
 
-      // Load subagent sessions (non-blocking). allMessages는 시스템 메시지 필터 적용 전이므로
-      // progress 메시지를 통한 parentToolUseID ↔ subagent 매핑이 성립.
-      void get().loadSubagents(sessionPath, allMessages);
+      // Load subagent sessions (non-blocking). windowMessages는 시스템 메시지 필터
+      // 적용 전 — meta.json 기반 매핑(주 경로)은 window와 무관하게 동작.
+      void get().loadSubagents(sessionPath, windowMessages);
 
       // Search index is built lazily on first search to avoid blocking UI
       // when loading large sessions (47k+ messages with tokenize:"full" is expensive).
@@ -314,6 +489,102 @@ export const createMessageSlice: StateCreator<
       }
       set({ isLoadingMessages: false });
     }
+  },
+
+  loadMoreMessages: async () => {
+    await loadOlderPage(MESSAGE_PAGE_SIZE);
+  },
+
+  ensureMessageLoaded: async (uuid: string) => {
+    const isLoaded = () => get().messages.some((m) => m.uuid === uuid);
+    if (isLoaded()) return true;
+
+    const session = get().selectedSession;
+    if (!session || !get().pagination.hasMore) return false;
+
+    const sessionPath = session.file_path;
+    const provider = session.provider ?? "claude";
+    const inSubagent = get().parentSessionStack.length > 0;
+
+    let offset: number | null;
+    try {
+      offset = await api<number | null>("get_provider_message_offset", {
+        provider,
+        sessionPath,
+        messageUuid: uuid,
+        excludeSidechain: shouldExcludeSidechain(inSubagent),
+      });
+    } catch (error) {
+      console.error("Failed to locate message offset:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to locate message: ${message}`);
+      return false;
+    }
+    if (offset == null) return false;
+    if (get().selectedSession?.file_path !== sessionPath) return false;
+
+    // Extend the window until it covers offset (+1 because offset is 0-based
+    // from the newest end). Pages are serialized through loadOlderChain.
+    const needed = offset + 1;
+    while (
+      get().selectedSession?.file_path === sessionPath &&
+      get().pagination.hasMore &&
+      get().pagination.currentOffset < needed
+    ) {
+      const before = get().pagination.currentOffset;
+      await loadOlderPage(
+        Math.min(needed - get().pagination.currentOffset, 500)
+      );
+      // No forward progress (error path) — bail out instead of spinning.
+      if (get().pagination.currentOffset === before) break;
+    }
+
+    // The uuid may still be absent even when covered (e.g. a claude
+    // tool_result that merged into its assistant message) — report honestly.
+    return isLoaded();
+  },
+
+  fetchFullSessionMessages: async () => {
+    const session = get().selectedSession;
+    if (!session) return [];
+
+    // Loaded window already covers the whole session — reuse it.
+    if (!get().pagination.hasMore) return get().messages;
+
+    const inSubagent = get().parentSessionStack.length > 0;
+    const excludeSidechain = shouldExcludeSidechain(inSubagent);
+    const showSystem = get().showSystemMessages;
+    const key = `${session.file_path}|${excludeSidechain}|${showSystem}`;
+
+    if (fullSessionCache?.key === key) {
+      return fullSessionCache.promise;
+    }
+
+    const provider = session.provider ?? "claude";
+    const promise = (async () => {
+      const all = await api<ClaudeMessage[]>("load_provider_messages", {
+        provider,
+        sessionPath: session.file_path,
+      });
+      const sidechainFiltered = excludeSidechain
+        ? all.filter((m) => !m.isSidechain)
+        : all;
+      return showSystem
+        ? sidechainFiltered
+        : sidechainFiltered.filter(
+            (m) =>
+              !(SYSTEM_MESSAGE_TYPES as readonly string[]).includes(m.type)
+          );
+    })();
+
+    fullSessionCache = { key, promise };
+    // A failed fetch must not poison the cache.
+    promise.catch(() => {
+      if (fullSessionCache?.promise === promise) {
+        fullSessionCache = null;
+      }
+    });
+    return promise;
   },
 
   refreshCurrentSession: async () => {

--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -237,6 +237,13 @@ export const createMessageSlice: StateCreator<
   // so concurrent callers can't fetch the same offset twice.
   let loadOlderChain: Promise<void> = Promise.resolve();
 
+  // Incremented at the start of every selectSession. Guards two races the
+  // file_path check alone cannot: (a) two overlapping in-place reloads of the
+  // SAME file with different filter settings — the stale one must not land
+  // last; (b) older-page loads queued for a session the user has since left
+  // and returned to via a fresh reload.
+  let sessionLoadEpoch = 0;
+
   const applySystemMessageFilter = (
     messages: ClaudeMessage[]
   ): ClaudeMessage[] => {
@@ -315,8 +322,20 @@ export const createMessageSlice: StateCreator<
    * live session file grew) are dropped on prepend.
    */
   const loadOlderPage = (limit: number): Promise<void> => {
+    // Capture the target at QUEUE time: a run executing after the user
+    // navigated away must not silently page the newly selected session.
+    const queuedSession = get().selectedSession;
+    const queuedEpoch = sessionLoadEpoch;
+
     const run = async (): Promise<void> => {
       const session = get().selectedSession;
+      if (
+        !queuedSession ||
+        queuedEpoch !== sessionLoadEpoch ||
+        session?.file_path !== queuedSession.file_path
+      ) {
+        return;
+      }
       const { pagination } = get();
       if (!session || !pagination.hasMore || pagination.isLoadingMore) return;
 
@@ -334,8 +353,14 @@ export const createMessageSlice: StateCreator<
           shouldExcludeSidechain(inSubagent)
         );
 
-        // Stale guard: user switched sessions while this page was in flight.
-        if (get().selectedSession?.file_path !== sessionPath) return;
+        // Stale guard: user switched sessions (or reloaded in place) while
+        // this page was in flight.
+        if (
+          queuedEpoch !== sessionLoadEpoch ||
+          get().selectedSession?.file_path !== sessionPath
+        ) {
+          return;
+        }
 
         const existing = get().messages;
         const known = new Set(existing.map((m) => m.uuid));
@@ -354,7 +379,12 @@ export const createMessageSlice: StateCreator<
           },
         });
       } catch (error) {
-        if (get().selectedSession?.file_path !== sessionPath) return;
+        if (
+          queuedEpoch !== sessionLoadEpoch ||
+          get().selectedSession?.file_path !== sessionPath
+        ) {
+          return;
+        }
         console.error("Failed to load earlier messages:", error);
         const message = error instanceof Error ? error.message : String(error);
         toast.error(`Failed to load earlier messages: ${message}`);
@@ -373,6 +403,10 @@ export const createMessageSlice: StateCreator<
     ...initialMessageState,
 
   selectSession: async (session: ClaudeSession) => {
+    // In-place reloads share a file_path, so the path guard alone cannot drop
+    // a stale overlapping reload (e.g. two quick filter toggles) — the epoch
+    // does. Captured before any await.
+    const epoch = ++sessionLoadEpoch;
     // Subagent intent를 await 전에 캡처하여 async race 차단.
     // - isSubagentNav: navigateToSubagent가 세팅한 1회성 플래그
     // - isInPlaceReload: filter toggle/refreshCurrentSession에서 같은 세션을 재로드하는 경우
@@ -433,9 +467,14 @@ export const createMessageSlice: StateCreator<
         shouldExcludeSidechain(shouldTreatAsSubagent)
       );
 
-      // Stale response guard: await 중 다른 세션으로 이동했으면 중단.
-      // (in-place reload는 selectedSession이 동일하므로 여기서 걸리지 않음)
-      if (get().selectedSession?.file_path !== session.file_path) return;
+      // Stale response guard: 다른 세션으로 이동했거나(경로), 같은 세션의 더
+      // 새로운 reload가 시작되었으면(epoch) 중단.
+      if (
+        epoch !== sessionLoadEpoch ||
+        get().selectedSession?.file_path !== session.file_path
+      ) {
+        return;
+      }
 
       // Apply system message filter (client-side; window-local)
       const filteredMessages = applySystemMessageFilter(windowMessages);
@@ -474,9 +513,14 @@ export const createMessageSlice: StateCreator<
       // Search index is built lazily on first search to avoid blocking UI
       // when loading large sessions (47k+ messages with tokenize:"full" is expensive).
     } catch (error) {
-      // Stale error guard: await 중 다른 세션으로 이동했으면 abandoned request의
-      // 에러·로딩 상태를 현재 UI에 덮어쓰지 않음 (success path의 L212 guard 미러링)
-      if (get().selectedSession?.file_path !== session.file_path) return;
+      // Stale error guard: 경로·epoch 둘 중 하나라도 어긋나면 abandoned request의
+      // 에러·로딩 상태를 현재 UI에 덮어쓰지 않음 (success path guard 미러링)
+      if (
+        epoch !== sessionLoadEpoch ||
+        get().selectedSession?.file_path !== session.file_path
+      ) {
+        return;
+      }
 
       console.error("Failed to load session messages:", error);
       // 서브에이전트 로딩 실패 시 toast로 알림 (전체 페이지 에러 방지).
@@ -501,6 +545,7 @@ export const createMessageSlice: StateCreator<
 
     const session = get().selectedSession;
     if (!session || !get().pagination.hasMore) return false;
+    const epoch = sessionLoadEpoch;
 
     const sessionPath = session.file_path;
     const provider = session.provider ?? "claude";
@@ -527,6 +572,7 @@ export const createMessageSlice: StateCreator<
     // from the newest end). Pages are serialized through loadOlderChain.
     const needed = offset + 1;
     while (
+      epoch === sessionLoadEpoch &&
       get().selectedSession?.file_path === sessionPath &&
       get().pagination.hasMore &&
       get().pagination.currentOffset < needed

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -130,8 +130,9 @@ export const createSearchSlice: StateCreator<
   // Session search (KakaoTalk-style navigation)
   setSessionSearchQuery: async (query: string) => {
     const requestId = ++sessionSearchRequestId;
-    const { messages, sessionSearch } = get();
+    const { sessionSearch } = get();
     const { filterType } = sessionSearch;
+    const sessionPath = get().selectedSession?.file_path;
 
     // Empty query clears search results
     if (!query.trim()) {
@@ -157,6 +158,20 @@ export const createSearchSlice: StateCreator<
     const isStillLatest = () => requestId === sessionSearchRequestId;
 
     try {
+      // Search over the COMPLETE session, not just the loaded window —
+      // matches in unloaded older pages must be findable. The fetch is
+      // cached per session in the message slice.
+      const searchableMessages = await get().fetchFullSessionMessages();
+
+      // Session-switch guard: the full fetch resolved for a session the
+      // user has already left.
+      if (
+        !isStillLatest() ||
+        get().selectedSession?.file_path !== sessionPath
+      ) {
+        return;
+      }
+
       // Search strategy: Worker (async) > linear fallback (sync)
       let searchResults: Array<{ messageUuid: string; messageIndex: number; matchIndex: number; matchCount: number }>;
 
@@ -165,9 +180,9 @@ export const createSearchSlice: StateCreator<
         searchResults = await searchMessagesAsync(query, filterType);
       } else {
         // Index not ready — use linear search (instant, ~100-200ms for 50k messages)
-        searchResults = linearSearchMessages(messages, query, filterType);
+        searchResults = linearSearchMessages(searchableMessages, query, filterType);
         // Trigger background Worker index build for future searches
-        buildSearchIndex(messages);
+        buildSearchIndex(searchableMessages);
       }
 
       // Drop stale results: a newer search has been started while this one
@@ -180,7 +195,8 @@ export const createSearchSlice: StateCreator<
       const matches: SearchMatch[] = searchResults
         .filter(
           (result) =>
-            result.messageIndex >= 0 && result.messageIndex < messages.length
+            result.messageIndex >= 0 &&
+            result.messageIndex < searchableMessages.length
         )
         .map((result) => ({
           messageUuid: result.messageUuid,
@@ -198,7 +214,7 @@ export const createSearchSlice: StateCreator<
           isSearching: false,
           filterType: state.sessionSearch.filterType,
           results: matches
-            .map((m) => messages[m.messageIndex])
+            .map((m) => searchableMessages[m.messageIndex])
             .filter((m): m is ClaudeMessage => m !== undefined),
         },
       }));

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -151,11 +151,14 @@ export const createSearchSlice: StateCreator<
       },
     }));
 
-    // Helper: predicate "this request is still the latest one".
-    // When false, every set() guarded by this is dropped so a newer
-    // request's state cannot be clobbered by stale data, AND the
-    // `isSearching: false` reset is left to that newer request.
-    const isStillLatest = () => requestId === sessionSearchRequestId;
+    // Helper: predicate "this request is still the latest one AND the user
+    // is still on the session it was issued for". Re-checked after EVERY
+    // await and in the catch path — a session switch does not bump the
+    // request id, so the id alone cannot stop a stale result (or a stale
+    // error) from landing on the new session's state.
+    const isStillLatest = () =>
+      requestId === sessionSearchRequestId &&
+      get().selectedSession?.file_path === sessionPath;
 
     try {
       // Search over the COMPLETE session, not just the loaded window —
@@ -165,10 +168,7 @@ export const createSearchSlice: StateCreator<
 
       // Session-switch guard: the full fetch resolved for a session the
       // user has already left.
-      if (
-        !isStillLatest() ||
-        get().selectedSession?.file_path !== sessionPath
-      ) {
+      if (!isStillLatest()) {
         return;
       }
 

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -234,6 +234,9 @@ export interface AppStoreActions {
 
   // Message actions
   selectSession: (session: ClaudeSession) => Promise<void>;
+  loadMoreMessages: () => Promise<void>;
+  ensureMessageLoaded: (uuid: string) => Promise<boolean>;
+  fetchFullSessionMessages: () => Promise<ClaudeMessage[]>;
   refreshCurrentSession: () => Promise<void>;
   loadSessionTokenStats: (sessionPath: string) => Promise<void>;
   loadProjectTokenStats: (projectPath: string) => Promise<void>;

--- a/src/test/App.accessibility.test.tsx
+++ b/src/test/App.accessibility.test.tsx
@@ -68,6 +68,13 @@ const { useAppStoreMock } = vi.hoisted(() => {
     setSelectedSession: vi.fn(),
     fontScale: 100,
     highContrast: false,
+    pagination: {
+      currentOffset: 0,
+      pageSize: 0,
+      totalCount: 0,
+      hasMore: false,
+      isLoadingMore: false,
+    },
   };
 
   type StoreMock = {

--- a/src/test/messageSlice.pagination.test.ts
+++ b/src/test/messageSlice.pagination.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for chat-style message pagination in messageSlice.
+ *
+ * - selectSession loads only the newest window (limit = MESSAGE_PAGE_SIZE)
+ * - loadMoreMessages prepends the older page and dedups overlap
+ * - in-place reload preserves the already-paged-in window span
+ * - ensureMessageLoaded extends the window to cover a deep-linked uuid
+ * - fetchFullSessionMessages returns the complete session and caches per key
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import type {
+  ClaudeMessage,
+  ClaudeSession,
+  ProjectStatsSummary,
+} from "../types";
+import {
+  createMessageSlice,
+  MESSAGE_PAGE_SIZE,
+  type MessageSlice,
+} from "../store/slices/messageSlice";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApi = vi.fn();
+vi.mock("@/services/api", () => ({
+  api: (...args: unknown[]) => mockApi(...args),
+}));
+
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("../utils/searchIndex", () => ({
+  buildSearchIndex: vi.fn(),
+  clearSearchIndex: vi.fn(),
+}));
+
+vi.mock("../services/analyticsApi", () => ({
+  fetchSessionTokenStats: vi.fn(),
+  fetchProjectTokenStats: vi.fn(),
+  fetchProjectStatsSummary: vi
+    .fn()
+    .mockResolvedValue({} as ProjectStatsSummary),
+  fetchSessionComparison: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Test store + fixtures
+// ---------------------------------------------------------------------------
+
+type TestStore = MessageSlice & {
+  selectedSession: ClaudeSession | null;
+  excludeSidechain: boolean;
+  showSystemMessages: boolean;
+  setError: ReturnType<typeof vi.fn>;
+  setSelectedSession: (s: ClaudeSession | null) => void;
+  resetMessageFilter: () => void;
+  selectedProject: null;
+  dateFilter: { start: null; end: null };
+};
+
+const createTestStore = () =>
+  create<TestStore>()((set, get) => ({
+    selectedSession: null,
+    excludeSidechain: true,
+    showSystemMessages: false,
+    setError: vi.fn(),
+    setSelectedSession: (s) => set({ selectedSession: s }),
+    resetMessageFilter: vi.fn(),
+    selectedProject: null,
+    dateFilter: { start: null, end: null },
+    ...createMessageSlice(
+      set as Parameters<typeof createMessageSlice>[0],
+      get as Parameters<typeof createMessageSlice>[1],
+    ),
+  }));
+
+const makeSession = (overrides: Partial<ClaudeSession> = {}): ClaudeSession =>
+  ({
+    session_id: "session-1",
+    actual_session_id: "session-1",
+    file_path: "/tmp/session.jsonl",
+    project_name: "proj",
+    message_count: 0,
+    first_message_time: "",
+    last_message_time: "",
+    last_modified: "",
+    has_tool_use: false,
+    has_errors: false,
+    summary: "",
+    ...overrides,
+  }) as ClaudeSession;
+
+const makeMessage = (uuid: string): ClaudeMessage =>
+  ({
+    uuid,
+    session_id: "session-1",
+    timestamp: "2026-07-12T00:00:00Z",
+    type: "user",
+    content: `content-${uuid}`,
+  }) as unknown as ClaudeMessage;
+
+/** A fake backing store of N chronological messages (uuid-1 .. uuid-N). */
+const makeBackend = (total: number) => {
+  const all = Array.from({ length: total }, (_, i) =>
+    makeMessage(`uuid-${i + 1}`),
+  );
+  const page = (args: { offset?: number; limit?: number }) => {
+    const offset = args.offset ?? 0;
+    const limit = args.limit ?? total;
+    const remaining = Math.max(total - offset, 0);
+    const toLoad = Math.min(limit, remaining);
+    const start = remaining - toLoad;
+    return {
+      messages: all.slice(start, remaining),
+      total_count: total,
+      has_more: start > 0,
+      next_offset: offset + toLoad,
+    };
+  };
+  return { all, page };
+};
+
+const installBackend = (backend: ReturnType<typeof makeBackend>) => {
+  mockApi.mockImplementation(
+    (
+      cmd: string,
+      args: { offset?: number; limit?: number; messageUuid?: string },
+    ) => {
+      if (cmd === "load_provider_messages_paginated") {
+        return Promise.resolve(backend.page(args));
+      }
+      if (cmd === "load_provider_messages") {
+        return Promise.resolve(backend.all);
+      }
+      if (cmd === "get_provider_message_offset") {
+        const idx = backend.all.findIndex((m) => m.uuid === args.messageUuid);
+        return Promise.resolve(
+          idx === -1 ? null : backend.all.length - 1 - idx,
+        );
+      }
+      if (cmd === "get_session_subagents") return Promise.resolve([]);
+      return Promise.reject(new Error(`unexpected: ${cmd}`));
+    },
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("messageSlice — chat-style pagination", () => {
+  beforeEach(() => {
+    mockApi.mockReset();
+    mockToastError.mockReset();
+  });
+
+  it("selectSession loads only the newest window", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(500);
+    installBackend(backend);
+
+    await store.getState().selectSession(makeSession());
+
+    const state = store.getState();
+    expect(state.messages).toHaveLength(MESSAGE_PAGE_SIZE);
+    expect(state.messages[0]?.uuid).toBe(`uuid-${500 - MESSAGE_PAGE_SIZE + 1}`);
+    expect(state.messages.at(-1)?.uuid).toBe("uuid-500");
+    expect(state.pagination).toMatchObject({
+      currentOffset: MESSAGE_PAGE_SIZE,
+      totalCount: 500,
+      hasMore: true,
+      isLoadingMore: false,
+    });
+  });
+
+  it("loadMoreMessages prepends the older page and keeps order", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(500);
+    installBackend(backend);
+    await store.getState().selectSession(makeSession());
+
+    await store.getState().loadMoreMessages();
+
+    const state = store.getState();
+    expect(state.messages).toHaveLength(MESSAGE_PAGE_SIZE * 2);
+    expect(state.messages[0]?.uuid).toBe(
+      `uuid-${500 - MESSAGE_PAGE_SIZE * 2 + 1}`,
+    );
+    expect(state.messages.at(-1)?.uuid).toBe("uuid-500");
+    expect(state.pagination.currentOffset).toBe(MESSAGE_PAGE_SIZE * 2);
+    expect(state.pagination.hasMore).toBe(true);
+
+    // Final partial page exhausts the session
+    await store.getState().loadMoreMessages();
+    expect(store.getState().messages).toHaveLength(500);
+    expect(store.getState().pagination.hasMore).toBe(false);
+  });
+
+  it("loadMoreMessages dedups overlap when the live file grew mid-scroll", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(300);
+    installBackend(backend);
+    await store.getState().selectSession(makeSession());
+    expect(store.getState().messages).toHaveLength(MESSAGE_PAGE_SIZE);
+
+    // Session file grows by 10 messages: offsets from the newest end shift,
+    // so the next page overlaps the already-loaded window head.
+    const grown = makeBackend(310);
+    installBackend(grown);
+
+    await store.getState().loadMoreMessages();
+
+    const uuids = store.getState().messages.map((m) => m.uuid);
+    expect(new Set(uuids).size).toBe(uuids.length); // no duplicates
+  });
+
+  it("in-place reload preserves the paged-in window span", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(500);
+    installBackend(backend);
+    const session = makeSession();
+    await store.getState().selectSession(session);
+    await store.getState().loadMoreMessages();
+    expect(store.getState().messages).toHaveLength(MESSAGE_PAGE_SIZE * 2);
+
+    // Re-select the same session (filter toggle / watcher refresh path)
+    await store.getState().selectSession(session);
+
+    expect(store.getState().messages).toHaveLength(MESSAGE_PAGE_SIZE * 2);
+    expect(store.getState().pagination.currentOffset).toBe(
+      MESSAGE_PAGE_SIZE * 2,
+    );
+  });
+
+  it("ensureMessageLoaded extends the window to cover a deep-linked uuid", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(900);
+    installBackend(backend);
+    await store.getState().selectSession(makeSession());
+    expect(
+      store.getState().messages.some((m) => m.uuid === "uuid-100"),
+    ).toBe(false);
+
+    const found = await store.getState().ensureMessageLoaded("uuid-100");
+
+    expect(found).toBe(true);
+    expect(
+      store.getState().messages.some((m) => m.uuid === "uuid-100"),
+    ).toBe(true);
+    // Window is contiguous back to the target
+    expect(store.getState().pagination.currentOffset).toBeGreaterThanOrEqual(
+      900 - 100 + 1,
+    );
+  });
+
+  it("ensureMessageLoaded returns false for an unknown uuid without looping", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(500);
+    installBackend(backend);
+    await store.getState().selectSession(makeSession());
+    const before = store.getState().pagination.currentOffset;
+
+    const found = await store.getState().ensureMessageLoaded("no-such-uuid");
+
+    expect(found).toBe(false);
+    expect(store.getState().pagination.currentOffset).toBe(before);
+  });
+
+  it("fetchFullSessionMessages returns the whole session and caches", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(500);
+    installBackend(backend);
+    await store.getState().selectSession(makeSession());
+
+    const full = await store.getState().fetchFullSessionMessages();
+    expect(full).toHaveLength(500);
+
+    const again = await store.getState().fetchFullSessionMessages();
+    expect(again).toBe(full); // cached promise result
+
+    const fullLoadCalls = mockApi.mock.calls.filter(
+      ([cmd]) => cmd === "load_provider_messages",
+    );
+    expect(fullLoadCalls).toHaveLength(1);
+  });
+
+  it("fetchFullSessionMessages reuses the window when everything is loaded", async () => {
+    const store = createTestStore();
+    const backend = makeBackend(50);
+    installBackend(backend);
+    await store.getState().selectSession(makeSession());
+    expect(store.getState().pagination.hasMore).toBe(false);
+
+    const full = await store.getState().fetchFullSessionMessages();
+
+    expect(full).toBe(store.getState().messages);
+    expect(
+      mockApi.mock.calls.filter(([cmd]) => cmd === "load_provider_messages"),
+    ).toHaveLength(0);
+  });
+});

--- a/src/test/messageSlice.pagination.test.ts
+++ b/src/test/messageSlice.pagination.test.ts
@@ -293,6 +293,48 @@ describe("messageSlice — chat-style pagination", () => {
     expect(fullLoadCalls).toHaveLength(1);
   });
 
+  it("drops a stale overlapping in-place reload (epoch guard)", async () => {
+    const store = createTestStore();
+    const session = makeSession();
+
+    // Two overlapping reloads of the SAME file: the first request resolves
+    // LAST and must not overwrite the newer reload's window.
+    let call = 0;
+    const resolvers: Array<(v: unknown) => void> = [];
+    mockApi.mockImplementation((cmd: string) => {
+      if (cmd === "load_provider_messages_paginated") {
+        call += 1;
+        const mine = call;
+        return new Promise((resolve) => {
+          resolvers[mine - 1] = resolve;
+        });
+      }
+      if (cmd === "get_session_subagents") return Promise.resolve([]);
+      return Promise.reject(new Error(`unexpected: ${cmd}`));
+    });
+
+    const first = store.getState().selectSession(session);
+    const second = store.getState().selectSession(session);
+
+    const pageOf = (uuid: string) => ({
+      messages: [makeMessage(uuid)],
+      total_count: 1,
+      has_more: false,
+      next_offset: 1,
+    });
+
+    // Newer request resolves first...
+    resolvers[1]?.(pageOf("from-second"));
+    await second;
+    // ...then the stale one lands late.
+    resolvers[0]?.(pageOf("from-first"));
+    await first;
+
+    expect(store.getState().messages.map((m) => m.uuid)).toEqual([
+      "from-second",
+    ]);
+  });
+
   it("fetchFullSessionMessages reuses the window when everything is loaded", async () => {
     const store = createTestStore();
     const backend = makeBackend(50);

--- a/src/test/messageSlice.subagent.test.ts
+++ b/src/test/messageSlice.subagent.test.ts
@@ -200,6 +200,39 @@ const defer = <T,>(): Deferred<T> => {
   return { promise, resolve };
 };
 
+/**
+ * Emulates the backend `load_provider_messages_paginated` contract over a raw
+ * message list: server-side sidechain filtering + chat-style slicing
+ * (offset 0 = newest).
+ */
+const asPage = (
+  rawMessages: ClaudeMessage[],
+  args?: { offset?: number; limit?: number; excludeSidechain?: boolean },
+) => {
+  const filtered = args?.excludeSidechain
+    ? rawMessages.filter((m) => !m.isSidechain)
+    : rawMessages;
+  const offset = args?.offset ?? 0;
+  const limit = args?.limit ?? filtered.length;
+  const total = filtered.length;
+  const remaining = Math.max(total - offset, 0);
+  const toLoad = Math.min(limit, remaining);
+  const start = remaining - toLoad;
+  return {
+    messages: filtered.slice(start, remaining),
+    total_count: total,
+    has_more: start > 0,
+    next_offset: offset + toLoad,
+  };
+};
+
+type PaginatedArgs = {
+  sessionPath: string;
+  offset?: number;
+  limit?: number;
+  excludeSidechain?: boolean;
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -226,11 +259,13 @@ describe("messageSlice.selectSession — async race & subagent intent", () => {
     const deferredA = defer<ClaudeMessage[]>();
     const deferredB = defer<ClaudeMessage[]>();
 
-    mockApi.mockImplementation((cmd: string, args: { sessionPath: string }) => {
-      if (cmd === "load_provider_messages") {
-        return args.sessionPath === "/tmp/A.jsonl"
-          ? deferredA.promise
-          : deferredB.promise;
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated") {
+        const source =
+          args.sessionPath === "/tmp/A.jsonl"
+            ? deferredA.promise
+            : deferredB.promise;
+        return source.then((msgs) => asPage(msgs, args));
       }
       if (cmd === "get_session_subagents") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected: ${cmd}`));
@@ -272,9 +307,9 @@ describe("messageSlice.selectSession — async race & subagent intent", () => {
       makeUserMessage("s1", true),
       makeUserMessage("s2", true),
     ];
-    mockApi.mockImplementation((cmd: string) => {
-      if (cmd === "load_provider_messages")
-        return Promise.resolve(subagentMessages);
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated")
+        return Promise.resolve(asPage(subagentMessages, args));
       if (cmd === "get_session_subagents") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected: ${cmd}`));
     });
@@ -299,8 +334,9 @@ describe("messageSlice.selectSession — async race & subagent intent", () => {
       isLoadingMessages: false,
     });
 
-    mockApi.mockImplementation((cmd: string) => {
-      if (cmd === "load_provider_messages") return refresh.promise;
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated")
+        return refresh.promise.then((msgs) => asPage(msgs, args));
       if (cmd === "get_session_subagents") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected: ${cmd}`));
     });
@@ -335,8 +371,9 @@ describe("messageSlice.selectSession — async race & subagent intent", () => {
       isLoadingMessages: false,
     });
 
-    mockApi.mockImplementation((cmd: string) => {
-      if (cmd === "load_provider_messages") return Promise.resolve([sameMessage]);
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated")
+        return Promise.resolve(asPage([sameMessage], args));
       return Promise.reject(new Error(`unexpected: ${cmd}`));
     });
 
@@ -356,8 +393,9 @@ describe("messageSlice.selectSession — async race & subagent intent", () => {
       selectedSession: makeSession({ file_path: "/tmp/other.jsonl" }),
       parentSessionStack: [makeSession({ file_path: "/tmp/ghost.jsonl" })],
     });
-    mockApi.mockImplementation((cmd: string) => {
-      if (cmd === "load_provider_messages") return Promise.resolve([]);
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated")
+        return Promise.resolve(asPage([], args));
       if (cmd === "get_session_subagents") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected: ${cmd}`));
     });
@@ -544,13 +582,21 @@ describe("messageSlice — navigate guards & error branches", () => {
     });
 
     // Top-level messages mix regular + sidechain — filter must strip sidechain
-    mockApi.mockImplementation((cmd: string, args: { sessionPath: string }) => {
-      if (cmd === "load_provider_messages" && args.sessionPath === "/tmp/top.jsonl") {
-        return Promise.resolve([
-          makeUserMessage("regular-1", false),
-          makeUserMessage("sidechain-1", true),
-          makeUserMessage("regular-2", false),
-        ]);
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (
+        cmd === "load_provider_messages_paginated" &&
+        args.sessionPath === "/tmp/top.jsonl"
+      ) {
+        return Promise.resolve(
+          asPage(
+            [
+              makeUserMessage("regular-1", false),
+              makeUserMessage("sidechain-1", true),
+              makeUserMessage("regular-2", false),
+            ],
+            args,
+          ),
+        );
       }
       if (cmd === "get_session_subagents") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected: ${cmd}`));
@@ -572,8 +618,9 @@ describe("messageSlice — navigate guards & error branches", () => {
     store.setState({ selectedSession: parent });
 
     const deferred = defer<ClaudeMessage[]>();
-    mockApi.mockImplementation((cmd: string) => {
-      if (cmd === "load_provider_messages") return deferred.promise;
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated")
+        return deferred.promise.then((msgs) => asPage(msgs, args));
       if (cmd === "get_session_subagents") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected: ${cmd}`));
     });
@@ -606,11 +653,11 @@ describe("messageSlice — navigate guards & error branches", () => {
     const rejectPromiseA = new Promise<ClaudeMessage[]>((_, reject) => {
       rejectA = reject;
     });
-    mockApi.mockImplementation((cmd: string, args: { sessionPath: string }) => {
-      if (cmd === "load_provider_messages") {
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated") {
         return args.sessionPath === "/tmp/A.jsonl"
           ? rejectPromiseA
-          : Promise.resolve([]);
+          : Promise.resolve(asPage([], args));
       }
       if (cmd === "get_session_subagents") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected: ${cmd}`));
@@ -633,7 +680,7 @@ describe("messageSlice — navigate guards & error branches", () => {
     const store = createTestStore();
     const topSession = makeSession({ file_path: "/tmp/top.jsonl" });
     mockApi.mockImplementation((cmd: string) => {
-      if (cmd === "load_provider_messages")
+      if (cmd === "load_provider_messages_paginated")
         return Promise.reject(new Error("boom"));
       return Promise.reject(new Error(`unexpected: ${cmd}`));
     });
@@ -657,7 +704,7 @@ describe("messageSlice — navigate guards & error branches", () => {
       selectedSession: subSession,
     });
     mockApi.mockImplementation((cmd: string) => {
-      if (cmd === "load_provider_messages")
+      if (cmd === "load_provider_messages_paginated")
         return Promise.reject(new Error("boom"));
       return Promise.reject(new Error(`unexpected: ${cmd}`));
     });

--- a/src/types/message.types.ts
+++ b/src/types/message.types.ts
@@ -282,8 +282,13 @@ export interface MessagePage {
 }
 
 /**
- * @deprecated Pagination is no longer used as we load all messages at once.
- * Kept for backward compatibility.
+ * Chat-style message pagination state.
+ *
+ * `currentOffset` counts messages already consumed from the NEWEST end of the
+ * session in the backend's index space (`load_provider_messages_paginated`
+ * `next_offset`) — for Claude this is pre-merge, so it can exceed the number
+ * of displayed (merged) messages. `totalCount` is the session total in the
+ * same space.
  */
 export interface PaginationState {
   currentOffset: number;


### PR DESCRIPTION
## Summary

Opening a session no longer loads the entire message set into memory / over IPC. This was P1 of the data-scaling audit: `selectSession` previously fetched ALL messages via `load_provider_messages` and faked the pagination state (`messageSlice.ts` set `hasMore: false` with `totalCount = length`), so a 10k+/47k-message session (including base64 image payloads) was held fully in the Zustand store and serialized whole across the Tauri IPC boundary.

### Backend

- **`load_provider_messages_paginated`** — unified chat-style entry point (offset 0 = newest):
  - `claude` uses the existing mmap fast path. Offsets are in **pre-merge index space** (stable across pages, consistent with `get_session_message_count`); `merge_tool_execution_messages` is applied **within the returned window**. A `tool_result` whose matching `tool_use` lives in an older unloaded page stays unmerged and renders via the existing standalone tool_result renderers (boundary-only artifact).
  - Other providers materialize the full session server-side (as they always have), merge, then slice — bounding the IPC payload and frontend memory.
- **`get_provider_message_offset`** — uuid → offset-from-newest lookup (early-exit reverse scan for claude); powers deep links into unloaded regions without a full load.
- 27-arm provider dispatch extracted to `load_non_claude_messages` so the full and paginated entry points cannot drift.
- Both commands wired in `lib.rs` **and** the WebUI server (routes + `READ_ONLY_ALLOWED_API_PATHS` + handlers); parity checker reports full sync.

### Frontend

- `messageSlice`: initial load = newest 200; `loadMoreMessages` prepends older pages (serialized via an internal chain, uuid-dedup against live-file growth); in-place reloads (filter toggle / watcher refresh) preserve the paged-in span; sidechain exclusion moved server-side.
- `ensureMessageLoaded(uuid)`: extends the window to cover deep-linked uuids — global-search jumps and search-match navigation into unloaded regions now work instead of silently no-oping.
- `fetchFullSessionMessages()`: cached full fetch for consumers that genuinely need the complete session — **export** and **in-session search** now cover the whole conversation while the store holds only a window.
- MessageViewer: load-earlier button (reuses existing `messageViewer.loadMoreMessages` i18n keys in all 5 locales) + near-top autoload; **multi-pass anchor restore** keeps the viewport stationary on prepend (single-pass totalSize-delta drifts under the virtualizer's estimate-vs-measured correction); auto-scroll-to-bottom skips prepends via `firstItemKey`.
- Counts: header shows loaded/total; AppLayout status bar appends `+` while partial.

## Verification

- Rust: 852 lib tests (incl. 9 new: chat-slice, in-window merge, boundary orphan, offset lookup round-trip) — `--test-threads=1`, clippy `-D warnings`, fmt.
- Frontend: tsc, 911 vitest (incl. 8 new pagination tests), eslint, i18n:validate.
- **Real run** (WebUI `--serve` + Playwright on a 2,076-message session): windowed open (150/2076 displayed), load-earlier works, near-top autoload works, **anchor shift 0px** after prepend, off-window in-session search finds the first message of the session, extends the window, and highlights it.
- HTTP smoke: `get_provider_message_offset` round-trips exactly with the pagination space (offset 5535 → page at that offset returns the same uuid).

## Accepted trade-offs

- Claude page boundary can show an orphan standalone tool_result (existing renderers handle it).
- MessageNavigator outline reflects the loaded window (extension candidate).
- Non-claude providers still parse the full session server-side (transient); bounding that is a separate follow-up.
- Pre-existing, unrelated drift surfaced by the parity check: `detect_claude_config_dir` has no WebUI route (will fix separately).

Spec: `specs/20260712-real-message-pagination/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat-style message pagination, loading recent messages first and fetching older messages on demand.
  * Added deep-link support that automatically loads and focuses targeted messages.
  * Search and exports now include the complete conversation, even when only part is loaded.
  * Added message-count indicators and a “load more” control.

* **Bug Fixes**
  * Improved scroll-position preservation when loading older messages.
  * Standardized message filtering across pagination, search, and navigation.
  * Prevented duplicate messages and stale session results during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->