### PR TITLE
perf(providers): parallelize per-workspace DB scans inside VS Code-family scanners

### DIFF
--- a/src-tauri/src/providers/cline.rs
+++ b/src-tauri/src/providers/cline.rs
@@ -40,58 +40,70 @@ pub fn detect() -> Option<ProviderInfo> {
 
 /// Scan all Cline/Roo Code projects
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
-    let mut projects = Vec::new();
-
-    for (base_path, label) in get_all_base_paths() {
-        let task_history = load_task_history(&base_path);
-        if task_history.is_empty() {
-            continue;
-        }
-
-        // Group tasks by cwd
-        let mut by_cwd: HashMap<String, Vec<&Value>> = HashMap::new();
-        for item in &task_history {
-            let cwd = task_cwd(item).unwrap_or("unknown");
-            by_cwd.entry(cwd.to_string()).or_default().push(item);
-        }
-
-        for (cwd, tasks) in &by_cwd {
-            let project_name = PathBuf::from(cwd)
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
-
-            let session_count = tasks.len();
-            let message_count: usize = tasks
-                .iter()
-                .filter_map(|t| t.get("tokensIn").and_then(Value::as_u64))
-                .count()
-                * 2; // rough estimate
-
-            let last_modified = tasks
-                .iter()
-                .filter_map(|t| t.get("ts").and_then(Value::as_f64))
-                .fold(0.0f64, f64::max);
-
-            let last_modified_str = ms_to_iso(last_modified as u64);
-
-            projects.push(ClaudeProject {
-                name: project_name,
-                path: format!("cline://{}:{}", base_path.to_string_lossy(), cwd),
-                actual_path: cwd.clone(),
-                session_count,
-                message_count,
-                last_modified: last_modified_str,
-                git_info: None,
-                provider: Some("cline".to_string()),
-                storage_type: Some("json".to_string()),
-                custom_directory_label: Some(label.clone()),
-            });
-        }
-    }
+    // Each base path may fall back to opening its editor's global state.vscdb
+    // (5s busy_timeout when the editor holds a lock), so the base paths are
+    // scanned on a bounded pool instead of stacking those waits sequentially.
+    let projects = crate::utils::par_map_bounded(get_all_base_paths(), |(base_path, label)| {
+        scan_base_path(&base_path, &label)
+    })
+    .into_iter()
+    .flatten()
+    .collect();
 
     Ok(projects)
+}
+
+/// All projects found under one extension base path (empty when it has no
+/// readable task history).
+fn scan_base_path(base_path: &Path, label: &str) -> Vec<ClaudeProject> {
+    let task_history = load_task_history(base_path);
+    if task_history.is_empty() {
+        return Vec::new();
+    }
+
+    // Group tasks by cwd
+    let mut by_cwd: HashMap<String, Vec<&Value>> = HashMap::new();
+    for item in &task_history {
+        let cwd = task_cwd(item).unwrap_or("unknown");
+        by_cwd.entry(cwd.to_string()).or_default().push(item);
+    }
+
+    let mut projects = Vec::new();
+    for (cwd, tasks) in &by_cwd {
+        let project_name = PathBuf::from(cwd)
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        let session_count = tasks.len();
+        let message_count: usize = tasks
+            .iter()
+            .filter_map(|t| t.get("tokensIn").and_then(Value::as_u64))
+            .count()
+            * 2; // rough estimate
+
+        let last_modified = tasks
+            .iter()
+            .filter_map(|t| t.get("ts").and_then(Value::as_f64))
+            .fold(0.0f64, f64::max);
+
+        let last_modified_str = ms_to_iso(last_modified as u64);
+
+        projects.push(ClaudeProject {
+            name: project_name,
+            path: format!("cline://{}:{}", base_path.to_string_lossy(), cwd),
+            actual_path: cwd.clone(),
+            session_count,
+            message_count,
+            last_modified: last_modified_str,
+            git_info: None,
+            provider: Some("cline".to_string()),
+            storage_type: Some("json".to_string()),
+            custom_directory_label: Some(label.to_string()),
+        });
+    }
+    projects
 }
 
 /// Load sessions for a Cline project

