### PR TITLE
fix(webui): wire detect_claude_config_dir into the server router

### DIFF
--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -423,6 +423,10 @@ handler_no_params!(
     get_claude_folder_path,
     commands::project::get_claude_folder_path
 );
+handler_no_params!(
+    detect_claude_config_dir,
+    commands::project::detect_claude_config_dir
+);
 handler_no_params!(get_system_info, commands::feedback::get_system_info);
 handler_no_params!(detect_providers, commands::multi_provider::detect_providers);
 handler_no_params!(load_presets, commands::settings::load_presets);

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -48,6 +48,7 @@ use self::state::AppState;
 /// This list must stay in sync with the POST routes registered on `protected_api`
 /// in `build_router`; the `read_only_*` tests below pin the current classification.
 const READ_ONLY_ALLOWED_API_PATHS: &[&str] = &[
+    "/detect_claude_config_dir",
     "/detect_providers",
     "/export_session",
     "/get_all_mcp_servers",
@@ -191,6 +192,10 @@ pub fn build_router(
         .route("/get_server_config", post(h::get_server_config))
         // Project commands
         .route("/get_claude_folder_path", post(h::get_claude_folder_path))
+        .route(
+            "/detect_claude_config_dir",
+            post(h::detect_claude_config_dir),
+        )
         .route("/validate_claude_folder", post(h::validate_claude_folder))
         .route(
             "/validate_custom_claude_dir",


### PR DESCRIPTION
## Summary

Pre-existing tauri-axum parity drift surfaced by the parity check during #458: `projectSlice.ts` invokes `detect_claude_config_dir` at startup, but the WebUI server had no route for it — every `--serve` session logged a 405 (`API error [detect_claude_config_dir]`) and `CLAUDE_CONFIG_DIR` auto-detection silently no-oped in web mode (#340 class).

## Changes

- `server/mod.rs`: route + `READ_ONLY_ALLOWED_API_PATHS` entry (read-only env-var probe, safe in read-only mode)
- `server/handlers.rs`: `handler_no_params!` wrapper

## Verification

- `cargo test --all-features server -- --test-threads=1` (28 server tests), clippy `-D warnings`, fmt — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)