### PR TITLE
chore(ci): fix chronic release-only Rust doc + security-audit failures

### DIFF
--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit configuration (read by the `Security Audit` CI job, which runs
+# `cargo audit` from this directory).
+#
+# The ignored advisories below are DoS-class issues in `quick-xml 0.37`, pulled
+# in transitively via `plist` -> `tauri` / `tauri-plugin-os` (used to parse
+# local macOS .plist files, not untrusted network input). They can only be
+# resolved once `plist`/Tauri adopt `quick-xml >= 0.41`, which is out of our
+# control. Re-check and remove these entries when a Tauri update lands.
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0194", # quick-xml: quadratic time on duplicate attribute names
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation
+]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -657,9 +657,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -795,6 +795,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1098,6 +1109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2130,10 +2150,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -4422,14 +4454,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4471,6 +4504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,7 +4526,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -4509,6 +4548,17 @@ checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4569,6 +4619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,6 +4640,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4838,9 +4903,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -4856,9 +4921,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5057,9 +5122,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5464,7 +5529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5540,9 +5605,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -5836,9 +5901,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -7295,7 +7360,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -316,7 +316,7 @@ fn expand_home_prefix(raw: &str) -> String {
 /// Resolve the Claude configuration roots a native rename may write to.
 ///
 /// Always includes the default `~/.claude`. A configured directory is only added
-/// once it passes [`validate_custom_claude_path`], which requires an absolute,
+/// once it passes [`crate::utils::validate_custom_claude_path`], which requires an absolute,
 /// non-symlinked base with a real `projects/` subdirectory. The allowlist can
 /// therefore only widen to directories the user registered and that the app
 /// already scans — never to arbitrary paths.

--- a/src-tauri/src/providers/continue_dev.rs
+++ b/src-tauri/src/providers/continue_dev.rs
@@ -8,7 +8,7 @@
 //!
 //! Continue defaults to `~/.continue` (overridable via `CONTINUE_GLOBAL_DIR`);
 //! `PearAI` rebrands the directory to `~/.pearai` (see [`super::pearai`]). The
-//! shared logic is parameterized by [`Family`].
+//! shared logic is parameterized by `Family`.
 //!
 //! Session file shape (Continue `Session`):
 //! ```json

--- a/src-tauri/src/providers/openinterpreter.rs
+++ b/src-tauri/src/providers/openinterpreter.rs
@@ -6,7 +6,7 @@
 //! (`CODEX_HOME` is deliberately ignored by Open Interpreter).
 //!
 //! Because the on-disk format is byte-compatible with Codex, this module reuses
-//! the Codex rollout parser ([`super::codex::parse_rollout_file`]) and metadata
+//! the Codex rollout parser (`super::codex::parse_rollout_file`) and metadata
 //! extractors, validating paths against the Open Interpreter root and re-tagging
 //! the provider on the result. Projects group rollouts by `cwd`, like Codex.
 


### PR DESCRIPTION
## What & why

The `Documentation` and `Security Audit` jobs in `rust-tests.yml` run **only on `main`** (`if: github.ref == 'refs/heads/main'`), so they never gate PRs/develop and have failed on **every release** (v1.17–v1.22). This makes them pass.

### Documentation
CI runs `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`:
- `rename.rs`: unresolved intra-doc link `validate_custom_claude_path` → qualified to `crate::utils::validate_custom_claude_path`.
- `continue_dev.rs` / `openinterpreter.rs`: links to private items (`Family`, `codex::parse_rollout_file`) demoted to code spans (also clean under a plain `cargo doc`).

### Security Audit
`cargo audit`: **14 → 0 vulnerabilities**.
- `cargo update` to advisory-fixed, semver-compatible versions: `bytes`, `crossbeam-epoch`, `quinn-proto`, `rkyv`, `rustls-webpki`, `slab`, `tar`.
- `.cargo/audit.toml` ignores the two remaining `quick-xml` DoS advisories (RUSTSEC-2026-0194/0195). They're transitive via `plist → tauri`/`tauri-plugin-os` (local `.plist` parsing, no untrusted-XML surface) and only resolvable once Tauri adopts `quick-xml >= 0.41`. Documented with a revisit note.

## Type

- [x] Refactor / perf (CI/build hygiene)

## Note on verification

The two fixed jobs are main-only, so this PR's CI won't exercise them. Verified locally with the **exact** CI commands:
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` → clean
- `cargo audit` → 0 vulnerabilities
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --all-features -- --test-threads=1` (913 lib) → all green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added security-audit configuration for two reviewed dependency advisories.
  - Documented when the advisory exceptions should be revisited.

- **Documentation**
  - Clarified internal references and formatting in session rename and provider documentation.
  - No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->