--- a/src-tauri/src/providers/crush.rs
+++ b/src-tauri/src/providers/crush.rs
@@ -57,39 +57,43 @@ pub fn get_base_path() -> Option<String> {
 
 /// Scan Crush projects — one per discovered `<project>/.crush/crush.db`.
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
-    let mut projects = Vec::new();
-    for db_path in discover_dbs(MAX_DBS) {
-        let Some(project_dir) = project_dir_of(&db_path) else {
-            continue;
-        };
-        let Ok(conn) = open_db(&db_path) else {
-            continue;
-        };
-        if let Ok((session_count, message_count, last_modified)) = project_stats(&conn) {
-            if session_count == 0 {
-                continue;
-            }
-            let name = Path::new(&project_dir)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .filter(|n| !n.is_empty())
-                .unwrap_or_else(|| project_dir.clone());
-            projects.push(ClaudeProject {
-                name,
-                path: format!("{SCHEME}{project_dir}"),
-                actual_path: project_dir,
-                session_count,
-                message_count,
-                last_modified,
-                git_info: None,
-                provider: Some(PROVIDER.to_string()),
-                storage_type: Some("sqlite".to_string()),
-                custom_directory_label: None,
-            });
-        }
-    }
+    // Up to MAX_DBS per-project DBs, each open parking up to 5s on a locked
+    // DB — scanned on a bounded pool instead of stacking those waits
+    // sequentially. A broken DB just yields None.
+    let mut projects: Vec<ClaudeProject> =
+        crate::utils::par_map_bounded(discover_dbs(MAX_DBS), |db_path| scan_db(&db_path))
+            .into_iter()
+            .flatten()
+            .collect();
     projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(projects)
+}
+
+/// One `crush.db` → one project, or `None` when the DB is unreadable or empty.
+fn scan_db(db_path: &Path) -> Option<ClaudeProject> {
+    let project_dir = project_dir_of(db_path)?;
+    let conn = open_db(db_path).ok()?;
+    let (session_count, message_count, last_modified) = project_stats(&conn).ok()?;
+    if session_count == 0 {
+        return None;
+    }
+    let name = Path::new(&project_dir)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| project_dir.clone());
+    Some(ClaudeProject {
+        name,
+        path: format!("{SCHEME}{project_dir}"),
+        actual_path: project_dir,
+        session_count,
+        message_count,
+        last_modified,
+        git_info: None,
+        provider: Some(PROVIDER.to_string()),
+        storage_type: Some("sqlite".to_string()),
+        custom_directory_label: None,
+    })
 }
 
 /// Load the sessions for one Crush project (`crush://<project_dir>`).

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -43,74 +43,85 @@ pub fn get_base_path() -> Option<PathBuf> {
 /// Scan Cursor projects by reading workspace directories
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     let base = get_base_path().ok_or("Cursor not found")?;
-    let ws_dir = base.join("workspaceStorage");
+    scan_projects_in(&base.join("workspaceStorage"))
+}
 
