### PR TITLE
fix(header): 支持从会话标识复制 ID 和恢复命令

### DIFF
--- a/src/components/SessionItem/hooks/useSessionEditing.ts
+++ b/src/components/SessionItem/hooks/useSessionEditing.ts
@@ -15,32 +15,7 @@ import {
   supportsSessionDeletion as providerSupportsSessionDeletion,
 } from "@/utils/providers";
 import type { ClaudeSession } from "@/types";
-
-function legacyCopy(text: string): void {
-  let copied = false;
-
-  const handleCopy = (event: ClipboardEvent) => {
-    event.preventDefault();
-    if (!event.clipboardData) {
-      return;
-    }
-
-    event.clipboardData.setData("text/plain", text);
-    copied = true;
-  };
-
-  try {
-    document.addEventListener("copy", handleCopy);
-    if (typeof document.execCommand !== "function" || !document.execCommand("copy")) {
-      throw new Error("Clipboard unavailable");
-    }
-    if (!copied) {
-      throw new Error("Clipboard payload unavailable");
-    }
-  } finally {
-    document.removeEventListener("copy", handleCopy);
-  }
-}
+import { copyTextToClipboard } from "@/utils/clipboard";
 
 export function useSessionEditing(session: ClaudeSession) {
   const { t } = useTranslation();
@@ -189,15 +164,7 @@ export function useSessionEditing(session: ClaudeSession) {
       e.stopPropagation();
       setIsContextMenuOpen(false);
       try {
-        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
-          try {
-            await navigator.clipboard.writeText(text);
-          } catch {
-            legacyCopy(text);
-          }
-        } else {
-          legacyCopy(text);
-        }
+        await copyTextToClipboard(text);
         toast.success(successMsg);
       } catch {
         toast.error(t("copyButton.error", "Copy failed"));

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -5,7 +5,6 @@ import {
   MessageSquare,
   Activity,
   FileEdit,
-  Terminal,
   SlidersHorizontal,
   Columns,
   Search,
@@ -22,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { getAssetPath, isMacOS, isTauri } from "@/utils/platform";
 import { SettingDropdown } from "./SettingDropdown";
+import { SessionCopyMenu } from "./SessionCopyMenu";
 
 interface HeaderProps {
   analyticsActions: UseAnalyticsReturn["actions"];
@@ -152,16 +152,19 @@ export const Header = ({ analyticsActions, analyticsComputed, updater }: HeaderP
 
       {/* Center: Quick Stats (when session selected) */}
       {selectedSession && computed.isMessagesView && (
-        <div className="relative z-10 hidden lg:flex items-center gap-2 pointer-events-none">
-          <Terminal className="w-3.5 h-3.5 text-muted-foreground" />
-          <span className="text-2xs text-muted-foreground font-mono">
-            {selectedSession.actual_session_id.slice(0, 8)}
-          </span>
+        <div className="relative z-10 hidden lg:flex items-center gap-2">
+          <SessionCopyMenu project={selectedProject} session={selectedSession} />
         </div>
       )}
 
       {/* Right: Actions */}
       <div className="relative z-10 flex items-center gap-1">
+        {selectedSession && computed.isMessagesView && (
+          <div className="lg:hidden">
+            <SessionCopyMenu compact project={selectedProject} session={selectedSession} />
+          </div>
+        )}
+
         {/* Search button with shortcut hint */}
         <button
           onClick={() => openModal("globalSearch")}

--- a/src/layouts/Header/SessionCopyMenu.test.tsx
+++ b/src/layouts/Header/SessionCopyMenu.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ClaudeProject, ClaudeSession } from "@/types";
+import { SessionCopyMenu } from "./SessionCopyMenu";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? "",
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: React.PropsWithChildren<{ onSelect?: () => void }>) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+}));
+
+const session: ClaudeSession = {
+  session_id: "session-id",
+  actual_session_id: "019f0000-1111-7222-8333-444455556666",
+  file_path: "/Users/test/.codex/sessions/session.jsonl",
+  project_name: "project",
+  message_count: 10,
+  first_message_time: "2026-07-06T00:00:00Z",
+  last_message_time: "2026-07-06T01:00:00Z",
+  last_modified: "2026-07-06T01:00:00Z",
+  has_tool_use: true,
+  has_errors: false,
+  provider: "codex",
+};
+
+const project: ClaudeProject = {
+  name: "project",
+  path: "/Users/test/.codex/sessions",
+  actual_path: "/Users/test/project",
+  session_count: 1,
+  message_count: 10,
+  last_modified: "2026-07-06T01:00:00Z",
+  provider: "codex",
+};
+
+describe("SessionCopyMenu", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("offers separate copy actions for the full id and resume command", async () => {
+    render(<SessionCopyMenu project={project} session={session} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Session ID" }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(session.actual_session_id);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Resume Command" }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "cd '/Users/test/project' && codex resume 019f0000-1111-7222-8333-444455556666",
+      );
+    });
+    expect(screen.getByText("019f0000")).toBeInTheDocument();
+  });
+
+  it("only offers the id action when the provider cannot resume", async () => {
+    render(
+      <SessionCopyMenu
+        project={{ ...project, provider: "aider" }}
+        session={{ ...session, provider: "aider" }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Copy Resume Command" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Copy Session ID" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(session.actual_session_id);
+    });
+  });
+
+  it("renders an accessible compact trigger", () => {
+    render(<SessionCopyMenu compact project={project} session={session} />);
+
+    expect(
+      screen.getByRole("button", { name: "Copy Session ID / Copy Resume Command…" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("019f0000")).not.toBeInTheDocument();
+  });
+});

