### PR TITLE
fix(rename): allow renaming sessions under depth-1 symlinked project dirs

### DIFF
--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -341,9 +341,13 @@ fn allowed_claude_roots() -> Vec<PathBuf> {
 ///
 /// Security checks performed:
 /// 1. Path must be absolute
-/// 2. No symlinks allowed in any path component
-/// 3. Filename must match pattern ^[A-Za-z0-9_-]+$
-/// 4. Canonical path must live under one of the allowed Claude roots
+/// 2. Filename must match pattern ^[A-Za-z0-9_-]+$
+/// 3. Path must be lexically under an allowed root's `projects/` folder, with no
+///    `.`/`..` traversal components
+/// 4. Depth-1 symlink policy (matches `scan_projects`, #277): the project
+///    directory may be a symlink to a directory (this is how shared sessions are
+///    linked in), but `projects/` and everything below the project directory must
+///    be symlink-free, and the session path must resolve to a regular file
 fn validate_claude_path(file_path: &str) -> Result<(), String> {
     validate_claude_path_with_roots(file_path, &allowed_claude_roots())
 }
@@ -361,65 +365,104 @@ fn validate_claude_path_with_roots(
         );
     }
 
-    // 2. Block symlinks in path components
-    // Check each ancestor for symlinks before canonicalizing
-    let mut current = file_path_buf.as_path();
-    while let Some(parent) = current.parent() {
-        if parent.as_os_str().is_empty() {
-            break;
-        }
-        // Use symlink_metadata to avoid following symlinks
-        if let Ok(metadata) = fs::symlink_metadata(parent) {
-            if metadata.file_type().is_symlink() {
-                return Err(RenameError::PermissionDenied(
-                    "Symlinks are not allowed in path".to_string(),
-                )
-                .to_string());
-            }
-        }
-        current = parent;
-    }
-
-    // Also check the final file itself for symlinks
-    if let Ok(metadata) = fs::symlink_metadata(&file_path_buf) {
-        if metadata.file_type().is_symlink() {
-            return Err(
-                RenameError::PermissionDenied("File path cannot be a symlink".to_string())
-                    .to_string(),
-            );
-        }
-    }
-
-    // 3. Validate filename pattern
-    if let Some(filename) = file_path_buf.file_stem() {
-        let filename_str = filename.to_string_lossy();
-        if !FILENAME_REGEX.is_match(&filename_str) {
-            return Err(RenameError::PermissionDenied(
-                "Filename must contain only alphanumeric characters, underscores, and hyphens"
-                    .to_string(),
-            )
-            .to_string());
-        }
-    } else {
+    // 2. Validate filename pattern
+    let Some(stem) = file_path_buf.file_stem() else {
         return Err(RenameError::PermissionDenied("Invalid filename".to_string()).to_string());
-    }
-
-    // Canonicalize to resolve .. components (symlinks already blocked above)
-    let canonical_path = file_path_buf
-        .canonicalize()
-        .map_err(|e| RenameError::IoError(e.to_string()).to_string())?;
-
-    // Verify the file lives under one of the allowed Claude roots (~/.claude or
-    // a custom Claude directory the user registered).
-    if !allowed_roots
-        .iter()
-        .any(|root| canonical_path.starts_with(root))
-    {
+    };
+    if !FILENAME_REGEX.is_match(&stem.to_string_lossy()) {
         return Err(RenameError::PermissionDenied(
-            "File path must be within ~/.claude or a registered custom Claude directory"
+            "Filename must contain only alphanumeric characters, underscores, and hyphens"
                 .to_string(),
         )
         .to_string());
+    }
+
+    // 3. The file must sit under an allowed root's `projects/` directory. Match
+    // lexically: the path from the root down to `projects/` is always real, so
+    // the only symlink (if any) is the project directory just below it.
+    let Some((projects_dir, relative)) = allowed_roots.iter().find_map(|root| {
+        let projects_dir = root.join("projects");
+        file_path_buf
+            .strip_prefix(&projects_dir)
+            .ok()
+            .map(|rel| (projects_dir, rel.to_path_buf()))
+    }) else {
+        return Err(RenameError::PermissionDenied(
+            "File path must be within the projects/ folder of ~/.claude or a registered custom \
+             Claude directory"
+                .to_string(),
+        )
+        .to_string());
+    };
+
+    // 4. Reject path traversal: every component under `projects/` must be a plain
+    // name (no `.` / `..` / prefixes), and there must be at least
+    // `<project>/<session>.jsonl`.
+    let components: Vec<std::path::Component> = relative.components().collect();
+    if components.len() < 2
+        || !components
+            .iter()
+            .all(|c| matches!(c, std::path::Component::Normal(_)))
+    {
+        return Err(RenameError::PermissionDenied(
+            "Invalid session path under projects/".to_string(),
+        )
+        .to_string());
+    }
+
+    // 5. `projects/` itself must be a real directory, never a symlink (mirrors
+    // validate_custom_claude_path).
+    if fs::symlink_metadata(&projects_dir)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return Err(
+            RenameError::PermissionDenied("projects/ must not be a symlink".to_string())
+                .to_string(),
+        );
+    }
+
+    // 6. Depth-1 symlink policy (matches scan_projects, #277): the project
+    // directory (first component under `projects/`) may be a symlink that
+    // resolves to a directory — this is how shared sessions are linked in — but
+    // nothing deeper may be a symlink, and the target must be a real file.
+    let project_dir = projects_dir.join(components[0]);
+    let project_meta = fs::symlink_metadata(&project_dir)
+        .map_err(|e| RenameError::IoError(e.to_string()).to_string())?;
+    if project_meta.file_type().is_symlink() {
+        if !project_dir.is_dir() {
+            return Err(RenameError::PermissionDenied(
+                "Project directory symlink does not resolve to a directory".to_string(),
+            )
+            .to_string());
+        }
+    } else if !project_meta.is_dir() {
+        return Err(
+            RenameError::PermissionDenied("Project path is not a directory".to_string())
+                .to_string(),
+        );
+    }
+
+    // Every component below the project directory must be symlink-free, and the
+    // session path must resolve to a regular file.
+    let mut current = project_dir;
+    let deeper = &components[1..];
+    for (i, comp) in deeper.iter().enumerate() {
+        current.push(comp);
+        let meta = fs::symlink_metadata(&current)
+            .map_err(|e| RenameError::IoError(e.to_string()).to_string())?;
+        if meta.file_type().is_symlink() {
+            return Err(RenameError::PermissionDenied(
+                "Symlinks are not allowed below the project directory".to_string(),
+            )
+            .to_string());
+        }
+        if i + 1 == deeper.len() && !meta.is_file() {
+            return Err(RenameError::PermissionDenied(
+                "Session path is not a regular file".to_string(),
+            )
+            .to_string());
+        }
     }
 
     Ok(())