+fn scan_projects_in(ws_dir: &Path) -> Result<Vec<ClaudeProject>, String> {
     if !ws_dir.is_dir() {
         return Ok(Vec::new());
     }
 
-    let mut projects = Vec::new();
+    let ws_paths: Vec<PathBuf> = fs::read_dir(ws_dir)
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .map(|entry| entry.path())
+        .collect();
 
-    for entry in fs::read_dir(&ws_dir).map_err(|e| e.to_string())?.flatten() {
-        let ws_path = entry.path();
-        if crate::utils::is_symlink(&ws_path) || !ws_path.is_dir() {
-            continue;
-        }
-
-        // Read workspace.json to get project folder
-        let workspace_json = ws_path.join("workspace.json");
-        let project_folder = match read_workspace_folder(&workspace_json) {
-            Some(f) => f,
-            None => continue,
-        };
-
-        // Read composer list from workspace state DB
-        let ws_db_path = ws_path.join("state.vscdb");
-        let composers = match read_workspace_composers(&ws_db_path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
-        if composers.is_empty() {
-            continue;
-        }
-
-        let project_name = PathBuf::from(&project_folder)
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-
-        let active_composers: Vec<&Value> = composers
-            .iter()
-            .filter(|c| {
-                !c.get("isArchived")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false)
-            })
+    // Each workspace visit opens its own state.vscdb (5s busy_timeout when
+    // locked), so with many workspaces the sequential loop dominated startup.
+    // Bounded parallel map; a broken workspace still just yields None.
+    let mut projects: Vec<ClaudeProject> =
+        crate::utils::par_map_bounded(ws_paths, |ws_path| scan_workspace(&ws_path))
+            .into_iter()
+            .flatten()
             .collect();
-        let session_count = active_composers.len();
-        let last_modified = active_composers
-            .iter()
-            .filter_map(|c| c.get("lastUpdatedAt").and_then(Value::as_f64))
-            .fold(0.0f64, f64::max);
-
-        projects.push(ClaudeProject {
-            name: project_name,
-            path: format!("cursor://{}", ws_path.to_string_lossy()),
-            actual_path: project_folder,
-            session_count,
-            message_count: 0, // Loaded on demand
-            last_modified: ms_to_iso(last_modified as u64),
-            git_info: None,
-            provider: Some("cursor".to_string()),
-            storage_type: Some("sqlite".to_string()),
-            custom_directory_label: None,
-        });
-    }
 
     projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(projects)
+}
+
+/// One workspace dir → one project, or `None` when the workspace has no
+/// (readable) composer data. All failure modes skip the workspace, never the
+/// whole scan.
+fn scan_workspace(ws_path: &Path) -> Option<ClaudeProject> {
+    if crate::utils::is_symlink(ws_path) || !ws_path.is_dir() {
+        return None;
+    }
+
+    // Read workspace.json to get project folder
+    let workspace_json = ws_path.join("workspace.json");
+    let project_folder = read_workspace_folder(&workspace_json)?;
+
+    // Read composer list from workspace state DB
+    let ws_db_path = ws_path.join("state.vscdb");
+    let composers = read_workspace_composers(&ws_db_path).ok()?;
+
+    if composers.is_empty() {
+        return None;
+    }
+
+    let project_name = PathBuf::from(&project_folder)
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let active_composers: Vec<&Value> = composers
+        .iter()
+        .filter(|c| {
+            !c.get("isArchived")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .collect();
+    let session_count = active_composers.len();
+    let last_modified = active_composers
+        .iter()
+        .filter_map(|c| c.get("lastUpdatedAt").and_then(Value::as_f64))
+        .fold(0.0f64, f64::max);
+
+    Some(ClaudeProject {
+        name: project_name,
+        path: format!("cursor://{}", ws_path.to_string_lossy()),
+        actual_path: project_folder,
+        session_count,
+        message_count: 0, // Loaded on demand
+        last_modified: ms_to_iso(last_modified as u64),
+        git_info: None,
+        provider: Some("cursor".to_string()),
+        storage_type: Some("sqlite".to_string()),
+        custom_directory_label: None,
+    })
 }
 
 /// Load sessions (composers) for a Cursor project
@@ -774,5 +785,74 @@ mod tests {
     fn test_empty_bubble() {
         let bubble = json!({"type": 2, "bubbleId": "empty", "text": ""});
         assert!(convert_cursor_bubble(&bubble, 2, "session-1").is_none());
+    }
+
+    /// Write a minimal valid Cursor workspace: `workspace.json` + a `state.vscdb`
+    /// with one active composer.
+    fn write_valid_workspace(ws_path: &Path, folder: &str, last_updated: u64) {
+        fs::create_dir_all(ws_path).unwrap();
+        fs::write(
+            ws_path.join("workspace.json"),
+            format!(r#"{{"folder":"file://{folder}"}}"#),
+        )
+        .unwrap();
+        let conn = Connection::open(ws_path.join("state.vscdb")).unwrap();
+        conn.execute(
+            "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+            [],
+        )
+        .unwrap();
+        let value = json!({
+            "allComposers": [{
+                "composerId": "comp-1",
+                "name": "chat",
+                "createdAt": last_updated,
+                "lastUpdatedAt": last_updated,
+                "isArchived": false
+            }]
+        })
+        .to_string();
+        conn.execute(
+            "INSERT INTO ItemTable (key, value) VALUES ('composer.composerData', ?1)",
+            [&value],
+        )
+        .unwrap();
+    }
+
+    /// One corrupt workspace DB must not fail (or block) the whole scan — the
+    /// valid workspaces still come back, sorted by `last_modified` desc.
+    #[test]
+    fn test_scan_projects_in_tolerates_corrupt_workspace_db() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let ws_dir = tmp.path().join("workspaceStorage");
+
+        write_valid_workspace(
+            &ws_dir.join("hash-old"),
+            "/Users/me/old-proj",
+            1_700_000_000_000,
+        );
+        write_valid_workspace(
+            &ws_dir.join("hash-new"),
+            "/Users/me/new-proj",
+            1_800_000_000_000,
+        );
+
+        // Corrupt workspace: workspace.json is fine but state.vscdb is garbage.
+        let broken = ws_dir.join("hash-broken");
+        fs::create_dir_all(&broken).unwrap();
+        fs::write(
+            broken.join("workspace.json"),
+            r#"{"folder":"file:///Users/me/broken-proj"}"#,
+        )
+        .unwrap();
+        fs::write(broken.join("state.vscdb"), b"this is not a sqlite database").unwrap();
+
+        let projects = scan_projects_in(&ws_dir).unwrap();
+        let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["new-proj", "old-proj"],
+            "valid workspaces survive a corrupt sibling, newest first: {names:?}"
+        );
     }
 }

--- a/src-tauri/src/providers/trae.rs
+++ b/src-tauri/src/providers/trae.rs
@@ -152,39 +152,49 @@ pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     let Some(storage) = workspace_storage() else {
         return Ok(vec![]);
     };
-    let mut projects = Vec::new();
-    for (hash, db_path) in workspace_dbs(&storage) {
-        let Ok(conn) = open_db(&db_path) else {
-            continue;
-        };
-        let Some(value) = read_icube_value(&conn) else {
-            continue;
-        };
-        let sessions = extract_sessions(&value);
-        if sessions.is_empty() {
-            continue;
-        }
-        let folder = workspace_folder(&db_path).unwrap_or_else(|| hash.clone());
-        let name = Path::new(&folder)
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .filter(|n| !n.is_empty())
-            .unwrap_or_else(|| folder.clone());
-        let message_count: usize = sessions.iter().map(|s| s.messages.len()).sum();
-        projects.push(ClaudeProject {
-            name,
-            path: format!("{SCHEME}{hash}"),
-            actual_path: folder,
-            session_count: sessions.len(),
-            message_count,
-            last_modified: String::new(),
-            git_info: None,
-            provider: Some(PROVIDER.to_string()),
-            storage_type: Some("sqlite".to_string()),
-            custom_directory_label: None,
-        });
+    Ok(scan_projects_in(&storage))
+}
+
+fn scan_projects_in(storage: &Path) -> Vec<ClaudeProject> {
+    // One state.vscdb open per workspace (5s busy_timeout when locked) — with
+    // many workspaces the sequential loop dominated startup. Bounded parallel
+    // map, input order preserved; a broken workspace DB just yields None.
+    crate::utils::par_map_bounded(workspace_dbs(storage), |(hash, db_path)| {
+        scan_workspace(&hash, &db_path)
+    })
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+/// One workspace `(hash, state.vscdb)` → one project, or `None` when the DB is
+/// unreadable or has no parseable chat sessions.
+fn scan_workspace(hash: &str, db_path: &Path) -> Option<ClaudeProject> {
+    let conn = open_db(db_path).ok()?;
+    let value = read_icube_value(&conn)?;
+    let sessions = extract_sessions(&value);
+    if sessions.is_empty() {
+        return None;
     }
-    Ok(projects)
+    let folder = workspace_folder(db_path).unwrap_or_else(|| hash.to_string());
+    let name = Path::new(&folder)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| folder.clone());
+    let message_count: usize = sessions.iter().map(|s| s.messages.len()).sum();
+    Some(ClaudeProject {
+        name,
+        path: format!("{SCHEME}{hash}"),
+        actual_path: folder,
+        session_count: sessions.len(),
+        message_count,
+        last_modified: String::new(),
+        git_info: None,
+        provider: Some(PROVIDER.to_string()),
+        storage_type: Some("sqlite".to_string()),
+        custom_directory_label: None,
+    })
 }
 
 /// Load the chat sessions for one Trae workspace (`trae://<hash>`).
@@ -598,5 +608,52 @@ mod tests {
         assert!(!valid_hash("a/b"));
         assert!(!valid_hash("a\\b"));
         assert!(!valid_hash(""));
+    }
+
+    /// A corrupt workspace state.vscdb must not fail the whole scan — valid
+    /// sibling workspaces still come back.
+    #[test]
+    fn scan_projects_in_tolerates_corrupt_workspace_db() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Valid workspace: real SQLite ItemTable with an icube session list.
+        let ok_ws = tmp.path().join("hash-ok");
+        std::fs::create_dir_all(&ok_ws).unwrap();
+        {
+            let conn = Connection::open(ok_ws.join("state.vscdb")).unwrap();
+            conn.execute(
+                "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+            let value = json!({
+                "list": [{
+                    "id": "sess-1",
+                    "title": "Fix bug",
+                    "messages": [{ "role": "user", "content": "hello" }]
+                }]
+            })
+            .to_string();
+            conn.execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('memento/icube-ai-agent-storage', ?1)",
+                [&value],
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            ok_ws.join("workspace.json"),
+            r#"{"folder":"file:///Users/me/ok-proj"}"#,
+        )
+        .unwrap();
+
+        // Corrupt workspace: state.vscdb is not a SQLite file at all.
+        let bad_ws = tmp.path().join("hash-bad");
+        std::fs::create_dir_all(&bad_ws).unwrap();
+        std::fs::write(bad_ws.join("state.vscdb"), b"this is not a sqlite database").unwrap();
+
+        let projects = scan_projects_in(tmp.path());
+        assert_eq!(projects.len(), 1, "only the valid workspace: {projects:?}");
+        assert_eq!(projects[0].name, "ok-proj");
+        assert_eq!(projects[0].session_count, 1);
     }
 }