--- a/src/layouts/Header/SessionCopyMenu.tsx
+++ b/src/layouts/Header/SessionCopyMenu.tsx
@@ -1,0 +1,103 @@
+import { ChevronDown, Copy, Terminal } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import type { ClaudeProject, ClaudeSession } from "@/types";
+import { copyTextToClipboard } from "@/utils/clipboard";
+import { getResumeCommand } from "@/utils/providers";
+
+interface SessionCopyMenuProps {
+  project: ClaudeProject | null;
+  session: ClaudeSession;
+  compact?: boolean;
+}
+
+export const SessionCopyMenu = ({
+  project,
+  session,
+  compact = false,
+}: SessionCopyMenuProps) => {
+  const { t } = useTranslation();
+  const providerId = session.provider ?? project?.provider ?? "claude";
+  const resumeCommand = getResumeCommand(
+    providerId,
+    session.actual_session_id,
+    project?.actual_path,
+    session.entrypoint,
+  );
+  const copySessionIdLabel = t("session.copySessionId", "Copy Session ID");
+  const triggerLabel = `${resumeCommand
+    ? `${copySessionIdLabel} / ${t("session.copyResumeCommand", "Copy Resume Command")}`
+    : copySessionIdLabel}…`;
+
+  const copyToClipboard = async (text: string, successMessage: string) => {
+    try {
+      await copyTextToClipboard(text);
+      toast.success(successMessage);
+    } catch {
+      toast.error(t("copyButton.error", "Copy failed"));
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={triggerLabel}
+          title={triggerLabel}
+          className={cn(
+            "inline-flex items-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+            compact ? "p-2" : "gap-1.5 px-2 py-1 text-2xs font-mono",
+          )}
+        >
+          <Terminal className={compact ? "h-4 w-4" : "h-3.5 w-3.5"} />
+          {!compact && (
+            <>
+              <span>{session.actual_session_id.slice(0, 8)}</span>
+              <ChevronDown className="h-3 w-3 opacity-60" />
+            </>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onSelect={() => {
+            void copyToClipboard(
+              session.actual_session_id,
+              t("session.copiedSessionId", "Session ID copied"),
+            );
+          }}
+        >
+          <Copy className="mr-2 h-4 w-4" />
+          {copySessionIdLabel}
+        </DropdownMenuItem>
+        {resumeCommand && (
+          <DropdownMenuItem
+            onSelect={() => {
+              void copyToClipboard(
+                resumeCommand,
+                project?.actual_path
+                  ? t("session.copiedResumeCommand", "Resume command copied")
+                  : t(
+                      "session.copiedResumeCommandNoCwd",
+                      "Resume command copied (working directory unknown)",
+                    ),
+              );
+            }}
+          >
+            <Terminal className="mr-2 h-4 w-4" />
+            {t("session.copyResumeCommand", "Copy Resume Command")}
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,39 @@
+function legacyCopy(text: string): void {
+  let copied = false;
+
+  const handleCopy = (event: ClipboardEvent) => {
+    event.preventDefault();
+    if (!event.clipboardData) {
+      return;
+    }
+
+    event.clipboardData.setData("text/plain", text);
+    copied = true;
+  };
+
+  try {
+    document.addEventListener("copy", handleCopy);
+    if (typeof document.execCommand !== "function" || !document.execCommand("copy")) {
+      throw new Error("Clipboard unavailable");
+    }
+    if (!copied) {
+      throw new Error("Clipboard payload unavailable");
+    }
+  } finally {
+    document.removeEventListener("copy", handleCopy);
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      legacyCopy(text);
+      return;
+    }
+  }
+
+  legacyCopy(text);
+}


### PR DESCRIPTION
## 修改内容与原因

点击全局搜索结果后，主内容区可以正常打开并定位目标会话，但左侧项目树不会同步展开或滚动到对应会话。会话较多时，目标行仍不可见，因此无法使用左侧右键菜单中的复制入口。

本 PR 将标题栏中已有的 8 位会话标识改为操作菜单，提供：

- 复制完整 Session ID
- provider 支持时，复制带工作目录的恢复命令
- 在窄窗口中显示紧凑入口

实现复用现有的 `getResumeCommand`、多语言文案和剪贴板降级逻辑，不修改全局搜索或项目树的状态管理。

Refs #331
Refs #390

## 类型

- [x] Bug fix
- [ ] New feature
- [ ] New provider
- [ ] Refactor / perf
- [ ] Docs

## 验证

- [x] `pnpm exec vitest run`（73 个测试文件，919 项测试通过）
- [x] `pnpm exec tsc --build .`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm run i18n:validate`
- [x] 未增加新的用户可见字符串，复用现有 5 种语言的 key

## Checklist

- [x] PR 目标分支为 `develop`
- [x] 已为变更行为补充测试
- [x] TypeScript 与 lint 检查通过
- [x] i18n 校验通过

## 后端命令

本次修改未增加前端可调用的后端命令。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a session menu for copying session IDs and available resume commands.
  * Added compact and full header layouts for session copy actions.
  * Improved clipboard copying across modern and legacy browser support.

* **Bug Fixes**
  * Preserved success and error notifications when copying session information.

* **Tests**
  * Added coverage for session ID copying, resume commands, unsupported resume providers, and compact menu accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->