@@ -1504,6 +1547,115 @@ mod tests {
                 "the default ~/.claude root must always be allowed"
             );
         }
+    }
+
+    #[cfg(unix)]
+    fn symlink_dir(target: &Path, link: &Path) {
+        std::os::unix::fs::symlink(target, link).unwrap();
+    }
+    #[cfg(windows)]
+    fn symlink_dir(target: &Path, link: &Path) {
+        std::os::windows::fs::symlink_dir(target, link).unwrap();
+    }
+
+    #[test]
+    fn validate_claude_path_accepts_symlinked_project_directory() {
+        // Mirrors the shared-sessions layout: a project directory under
+        // <root>/projects is a symlink into a real directory elsewhere (e.g.
+        // /Users/Shared/.claude/projects). The session file is a real file.
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = real_temp_root(&temp).join(".claude");
+        fs::create_dir_all(root.join("projects")).unwrap();
+
+        let shared = real_temp_root(&temp).join("shared").join("-Shared-proj");
+        fs::create_dir_all(&shared).unwrap();
+        let session = shared.join("session-1.jsonl");
+        fs::write(&session, "{}\n").unwrap();
+
+        // <root>/projects/-Shared-proj -> <temp>/shared/-Shared-proj
+        symlink_dir(&shared, &root.join("projects").join("-Shared-proj"));
+
+        let session_path = root
+            .join("projects")
+            .join("-Shared-proj")
+            .join("session-1.jsonl")
+            .to_string_lossy()
+            .to_string();
+        let roots = resolve_claude_roots(&[root.to_string_lossy().to_string()]);
+        assert!(
+            validate_claude_path_with_roots(&session_path, &roots).is_ok(),
+            "a session under a depth-1 symlinked project directory must be renameable"
+        );
+    }
+
+    #[test]
+    fn validate_claude_path_rejects_symlink_below_project_directory() {
+        // A symlink deeper than the project directory is not allowed.
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = real_temp_root(&temp).join(".claude");
+        let project_dir = root.join("projects").join("-proj");
+        fs::create_dir_all(&project_dir).unwrap();
+
+        let elsewhere = real_temp_root(&temp).join("elsewhere");
+        fs::create_dir_all(&elsewhere).unwrap();
+        fs::write(elsewhere.join("session-1.jsonl"), "{}\n").unwrap();
+
+        // <root>/projects/-proj/subdir -> <temp>/elsewhere  (symlink below depth 1)
+        symlink_dir(&elsewhere, &project_dir.join("subdir"));
+
+        let session_path = project_dir
+            .join("subdir")
+            .join("session-1.jsonl")
+            .to_string_lossy()
+            .to_string();
+        let roots = resolve_claude_roots(&[root.to_string_lossy().to_string()]);
+        assert!(
+            validate_claude_path_with_roots(&session_path, &roots).is_err(),
+            "symlinks below the project directory must stay rejected"
+        );
+    }
+
+    #[test]
+    fn validate_claude_path_rejects_symlinked_session_file() {
+        // The session file itself must be a real file, not a symlink.
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = real_temp_root(&temp).join(".claude");
+        let project_dir = root.join("projects").join("-proj");
+        fs::create_dir_all(&project_dir).unwrap();
+
+        let real_file = real_temp_root(&temp).join("target.jsonl");
+        fs::write(&real_file, "{}\n").unwrap();
+        let link = project_dir.join("session-1.jsonl");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_file, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&real_file, &link).unwrap();
+
+        let roots = resolve_claude_roots(&[root.to_string_lossy().to_string()]);
+        assert!(
+            validate_claude_path_with_roots(&link.to_string_lossy(), &roots).is_err(),
+            "a symlinked session file must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_claude_path_rejects_path_traversal_under_projects() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = real_temp_root(&temp).join(".claude");
+        fs::create_dir_all(root.join("projects")).unwrap();
+
+        let traversal = root
+            .join("projects")
+            .join("..")
+            .join("evil")
+            .join("session-1.jsonl")
+            .to_string_lossy()
+            .to_string();
+        let roots = resolve_claude_roots(&[root.to_string_lossy().to_string()]);
+        assert!(
+            validate_claude_path_with_roots(&traversal, &roots).is_err(),
+            "`..` traversal under projects/ must be rejected"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -324,10 +324,23 @@ fn resolve_claude_roots(configured: &[String]) -> Vec<PathBuf> {
 
 /// Push a root, resolved to its canonical form so it compares correctly against
 /// the canonicalized file path. Duplicates are skipped.
+/// Add an allowed Claude root. A root that is itself a symlink is rejected, so a
+/// symlinked `~/.claude` cannot smuggle its target into the allowlist and bypass
+/// the "only the project directory may be a symlink" policy.
+///
+/// The path is stored as-is (not canonicalized): `validate_claude_path_with_roots`
+/// compares it lexically against the raw request path, so both sides must use the
+/// same representation. Canonicalizing here would break that on Windows, where
+/// `canonicalize()` yields the `\\?\` verbatim form.
 fn push_root(roots: &mut Vec<PathBuf>, path: PathBuf) {
-    let resolved = path.canonicalize().unwrap_or(path);
-    if !roots.contains(&resolved) {
-        roots.push(resolved);
+    let is_symlink = fs::symlink_metadata(&path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+    if is_symlink {
+        return;
+    }
+    if !roots.contains(&path) {
+        roots.push(path);
     }
 }
 
@@ -341,7 +354,7 @@ fn allowed_claude_roots() -> Vec<PathBuf> {
 ///
 /// Security checks performed:
 /// 1. Path must be absolute
-/// 2. Filename must match pattern ^[A-Za-z0-9_-]+$
+/// 2. Filename stem must match ^[A-Za-z0-9_-]+$ and the extension must be `.jsonl`
 /// 3. Path must be lexically under an allowed root's `projects/` folder, with no
 ///    `.`/`..` traversal components
 /// 4. Depth-1 symlink policy (matches `scan_projects`, #277): the project
@@ -373,6 +386,14 @@ fn validate_claude_path_with_roots(
         return Err(RenameError::PermissionDenied(
             "Filename must contain only alphanumeric characters, underscores, and hyphens"
                 .to_string(),
+        )
+        .to_string());
+    }
+    // Require a `.jsonl` extension so rename cannot rewrite non-session files
+    // (e.g. notes.txt, config.json) that happen to be valid JSON lines.
+    if file_path_buf.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+        return Err(RenameError::PermissionDenied(
+            "Session file must have a .jsonl extension".to_string(),
         )
         .to_string());
     }
@@ -1541,12 +1562,54 @@ mod tests {
         let roots = resolve_claude_roots(&[]);
         if let Some(home) = dirs::home_dir() {
             let default_root = home.join(".claude");
-            let expected = default_root.canonicalize().unwrap_or(default_root);
-            assert!(
-                roots.contains(&expected),
-                "the default ~/.claude root must always be allowed"
-            );
+            // Roots are stored as-is (not canonicalized), unless ~/.claude is a
+            // symlink (then push_root drops it).
+            let is_symlink = fs::symlink_metadata(&default_root)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false);
+            if !is_symlink {
+                assert!(
+                    roots.contains(&default_root),
+                    "the default ~/.claude root must always be allowed"
+                );
+            }
         }
+    }
+
+    #[test]
+    fn push_root_rejects_symlinked_root() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let real = real_temp_root(&temp).join("real-root");
+        fs::create_dir_all(&real).unwrap();
+        let link = real_temp_root(&temp).join("linked-root");
+        symlink_dir(&real, &link);
+
+        let mut roots = Vec::new();
+        push_root(&mut roots, link.clone());
+        assert!(
+            !roots.contains(&link) && roots.is_empty(),
+            "a symlinked root must not enter the allowlist"
+        );
+
+        // A real root is still accepted, stored as-is (not canonicalized).
+        push_root(&mut roots, real.clone());
+        assert_eq!(roots, vec![real]);
+    }
+
+    #[test]
+    fn validate_claude_path_rejects_non_jsonl_extension() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = real_temp_root(&temp).join(".claude");
+        let project_dir = root.join("projects").join("-proj");
+        fs::create_dir_all(&project_dir).unwrap();
+        let non_session = project_dir.join("config.json");
+        fs::write(&non_session, "{}\n").unwrap();
+
+        let roots = resolve_claude_roots(&[root.to_string_lossy().to_string()]);
+        assert!(
+            validate_claude_path_with_roots(&non_session.to_string_lossy(), &roots).is_err(),
+            "only .jsonl session files may be renamed"
+        );
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::command;
 use uuid::Uuid;
@@ -254,14 +254,104 @@ fn reset_claude_session_file(file_path: &str) -> Result<NativeRenameResult, Stri
     })
 }
 