--- a/src-tauri/src/providers/vscode.rs
+++ b/src-tauri/src/providers/vscode.rs
@@ -264,87 +264,110 @@ fn scan_projects_in(
         return Ok(Vec::new());
     }
 
+    let ws_paths: Vec<PathBuf> = fs::read_dir(ws_root)
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .map(|entry| entry.path())
+        .collect();
+
+    // Probing every chatSessions/*.jsonl per workspace is I/O-heavy, so the
+    // per-workspace work runs on a bounded pool. Order-preserving, and the
+    // sequential loop's error semantics are kept: an unreadable chatSessions
+    // dir still fails the scan (first error in input order), while workspaces
+    // without usable sessions are skipped.
+    let results = crate::utils::par_map_bounded(ws_paths, |ws_path| {
+        scan_workspace(&ws_path, custom_directory_label)
+    });
+
     let mut projects = Vec::new();
-
-    for entry in fs::read_dir(ws_root).map_err(|e| e.to_string())?.flatten() {
-        let ws_path = entry.path();
-        if is_symlink(&ws_path) || !ws_path.is_dir() {
-            continue;
+    for result in results {
+        if let Some(project) = result? {
+            projects.push(project);
         }
-
-        let folder = match read_workspace_folder(&ws_path.join("workspace.json")) {
-            Some(f) => f,
-            None => continue,
-        };
-
-        let chat_dir = ws_path.join("chatSessions");
-        if !chat_dir.is_dir() {
-            continue;
-        }
-
-        let mut session_count = 0usize;
-        let mut last_modified_ms: u64 = 0;
-        let mut message_count = 0usize;
-
-        for chat_entry in fs::read_dir(&chat_dir)
-            .map_err(|e| e.to_string())?
-            .flatten()
-        {
-            let session_path = chat_entry.path();
-            if is_symlink(&session_path) || !session_path.is_file() {
-                continue;
-            }
-            if session_path
-                .extension()
-                .and_then(|e| e.to_str())
-                .map(str::to_ascii_lowercase)
-                .as_deref()
-                != Some("jsonl")
-            {
-                continue;
-            }
-
-            let info = match probe_session_metadata(&session_path) {
-                Some(i) => i,
-                None => continue,
-            };
-            // Empty chat panels (kind:0 with requests:[]) should not be
-            // counted as sessions or contribute to the project's tally.
-            if info.message_count == 0 {
-                continue;
-            }
-            session_count += 1;
-            message_count += info.message_count;
-            if info.last_modified_ms > last_modified_ms {
-                last_modified_ms = info.last_modified_ms;
-            }
-        }
-
-        if session_count == 0 {
-            continue;
-        }
-
-        let name = PathBuf::from(&folder)
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| folder.clone());
-
-        projects.push(ClaudeProject {
-            name,
-            path: format!("vscode://{}", ws_path.to_string_lossy()),
-            actual_path: folder,
-            session_count,
-            message_count,
-            last_modified: ms_to_iso(last_modified_ms),
-            git_info: None,
-            provider: Some(PROVIDER_ID.to_string()),
-            storage_type: None,
-            custom_directory_label: custom_directory_label.map(ToString::to_string),
-        });
     }
 
     projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(projects)
+}
+
+/// One workspace dir → one project (`Ok(None)` = no usable chat sessions,
+/// `Err` = the chatSessions dir exists but cannot be read).
+fn scan_workspace(
+    ws_path: &Path,
+    custom_directory_label: Option<&str>,
+) -> Result<Option<ClaudeProject>, String> {
+    if is_symlink(ws_path) || !ws_path.is_dir() {
+        return Ok(None);
+    }
+
+    let Some(folder) = read_workspace_folder(&ws_path.join("workspace.json")) else {
+        return Ok(None);
+    };
+
+    let chat_dir = ws_path.join("chatSessions");
+    if !chat_dir.is_dir() {
+        return Ok(None);
+    }
+
+    let mut session_count = 0usize;
+    let mut last_modified_ms: u64 = 0;
+    let mut message_count = 0usize;
+
+    for chat_entry in fs::read_dir(&chat_dir)
+        .map_err(|e| e.to_string())?
+        .flatten()
+    {
+        let session_path = chat_entry.path();
+        if is_symlink(&session_path) || !session_path.is_file() {
+            continue;
+        }
+        if session_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+            != Some("jsonl")
+        {
+            continue;
+        }
+
+        let info = match probe_session_metadata(&session_path) {
+            Some(i) => i,
+            None => continue,
+        };
+        // Empty chat panels (kind:0 with requests:[]) should not be
+        // counted as sessions or contribute to the project's tally.
+        if info.message_count == 0 {
+            continue;
+        }
+        session_count += 1;
+        message_count += info.message_count;
+        if info.last_modified_ms > last_modified_ms {
+            last_modified_ms = info.last_modified_ms;
+        }
+    }
+
+    if session_count == 0 {
+        return Ok(None);
+    }
+
+    let name = PathBuf::from(&folder)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| folder.clone());
+
+    Ok(Some(ClaudeProject {
+        name,
+        path: format!("vscode://{}", ws_path.to_string_lossy()),
+        actual_path: folder,
+        session_count,
+        message_count,
+        last_modified: ms_to_iso(last_modified_ms),
+        git_info: None,
+        provider: Some(PROVIDER_ID.to_string()),
+        storage_type: None,
+        custom_directory_label: custom_directory_label.map(ToString::to_string),
+    }))
 }
 
 /// Sessions for a single workspace.

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -435,6 +435,49 @@ pub fn ms_to_iso(ms: u64) -> String {
         .unwrap_or_default()
 }
 
