### PR TITLE
fix(search): reveal & highlight in-session matches inside tool cards (#429)

### DIFF
--- a/src/components/MessageViewer/hooks/useScrollNavigation.ts
+++ b/src/components/MessageViewer/hooks/useScrollNavigation.ts
@@ -158,58 +158,52 @@ export const useScrollNavigation = ({
   const scrollToHighlight = useCallback((matchUuid: string | null) => {
     if (!matchUuid) return;
 
-    // Use virtualizer if available
+    const viewport = getScrollViewport();
+
+    // Prefer the active highlight if it is already rendered. This is the
+    // common case when moving between occurrences WITHIN one (long) message:
+    // scroll straight to the occurrence instead of first jumping the whole
+    // message into view, which caused a visible double-scroll. (#429)
+    const activeHighlight = viewport?.querySelector(
+      '[data-search-highlight="current"]'
+    );
+    if (activeHighlight) {
+      activeHighlight.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
+
+    // Target message isn't rendered yet (virtualized off-screen) — bring it
+    // in via the virtualizer, then scroll to the highlight once it mounts.
     if (virtualizer && getScrollIndex) {
       const index = getScrollIndex(matchUuid);
       if (index !== null) {
         virtualizer.scrollToIndex(index, { align: "center" });
-        // After virtualizer scrolls, try to find the highlight element
         setTimeout(() => {
-          const viewport = getScrollViewport();
-          if (!viewport) return;
-          const highlightElement = viewport.querySelector(
+          const vp = getScrollViewport();
+          if (!vp) return;
+          const highlightElement = vp.querySelector(
             '[data-search-highlight="current"]'
           );
           if (highlightElement) {
-            highlightElement.scrollIntoView({
-              behavior: "smooth",
-              block: "center",
-            });
+            highlightElement.scrollIntoView({ behavior: "smooth", block: "center" });
+            return;
           }
+          // No highlight in the now-rendered message (e.g. match outside the
+          // visible text window) — center the message as a fallback.
+          const messageElement = vp.querySelector(
+            `[data-message-uuid="${matchUuid}"]`
+          );
+          messageElement?.scrollIntoView({ behavior: "smooth", block: "center" });
         }, 100);
         return;
       }
     }
 
-    // Fallback to DOM-based scrolling
-    const viewport = getScrollViewport();
-    if (!viewport) return;
-
-    // 먼저 하이라이트된 텍스트 요소를 찾음
-    const highlightElement = viewport.querySelector(
-      '[data-search-highlight="current"]'
-    );
-
-    if (highlightElement) {
-      // 하이라이트된 텍스트로 스크롤
-      highlightElement.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-      return;
-    }
-
-    // 하이라이트 요소가 없으면 메시지 영역으로 스크롤 (fallback)
-    const messageElement = viewport.querySelector(
+    // DOM-only fallback (no virtualizer): center the message.
+    const messageElement = viewport?.querySelector(
       `[data-message-uuid="${matchUuid}"]`
     );
-
-    if (messageElement) {
-      messageElement.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-    }
+    messageElement?.scrollIntoView({ behavior: "smooth", block: "center" });
   }, [getScrollViewport, virtualizer, getScrollIndex]);
 
   // 메시지 로드 완료 후 스크롤 실행

--- a/src/components/MessageViewer/hooks/useScrollNavigation.ts
+++ b/src/components/MessageViewer/hooks/useScrollNavigation.ts
@@ -158,22 +158,26 @@ export const useScrollNavigation = ({
   const scrollToHighlight = useCallback((matchUuid: string | null) => {
     if (!matchUuid) return;
 
+    const messageSelector = `[data-message-uuid="${matchUuid}"]`;
+    // Scope the highlight lookup to the TARGET message so a `current` mark on
+    // another message (e.g. a deep-link target rendered simultaneously) can't
+    // hijack the scroll. (#429)
+    const findActiveHighlight = (root: ParentNode) =>
+      root.querySelector(`${messageSelector} [data-search-highlight="current"]`);
+
     const viewport = getScrollViewport();
 
-    // Prefer the active highlight if it is already rendered. This is the
-    // common case when moving between occurrences WITHIN one (long) message:
+    // Prefer the active highlight if the target message is already rendered:
     // scroll straight to the occurrence instead of first jumping the whole
     // message into view, which caused a visible double-scroll. (#429)
-    const activeHighlight = viewport?.querySelector(
-      '[data-search-highlight="current"]'
-    );
+    const activeHighlight = viewport ? findActiveHighlight(viewport) : null;
     if (activeHighlight) {
       activeHighlight.scrollIntoView({ behavior: "smooth", block: "center" });
       return;
     }
 
-    // Target message isn't rendered yet (virtualized off-screen) — bring it
-    // in via the virtualizer, then scroll to the highlight once it mounts.
+    // Target message isn't rendered yet (virtualized off-screen) — bring it in
+    // via the virtualizer, then scroll to its highlight once it mounts.
     if (virtualizer && getScrollIndex) {
       const index = getScrollIndex(matchUuid);
       if (index !== null) {
@@ -181,18 +185,14 @@ export const useScrollNavigation = ({
         setTimeout(() => {
           const vp = getScrollViewport();
           if (!vp) return;
-          const highlightElement = vp.querySelector(
-            '[data-search-highlight="current"]'
-          );
+          const highlightElement = findActiveHighlight(vp);
           if (highlightElement) {
             highlightElement.scrollIntoView({ behavior: "smooth", block: "center" });
             return;
           }
           // No highlight in the now-rendered message (e.g. match outside the
           // visible text window) — center the message as a fallback.
-          const messageElement = vp.querySelector(
-            `[data-message-uuid="${matchUuid}"]`
-          );
+          const messageElement = vp.querySelector(messageSelector);
           messageElement?.scrollIntoView({ behavior: "smooth", block: "center" });
         }, 100);
         return;
@@ -200,9 +200,7 @@ export const useScrollNavigation = ({
     }
 
     // DOM-only fallback (no virtualizer): center the message.
-    const messageElement = viewport?.querySelector(
-      `[data-message-uuid="${matchUuid}"]`
-    );
+    const messageElement = viewport?.querySelector(messageSelector);
     messageElement?.scrollIntoView({ behavior: "smooth", block: "center" });
   }, [getScrollViewport, virtualizer, getScrollIndex]);
 

--- a/src/components/contentRenderer/ClaudeContentArrayRenderer.tsx
+++ b/src/components/contentRenderer/ClaudeContentArrayRenderer.tsx
@@ -172,6 +172,9 @@ export const ClaudeContentArrayRenderer = memo(({
               toolUse={entry.toolUse}
               toolResults={skipToolResults ? [] : entry.toolResults}
               onViewSubagent={onViewSubagent}
+              searchQuery={searchQuery}
+              isCurrentMatch={isCurrentMatch}
+              currentMatchIndex={currentMatchIndex}
             />
           );
         }

--- a/src/components/contentRenderer/UnifiedToolExecutionRenderer.tsx
+++ b/src/components/contentRenderer/UnifiedToolExecutionRenderer.tsx
@@ -26,6 +26,7 @@ import {
   WebFetchCard,
   AgentCard,
   WorkflowCard,
+  AskUserQuestionCard,
   DefaultCard,
 } from "./unifiedCards";
 import type { Props } from "./unifiedCards";
@@ -36,6 +37,9 @@ export const UnifiedToolExecutionRenderer = memo(function UnifiedToolExecutionRe
   toolUse,
   toolResults,
   onViewSubagent,
+  searchQuery,
+  isCurrentMatch,
+  currentMatchIndex,
 }: Props) {
   const toolName = (toolUse.name as string) || "";
 
@@ -53,6 +57,24 @@ export const UnifiedToolExecutionRenderer = memo(function UnifiedToolExecutionRe
     case "Agent":
     case "Task":      return <AgentCard toolUse={toolUse} toolResults={toolResults} onViewSubagent={onViewSubagent} />;
     case "Workflow":  return <WorkflowCard toolUse={toolUse} toolResults={toolResults} />;
-    default:          return <DefaultCard toolUse={toolUse} toolResults={toolResults} />;
+    case "AskUserQuestion":
+      return (
+        <AskUserQuestionCard
+          toolUse={toolUse}
+          toolResults={toolResults}
+          searchQuery={searchQuery}
+          isCurrentMatch={isCurrentMatch}
+          currentMatchIndex={currentMatchIndex}
+        />
+      );
+    default:          return (
+      <DefaultCard
+        toolUse={toolUse}
+        toolResults={toolResults}
+        searchQuery={searchQuery}
+        isCurrentMatch={isCurrentMatch}
+        currentMatchIndex={currentMatchIndex}
+      />
+    );
   }
 });

--- a/src/components/contentRenderer/unifiedCards/AskUserQuestionCard.tsx
+++ b/src/components/contentRenderer/unifiedCards/AskUserQuestionCard.tsx
@@ -1,0 +1,190 @@
+import { memo } from "react";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { CheckSquare, Circle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Renderer } from "@/shared/RendererHeader";
+import { ToolIcon } from "../../ToolIcon";
+import { getToolVariant } from "@/utils/toolIconUtils";
+import { getVariantStyles, layout } from "../../renderers";
+import { HighlightedText } from "../../common/HighlightedText";
+import type { Props } from "./shared";
+import { isError } from "./shared";
+import { StatusBadge } from "./StatusBadge";
+import { ResultBlock } from "./ResultBlock";
+import { DefaultCard } from "./DefaultCard";
+
+interface AskOption {
+  label: string;
+  description?: string;
+}
+
+interface AskQuestion {
+  question: string;
+  header?: string;
+  multiSelect: boolean;
+  options: AskOption[];
+}
+
+// Defensive parse of the AskUserQuestion tool input. Returns null when the
+// shape is not recognized so callers can fall back to the generic renderer.
+function parseQuestions(input: unknown): AskQuestion[] | null {
+  if (!input || typeof input !== "object") return null;
+  const raw = (input as Record<string, unknown>).questions;
+  if (!Array.isArray(raw) || raw.length === 0) return null;
+
+  const questions: AskQuestion[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") return null;
+    const rec = item as Record<string, unknown>;
+    if (typeof rec.question !== "string") return null;
+
+    const options: AskOption[] = [];
+    if (Array.isArray(rec.options)) {
+      for (const opt of rec.options) {
+        if (opt && typeof opt === "object") {
+          const o = opt as Record<string, unknown>;
+          if (typeof o.label === "string") {
+            options.push({
+              label: o.label,
+              description:
+                typeof o.description === "string" ? o.description : undefined,
+            });
+          }
+        }
+      }
+    }
+
+    questions.push({
+      question: rec.question,
+      header: typeof rec.header === "string" ? rec.header : undefined,
+      multiSelect: rec.multiSelect === true,
+      options,
+    });
+  }
+  return questions;
+}
+
+export const AskUserQuestionCard = memo(function AskUserQuestionCard({
+  toolUse,
+  toolResults,
+  searchQuery = "",
+  isCurrentMatch = false,
+  currentMatchIndex = 0,
+}: Props) {
+  const { t } = useTranslation();
+  const questions = parseQuestions(toolUse.input);
+
+  // Unknown/unexpected shape → keep the generic fallback renderer (never break
+  // rendering on schema drift). #429
+  if (!questions) {
+    return (
+      <DefaultCard
+        toolUse={toolUse}
+        toolResults={toolResults}
+        searchQuery={searchQuery}
+        isCurrentMatch={isCurrentMatch}
+        currentMatchIndex={currentMatchIndex}
+      />
+    );
+  }
+
+  const toolName = (toolUse.name as string) || "AskUserQuestion";
+  const toolId = (toolUse.id as string) || "";
+  const variant = getToolVariant(toolName);
+  const styles = getVariantStyles(variant);
+
+  // Reveal + highlight when the search term is anywhere in the questions or
+  // options, so a match inside a collapsed card is actually visible. #429
+  const haystack = questions
+    .flatMap((q) => [
+      q.header ?? "",
+      q.question,
+      ...q.options.flatMap((o) => [o.label, o.description ?? ""]),
+    ])
+    .join(" ")
+    .toLowerCase();
+  const matchesSearch =
+    !!searchQuery && haystack.includes(searchQuery.toLowerCase());
+
+  const highlight = (text: string): ReactNode =>
+    searchQuery ? (
+      <HighlightedText
+        text={text}
+        searchQuery={searchQuery}
+        isCurrentMatch={isCurrentMatch}
+        currentMatchIndex={currentMatchIndex}
+      />
+    ) : (
+      text
+    );
+
+  return (
+    <Renderer
+      className={styles.container}
+      hasError={toolResults.length > 0 && toolResults.some(isError)}
+      expandKey={`unified-ask-${toolId}`}
+      autoExpand={matchesSearch}
+    >
+      <Renderer.Header
+        title={toolName}
+        icon={<ToolIcon toolName={toolName} className={cn(layout.iconSize, styles.icon)} />}
+        titleClassName={styles.title}
+        rightContent={
+          <div className={cn("flex items-center gap-2", layout.smallText)}>
+            <StatusBadge results={toolResults} />
+            {toolId && (
+              <code className={cn(layout.monoText, "hidden md:inline px-2 py-0.5", layout.rounded, styles.badge, styles.badgeText)}>
+                {t("common.id")}: {toolId}
+              </code>
+            )}
+          </div>
+        }
+      />
+      <Renderer.Content>
+        <div className="space-y-3">
+          {questions.map((q, qi) => {
+            const OptionIcon = q.multiSelect ? CheckSquare : Circle;
+            return (
+              <div key={qi} className="border-l-2 border-border pl-3">
+                {q.header && (
+                  <div className={cn(layout.monoText, "mb-1 inline-block px-1.5 py-0.5", layout.rounded, styles.badge, styles.badgeText)}>
+                    {highlight(q.header)}
+                  </div>
+                )}
+                <div className={cn(layout.bodyText, "font-semibold text-foreground whitespace-pre-wrap")}>
+                  {highlight(q.question)}
+                </div>
+                {q.options.length > 0 && (
+                  <ul className="mt-2 space-y-1.5">
+                    {q.options.map((opt, oi) => (
+                      <li key={oi} className={cn("flex items-start", layout.iconGap)}>
+                        <OptionIcon className={cn(layout.iconSizeSmall, "mt-0.5 shrink-0 text-muted-foreground")} />
+                        <div className="min-w-0">
+                          <div className={cn(layout.bodyText, "text-foreground")}>
+                            {highlight(opt.label)}
+                          </div>
+                          {opt.description && (
+                            <div className={cn(layout.smallText, "text-muted-foreground whitespace-pre-wrap")}>
+                              {highlight(opt.description)}
+                            </div>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        <ResultBlock
+          results={toolResults}
+          searchQuery={searchQuery}
+          isCurrentMatch={isCurrentMatch}
+          currentMatchIndex={currentMatchIndex}
+        />
+      </Renderer.Content>
+    </Renderer>
+  );
+});

--- a/src/components/contentRenderer/unifiedCards/DefaultCard.tsx
+++ b/src/components/contentRenderer/unifiedCards/DefaultCard.tsx
@@ -9,8 +9,15 @@ import type { Props } from "./shared";
 import { truncate, isError } from "./shared";
 import { StatusBadge } from "./StatusBadge";
 import { ResultBlock } from "./ResultBlock";
+import { HighlightedText } from "../../common/HighlightedText";
 
-export const DefaultCard = memo(function DefaultCard({ toolUse, toolResults }: Props) {
+export const DefaultCard = memo(function DefaultCard({
+  toolUse,
+  toolResults,
+  searchQuery = "",
+  isCurrentMatch = false,
+  currentMatchIndex = 0,
+}: Props) {
   const { t } = useTranslation();
   const toolName = (toolUse.name as string) || "";
   const toolId = (toolUse.id as string) || "";
@@ -18,9 +25,20 @@ export const DefaultCard = memo(function DefaultCard({ toolUse, toolResults }: P
   const variant = getToolVariant(toolName);
   const styles = getVariantStyles(variant);
 
+  const inputJson = truncate(JSON.stringify(input, null, 2));
+  // Reveal + highlight the input when the in-session search term is inside it,
+  // so a match in a collapsed tool card (e.g. AskUserQuestion) is actually
+  // visible instead of only flagging the message card (#429).
+  const inputMatchesSearch =
+    !!searchQuery && inputJson.toLowerCase().includes(searchQuery.toLowerCase());
 
   return (
-    <Renderer className={styles.container} hasError={toolResults.length > 0 && toolResults.some(isError)} expandKey={`unified-${(toolUse.id as string) || ""}`}>
+    <Renderer
+      className={styles.container}
+      hasError={toolResults.length > 0 && toolResults.some(isError)}
+      expandKey={`unified-${(toolUse.id as string) || ""}`}
+      autoExpand={inputMatchesSearch}
+    >
       <Renderer.Header
         title={toolName || t("common.unknown")}
         icon={<ToolIcon toolName={toolName} className={cn(layout.iconSize, styles.icon)} />}
@@ -37,15 +55,29 @@ export const DefaultCard = memo(function DefaultCard({ toolUse, toolResults }: P
         }
       />
       <Renderer.Content>
-        <details className="mb-2">
+        <details className="mb-2" open={inputMatchesSearch}>
           <summary className={cn(layout.smallText, "cursor-pointer text-muted-foreground")}>
             {t("common.input")} ({Object.keys(input).join(", ")})
           </summary>
           <pre className={cn(layout.monoText, "mt-2 p-2 bg-secondary text-foreground rounded overflow-x-auto whitespace-pre-wrap", layout.codeMaxHeight)}>
-            {truncate(JSON.stringify(input, null, 2))}
+            {inputMatchesSearch ? (
+              <HighlightedText
+                text={inputJson}
+                searchQuery={searchQuery}
+                isCurrentMatch={isCurrentMatch}
+                currentMatchIndex={currentMatchIndex}
+              />
+            ) : (
+              inputJson
+            )}
           </pre>
         </details>
-        <ResultBlock results={toolResults} />
+        <ResultBlock
+          results={toolResults}
+          searchQuery={searchQuery}
+          isCurrentMatch={isCurrentMatch}
+          currentMatchIndex={currentMatchIndex}
+        />
       </Renderer.Content>
     </Renderer>
   );

--- a/src/components/contentRenderer/unifiedCards/ResultBlock.tsx
+++ b/src/components/contentRenderer/unifiedCards/ResultBlock.tsx
@@ -4,7 +4,17 @@ import { layout } from "../../renderers";
 import { ToolExecutionResultRouter } from "../../messageRenderer/ToolExecutionResultRouter";
 import type { ToolResultLike } from "./shared";
 
-export function ResultBlock({ results }: { results: ToolResultLike[] }) {
+export function ResultBlock({
+  results,
+  searchQuery,
+  isCurrentMatch,
+  currentMatchIndex,
+}: {
+  results: ToolResultLike[];
+  searchQuery?: string;
+  isCurrentMatch?: boolean;
+  currentMatchIndex?: number;
+}) {
   const { t } = useTranslation();
   if (results.length === 0) return (
     <div className={cn(layout.smallText, "text-muted-foreground italic mt-2")}>{t("common.pending")}</div>
@@ -17,6 +27,9 @@ export function ResultBlock({ results }: { results: ToolResultLike[] }) {
           <ToolExecutionResultRouter
             key={idx}
             toolResult={content as Record<string, unknown> | string | unknown[]}
+            searchQuery={searchQuery}
+            isCurrentMatch={isCurrentMatch}
+            currentMatchIndex={currentMatchIndex}
           />
         );
       })}

--- a/src/components/contentRenderer/unifiedCards/index.ts
+++ b/src/components/contentRenderer/unifiedCards/index.ts
@@ -8,6 +8,7 @@ export { WebSearchCard } from "./WebSearchCard";
 export { WebFetchCard } from "./WebFetchCard";
 export { AgentCard } from "./AgentCard";
 export { WorkflowCard } from "./WorkflowCard";
+export { AskUserQuestionCard } from "./AskUserQuestionCard";
 export { DefaultCard } from "./DefaultCard";
 export { StatusBadge } from "./StatusBadge";
 export { ResultBlock } from "./ResultBlock";

--- a/src/components/contentRenderer/unifiedCards/shared.ts
+++ b/src/components/contentRenderer/unifiedCards/shared.ts
@@ -6,6 +6,9 @@ export interface Props {
   toolUse: Record<string, unknown>;
   toolResults: ToolResultLike[];
   onViewSubagent?: (toolUseId: string) => void;
+  searchQuery?: string;
+  isCurrentMatch?: boolean;
+  currentMatchIndex?: number;
 }
 
 export const truncate = (text: string, max = PREVIEW_MAX_LEN) =>

--- a/src/shared/RendererHeader.tsx
+++ b/src/shared/RendererHeader.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight, X } from "lucide-react";
 import { useToggle } from "../hooks";
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { layout } from "@/components/renderers";
@@ -22,6 +22,8 @@ type ContentProviderProps = {
   hasError?: boolean;
   enableToggle?: boolean;
   expandKey?: string;
+  /** When true, force the content open (e.g. a search match lives inside). */
+  autoExpand?: boolean;
 };
 
 const ContentProvider = ({
@@ -29,8 +31,16 @@ const ContentProvider = ({
   hasError,
   enableToggle,
   expandKey,
+  autoExpand,
 }: ContentProviderProps) => {
-  const [isOpen, toggle] = useToggle(expandKey ?? "renderer");
+  const [isOpen, toggle, setIsOpen] = useToggle(expandKey ?? "renderer");
+
+  // Reveal collapsed content when a search match is inside it, so the
+  // highlighted term is actually visible (#429). Runs only on the rising
+  // edge of autoExpand, leaving manual toggling intact afterward.
+  useEffect(() => {
+    if (autoExpand) setIsOpen(true);
+  }, [autoExpand, setIsOpen]);
 
   return (
     <ContentContext.Provider value={{ isOpen, toggle, hasError, enableToggle }}>
@@ -45,6 +55,8 @@ type RendererWrapperProps = {
   hasError?: boolean;
   enableToggle?: boolean;
   expandKey?: string;
+  /** When true, force the content open (e.g. a search match lives inside). */
+  autoExpand?: boolean;
 };
 
 const RendererWrapper = ({
@@ -53,9 +65,10 @@ const RendererWrapper = ({
   hasError = false,
   enableToggle = true,
   expandKey,
+  autoExpand,
 }: RendererWrapperProps) => {
   return (
-    <ContentProvider hasError={hasError} enableToggle={enableToggle} expandKey={expandKey}>
+    <ContentProvider hasError={hasError} enableToggle={enableToggle} expandKey={expandKey} autoExpand={autoExpand}>
       <div
         className={cn(
           "mt-1.5 border border-border overflow-hidden",

--- a/src/shared/RendererHeader.tsx
+++ b/src/shared/RendererHeader.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight, X } from "lucide-react";
 import { useToggle } from "../hooks";
-import { createContext, useContext, useEffect } from "react";
+import { createContext, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { layout } from "@/components/renderers";
@@ -33,17 +33,17 @@ const ContentProvider = ({
   expandKey,
   autoExpand,
 }: ContentProviderProps) => {
-  const [isOpen, toggle, setIsOpen] = useToggle(expandKey ?? "renderer");
+  const [isOpen, toggle] = useToggle(expandKey ?? "renderer");
 
   // Reveal collapsed content when a search match is inside it, so the
-  // highlighted term is actually visible (#429). Runs only on the rising
-  // edge of autoExpand, leaving manual toggling intact afterward.
-  useEffect(() => {
-    if (autoExpand) setIsOpen(true);
-  }, [autoExpand, setIsOpen]);
-
+  // highlighted term is actually visible (#429). `autoExpand` is applied as an
+  // ephemeral override rather than written through `setIsOpen`, so it does not
+  // mutate the persisted expand registry (which the WYSIWYG capture renderer
+  // reads) and cleanly reverts once the search term clears.
   return (
-    <ContentContext.Provider value={{ isOpen, toggle, hasError, enableToggle }}>
+    <ContentContext.Provider
+      value={{ isOpen: isOpen || autoExpand === true, toggle, hasError, enableToggle }}
+    >
       {children}
     </ContentContext.Provider>
   );

--- a/src/test/AskUserQuestionCard.test.tsx
+++ b/src/test/AskUserQuestionCard.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { ClaudeContentArrayRenderer } from "@/components/contentRenderer/ClaudeContentArrayRenderer";
+import { ExpandKeyProvider } from "@/contexts/CaptureExpandContext";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+const makeToolUse = (id: string, input: unknown) => ({
+  type: "tool_use",
+  id,
+  name: "AskUserQuestion",
+  input,
+});
+
+const renderContent = (
+  id: string,
+  input: unknown,
+  props: { searchQuery?: string; isCurrentMatch?: boolean; currentMatchIndex?: number } = {}
+) =>
+  render(
+    <ExpandKeyProvider value="test-message">
+      <ClaudeContentArrayRenderer content={[makeToolUse(id, input)]} {...props} />
+    </ExpandKeyProvider>
+  );
+
+const validInput = {
+  questions: [
+    {
+      question: "Which storage backend?",
+      header: "Storage",
+      multiSelect: false,
+      options: [
+        { label: "SQLite", description: "Bundled file database" },
+        { label: "PostgreSQL", description: "Networked server" },
+      ],
+    },
+  ],
+};
+
+describe("AskUserQuestionCard (#429)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders the question, header, and option labels/descriptions when expanded", () => {
+    // Search match forces the collapsed card open so its content is asserted.
+    const { container } = renderContent("ask_1", validInput, { searchQuery: "PostgreSQL" });
+
+    expect(container.textContent).toContain("Which storage backend?");
+    expect(container.textContent).toContain("Storage");
+    expect(container.textContent).toContain("SQLite");
+    expect(container.textContent).toContain("Bundled file database");
+    expect(container.textContent).toContain("Networked server");
+
+    // The matched option label is highlighted, not shown as raw JSON.
+    const marks = container.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThan(0);
+    expect(
+      Array.from(marks).some((m) => m.textContent === "PostgreSQL")
+    ).toBe(true);
+    // Not the generic JSON fallback.
+    expect(container.textContent).not.toContain('"multiSelect"');
+  });
+
+  it("falls back to the generic renderer for an unrecognized input shape", () => {
+    // Missing `questions` → parse returns null → DefaultCard JSON fallback.
+    const { container } = renderContent(
+      "ask_bad",
+      { prompt: "not a questions array" },
+      { searchQuery: "questions array" }
+    );
+
+    // DefaultCard renders the raw input JSON (auto-expanded on match).
+    expect(container.textContent).toContain("not a questions array");
+    expect(container.textContent).toContain('"prompt"');
+  });
+});

--- a/src/test/DefaultCard.search.test.tsx
+++ b/src/test/DefaultCard.search.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { ClaudeContentArrayRenderer } from "@/components/contentRenderer/ClaudeContentArrayRenderer";
+import { ExpandKeyProvider } from "@/contexts/CaptureExpandContext";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+  initReactI18next: {
+    type: "3rdParty",
+    init: () => {},
+  },
+}));
+
+// A tool_use with a string id normalizes into a unified tool execution and
+// renders via DefaultCard (no dedicated renderer for AskUserQuestion). #429
+// NOTE: expand state is cached in a module-level registry keyed by tool id,
+// so each case uses a distinct id to stay isolated.
+const makeAskUserQuestion = (id: string) => ({
+  type: "tool_use",
+  id,
+  name: "AskUserQuestion",
+  input: {
+    questions: [{ question: "What reflectance model should we use?" }],
+  },
+});
+
+const renderContent = (
+  id: string,
+  props: {
+    searchQuery?: string;
+    isCurrentMatch?: boolean;
+    currentMatchIndex?: number;
+  }
+) =>
+  render(
+    <ExpandKeyProvider value="test-message">
+      <ClaudeContentArrayRenderer content={[makeAskUserQuestion(id)]} {...props} />
+    </ExpandKeyProvider>
+  );
+
+describe("DefaultCard in-session search (#429)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the tool input collapsed and hidden when there is no search", () => {
+    const { container } = renderContent("toolu_ask_none", {});
+
+    // Collapsed by default: the matched input text is not rendered at all.
+    expect(container.textContent).not.toContain("reflectance model");
+    expect(container.querySelector("mark")).toBeNull();
+  });
+
+  it("auto-expands and highlights the tool input when the search term is inside it", () => {
+    const { container } = renderContent("toolu_ask_hit", {
+      searchQuery: "reflectance",
+      isCurrentMatch: true,
+      currentMatchIndex: 0,
+    });
+
+    // Auto-expanded: the previously-collapsed input is now visible.
+    expect(container.textContent).toContain("reflectance model");
+
+    // Highlighted: the match is wrapped in a <mark> and flagged as current.
+    const marks = container.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThan(0);
+    expect(marks[0]?.textContent?.toLowerCase()).toBe("reflectance");
+    expect(container.querySelector('mark[aria-current="true"]')).not.toBeNull();
+  });
+
+  it("does not expand when the search term is absent from the input", () => {
+    const { container } = renderContent("toolu_ask_miss", {
+      searchQuery: "nonexistent-term",
+    });
+
+    // No match inside → stays collapsed, nothing highlighted.
+    expect(container.textContent).not.toContain("reflectance model");
+    expect(container.querySelector("mark")).toBeNull();
+  });
+});

--- a/src/test/useScrollNavigation.search.test.ts
+++ b/src/test/useScrollNavigation.search.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import type { OverlayScrollbarsComponentRef } from "overlayscrollbars-react";
+import type { Virtualizer } from "@tanstack/react-virtual";
+import { useScrollNavigation } from "@/components/MessageViewer/hooks/useScrollNavigation";
+
+// Builds a fake OverlayScrollbars ref whose viewport is a real DOM node we
+// control, so getScrollViewport() resolves to it.
+function makeScrollRef(
+  viewport: HTMLElement
+): RefObject<OverlayScrollbarsComponentRef | null> {
+  return {
+    current: {
+      osInstance: () => ({
+        elements: () => ({ viewport }),
+      }),
+    },
+  } as unknown as RefObject<OverlayScrollbarsComponentRef | null>;
+}
+
+function makeVirtualizer(scrollToIndex: Mock): Virtualizer<HTMLElement, Element> {
+  return { scrollToIndex } as unknown as Virtualizer<HTMLElement, Element>;
+}
+
+describe("useScrollNavigation — search scroll (#429)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("scrolls straight to the active highlight without a message-level jump when it is already rendered", () => {
+    const viewport = document.createElement("div");
+    const mark = document.createElement("mark");
+    mark.setAttribute("data-search-highlight", "current");
+    const markScrollIntoView = vi.fn();
+    mark.scrollIntoView = markScrollIntoView;
+    viewport.appendChild(mark);
+
+    const scrollToIndex = vi.fn();
+
+    renderHook(() =>
+      useScrollNavigation({
+        scrollContainerRef: makeScrollRef(viewport),
+        currentMatchUuid: "msg-1",
+        currentMatchIndex: 2,
+        messagesLength: 10,
+        isLoading: false,
+        virtualizer: makeVirtualizer(scrollToIndex),
+        getScrollIndex: () => 5,
+        scrollElementReady: false, // disables the unrelated scroll-to-bottom effect
+      })
+    );
+
+    vi.runAllTimers();
+
+    // The whole point of the fix: no double-jump. We go directly to the
+    // occurrence and never ask the virtualizer to bring the message into view.
+    expect(scrollToIndex).not.toHaveBeenCalled();
+    expect(markScrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+    });
+  });
+
+  it("falls back to the virtualizer when the target highlight is not yet rendered", () => {
+    const viewport = document.createElement("div"); // no highlight inside
+    const scrollToIndex = vi.fn();
+
+    renderHook(() =>
+      useScrollNavigation({
+        scrollContainerRef: makeScrollRef(viewport),
+        currentMatchUuid: "msg-2",
+        currentMatchIndex: 0,
+        messagesLength: 10,
+        isLoading: false,
+        virtualizer: makeVirtualizer(scrollToIndex),
+        getScrollIndex: () => 7,
+        scrollElementReady: false,
+      })
+    );
+
+    vi.runAllTimers();
+
+    expect(scrollToIndex).toHaveBeenCalledWith(7, { align: "center" });
+  });
+});

--- a/src/test/useScrollNavigation.search.test.ts
+++ b/src/test/useScrollNavigation.search.test.ts
@@ -24,6 +24,22 @@ function makeVirtualizer(scrollToIndex: Mock): Virtualizer<HTMLElement, Element>
   return { scrollToIndex } as unknown as Virtualizer<HTMLElement, Element>;
 }
 
+// A message container with an active-highlight <mark> inside it, mirroring the
+// real DOM: [data-message-uuid] wraps the highlighted text.
+function makeMessageWithHighlight(uuid: string): {
+  message: HTMLElement;
+  markScrollIntoView: Mock;
+} {
+  const message = document.createElement("div");
+  message.setAttribute("data-message-uuid", uuid);
+  const mark = document.createElement("mark");
+  mark.setAttribute("data-search-highlight", "current");
+  const markScrollIntoView = vi.fn();
+  mark.scrollIntoView = markScrollIntoView;
+  message.appendChild(mark);
+  return { message, markScrollIntoView };
+}
+
 describe("useScrollNavigation — search scroll (#429)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -35,11 +51,8 @@ describe("useScrollNavigation — search scroll (#429)", () => {
 
   it("scrolls straight to the active highlight without a message-level jump when it is already rendered", () => {
     const viewport = document.createElement("div");
-    const mark = document.createElement("mark");
-    mark.setAttribute("data-search-highlight", "current");
-    const markScrollIntoView = vi.fn();
-    mark.scrollIntoView = markScrollIntoView;
-    viewport.appendChild(mark);
+    const { message, markScrollIntoView } = makeMessageWithHighlight("msg-1");
+    viewport.appendChild(message);
 
     const scrollToIndex = vi.fn();
 
@@ -86,6 +99,36 @@ describe("useScrollNavigation — search scroll (#429)", () => {
 
     vi.runAllTimers();
 
+    expect(scrollToIndex).toHaveBeenCalledWith(7, { align: "center" });
+  });
+
+  it("does not let another message's highlight hijack the scroll (scopes to matchUuid)", () => {
+    // A `current` highlight exists, but it belongs to a DIFFERENT message than
+    // the one we're navigating to (e.g. a deep-link target rendered alongside).
+    const viewport = document.createElement("div");
+    const { message: foreign, markScrollIntoView: foreignScroll } =
+      makeMessageWithHighlight("other-msg");
+    viewport.appendChild(foreign);
+
+    const scrollToIndex = vi.fn();
+
+    renderHook(() =>
+      useScrollNavigation({
+        scrollContainerRef: makeScrollRef(viewport),
+        currentMatchUuid: "msg-2", // target is NOT the message holding the mark
+        currentMatchIndex: 0,
+        messagesLength: 10,
+        isLoading: false,
+        virtualizer: makeVirtualizer(scrollToIndex),
+        getScrollIndex: () => 7,
+        scrollElementReady: false,
+      })
+    );
+
+    vi.runAllTimers();
+
+    // Must ignore the foreign highlight and use the virtualizer for the target.
+    expect(foreignScroll).not.toHaveBeenCalled();
     expect(scrollToIndex).toHaveBeenCalledWith(7, { align: "center" });
   });
 });


### PR DESCRIPTION
## What & why

In-session search already indexes `tool_use.input` content (#437/#458), but matches **inside collapsed tool cards were effectively invisible**, which is what @MostEmpire reported still happening on v1.21.0:

- A match inside an `AskUserQuestion` card highlighted the message card, but the body stayed **collapsed** — you couldn't see where the match was.
- Even when expanded, the input rendered as raw JSON with **no in-text highlight**.
- Navigating between occurrences **within one long message double-scrolled** (jumped to the message top, then down to the occurrence).

Closes #429

## Changes

- **Shared `Renderer`**: new `autoExpand` prop — a collapsed card opens when a search match is inside it (consistent with the existing `CommandRenderer`/`ThinkingRenderer` pattern).
- **Plumb search context** through the unified tool-execution path: `ClaudeContentArrayRenderer → UnifiedToolExecutionRenderer → DefaultCard / ResultBlock → ToolExecutionResultRouter` (previously dropped entirely).
- **`DefaultCard`**: auto-expand, open the `<details>`, and highlight the input JSON when the term is inside it.
- **`useScrollNavigation`**: scroll straight to the active highlight when it is already rendered (within-message navigation); only fall back to `virtualizer.scrollToIndex` to bring off-screen messages into view — removes the double-jump.
- **New `AskUserQuestionCard`**: renders questions, headers, and options (label + description, single/multi-select) CLI-style with search highlighting; **defensively falls back** to the generic JSON card on unrecognized shapes (no crash on schema drift).

No new i18n strings (renders the data itself + icons), so no locale sync needed.

## Type

- [x] Bug fix
- [x] New feature (AskUserQuestion renderer)

## Checklist

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — full suite green (923 tests)
- [x] Added tests: `DefaultCard.search`, `useScrollNavigation.search`, `AskUserQuestionCard`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an “Ask User Question” tool card, including question/option details, selection type, and optional descriptions.
  * Search now auto-expands matching tool cards and highlights matched text within inputs and results.

* **Bug Fixes**
  * Improved search scrolling to avoid duplicate scrolling and to reliably target the correct highlighted match, with safe fallbacks when content isn’t yet rendered.

* **Tests**
  * Added/expanded test coverage for the Ask User Question card, in-session search highlighting/auto-expand behavior, and search navigation scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->