-/// Validates that the file path is within the ~/.claude directory.
-/// This prevents path traversal attacks that could modify arbitrary files.
+/// Collect the Claude configuration directories the user has registered, plus
+/// `CLAUDE_CONFIG_DIR`. These are the same sources `scan_all_projects` reads, so
+/// any directory whose sessions the app displays is represented here.
+fn configured_claude_dirs() -> Vec<String> {
+    let mut dirs = Vec::new();
+
+    if let Ok(user_data_path) = crate::commands::metadata::get_user_data_path() {
+        if let Ok(content) = fs::read_to_string(user_data_path) {
+            if let Ok(metadata) = serde_json::from_str::<crate::models::UserMetadata>(&content) {
+                dirs.extend(
+                    metadata
+                        .settings
+                        .custom_claude_paths
+                        .into_iter()
+                        .map(|custom| custom.path),
+                );
+            }
+        }
+    }
+
+    if let Ok(env_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        let trimmed = env_dir.trim();
+        if !trimmed.is_empty() {
+            dirs.push(expand_home_prefix(trimmed));
+        }
+    }
+
+    dirs
+}
+
+/// Expand a leading `~` to the home directory, mirroring `detect_claude_config_dir`.
+fn expand_home_prefix(raw: &str) -> String {
+    let Some(home) = dirs::home_dir() else {
+        return raw.to_string();
+    };
+    if raw == "~" {
+        return home.to_string_lossy().to_string();
+    }
+    match raw.strip_prefix("~/") {
+        Some(rest) => home.join(rest).to_string_lossy().to_string(),
+        None => raw.to_string(),
+    }
+}
+
+/// Resolve the Claude configuration roots a native rename may write to.
+///
+/// Always includes the default `~/.claude`. A configured directory is only added
+/// once it passes [`validate_custom_claude_path`], which requires an absolute,
+/// non-symlinked base with a real `projects/` subdirectory. The allowlist can
+/// therefore only widen to directories the user registered and that the app
+/// already scans — never to arbitrary paths.
+fn resolve_claude_roots(configured: &[String]) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    if let Some(home) = dirs::home_dir() {
+        push_root(&mut roots, home.join(".claude"));
+    }
+
+    for dir in configured {
+        let candidate = PathBuf::from(dir);
+        if crate::utils::validate_custom_claude_path(&candidate).is_ok() {
+            push_root(&mut roots, candidate);
+        }
+    }
+
+    roots
+}
+
+/// Push a root, resolved to its canonical form so it compares correctly against
+/// the canonicalized file path. Duplicates are skipped.
+fn push_root(roots: &mut Vec<PathBuf>, path: PathBuf) {
+    let resolved = path.canonicalize().unwrap_or(path);
+    if !roots.contains(&resolved) {
+        roots.push(resolved);
+    }
+}
+
+fn allowed_claude_roots() -> Vec<PathBuf> {
+    resolve_claude_roots(&configured_claude_dirs())
+}
+
+/// Validates that the file path is within `~/.claude` or a registered custom
+/// Claude directory. This prevents path traversal attacks that could modify
+/// arbitrary files.
 ///
 /// Security checks performed:
 /// 1. Path must be absolute
 /// 2. No symlinks allowed in any path component
 /// 3. Filename must match pattern ^[A-Za-z0-9_-]+$
