### PR TITLE
perf(projects): defer project search filtering + skip offscreen row rendering

### DIFF
--- a/src/components/ProjectTree/components/GroupedProjectList.tsx
+++ b/src/components/ProjectTree/components/GroupedProjectList.tsx
@@ -84,8 +84,18 @@ export const GroupedProjectList: React.FC<GroupedProjectListProps> = ({
     const isExpanded = isProjectExpanded(project.path);
     const showSessions = isExpanded && selectedProject?.path === project.path;
 
+    // Collapsed rows skip offscreen layout/paint entirely — with thousands of
+    // projects this is what keeps sidebar scrolling and search re-filters
+    // cheap without virtualizing the (a11y-tree-navigated, nested) list.
+    // The expanded row is excluded: content-visibility's paint containment
+    // would break the sticky selection bar and the nested virtualized
+    // session list inside it.
+    const rowStyle: React.CSSProperties | undefined = showSessions
+      ? undefined
+      : { contentVisibility: "auto", containIntrinsicSize: "auto 48px" };
+
     return (
-      <div key={project.path} role="none">
+      <div key={project.path} role="none" style={rowStyle}>
         <ProjectItem
           project={project}
           isExpanded={isExpanded}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -1,5 +1,5 @@
 // src/components/ProjectTree/index.tsx
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import {
   Folder,
   Database,
@@ -316,7 +316,14 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
     await applyProviderSelection(next.length > 0 ? next : [provider]);
   }, [applyProviderSelection, isAllProvidersSelected, selectableProviderIds, selectedProviderFilters]);
 
-  const normalizedSearchTerm = useMemo(() => searchTerm.trim().toLowerCase(), [searchTerm]);
+  // Defer the filtering work: the input echoes each keystroke immediately
+  // while re-filtering hundreds/thousands of projects runs as an
+  // interruptible low-priority render (no per-keystroke jank).
+  const deferredSearchTerm = useDeferredValue(searchTerm);
+  const normalizedSearchTerm = useMemo(
+    () => deferredSearchTerm.trim().toLowerCase(),
+    [deferredSearchTerm]
+  );
 
   const matchesSearch = useCallback(
     (project: (typeof projects)[number]) => {


### PR DESCRIPTION
## Summary

P3 of the data-scaling audit. The project sidebar renders every project with `.map()` in all three grouping strategies, and each keystroke in the project search re-filtered the entire list synchronously (no debounce).

## Changes

- **Search**: filtering now keys off `useDeferredValue(searchTerm)` — the input echoes keystrokes immediately; re-filtering hundreds/thousands of projects becomes an interruptible low-priority render.
- **Offscreen rows**: collapsed project rows get `content-visibility: auto` + `contain-intrinsic-size: auto 48px`, so offscreen rows skip layout/paint. The expanded row is deliberately excluded — paint containment would break the sticky session-selection bar and the nested virtualized `SessionList` inside it.

## Why not react-window for the outer list

The project tree ships roving-tabindex keyboard navigation (arrows/Home/End/typeahead over `treeitem`s), and the selected project expands an embedded, separately-virtualized session list. Windowing the outer tree would remove offscreen treeitems from the DOM and break those a11y flows for a marginal win over paint containment. `content-visibility` keeps the DOM/a11y tree intact while eliminating the rendering cost; browsers without support simply ignore it.

## Verification

- `pnpm tsc --build .`, `pnpm exec vitest run` (903 passed), `pnpm lint` — green.
- Visual verification of sidebar render/search/sticky bar planned in the combined WebUI pass with #459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved project tree performance when browsing collapsed project rows.
  * Search input remains responsive during rapid typing by deferring filtering work.
  * Reduced unnecessary rendering and layout work for offscreen project content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->