+/// Max threads a single provider scanner may use for its per-workspace work.
+/// ~27 scanners already run concurrently on the blocking pool (#434), so each
+/// one stays modest instead of grabbing every core.
+const MAX_SCAN_THREADS: usize = 8;
+
+/// Map `f` over `items` in parallel on a small dedicated rayon pool,
+/// preserving input order in the returned `Vec`.
+///
+/// Built for provider scanners that visit one `SQLite` DB (or session dir) per
+/// workspace: each visit can park up to `busy_timeout` on a locked DB, so
+/// running them sequentially makes startup scale with the workspace count
+/// (dozens of workspaces × 5s worst case). A *dedicated* pool — not rayon's
+/// global one — keeps those parked waits from starving other scanners'
+/// `par_iter` work, and is capped at `min(MAX_SCAN_THREADS, cores)`.
+///
+/// Falls back to a plain sequential map when there is at most one item or the
+/// pool cannot be built, so callers never gain a new failure mode.
+pub fn par_map_bounded<T, R, F>(items: Vec<T>, f: F) -> Vec<R>
+where
+    T: Send,
+    R: Send,
+    F: Fn(T) -> R + Sync + Send,
+{
+    let threads = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1)
+        .min(MAX_SCAN_THREADS);
+
+    if items.len() <= 1 || threads <= 1 {
+        return items.into_iter().map(f).collect();
+    }
+
+    match rayon::ThreadPoolBuilder::new().num_threads(threads).build() {
+        Ok(pool) => {
+            use rayon::prelude::*;
+            // `into_par_iter` on a Vec is indexed, so `collect` preserves the
+            // input order — callers keep their pre-parallel ordering semantics.
+            pool.install(|| items.into_par_iter().map(f).collect())
+        }
+        Err(_) => items.into_iter().map(f).collect(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Build a `ClaudeMessage` with common defaults for provider implementations.
 ///
@@ -591,6 +634,21 @@ fn collect_workflow_agent_files(workflows_dir: &Path, files: &mut Vec<std::path:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ===== par_map_bounded Tests =====
+
+    #[test]
+    fn test_par_map_bounded_preserves_input_order() {
+        let items: Vec<usize> = (0..100).collect();
+        let out = par_map_bounded(items, |i| i * 2);
+        assert_eq!(out, (0..100).map(|i| i * 2).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_par_map_bounded_handles_empty_and_single() {
+        assert!(par_map_bounded(Vec::<u8>::new(), |i| i).is_empty());
+        assert_eq!(par_map_bounded(vec![7u8], |i| i + 1), vec![8]);
+    }
 
     // ===== Line Utils Tests =====
 


### PR DESCRIPTION
## Summary

Backlog item from the data-scaling audit. #434 parallelized scanning ACROSS providers, but inside the VS Code-family scanners every `workspaceStorage/*` directory was still visited sequentially, each opening a per-workspace SQLite DB with a 5s busy_timeout — dozens of workspaces with the editor holding locks stack into tens of seconds inside one scanner, and the whole startup scan is only as fast as its slowest provider.

## Changes

- New `utils::par_map_bounded`: order-preserving parallel map on a **dedicated** rayon pool capped at `min(8, cores)` — dedicated so threads parked in SQLite busy-waits can't starve the ~27 concurrently running scanners on the global pool. Sequential fallback for ≤1 item or pool-build failure.
- Applied to the five scanners that actually had the pattern (verified individually): `cursor` (per-workspace `state.vscdb`), `vscode` (per-workspace `chatSessions` probing), `trae` (per-workspace DB), `cline` (per-extension globalStorage DBs), `crush` (per-project `crush.db`, up to 200).
- Ordering semantics preserved (indexed collect keeps input order; existing post-sorts unchanged; `vscode`'s first-error propagation re-checked in input order).
- Skip-and-continue on broken DBs preserved everywhere; no public signature changes.
- `busy_timeout` deliberately left at 5s: the open helpers are shared with interactive load paths, and lowering it risks silently omitting projects during legitimate writes/WAL checkpoints. Bounded parallelism already collapses the worst case from `N × 5s` to `ceil(N/8) × 5s`.

## Tests

- `par_map_bounded` order/empty/single tests
- `cursor`: two valid workspaces + one corrupt `state.vscdb` → both valid projects returned, newest first
- `trae`: valid workspace + non-SQLite garbage sibling → valid project returned

## Gates

`cargo test -- --test-threads=1` 823 passed, `--all-features` 865 passed, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Project discovery is now faster through bounded parallel scanning across supported coding-assistant data sources.
  * Results remain consistently ordered by most recent activity.

* **Bug Fixes**
  * Invalid or unreadable project data is skipped without preventing other valid projects from appearing.
  * Empty or unusable sessions are excluded from project results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->