+/// 4. Canonical path must live under one of the allowed Claude roots
 fn validate_claude_path(file_path: &str) -> Result<(), String> {
+    validate_claude_path_with_roots(file_path, &allowed_claude_roots())
+}
+
+fn validate_claude_path_with_roots(
+    file_path: &str,
+    allowed_roots: &[PathBuf],
+) -> Result<(), String> {
     let file_path_buf = std::path::PathBuf::from(file_path);
 
     // 1. Require absolute path
@@ -319,18 +409,15 @@ fn validate_claude_path(file_path: &str) -> Result<(), String> {
         .canonicalize()
         .map_err(|e| RenameError::IoError(e.to_string()).to_string())?;
 
-    // Get home directory
-    let home_dir = dirs::home_dir().ok_or_else(|| {
-        RenameError::IoError("Cannot determine home directory".to_string()).to_string()
-    })?;
-
-    // Build the allowed claude directory path
-    let claude_dir = home_dir.join(".claude");
-
-    // Verify the file is within ~/.claude
-    if !canonical_path.starts_with(&claude_dir) {
+    // Verify the file lives under one of the allowed Claude roots (~/.claude or
+    // a custom Claude directory the user registered).
+    if !allowed_roots
+        .iter()
+        .any(|root| canonical_path.starts_with(root))
+    {
         return Err(RenameError::PermissionDenied(
-            "File path must be within ~/.claude directory".to_string(),
+            "File path must be within ~/.claude or a registered custom Claude directory"
+                .to_string(),
         )
         .to_string());
     }
@@ -1323,6 +1410,100 @@ mod tests {
         // Nonexistent file should fail at canonicalize
         let result = validate_claude_path("/nonexistent/path/to/file.jsonl");
         assert!(result.is_err());
+    }
+
+    /// Canonicalize the temp root: on macOS `TempDir` sits under `/var/folders`,
+    /// and `/var` is a symlink, which `validate_claude_path` rejects outright.
+    /// Real Claude directories under `$HOME` have no symlinked ancestors.
+    fn real_temp_root(temp: &tempfile::TempDir) -> PathBuf {
+        temp.path().canonicalize().unwrap()
+    }
+
+    /// Build a Claude-shaped config dir (`<base>/projects/<project>/<name>.jsonl`)
+    /// and return the base plus the session file path.
+    fn make_claude_dir(base: &Path, session_name: &str) -> (PathBuf, String) {
+        let project_dir = base.join("projects").join("-tmp-demo");
+        fs::create_dir_all(&project_dir).unwrap();
+        let session = project_dir.join(format!("{session_name}.jsonl"));
+        fs::write(&session, "{}\n").unwrap();
+        (base.to_path_buf(), session.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn validate_claude_path_accepts_registered_custom_directory() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let custom_base = real_temp_root(&temp).join(".claude-holophonix");
+        fs::create_dir_all(&custom_base).unwrap();
+        let (base, session_path) = make_claude_dir(&custom_base, "session-1");
+
+        let roots = resolve_claude_roots(&[base.to_string_lossy().to_string()]);
+        assert!(
+            validate_claude_path_with_roots(&session_path, &roots).is_ok(),
+            "a session inside a registered custom Claude directory must be renameable"
+        );
+    }
+
+    #[test]
+    fn validate_claude_path_rejects_directory_that_is_not_registered() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let unregistered = real_temp_root(&temp).join(".claude-other");
+        fs::create_dir_all(&unregistered).unwrap();
+        let (_base, session_path) = make_claude_dir(&unregistered, "session-1");
+
+        // Roots resolved without the directory being configured. The path itself
+        // is symlink-free, so this fails on root containment specifically.
+        let roots = resolve_claude_roots(&[]);
+        assert!(
+            validate_claude_path_with_roots(&session_path, &roots).is_err(),
+            "an unregistered directory must stay rejected"
+        );
+    }
+
+    #[test]
+    fn resolve_claude_roots_skips_directory_without_projects_subdir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let bogus = real_temp_root(&temp).join(".claude-bogus");
+        fs::create_dir_all(&bogus).unwrap(); // no projects/ inside
+
+        let roots = resolve_claude_roots(&[bogus.to_string_lossy().to_string()]);
+        let bogus_canonical = bogus.canonicalize().unwrap();
+        assert!(
+            !roots.contains(&bogus_canonical),
+            "a directory failing validate_custom_claude_path must not widen the allowlist"
+        );
+    }
+
+    #[test]
+    fn resolve_claude_roots_skips_symlinked_custom_directory() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let real_base = real_temp_root(&temp).join("real-claude");
+        fs::create_dir_all(real_base.join("projects")).unwrap();
+        let link = real_temp_root(&temp).join("linked-claude");
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_base, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&real_base, &link).unwrap();
+
+        let roots = resolve_claude_roots(&[link.to_string_lossy().to_string()]);
+        // The symlinked base is rejected, so only the default ~/.claude root remains.
+        assert!(
+            !roots.iter().any(|r| r.starts_with(real_temp_root(&temp))),
+            "a symlinked custom base must be rejected"
+        );
+    }
+
+    #[test]
+    fn resolve_claude_roots_always_includes_default_claude_dir() {
+        let roots = resolve_claude_roots(&[]);
+        if let Some(home) = dirs::home_dir() {
+            let default_root = home.join(".claude");
+            let expected = default_root.canonicalize().unwrap_or(default_root);
+            assert!(
+                roots.contains(&expected),
+                "the default ~/.claude root must always be allowed"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Sessions shared across macOS accounts via a **symlinked project directory** — e.g. `~/.claude/projects/-Volumes-Data-Odroid` → `/Users/Shared/.claude/projects/…` — could be browsed and deleted in CCHV but **not renamed**: "Rename in Claude Code" failed with

> `Permission denied: Symlinks are not allowed in path`

The native-rename validator blocked *any* symlink in the path, even though **`scan_projects` already follows exactly these symlinks** under the depth-1 policy from #277. So the write path was stricter than the read path that surfaced the sessions.

## Approach — mirror the #277 depth-1 policy

The validator now:
1. Anchors the path **lexically** under an allowed root's `projects/` folder (the path down to `projects/` is always real), rejecting `.`/`..` traversal components.
2. Allows the **project directory** (one level under `projects/`) to be a symlink that resolves to a directory — this is how shared sessions are linked in.
3. Keeps blocking symlinks on `projects/` itself and on **every component below** the project directory, and requires the session path to resolve to a **regular file**.

This replaces the previous `canonicalize()`-then-`starts_with(root)` containment (which resolved the shared symlink to `/Users/Shared/.claude` and then rejected it for not being a registered root). Escape vectors stay closed — verified by tests: symlink below the project dir, symlinked session file, `..` traversal, and non-`projects/` paths are all rejected.

## Relationship to other PRs

**Stacked on #476** (custom-directory rename) — it reworks the same validator. The diff shown here includes #476 until that merges; once #476 lands, this reduces to just the symlink change. Independent of #477 (custom-title write), which touches different functions; all three compose on `develop`.

## Test plan

- [x] New tests: depth-1 symlinked project dir **accepted**; symlink below project dir **rejected**; symlinked session file **rejected**; `..` traversal **rejected**. All existing validator tests still pass.
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -- --test-threads=1` — 851 passing (the lone `get_git_log` failure is a local-env git-author override, green in CI).
- [x] Verified against the real shared setup: `validate_claude_path` returns `Ok` for an actual `~/.claude/projects/-Volumes-Data-Odroid/…jsonl` symlinked into `/Users/Shared`, where it previously errored.
- [x] In-app: renamed a real shared/symlinked session in a locally built CCHV (stacked with #476 + #477) — succeeds in-app and now reflects in `claude -r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session rename security to work with both the default Claude config directory and user-registered custom configuration directories.
  * Added stricter validation for rename targets, including rejection of unauthorized locations, path traversal attempts, non-session filenames, and unsafe symbolic-link scenarios.
  * Continued to allow renames for legitimate `.jsonl` session files stored under approved configuration roots, including cases where the project folder itself is a safe symlink.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->