### PR TITLE
feat(providers): add Grok CLI provider and model attribution

### DIFF
--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -38,6 +38,7 @@ pub async fn scan_all_projects(
             "copilot".to_string(),
             "gemini".to_string(),
             "goose".to_string(),
+            "grok".to_string(),
             "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
@@ -125,6 +126,7 @@ pub async fn scan_all_projects(
         ("pearai", providers::pearai::scan_projects),
         ("gemini", providers::gemini::scan_projects),
         ("goose", providers::goose::scan_projects),
+        ("grok", providers::grok::scan_projects),
         ("kimi", providers::kimi::scan_projects),
         ("forgecode", providers::forgecode::scan_projects),
         ("opencode", providers::opencode::scan_projects),
@@ -319,6 +321,7 @@ pub async fn load_provider_sessions(
         "copilot" => providers::copilot::load_sessions(&project_path, exclude),
         "gemini" => providers::gemini::load_sessions(&project_path, exclude),
         "goose" => providers::goose::load_sessions(&project_path, exclude),
+        "grok" => providers::grok::load_sessions(&project_path, exclude),
         "kimi" => providers::kimi::load_sessions(&project_path, exclude),
         "forgecode" => providers::forgecode::load_sessions(&project_path, exclude),
         "opencode" => providers::opencode::load_sessions(&project_path, exclude),
@@ -431,6 +434,7 @@ fn load_non_claude_messages(
         "copilot" => providers::copilot::load_messages(session_path),
         "gemini" => providers::gemini::load_messages(session_path),
         "goose" => providers::goose::load_messages(session_path),
+        "grok" => providers::grok::load_messages(session_path),
         "kimi" => providers::kimi::load_messages(session_path),
         "forgecode" => providers::forgecode::load_messages(session_path),
         "opencode" => providers::opencode::load_messages(session_path),
@@ -606,6 +610,7 @@ pub async fn search_all_providers(
             "copilot".to_string(),
             "gemini".to_string(),
             "goose".to_string(),
+            "grok".to_string(),
             "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
@@ -735,6 +740,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Goose search failed: {e}");
+            }
+        }
+    }
+
+    // Grok
+    if providers_to_search.iter().any(|p| p == "grok") {
+        match providers::grok::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Grok search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -27,6 +27,7 @@ enum StatsProvider {
     Codex,
     ForgeCode,
     OpenCode,
+    Grok,
     Kimi,
     Antigravity,
     Copilot,
@@ -68,6 +69,7 @@ fn stats_provider_id(provider: StatsProvider) -> &'static str {
         StatsProvider::Codex => "codex",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
+        StatsProvider::Grok => "grok",
         StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
         StatsProvider::Copilot => "copilot",
@@ -227,6 +229,7 @@ fn all_stats_providers() -> HashSet<StatsProvider> {
         StatsProvider::Codex,
         StatsProvider::ForgeCode,
         StatsProvider::OpenCode,
+        StatsProvider::Grok,
         StatsProvider::Kimi,
         StatsProvider::Antigravity,
         StatsProvider::Copilot,
@@ -253,6 +256,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
             "codex" => Some(StatsProvider::Codex),
             "forgecode" => Some(StatsProvider::ForgeCode),
             "opencode" => Some(StatsProvider::OpenCode),
+            "grok" => Some(StatsProvider::Grok),
             "kimi" => Some(StatsProvider::Kimi),
             "antigravity" => Some(StatsProvider::Antigravity),
             "copilot" => Some(StatsProvider::Copilot),
@@ -284,6 +288,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::ForgeCode
     } else if project_path.starts_with("opencode://") {
         StatsProvider::OpenCode
+    } else if project_path.starts_with("grok://") {
+        StatsProvider::Grok
     } else if project_path.starts_with("kimi://") {
         StatsProvider::Kimi
     } else if project_path.starts_with("gemini://") {
@@ -311,6 +317,10 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
 fn detect_session_provider(session_path: &str) -> StatsProvider {
     if session_path.starts_with("opencode://") {
         return StatsProvider::OpenCode;
+    }
+
+    if is_grok_path(session_path) {
+        return StatsProvider::Grok;
     }
 
     if is_kimi_path(session_path) {
@@ -479,6 +489,27 @@ fn is_gemini_path(path: &str) -> bool {
                 .starts_with(path_from_current_dir(PathBuf::from(root).join("tmp")))
         })
         .unwrap_or(false)
+}
+
+fn is_grok_path(path: &str) -> bool {
+    providers::grok::get_base_path()
+        .map(|root| Path::new(path).starts_with(root))
+        .unwrap_or(false)
+}
+
+fn grok_virtual_paths_match(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let left_path = left.strip_prefix("grok://").unwrap_or(left);
+    let right_path = right.strip_prefix("grok://").unwrap_or(right);
+    match (
+        Path::new(left_path).canonicalize(),
+        Path::new(right_path).canonicalize(),
+    ) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 /// Parse a line using simd-json (requires mutable slice)
@@ -1190,6 +1221,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Codex => providers::codex::scan_projects().unwrap_or_default(),
         StatsProvider::ForgeCode => providers::forgecode::scan_projects().unwrap_or_default(),
         StatsProvider::OpenCode => providers::opencode::scan_projects().unwrap_or_default(),
+        StatsProvider::Grok => providers::grok::scan_projects().unwrap_or_default(),
         StatsProvider::Kimi => providers::kimi::scan_projects().unwrap_or_default(),
         StatsProvider::Antigravity => providers::antigravity::scan_projects().unwrap_or_default(),
         StatsProvider::Copilot => providers::copilot::scan_projects().unwrap_or_default(),
@@ -1213,6 +1245,7 @@ fn collect_provider_global_file_stats(
             StatsProvider::Codex => providers::codex::load_sessions(&project.path, false),
             StatsProvider::ForgeCode => providers::forgecode::load_sessions(&project.path, false),
             StatsProvider::OpenCode => providers::opencode::load_sessions(&project.path, false),
+            StatsProvider::Grok => providers::grok::load_sessions(&project.path, false),
             StatsProvider::Kimi => providers::kimi::load_sessions(&project.path, false),
             StatsProvider::Antigravity => {
                 providers::antigravity::load_sessions(&project.path, false)
@@ -1239,6 +1272,7 @@ fn collect_provider_global_file_stats(
                 StatsProvider::Codex => providers::codex::load_messages(file_path),
                 StatsProvider::ForgeCode => providers::forgecode::load_messages(file_path),
                 StatsProvider::OpenCode => providers::opencode::load_messages(file_path),
+                StatsProvider::Grok => providers::grok::load_messages(file_path),
                 StatsProvider::Kimi => providers::kimi::load_messages(file_path),
                 StatsProvider::Antigravity => providers::antigravity::load_messages(file_path),
                 StatsProvider::Copilot => providers::copilot::load_messages(file_path),
@@ -1966,6 +2000,32 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                 .unwrap_or(project_path)
                 .to_string()
         }
+        StatsProvider::Grok => {
+            if let Ok(projects) = providers::grok::scan_projects() {
+                if let Some(project) = projects
+                    .into_iter()
+                    .find(|p| grok_virtual_paths_match(&p.path, project_path))
+                {
+                    return project.name;
+                }
+            }
+            project_path
+                .strip_prefix("grok://")
+                .and_then(|p| {
+                    PathBuf::from(p).file_name().map(|n| {
+                        let encoded = n.to_string_lossy().to_string();
+                        let decoded = urlencoding::decode(&encoded)
+                            .map(std::borrow::Cow::into_owned)
+                            .unwrap_or_else(|_| encoded.clone());
+                        Path::new(&decoded)
+                            .file_name()
+                            .map(|name| name.to_string_lossy().to_string())
+                            .filter(|name| !name.is_empty())
+                            .unwrap_or(encoded)
+                    })
+                })
+                .unwrap_or_else(|| project_path.to_string())
+        }
         StatsProvider::Kimi => {
             if let Ok(projects) = providers::kimi::scan_projects() {
                 if let Some(project) = projects.into_iter().find(|p| p.path == project_path) {
@@ -2079,6 +2139,13 @@ fn resolve_provider_project_name_from_session(
             }
             "codex".to_string()
         }
+        StatsProvider::Grok => {
+            if let Some(project_dir) = Path::new(session_path).parent() {
+                let project_path = format!("grok://{}", project_dir.to_string_lossy());
+                return resolve_provider_project_name(provider, &project_path);
+            }
+            "grok".to_string()
+        }
         StatsProvider::Kimi => {
             if let Some(project_dir) = Path::new(session_path).parent() {
                 let project_path = format!("kimi://{}", project_dir.to_string_lossy());
@@ -2149,6 +2216,7 @@ fn load_provider_sessions_for_stats(
         StatsProvider::Codex => providers::codex::load_sessions(project_path, false),
         StatsProvider::ForgeCode => providers::forgecode::load_sessions(project_path, false),
         StatsProvider::OpenCode => providers::opencode::load_sessions(project_path, false),
+        StatsProvider::Grok => providers::grok::load_sessions(project_path, false),
         StatsProvider::Kimi => providers::kimi::load_sessions(project_path, false),
         StatsProvider::Antigravity => providers::antigravity::load_sessions(project_path, false),
         StatsProvider::Copilot => providers::copilot::load_sessions(project_path, false),
@@ -2171,6 +2239,7 @@ fn load_provider_messages_for_stats(
         StatsProvider::Codex => providers::codex::load_messages(&session.file_path),
         StatsProvider::ForgeCode => providers::forgecode::load_messages(&session.file_path),
         StatsProvider::OpenCode => providers::opencode::load_messages(&session.file_path),
+        StatsProvider::Grok => providers::grok::load_messages(&session.file_path),
         StatsProvider::Kimi => providers::kimi::load_messages(&session.file_path),
         StatsProvider::Antigravity => providers::antigravity::load_messages(&session.file_path),
         StatsProvider::Copilot => providers::copilot::load_messages(&session.file_path),
@@ -2921,6 +2990,7 @@ pub async fn get_session_token_stats(
             StatsProvider::Codex => providers::codex::load_messages(&session_path)?,
             StatsProvider::ForgeCode => providers::forgecode::load_messages(&session_path)?,
             StatsProvider::OpenCode => providers::opencode::load_messages(&session_path)?,
+            StatsProvider::Grok => providers::grok::load_messages(&session_path)?,
             StatsProvider::Kimi => providers::kimi::load_messages(&session_path)?,
             StatsProvider::Antigravity => providers::antigravity::load_messages(&session_path)?,
             StatsProvider::Copilot => providers::copilot::load_messages(&session_path)?,
@@ -3876,6 +3946,13 @@ pub async fn get_global_stats_summary(
         file_stats.extend(opencode_stats);
     }
 
+    if providers_to_include.contains(&StatsProvider::Grok) {
+        let (grok_stats, grok_projects) =
+            collect_provider_global_file_stats(StatsProvider::Grok, mode, s_ref, e_ref);
+        project_names.extend(grok_projects);
+        file_stats.extend(grok_stats);
+    }
+
     if providers_to_include.contains(&StatsProvider::Kimi) {
         let (kimi_stats, kimi_projects) =
             collect_provider_global_file_stats(StatsProvider::Kimi, mode, s_ref, e_ref);
@@ -4799,6 +4876,10 @@ mod tests {
             StatsProvider::OpenCode
         );
         assert_eq!(
+            detect_project_provider("grok:///Users/jack/.grok/sessions/%2FUsers%2Fjack%2Frepo"),
+            StatsProvider::Grok
+        );
+        assert_eq!(
             detect_project_provider("kimi:///Users/jack/.kimi/sessions/project-hash"),
             StatsProvider::Kimi
         );
@@ -4853,6 +4934,15 @@ mod tests {
             detect_session_provider("opencode://project/ses_abc"),
             StatsProvider::OpenCode
         );
+        if let Some(root) = providers::grok::get_base_path() {
+            let grok_session = PathBuf::from(root)
+                .join("sessions")
+                .join("%2FUsers%2Fjack%2Frepo")
+                .join("session-id")
+                .to_string_lossy()
+                .to_string();
+            assert_eq!(detect_session_provider(&grok_session), StatsProvider::Grok);
+        }
         if let Some(root) = providers::kimi::get_base_path() {
             let kimi_session = PathBuf::from(root)
                 .join("sessions")
@@ -4926,6 +5016,7 @@ mod tests {
         assert!(providers.contains(&StatsProvider::Codex));
         assert!(providers.contains(&StatsProvider::ForgeCode));
         assert!(providers.contains(&StatsProvider::OpenCode));
+        assert!(providers.contains(&StatsProvider::Grok));
         assert!(providers.contains(&StatsProvider::Kimi));
         assert!(providers.contains(&StatsProvider::Antigravity));
         assert!(providers.contains(&StatsProvider::Copilot));
@@ -4960,6 +5051,14 @@ mod tests {
         let providers = parse_active_stats_providers(Some(vec!["forgecode".to_string()]));
         assert_eq!(providers.len(), 1);
         assert!(providers.contains(&StatsProvider::ForgeCode));
+    }
+
+    #[test]
+    /// Verify parse active stats providers supports Grok.
+    fn test_parse_active_stats_providers_supports_grok() {
+        let providers = parse_active_stats_providers(Some(vec!["grok".to_string()]));
+        assert_eq!(providers.len(), 1);
+        assert!(providers.contains(&StatsProvider::Grok));
     }
 
     #[test]
@@ -5059,6 +5158,96 @@ mod tests {
             false,
             StatsMode::BillingTotal
         ));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_project_stats_summary_accepts_grok_virtual_path() {
+        let temp = TempDir::new().expect("temp dir");
+        let encoded = "%2FUsers%2Ftest%2Fdemo";
+        let session_id = "019fa555-791c-71e2-8c92-ff2e6fa26d6e";
+        let project_dir = temp.path().join("sessions").join(encoded);
+        let session_dir = project_dir.join(session_id);
+        fs::create_dir_all(&session_dir).unwrap();
+
+        fs::write(
+            session_dir.join("summary.json"),
+            serde_json::json!({
+                "info": { "id": session_id, "cwd": "/Users/test/demo" },
+                "generated_title": "Demo",
+                "created_at": "2026-07-27T20:47:50Z",
+                "updated_at": "2026-07-27T21:11:25Z",
+                "num_chat_messages": 2,
+                "current_model_id": "grok-4.5"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        fs::write(
+            session_dir.join("chat_history.jsonl"),
+            r#"{"type":"user","content":"hello"}
+{"type":"assistant","content":"hi","model_id":"grok-4.5"}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            session_dir.join("signals.json"),
+            serde_json::json!({
+                "contextTokensUsed": 42,
+                "primaryModelId": "grok-4.5",
+                "toolCallCount": 0
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let _env = EnvVarGuard::set("GROK_HOME", temp.path());
+        let project_path = format!("grok://{}", project_dir.to_string_lossy());
+
+        assert_eq!(detect_project_provider(&project_path), StatsProvider::Grok);
+
+        let summary = get_project_stats_summary(project_path.clone(), None, None, None)
+            .await
+            .expect("grok virtual project path should load stats");
+        assert_eq!(summary.project_name, "demo");
+        assert!(summary.total_sessions >= 1);
+        assert!(summary.total_messages >= 1);
+        assert_eq!(summary.total_tokens, 42);
+
+        let global = get_global_stats_summary(
+            "/tmp".to_string(),
+            Some(vec!["grok".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("grok should contribute to global stats");
+        assert!(
+            global
+                .provider_distribution
+                .iter()
+                .any(|provider| provider.provider_id == "grok" && provider.tokens >= 42),
+            "expected grok in provider_distribution: {:?}",
+            global.provider_distribution
+        );
+        assert!(
+            global
+                .model_distribution
+                .iter()
+                .any(|model| model.model_name.contains("grok") && model.token_count >= 42),
+            "expected grok model in model_distribution: {:?}",
+            global.model_distribution
+        );
+        assert!(
+            global
+                .top_projects
+                .iter()
+                .any(|project| project.project_name.contains("demo")),
+            "expected grok project in top_projects: {:?}",
+            global.top_projects
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -1,0 +1,1064 @@
+use super::ProviderInfo;
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
+use crate::utils::{
+    build_provider_message, detect_git_worktree_info, is_symlink,
+    search_json_value_case_insensitive,
+};
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PROVIDER_ID: &str = "grok";
+const SESSIONS_DIR: &str = "sessions";
+const SUMMARY_FILE: &str = "summary.json";
+const CHAT_HISTORY_FILE: &str = "chat_history.jsonl";
+
+pub fn detect() -> Option<ProviderInfo> {
+    let base = get_base_path()?;
+    let sessions_path = Path::new(&base).join(SESSIONS_DIR);
+
+    Some(ProviderInfo {
+        id: PROVIDER_ID.to_string(),
+        display_name: "Grok CLI".to_string(),
+        base_path: base,
+        is_available: sessions_path.exists() && sessions_path.is_dir(),
+    })
+}
+
+pub fn get_base_path() -> Option<String> {
+    if let Ok(env_val) = std::env::var("GROK_HOME") {
+        let path = PathBuf::from(&env_val);
+        let absolute_path = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir().ok()?.join(path)
+        };
+        if absolute_path.exists() {
+            let normalized = absolute_path.canonicalize().unwrap_or(absolute_path);
+            return Some(normalized.to_string_lossy().to_string());
+        }
+    }
+
+    let default = dirs::home_dir()?.join(".grok");
+    if default.exists() {
+        let normalized = default.canonicalize().unwrap_or(default);
+        Some(normalized.to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
+pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
+    crate::utils::require_absolute_path(base_path, "Grok base path")?;
+    let base = Path::new(base_path);
+    let sessions_root = base.join(SESSIONS_DIR);
+
+    if is_symlink(&sessions_root) || !sessions_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    let mut projects = Vec::new();
+
+    for entry in
+        fs::read_dir(&sessions_root).map_err(|e| format!("Failed to read Grok sessions: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Grok project entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let project_dir = entry.path();
+        if !path_is_inside(&project_dir, &canonical_base)? {
+            continue;
+        }
+
+        let mut infos = Vec::new();
+        for session_entry in fs::read_dir(&project_dir)
+            .map_err(|e| format!("Failed to read Grok project dir: {e}"))?
+        {
+            let session_entry =
+                session_entry.map_err(|e| format!("Failed to read Grok session entry: {e}"))?;
+            if session_entry
+                .file_type()
+                .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+            {
+                continue;
+            }
+            if let Some(info) = extract_session_info(&session_entry.path()) {
+                infos.push(info);
+            }
+        }
+
+        if infos.is_empty() {
+            continue;
+        }
+
+        let encoded_name = project_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| "grok".to_string());
+        let actual_path = infos
+            .iter()
+            .find_map(|info| info.cwd.clone())
+            .unwrap_or_else(|| decode_cwd_dirname(&encoded_name));
+        let name = project_name_from_actual_path(&actual_path, &encoded_name);
+        let message_count = infos.iter().map(|info| info.message_count).sum();
+        let last_modified = infos
+            .iter()
+            .map(|info| info.last_modified.as_str())
+            .max()
+            .unwrap_or_default()
+            .to_string();
+
+        let project_uri_path = project_dir
+            .canonicalize()
+            .unwrap_or_else(|_| project_dir.clone());
+
+        projects.push(ClaudeProject {
+            name,
+            path: format!("grok://{}", project_uri_path.to_string_lossy()),
+            actual_path: actual_path.clone(),
+            session_count: infos.len(),
+            message_count,
+            last_modified,
+            git_info: if Path::new(&actual_path).is_absolute() {
+                detect_git_worktree_info(&actual_path)
+            } else {
+                None
+            },
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            custom_directory_label: None,
+        });
+    }
+
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    scan_projects_from_path(&base)
+}
+
+pub fn load_sessions(
+    project_path: &str,
+    exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    load_sessions_from_base_path(&base, project_path, exclude_sidechain)
+}
+
+pub fn load_sessions_from_base_path(
+    base_path: &str,
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    crate::utils::require_absolute_path(base_path, "Grok base path")?;
+    let base = Path::new(base_path);
+    let project_dir = resolve_project_dir(base, project_path)?;
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    if !path_is_inside(&project_dir, &canonical_base)? {
+        return Err("Grok project path is outside Grok base path".to_string());
+    }
+
+    let fallback_project_name = project_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "grok".to_string());
+
+    let mut sessions = Vec::new();
+    for entry in
+        fs::read_dir(&project_dir).map_err(|e| format!("Failed to read Grok project dir: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Grok session entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let session_dir = entry.path();
+        let Some(info) = extract_session_info(&session_dir) else {
+            continue;
+        };
+        let project_name = info
+            .cwd
+            .as_deref()
+            .map(|cwd| project_name_from_actual_path(cwd, &fallback_project_name))
+            .unwrap_or_else(|| {
+                project_name_from_actual_path(
+                    &decode_cwd_dirname(&fallback_project_name),
+                    &fallback_project_name,
+                )
+            });
+
+        sessions.push(ClaudeSession {
+            session_id: session_dir.to_string_lossy().to_string(),
+            actual_session_id: info.session_id.clone(),
+            file_path: session_dir.to_string_lossy().to_string(),
+            project_name,
+            message_count: info.message_count,
+            first_message_time: info.first_message_time,
+            last_message_time: info.last_message_time,
+            last_modified: info.last_modified,
+            has_tool_use: info.has_tool_use,
+            has_errors: false,
+            summary: info.summary,
+            is_renamed: false,
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            entrypoint: None,
+        });
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    load_messages_from_base_path(&base, session_path)
+}
+
+pub fn load_messages_from_base_path(
+    base_path: &str,
+    session_path: &str,
+) -> Result<Vec<ClaudeMessage>, String> {
+    crate::utils::require_absolute_path(base_path, "Grok base path")?;
+    let base = Path::new(base_path);
+    let session_dir = PathBuf::from(session_path);
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    if !session_dir.is_absolute() || !path_is_inside(&session_dir, &canonical_base)? {
+        return Err("Grok session path is outside Grok base path".to_string());
+    }
+    if is_symlink(&session_dir) || !session_dir.is_dir() {
+        return Err("Grok session path is not a directory".to_string());
+    }
+
+    let session_id = session_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let summary = read_json_file(&session_dir.join(SUMMARY_FILE)).unwrap_or(Value::Null);
+    let created_at = summary
+        .get("created_at")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let updated_at = summary
+        .get("updated_at")
+        .or_else(|| summary.get("last_active_at"))
+        .and_then(Value::as_str)
+        .unwrap_or(created_at.as_str())
+        .to_string();
+    let model = summary
+        .get("current_model_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    let mut messages = Vec::new();
+    let mut counter = 0u64;
+
+    for value in read_jsonl_values(&session_dir.join(CHAT_HISTORY_FILE))? {
+        if let Some(message) = convert_chat_message(
+            &value,
+            &session_id,
+            &created_at,
+            model.clone(),
+            &mut counter,
+        ) {
+            messages.push(message);
+        }
+    }
+
+    if let Some(last) = messages.last_mut() {
+        if !updated_at.is_empty() {
+            last.timestamp.clone_from(&updated_at);
+        }
+    }
+
+    attach_session_token_usage(&session_dir, &mut messages);
+
+    if !updated_at.is_empty() {
+        if let Some(message) = messages
+            .iter_mut()
+            .rev()
+            .find(|message| message.usage.is_some())
+        {
+            message.timestamp = updated_at;
+        }
+    }
+
+    Ok(messages)
+}
+
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    search_from_base_path(&base, query, limit)
+}
+
+pub fn search_from_base_path(
+    base_path: &str,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<ClaudeMessage>, String> {
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for project in scan_projects_from_path(base_path)? {
+        for session in load_sessions_from_base_path(base_path, &project.path, false)? {
+            for mut message in load_messages_from_base_path(base_path, &session.file_path)? {
+                if let Some(content) = &message.content {
+                    if search_json_value_case_insensitive(content, &query_lower) {
+                        message.project_name = Some(project.name.clone());
+                        results.push(message);
+                        if results.len() >= limit {
+                            return Ok(results);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[derive(Debug, Clone)]
+struct SessionInfo {
+    session_id: String,
+    cwd: Option<String>,
+    message_count: usize,
+    first_message_time: String,
+    last_message_time: String,
+    last_modified: String,
+    has_tool_use: bool,
+    summary: Option<String>,
+}
+
+fn extract_session_info(session_dir: &Path) -> Option<SessionInfo> {
+    if is_symlink(session_dir) || !session_dir.is_dir() {
+        return None;
+    }
+    let summary_path = session_dir.join(SUMMARY_FILE);
+    let chat_path = session_dir.join(CHAT_HISTORY_FILE);
+    if is_symlink(&summary_path) || !summary_path.is_file() {
+        return None;
+    }
+    if is_symlink(&chat_path) || !chat_path.is_file() {
+        return None;
+    }
+
+    let summary = read_json_file(&summary_path).ok()?;
+    let session_id = summary
+        .pointer("/info/id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            session_dir
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })?;
+
+    let cwd = summary
+        .pointer("/info/cwd")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+        .map(ToOwned::to_owned);
+
+    let title = summary
+        .get("generated_title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .or_else(|| {
+            summary
+                .get("session_summary")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|title| !title.is_empty())
+        })
+        .map(ToOwned::to_owned);
+
+    let created_at = summary
+        .get("created_at")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let updated_at = summary
+        .get("updated_at")
+        .or_else(|| summary.get("last_active_at"))
+        .and_then(Value::as_str)
+        .unwrap_or(created_at.as_str())
+        .to_string();
+
+    let mut message_count = summary
+        .get("num_chat_messages")
+        .or_else(|| summary.get("num_messages"))
+        .and_then(Value::as_u64)
+        .map(|n| n as usize)
+        .unwrap_or(0);
+
+    let signals = read_json_file(&session_dir.join("signals.json")).unwrap_or(Value::Null);
+    let mut has_tool_use = signals
+        .get("toolCallCount")
+        .and_then(Value::as_u64)
+        .is_some_and(|n| n > 0);
+
+    if message_count == 0 {
+        if let Ok(values) = read_jsonl_values(&chat_path) {
+            message_count = values
+                .iter()
+                .filter(|value| {
+                    matches!(
+                        value.get("type").and_then(Value::as_str),
+                        Some("user" | "assistant" | "tool_result" | "reasoning" | "system")
+                    )
+                })
+                .count();
+            if !has_tool_use {
+                has_tool_use = values.iter().any(value_has_tool_use);
+            }
+        }
+    } else if !has_tool_use {
+        has_tool_use = chat_history_has_tool_use(&chat_path);
+    }
+
+    if message_count == 0 {
+        return None;
+    }
+
+    let last_modified = if updated_at.is_empty() {
+        file_modified_iso(&summary_path).unwrap_or_default()
+    } else {
+        updated_at.clone()
+    };
+
+    Some(SessionInfo {
+        session_id,
+        cwd,
+        message_count,
+        first_message_time: created_at,
+        last_message_time: updated_at,
+        last_modified,
+        has_tool_use,
+        summary: title,
+    })
+}
+
+fn convert_chat_message(
+    value: &Value,
+    session_id: &str,
+    timestamp: &str,
+    model: Option<String>,
+    counter: &mut u64,
+) -> Option<ClaudeMessage> {
+    let msg_type = value.get("type").and_then(Value::as_str)?;
+    *counter += 1;
+    let uuid = value
+        .get("id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("{session_id}-{counter}"));
+
+    match msg_type {
+        "system" => {
+            let content = content_to_blocks(value.get("content"));
+            if content_is_empty(&content) {
+                return None;
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp.to_string(),
+                "system",
+                Some("system"),
+                Some(content),
+                None,
+            ))
+        }
+        "user" => Some(build_provider_message(
+            PROVIDER_ID,
+            uuid,
+            session_id,
+            timestamp.to_string(),
+            "user",
+            Some("user"),
+            Some(content_to_blocks(value.get("content"))),
+            None,
+        )),
+        "assistant" => {
+            let mut blocks = content_to_blocks(value.get("content"));
+            if let Some(calls) = value.get("tool_calls").and_then(Value::as_array) {
+                if let Some(arr) = blocks.as_array_mut() {
+                    for call in calls {
+                        arr.push(convert_tool_call(call));
+                    }
+                }
+            }
+            let model_id = value
+                .get("model_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+                .or(model);
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp.to_string(),
+                "assistant",
+                Some("assistant"),
+                Some(blocks),
+                model_id,
+            ))
+        }
+        "reasoning" => {
+            let thinking = extract_reasoning_text(value);
+            if thinking.trim().is_empty() {
+                return None;
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp.to_string(),
+                "assistant",
+                Some("assistant"),
+                Some(json!([{ "type": "thinking", "thinking": thinking }])),
+                model,
+            ))
+        }
+        "tool_result" => Some(build_provider_message(
+            PROVIDER_ID,
+            uuid,
+            session_id,
+            timestamp.to_string(),
+            "user",
+            Some("user"),
+            Some(json!([{
+                "type": "tool_result",
+                "tool_use_id": value.get("tool_call_id").and_then(Value::as_str).unwrap_or(""),
+                "content": value.get("content").cloned().unwrap_or(Value::Null)
+            }])),
+            None,
+        )),
+        "backend_tool_call" => convert_backend_tool_call(value, &uuid, session_id, timestamp),
+        _ => None,
+    }
+}
+
+fn convert_backend_tool_call(
+    value: &Value,
+    uuid: &str,
+    session_id: &str,
+    timestamp: &str,
+) -> Option<ClaudeMessage> {
+    let kind = value.get("kind")?;
+    let name = kind
+        .get("tool_type")
+        .and_then(Value::as_str)
+        .unwrap_or("backend_tool");
+    Some(build_provider_message(
+        PROVIDER_ID,
+        uuid.to_string(),
+        session_id,
+        timestamp.to_string(),
+        "assistant",
+        Some("assistant"),
+        Some(json!([{
+            "type": "tool_use",
+            "id": uuid,
+            "name": name,
+            "input": kind.get("action").cloned().unwrap_or_else(|| kind.clone())
+        }])),
+        None,
+    ))
+}
+
+fn extract_reasoning_text(value: &Value) -> String {
+    if let Some(text) = value.get("content").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    if let Some(text) = value.get("thinking").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    if let Some(items) = value.get("summary").and_then(Value::as_array) {
+        return items
+            .iter()
+            .filter_map(|item| {
+                item.get("text")
+                    .and_then(Value::as_str)
+                    .or_else(|| item.as_str())
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    String::new()
+}
+
+fn content_to_blocks(content: Option<&Value>) -> Value {
+    match content {
+        Some(Value::Array(items)) => {
+            Value::Array(items.iter().map(normalize_content_block).collect())
+        }
+        Some(Value::String(text)) => json!([{ "type": "text", "text": text }]),
+        Some(Value::Null) | None => Value::Array(Vec::new()),
+        Some(other) => json!([{ "type": "text", "text": other.to_string() }]),
+    }
+}
+
+fn normalize_content_block(item: &Value) -> Value {
+    item.clone()
+}
+
+fn content_is_empty(content: &Value) -> bool {
+    match content {
+        Value::Array(items) => {
+            items.is_empty()
+                || items.iter().all(|item| {
+                    item.get("text")
+                        .and_then(Value::as_str)
+                        .map_or(true, |text| text.trim().is_empty())
+                })
+        }
+        Value::String(text) => text.trim().is_empty(),
+        Value::Null => true,
+        _ => false,
+    }
+}
+
+fn convert_tool_call(call: &Value) -> Value {
+    let function = call.get("function").unwrap_or(&Value::Null);
+    let name = function
+        .get("name")
+        .or_else(|| call.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("tool");
+    let input = function
+        .get("arguments")
+        .or_else(|| call.get("arguments"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    json!({
+        "type": "tool_use",
+        "id": call.get("id").and_then(Value::as_str).unwrap_or(""),
+        "name": name,
+        "input": normalize_tool_input(input)
+    })
+}
+
+fn normalize_tool_input(input: Value) -> Value {
+    if let Some(s) = input.as_str() {
+        serde_json::from_str(s).unwrap_or_else(|_| json!({ "input": s }))
+    } else {
+        input
+    }
+}
+
+fn decode_cwd_dirname(encoded: &str) -> String {
+    urlencoding::decode(encoded)
+        .map(std::borrow::Cow::into_owned)
+        .unwrap_or_else(|_| encoded.to_string())
+}
+
+fn attach_session_token_usage(session_dir: &Path, messages: &mut [ClaudeMessage]) {
+    if messages.is_empty() {
+        return;
+    }
+
+    let signals = read_json_file(&session_dir.join("signals.json")).unwrap_or(Value::Null);
+    let tokens = signals
+        .get("contextTokensUsed")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if tokens == 0 {
+        return;
+    }
+
+    let model = signals
+        .get("primaryModelId")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    let capped = u32::try_from(tokens.min(u64::from(u32::MAX))).unwrap_or(u32::MAX);
+    if let Some(message) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.message_type == "assistant")
+    {
+        message.usage = Some(TokenUsage {
+            input_tokens: Some(capped),
+            output_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+            service_tier: None,
+        });
+        if let Some(model) = model {
+            message.model = Some(model);
+        }
+    }
+}
+
+fn read_json_file(path: &Path) -> Result<Value, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Grok JSON file".to_string());
+    }
+    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read JSON file: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON file: {e}"))
+}
+
+fn read_jsonl_values(path: &Path) -> Result<Vec<Value>, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Grok JSONL file".to_string());
+    }
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read JSONL file: {e}"))?;
+    let mut values = Vec::new();
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        if let Ok(value) = serde_json::from_str::<Value>(line) {
+            values.push(value);
+        }
+    }
+    Ok(values)
+}
+
+fn value_has_tool_use(value: &Value) -> bool {
+    matches!(
+        value.get("type").and_then(Value::as_str),
+        Some("tool_result" | "backend_tool_call")
+    ) || value
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .is_some_and(|calls| !calls.is_empty())
+}
+
+fn chat_history_has_tool_use(path: &Path) -> bool {
+    use std::io::{BufRead, BufReader};
+
+    if is_symlink(path) || !path.is_file() {
+        return false;
+    }
+    let Ok(file) = fs::File::open(path) else {
+        return false;
+    };
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<Value>(&line) {
+            if value_has_tool_use(&value) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn file_modified_iso(path: &Path) -> Option<String> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .map(|time| {
+            let dt: DateTime<Utc> = time.into();
+            dt.to_rfc3339()
+        })
+}
+
+fn resolve_project_dir(base: &Path, project_path: &str) -> Result<PathBuf, String> {
+    let raw = project_path.strip_prefix("grok://").unwrap_or(project_path);
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err("Grok project path must be absolute".to_string());
+    }
+    if is_symlink(&path) || !path.is_dir() {
+        return Err("Grok project path is not a directory".to_string());
+    }
+
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    let sessions_root = canonical_base.join(SESSIONS_DIR);
+    let canonical_sessions = sessions_root
+        .canonicalize()
+        .unwrap_or_else(|_| sessions_root.clone());
+    let canonical_path = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve Grok project path: {e}"))?;
+    if !canonical_path.starts_with(&canonical_sessions) {
+        return Err("Grok project path is outside Grok sessions directory".to_string());
+    }
+    Ok(canonical_path)
+}
+
+fn canonical_existing(path: &Path, label: &str) -> Result<PathBuf, String> {
+    path.canonicalize()
+        .map_err(|e| format!("Failed to resolve {label}: {e}"))
+}
+
+fn path_is_inside(path: &Path, canonical_base: &Path) -> Result<bool, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve path: {e}"))?;
+    Ok(canonical.starts_with(canonical_base))
+}
+
+fn project_name_from_actual_path(actual_path: &str, fallback: &str) -> String {
+    Path::new(actual_path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::fs;
+    use tempfile::TempDir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: std::ffi::OsString) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.original.as_ref() {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn write_fixture(root: &Path) -> (PathBuf, PathBuf) {
+        let encoded = "%2FUsers%2Ftest%2Fdemo";
+        let session_id = "019fa555-791c-71e2-8c92-ff2e6fa26d6e";
+        let project_dir = root.join("sessions").join(encoded);
+        let session_dir = project_dir.join(session_id);
+        fs::create_dir_all(&session_dir).unwrap();
+
+        let summary = json!({
+            "info": {
+                "id": session_id,
+                "cwd": "/Users/test/demo"
+            },
+            "session_summary": "Demo session",
+            "generated_title": "Demo Title",
+            "created_at": "2026-07-27T20:47:50Z",
+            "updated_at": "2026-07-27T21:11:25Z",
+            "num_chat_messages": 4,
+            "current_model_id": "grok-4.5"
+        });
+        fs::write(
+            session_dir.join(SUMMARY_FILE),
+            serde_json::to_string_pretty(&summary).unwrap(),
+        )
+        .unwrap();
+
+        let lines = [
+            r#"{"type":"system","content":"You are Grok."}"#,
+            r#"{"type":"user","content":[{"type":"text","text":"Hello grok"}]}"#,
+            r#"{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"Thinking about hello"}]}"#,
+            r#"{"type":"assistant","content":"Hi there","tool_calls":[{"id":"call-1","name":"read_file","arguments":"{\"target_file\":\"/tmp/a.txt\"}"}],"model_id":"grok-4.5"}"#,
+            r#"{"type":"tool_result","tool_call_id":"call-1","content":"file contents"}"#,
+            r#"{"type":"backend_tool_call","kind":{"tool_type":"web_search","action":{"type":"search","query":"rust"}}}"#,
+            r"not-json",
+        ];
+        fs::write(session_dir.join(CHAT_HISTORY_FILE), lines.join("\n")).unwrap();
+        fs::write(
+            session_dir.join("signals.json"),
+            serde_json::to_string_pretty(&json!({
+                "contextTokensUsed": 12345,
+                "toolCallCount": 3,
+                "primaryModelId": "grok-4.5",
+                "modelsUsed": ["grok-4.5"]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        (project_dir, session_dir)
+    }
+
+    #[test]
+    fn decode_cwd_dirname_percent_decodes_paths() {
+        assert_eq!(
+            decode_cwd_dirname("%2FUsers%2Flucashr%2FDownloads"),
+            "/Users/lucashr/Downloads"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_prefers_grok_home() {
+        let temp = TempDir::new().unwrap();
+        let home_dir = temp.path().join("grok-home");
+        fs::create_dir_all(&home_dir).unwrap();
+        let _env = EnvVarGuard::set("GROK_HOME", home_dir.as_os_str().to_owned());
+        let path = get_base_path().unwrap();
+        assert_eq!(PathBuf::from(path), home_dir.canonicalize().unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_returns_none_when_default_dir_absent() {
+        let _env = EnvVarGuard::remove("GROK_HOME");
+        if dirs::home_dir()
+            .map(|h| h.join(".grok").exists())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        assert!(get_base_path().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn scan_load_and_search_fixture_session() {
+        let temp = TempDir::new().unwrap();
+        let (_project_dir, session_dir) = write_fixture(temp.path());
+        let _env = EnvVarGuard::set("GROK_HOME", temp.path().as_os_str().to_owned());
+
+        let projects = scan_projects().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].provider.as_deref(), Some("grok"));
+        assert_eq!(projects[0].actual_path, "/Users/test/demo");
+        assert_eq!(projects[0].name, "demo");
+        assert!(projects[0].path.starts_with("grok://"));
+
+        let sessions = load_sessions(&projects[0].path, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].actual_session_id,
+            "019fa555-791c-71e2-8c92-ff2e6fa26d6e"
+        );
+        assert_eq!(sessions[0].summary.as_deref(), Some("Demo Title"));
+        assert!(sessions[0].has_tool_use);
+
+        let messages = load_messages(&session_dir.to_string_lossy()).unwrap();
+        assert!(messages.len() >= 5);
+        assert!(messages.iter().any(|m| m.message_type == "user"));
+        assert!(messages.iter().any(|m| {
+            m.content
+                .as_ref()
+                .and_then(|c| c.as_array())
+                .is_some_and(|arr| {
+                    arr.iter()
+                        .any(|item| item.get("type").and_then(Value::as_str) == Some("thinking"))
+                })
+        }));
+        assert!(messages.iter().any(|m| {
+            m.content
+                .as_ref()
+                .and_then(|c| c.as_array())
+                .is_some_and(|arr| {
+                    arr.iter()
+                        .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+                })
+        }));
+        assert!(messages.iter().any(|m| {
+            m.usage
+                .as_ref()
+                .and_then(|usage| usage.input_tokens)
+                .is_some_and(|tokens| tokens == 12345)
+        }));
+
+        let results = search("Hello grok", 10).unwrap();
+        assert!(!results.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn smoke_scan_real_grok_home_when_present() {
+        let _env = EnvVarGuard::remove("GROK_HOME");
+        let Some(base) = dirs::home_dir().map(|h| h.join(".grok")) else {
+            return;
+        };
+        if !base.join("sessions").is_dir() {
+            return;
+        }
+
+        let projects = scan_projects().expect("scan real Grok projects");
+        assert!(
+            !projects.is_empty(),
+            "expected at least one Grok project under ~/.grok/sessions"
+        );
+        assert!(projects
+            .iter()
+            .all(|p| p.provider.as_deref() == Some("grok")));
+
+        let sessions = load_sessions(&projects[0].path, false).expect("load real sessions");
+        assert!(!sessions.is_empty());
+
+        let messages =
+            load_messages(&sessions[0].file_path).expect("load real chat_history messages");
+        assert!(
+            !messages.is_empty(),
+            "expected messages in first real Grok session"
+        );
+    }
+
+    #[test]
+    fn convert_chat_message_maps_tool_result_and_backend_call() {
+        let mut counter = 0u64;
+        let tool_result = json!({
+            "type": "tool_result",
+            "tool_call_id": "call-1",
+            "content": "ok"
+        });
+        let msg = convert_chat_message(
+            &tool_result,
+            "sess",
+            "2026-01-01T00:00:00Z",
+            None,
+            &mut counter,
+        )
+        .unwrap();
+        assert_eq!(msg.message_type, "user");
+
+        let backend = json!({
+            "type": "backend_tool_call",
+            "kind": {
+                "tool_type": "web_search",
+                "action": { "query": "x" }
+            }
+        });
+        let msg =
+            convert_chat_message(&backend, "sess", "2026-01-01T00:00:00Z", None, &mut counter)
+                .unwrap();
+        assert_eq!(msg.message_type, "assistant");
+        let name = msg
+            .content
+            .as_ref()
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|item| item.get("name"))
+            .and_then(Value::as_str);
+        assert_eq!(name, Some("web_search"));
+    }
+}

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -287,16 +287,6 @@ pub fn load_messages_from_base_path(
 
     attach_session_token_usage(&session_dir, &mut messages);
 
-    if !updated_at.is_empty() {
-        if let Some(message) = messages
-            .iter_mut()
-            .rev()
-            .find(|message| message.usage.is_some())
-        {
-            message.timestamp = updated_at;
-        }
-    }
-
     Ok(messages)
 }
 
@@ -314,8 +304,28 @@ pub fn search_from_base_path(
     let mut results = Vec::new();
 
     for project in scan_projects_from_path(base_path)? {
-        for session in load_sessions_from_base_path(base_path, &project.path, false)? {
-            for mut message in load_messages_from_base_path(base_path, &session.file_path)? {
+        let sessions = match load_sessions_from_base_path(base_path, &project.path, false) {
+            Ok(sessions) => sessions,
+            Err(error) => {
+                log::warn!(
+                    "Skipping unreadable Grok project during search {}: {error}",
+                    project.path
+                );
+                continue;
+            }
+        };
+        for session in sessions {
+            let messages = match load_messages_from_base_path(base_path, &session.file_path) {
+                Ok(messages) => messages,
+                Err(error) => {
+                    log::warn!(
+                        "Skipping unreadable Grok session during search {}: {error}",
+                        session.file_path
+                    );
+                    continue;
+                }
+            };
+            for mut message in messages {
                 if let Some(content) = &message.content {
                     if search_json_value_case_insensitive(content, &query_lower) {
                         message.project_name = Some(project.name.clone());
@@ -686,7 +696,7 @@ fn attach_session_token_usage(session_dir: &Path, messages: &mut [ClaudeMessage]
         return;
     }
 
-    let model = signals
+    let fallback_model = signals
         .get("primaryModelId")
         .and_then(Value::as_str)
         .map(ToOwned::to_owned);
@@ -697,6 +707,10 @@ fn attach_session_token_usage(session_dir: &Path, messages: &mut [ClaudeMessage]
         .rev()
         .find(|message| message.message_type == "assistant")
     {
+        // Grok exposes contextTokensUsed as a session-level context snapshot,
+        // not per-response billing. The shared message schema has no context
+        // field, so retain it as an explicitly approximate input count for
+        // aggregate analytics.
         message.usage = Some(TokenUsage {
             input_tokens: Some(capped),
             output_tokens: None,
@@ -704,8 +718,8 @@ fn attach_session_token_usage(session_dir: &Path, messages: &mut [ClaudeMessage]
             cache_read_input_tokens: None,
             service_tier: None,
         });
-        if let Some(model) = model {
-            message.model = Some(model);
+        if message.model.is_none() {
+            message.model = fallback_model;
         }
     }
 }
@@ -887,6 +901,7 @@ mod tests {
             r#"{"type":"assistant","content":"Hi there","tool_calls":[{"id":"call-1","name":"read_file","arguments":"{\"target_file\":\"/tmp/a.txt\"}"}],"model_id":"grok-4.5"}"#,
             r#"{"type":"tool_result","tool_call_id":"call-1","content":"file contents"}"#,
             r#"{"type":"backend_tool_call","kind":{"tool_type":"web_search","action":{"type":"search","query":"rust"}}}"#,
+            r#"{"type":"assistant","content":"Final answer","model_id":"grok-4.5"}"#,
             r"not-json",
         ];
         fs::write(session_dir.join(CHAT_HISTORY_FILE), lines.join("\n")).unwrap();
@@ -987,40 +1002,14 @@ mod tests {
                 .and_then(|usage| usage.input_tokens)
                 .is_some_and(|tokens| tokens == 12345)
         }));
+        let usage_message = messages
+            .iter()
+            .find(|message| message.usage.is_some())
+            .unwrap();
+        assert_eq!(usage_message.model.as_deref(), Some("grok-4.5"));
 
         let results = search("Hello grok", 10).unwrap();
         assert!(!results.is_empty());
-    }
-
-    #[test]
-    #[serial]
-    fn smoke_scan_real_grok_home_when_present() {
-        let _env = EnvVarGuard::remove("GROK_HOME");
-        let Some(base) = dirs::home_dir().map(|h| h.join(".grok")) else {
-            return;
-        };
-        if !base.join("sessions").is_dir() {
-            return;
-        }
-
-        let projects = scan_projects().expect("scan real Grok projects");
-        assert!(
-            !projects.is_empty(),
-            "expected at least one Grok project under ~/.grok/sessions"
-        );
-        assert!(projects
-            .iter()
-            .all(|p| p.provider.as_deref() == Some("grok")));
-
-        let sessions = load_sessions(&projects[0].path, false).expect("load real sessions");
-        assert!(!sessions.is_empty());
-
-        let messages =
-            load_messages(&sessions[0].file_path).expect("load real chat_history messages");
-        assert!(
-            !messages.is_empty(),
-            "expected messages in first real Grok session"
-        );
     }
 
     #[test]

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -19,6 +19,7 @@ pub mod cursor_agent;
 pub mod forgecode;
 pub mod gemini;
 pub mod goose;
+pub mod grok;
 pub mod kimi;
 pub mod kiro;
 pub mod llm;
@@ -63,6 +64,8 @@ pub enum ProviderId {
     CursorAgent,
     Gemini,
     Goose,
+    /// xAI Grok CLI (`~/.grok/sessions`).
+    Grok,
     Kimi,
     ForgeCode,
     Kiro,
@@ -105,6 +108,7 @@ impl ProviderId {
             Self::CursorAgent => "cursor-agent",
             Self::Gemini => "gemini",
             Self::Goose => "goose",
+            Self::Grok => "grok",
             Self::Kimi => "kimi",
             Self::ForgeCode => "forgecode",
             Self::Kiro => "kiro",
@@ -138,6 +142,7 @@ impl ProviderId {
             "cursor-agent" => Some(Self::CursorAgent),
             "gemini" => Some(Self::Gemini),
             "goose" => Some(Self::Goose),
+            "grok" => Some(Self::Grok),
             "kimi" => Some(Self::Kimi),
             "forgecode" => Some(Self::ForgeCode),
             "kiro" => Some(Self::Kiro),
@@ -172,6 +177,7 @@ impl ProviderId {
             Self::CursorAgent => "Cursor Agent",
             Self::Gemini => "Gemini CLI",
             Self::Goose => "Goose",
+            Self::Grok => "Grok CLI",
             Self::Kimi => "Kimi CLI",
             Self::ForgeCode => "ForgeCode",
             Self::Kiro => "Kiro CLI",
@@ -219,6 +225,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = goose::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = grok::detect() {
         providers.push(info);
     }
     if let Some(info) = kimi::detect() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -346,23 +346,6 @@ function App() {
     void loadGlobalStats();
   }, [clearProjectSelection, loadGlobalStats, setAnalyticsCurrentView]);
 
-  const activeProvidersKey = useMemo(
-    () => normalizeProviderIds(activeProviders).join(","),
-    [activeProviders]
-  );
-  const prevGlobalProvidersKeyRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!isViewingGlobalStats) {
-      prevGlobalProvidersKeyRef.current = activeProvidersKey;
-      return;
-    }
-    if (prevGlobalProvidersKeyRef.current === activeProvidersKey) {
-      return;
-    }
-    prevGlobalProvidersKeyRef.current = activeProvidersKey;
-    void loadGlobalStats();
-  }, [activeProvidersKey, isViewingGlobalStats, loadGlobalStats]);
-
   const handleToggleSidebar = useCallback(() => {
     setIsSidebarCollapsed((prev) => !prev);
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -346,6 +346,23 @@ function App() {
     void loadGlobalStats();
   }, [clearProjectSelection, loadGlobalStats, setAnalyticsCurrentView]);
 
+  const activeProvidersKey = useMemo(
+    () => normalizeProviderIds(activeProviders).join(","),
+    [activeProviders]
+  );
+  const prevGlobalProvidersKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isViewingGlobalStats) {
+      prevGlobalProvidersKeyRef.current = activeProvidersKey;
+      return;
+    }
+    if (prevGlobalProvidersKeyRef.current === activeProvidersKey) {
+      return;
+    }
+    prevGlobalProvidersKeyRef.current = activeProvidersKey;
+    void loadGlobalStats();
+  }, [activeProvidersKey, isViewingGlobalStats, loadGlobalStats]);
+
   const handleToggleSidebar = useCallback(() => {
     setIsSidebarCollapsed((prev) => !prev);
   }, []);

--- a/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
+++ b/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
@@ -16,6 +16,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   codex: "var(--metric-green)",
   cursor: "var(--metric-cyan)",
   gemini: "var(--metric-purple)",
+  grok: "var(--metric-red)",
   opencode: "var(--metric-blue)",
 };
 

--- a/src/components/AnalyticsDashboard/utils/calculations.test.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { calculateModelPrice } from "./calculations";
+
+const oneMillionTokens = 1_000_000;
+
+describe("Grok model pricing", () => {
+  it("uses Grok 4.5 pricing for the grok-build-latest alias", () => {
+    expect(
+      calculateModelPrice(
+        "grok-build-latest",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens
+      )
+    ).toBeCloseTo(8.3);
+  });
+
+  it("uses Grok Build 0.1 pricing for its exact model id", () => {
+    expect(
+      calculateModelPrice(
+        "grok-build-0.1",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens
+      )
+    ).toBeCloseTo(3.2);
+  });
+
+  it("does not downgrade a Grok 4.5 model with a build suffix", () => {
+    expect(
+      calculateModelPrice(
+        "grok-4.5-build",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens
+      )
+    ).toBeCloseTo(8.3);
+  });
+});

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -68,10 +68,17 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   // Google models (OpenCode)
   'gemini-2.5-pro': { input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 },
   'gemini-2.5-flash': { input: 0.15, output: 0.60, cacheWrite: 0, cacheRead: 0 },
-  'grok-4.5-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  // xAI's Grok Build aliases: grok-build-latest resolves to Grok 4.5,
+  // while grok-build-0.1 / grok-code-fast are the lower-priced Build model.
+  'grok-build-latest': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
+  'grok-build-0.1': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-code-fast-1-0825': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-code-fast-1': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-code-fast': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-4.5-build': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
   'grok-4.5': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
   'grok-4.3': { input: 1.25, output: 2.5, cacheWrite: 0, cacheRead: 0.20 },
-  'grok-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-build': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
   'grok-4': { input: 3, output: 15, cacheWrite: 0, cacheRead: 0.75 },
 };
 

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -68,6 +68,11 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   // Google models (OpenCode)
   'gemini-2.5-pro': { input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 },
   'gemini-2.5-flash': { input: 0.15, output: 0.60, cacheWrite: 0, cacheRead: 0 },
+  'grok-4.5-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-4.5': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
+  'grok-4.3': { input: 1.25, output: 2.5, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-4': { input: 3, output: 15, cacheWrite: 0, cacheRead: 0.75 },
 };
 
 const DEFAULT_PRICING: ModelPricing = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 };

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -151,6 +151,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       forgecode: 0,
       gemini: 0,
       goose: 0,
+      grok: 0,
       kimi: 0,
       kiro: 0,
       llm: 0,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "Failed to detect providers. Using Claude only.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "プロバイダーの検出に失敗しました。Claude のみ使用します。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "프로바이더 감지에 실패했습니다. Claude만 사용합니다.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "检测提供商失败。将仅使用 Claude。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "偵測提供者失敗。將僅使用 Claude。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-07-19T07:35:41.789Z
- * 총 키 개수: 1877
+ * 생성 시간: 2026-08-01T03:15:38.501Z
+ * 총 키 개수: 1878
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (181개)
+ * common namespace의 번역 키 (182개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -123,6 +123,7 @@ export type CommonKeys =
   | 'common.provider.forgecode'
   | 'common.provider.gemini'
   | 'common.provider.goose'
+  | 'common.provider.grok'
   | 'common.provider.kimi'
   | 'common.provider.kiro'
   | 'common.provider.llm'
@@ -2368,6 +2369,7 @@ export type TranslationKey =
   | 'common.provider.forgecode'
   | 'common.provider.gemini'
   | 'common.provider.goose'
+  | 'common.provider.grok'
   | 'common.provider.kimi'
   | 'common.provider.kiro'
   | 'common.provider.llm'

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -54,6 +54,7 @@ describe("providers utils", () => {
       "forgecode",
       "gemini",
       "goose",
+      "grok",
       "kimi",
       "kiro",
       "llm",

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -22,6 +22,7 @@ const PROVIDER_TRANSLATIONS: Record<
   forgecode: { key: "common.provider.forgecode", fallback: "ForgeCode" },
   gemini: { key: "common.provider.gemini", fallback: "Gemini CLI" },
   goose: { key: "common.provider.goose", fallback: "Goose" },
+  grok: { key: "common.provider.grok", fallback: "Grok CLI" },
   kimi: { key: "common.provider.kimi", fallback: "Kimi CLI" },
   kiro: { key: "common.provider.kiro", fallback: "Kiro CLI" },
   llm: { key: "common.provider.llm", fallback: "llm" },
@@ -156,6 +157,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  grok: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   kimi: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
@@ -276,6 +284,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "cursor-agent":
     case "gemini":
     case "goose":
+    case "grok":
     case "kimi":
     case "forgecode":
     case "kiro":
@@ -442,6 +451,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   forgecode: "bg-orange-500/15 text-orange-700 dark:text-orange-300",
   gemini: "bg-purple-500/15 text-purple-600 dark:text-purple-400",
   goose: "bg-red-500/15 text-red-600 dark:text-red-400",
+  grok: "bg-zinc-800/15 text-zinc-800 dark:text-zinc-200",
   kimi: "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-300",
   kiro: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
   llm: "bg-slate-500/15 text-slate-600 dark:text-slate-400",


### PR DESCRIPTION
## Summary
- Add a Grok CLI provider that reads `~/.grok` (or `$GROK_HOME`) sessions so Grok history appears in the project tree alongside Claude, OpenCode, and others.
- Map Grok chat history into the shared message model and attach peak context token/model signals from `signals.json` so analytics can identify which Grok CLI models were used (`grok-4.5`, `grok-4.5-build`, etc.).
- Wire Grok into Global Overview stats (provider distribution, model distribution, top projects, pricing) and reload global stats when the active provider set changes.

## Commits
1. `feat(providers): add Grok CLI backend provider`
2. `feat(frontend): register Grok CLI provider in UI and i18n`
3. `feat(stats): attribute Grok CLI models in global analytics`

## Test plan
- [ ] With `~/.grok/sessions` present, Grok CLI projects appear in Explorer with the Grok provider badge
- [ ] Opening a Grok project loads sessions/messages without `project_path must be absolute`
- [ ] Global Overview includes Grok in Provider Distribution when Grok is selected
- [ ] Model Distribution shows Grok model IDs (e.g. `grok-4.5` / `grok-4.5-build`)
- [ ] Date filter covering a Grok session’s `updated_at` still attributes tokens/models
- [ ] `cargo test --lib providers::grok -- --test-threads=1`
- [ ] `cargo test --lib get_project_stats_summary_accepts_grok_virtual_path -- --test-threads=1`
- [ ] `pnpm exec tsc --build .` and `pnpm run i18n:validate`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for browsing Grok CLI projects, sessions, messages, and conversation history.
  * Added Grok conversation search with failure warnings.
  * Included Grok in project scanning, statistics, analytics, provider counts, and visualizations.
  * Added token usage and model pricing support for Grok models.
  * Added Grok CLI labels across supported languages.

* **Tests**
  * Added coverage for Grok discovery, parsing, searching, statistics, and pricing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->