### PR TITLE
feat(providers): add Grok CLI + Cursor IDE to history and Global Overview

### DIFF
--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -38,6 +38,7 @@ pub async fn scan_all_projects(
             "copilot".to_string(),
             "gemini".to_string(),
             "goose".to_string(),
+            "grok".to_string(),
             "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
@@ -125,6 +126,7 @@ pub async fn scan_all_projects(
         ("pearai", providers::pearai::scan_projects),
         ("gemini", providers::gemini::scan_projects),
         ("goose", providers::goose::scan_projects),
+        ("grok", providers::grok::scan_projects),
         ("kimi", providers::kimi::scan_projects),
         ("forgecode", providers::forgecode::scan_projects),
         ("opencode", providers::opencode::scan_projects),
@@ -319,6 +321,7 @@ pub async fn load_provider_sessions(
         "copilot" => providers::copilot::load_sessions(&project_path, exclude),
         "gemini" => providers::gemini::load_sessions(&project_path, exclude),
         "goose" => providers::goose::load_sessions(&project_path, exclude),
+        "grok" => providers::grok::load_sessions(&project_path, exclude),
         "kimi" => providers::kimi::load_sessions(&project_path, exclude),
         "forgecode" => providers::forgecode::load_sessions(&project_path, exclude),
         "opencode" => providers::opencode::load_sessions(&project_path, exclude),
@@ -431,6 +434,7 @@ fn load_non_claude_messages(
         "copilot" => providers::copilot::load_messages(session_path),
         "gemini" => providers::gemini::load_messages(session_path),
         "goose" => providers::goose::load_messages(session_path),
+        "grok" => providers::grok::load_messages(session_path),
         "kimi" => providers::kimi::load_messages(session_path),
         "forgecode" => providers::forgecode::load_messages(session_path),
         "opencode" => providers::opencode::load_messages(session_path),
@@ -606,6 +610,7 @@ pub async fn search_all_providers(
             "copilot".to_string(),
             "gemini".to_string(),
             "goose".to_string(),
+            "grok".to_string(),
             "kimi".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
@@ -735,6 +740,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Goose search failed: {e}");
+            }
+        }
+    }
+
+    // Grok
+    if providers_to_search.iter().any(|p| p == "grok") {
+        match providers::grok::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Grok search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -27,6 +27,7 @@ enum StatsProvider {
     Codex,
     ForgeCode,
     OpenCode,
+    Grok,
     Kimi,
     Antigravity,
     Copilot,
@@ -65,6 +66,7 @@ fn stats_provider_id(provider: StatsProvider) -> &'static str {
         StatsProvider::Codex => "codex",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
+        StatsProvider::Grok => "grok",
         StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
         StatsProvider::Copilot => "copilot",
@@ -221,6 +223,7 @@ fn all_stats_providers() -> HashSet<StatsProvider> {
         StatsProvider::Codex,
         StatsProvider::ForgeCode,
         StatsProvider::OpenCode,
+        StatsProvider::Grok,
         StatsProvider::Kimi,
         StatsProvider::Antigravity,
         StatsProvider::Copilot,
@@ -244,6 +247,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
             "codex" => Some(StatsProvider::Codex),
             "forgecode" => Some(StatsProvider::ForgeCode),
             "opencode" => Some(StatsProvider::OpenCode),
+            "grok" => Some(StatsProvider::Grok),
             "kimi" => Some(StatsProvider::Kimi),
             "antigravity" => Some(StatsProvider::Antigravity),
             "copilot" => Some(StatsProvider::Copilot),
@@ -272,6 +276,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::ForgeCode
     } else if project_path.starts_with("opencode://") {
         StatsProvider::OpenCode
+    } else if project_path.starts_with("grok://") {
+        StatsProvider::Grok
     } else if project_path.starts_with("kimi://") {
         StatsProvider::Kimi
     } else if is_antigravity_path(project_path) {
@@ -293,6 +299,10 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
 fn detect_session_provider(session_path: &str) -> StatsProvider {
     if session_path.starts_with("opencode://") {
         return StatsProvider::OpenCode;
+    }
+
+    if is_grok_path(session_path) {
+        return StatsProvider::Grok;
     }
 
     if is_kimi_path(session_path) {
@@ -392,6 +402,27 @@ fn is_kimi_path(path: &str) -> bool {
     providers::kimi::get_base_path()
         .map(|root| Path::new(path).starts_with(root))
         .unwrap_or(false)
+}
+
+fn is_grok_path(path: &str) -> bool {
+    providers::grok::get_base_path()
+        .map(|root| Path::new(path).starts_with(root))
+        .unwrap_or(false)
+}
+
+fn grok_virtual_paths_match(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let left_path = left.strip_prefix("grok://").unwrap_or(left);
+    let right_path = right.strip_prefix("grok://").unwrap_or(right);
+    match (
+        Path::new(left_path).canonicalize(),
+        Path::new(right_path).canonicalize(),
+    ) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 /// Parse a line using simd-json (requires mutable slice)
@@ -1103,6 +1134,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Codex => providers::codex::scan_projects().unwrap_or_default(),
         StatsProvider::ForgeCode => providers::forgecode::scan_projects().unwrap_or_default(),
         StatsProvider::OpenCode => providers::opencode::scan_projects().unwrap_or_default(),
+        StatsProvider::Grok => providers::grok::scan_projects().unwrap_or_default(),
         StatsProvider::Kimi => providers::kimi::scan_projects().unwrap_or_default(),
         StatsProvider::Antigravity => providers::antigravity::scan_projects().unwrap_or_default(),
         StatsProvider::Copilot => providers::copilot::scan_projects().unwrap_or_default(),
@@ -1114,6 +1146,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Codex => "codex",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
+        StatsProvider::Grok => "grok",
         StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
         StatsProvider::Copilot => "copilot",
@@ -1132,6 +1165,7 @@ fn collect_provider_global_file_stats(
             StatsProvider::Codex => providers::codex::load_sessions(&project.path, false),
             StatsProvider::ForgeCode => providers::forgecode::load_sessions(&project.path, false),
             StatsProvider::OpenCode => providers::opencode::load_sessions(&project.path, false),
+            StatsProvider::Grok => providers::grok::load_sessions(&project.path, false),
             StatsProvider::Kimi => providers::kimi::load_sessions(&project.path, false),
             StatsProvider::Antigravity => {
                 providers::antigravity::load_sessions(&project.path, false)
@@ -1155,6 +1189,7 @@ fn collect_provider_global_file_stats(
                 StatsProvider::Codex => providers::codex::load_messages(file_path),
                 StatsProvider::ForgeCode => providers::forgecode::load_messages(file_path),
                 StatsProvider::OpenCode => providers::opencode::load_messages(file_path),
+                StatsProvider::Grok => providers::grok::load_messages(file_path),
                 StatsProvider::Kimi => providers::kimi::load_messages(file_path),
                 StatsProvider::Antigravity => providers::antigravity::load_messages(file_path),
                 StatsProvider::Copilot => providers::copilot::load_messages(file_path),
@@ -1879,6 +1914,32 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                 .unwrap_or(project_path)
                 .to_string()
         }
+        StatsProvider::Grok => {
+            if let Ok(projects) = providers::grok::scan_projects() {
+                if let Some(project) = projects
+                    .into_iter()
+                    .find(|p| grok_virtual_paths_match(&p.path, project_path))
+                {
+                    return project.name;
+                }
+            }
+            project_path
+                .strip_prefix("grok://")
+                .and_then(|p| {
+                    PathBuf::from(p).file_name().map(|n| {
+                        let encoded = n.to_string_lossy().to_string();
+                        let decoded = urlencoding::decode(&encoded)
+                            .map(std::borrow::Cow::into_owned)
+                            .unwrap_or_else(|_| encoded.clone());
+                        Path::new(&decoded)
+                            .file_name()
+                            .map(|name| name.to_string_lossy().to_string())
+                            .filter(|name| !name.is_empty())
+                            .unwrap_or(encoded)
+                    })
+                })
+                .unwrap_or_else(|| project_path.to_string())
+        }
         StatsProvider::Kimi => {
             if let Ok(projects) = providers::kimi::scan_projects() {
                 if let Some(project) = projects.into_iter().find(|p| p.path == project_path) {
@@ -1962,6 +2023,13 @@ fn resolve_provider_project_name_from_session(
             }
             "codex".to_string()
         }
+        StatsProvider::Grok => {
+            if let Some(project_dir) = Path::new(session_path).parent() {
+                let project_path = format!("grok://{}", project_dir.to_string_lossy());
+                return resolve_provider_project_name(provider, &project_path);
+            }
+            "grok".to_string()
+        }
         StatsProvider::Kimi => {
             if let Some(project_dir) = Path::new(session_path).parent() {
                 let project_path = format!("kimi://{}", project_dir.to_string_lossy());
@@ -1996,6 +2064,7 @@ fn load_provider_sessions_for_stats(
         StatsProvider::Codex => providers::codex::load_sessions(project_path, false),
         StatsProvider::ForgeCode => providers::forgecode::load_sessions(project_path, false),
         StatsProvider::OpenCode => providers::opencode::load_sessions(project_path, false),
+        StatsProvider::Grok => providers::grok::load_sessions(project_path, false),
         StatsProvider::Kimi => providers::kimi::load_sessions(project_path, false),
         StatsProvider::Antigravity => providers::antigravity::load_sessions(project_path, false),
         StatsProvider::Copilot => providers::copilot::load_sessions(project_path, false),
@@ -2015,6 +2084,7 @@ fn load_provider_messages_for_stats(
         StatsProvider::Codex => providers::codex::load_messages(&session.file_path),
         StatsProvider::ForgeCode => providers::forgecode::load_messages(&session.file_path),
         StatsProvider::OpenCode => providers::opencode::load_messages(&session.file_path),
+        StatsProvider::Grok => providers::grok::load_messages(&session.file_path),
         StatsProvider::Kimi => providers::kimi::load_messages(&session.file_path),
         StatsProvider::Antigravity => providers::antigravity::load_messages(&session.file_path),
         StatsProvider::Copilot => providers::copilot::load_messages(&session.file_path),
@@ -2762,6 +2832,7 @@ pub async fn get_session_token_stats(
             StatsProvider::Codex => providers::codex::load_messages(&session_path)?,
             StatsProvider::ForgeCode => providers::forgecode::load_messages(&session_path)?,
             StatsProvider::OpenCode => providers::opencode::load_messages(&session_path)?,
+            StatsProvider::Grok => providers::grok::load_messages(&session_path)?,
             StatsProvider::Kimi => providers::kimi::load_messages(&session_path)?,
             StatsProvider::Antigravity => providers::antigravity::load_messages(&session_path)?,
             StatsProvider::Copilot => providers::copilot::load_messages(&session_path)?,
@@ -3714,6 +3785,13 @@ pub async fn get_global_stats_summary(
         file_stats.extend(opencode_stats);
     }
 
+    if providers_to_include.contains(&StatsProvider::Grok) {
+        let (grok_stats, grok_projects) =
+            collect_provider_global_file_stats(StatsProvider::Grok, mode, s_ref, e_ref);
+        project_names.extend(grok_projects);
+        file_stats.extend(grok_stats);
+    }
+
     if providers_to_include.contains(&StatsProvider::Kimi) {
         let (kimi_stats, kimi_projects) =
             collect_provider_global_file_stats(StatsProvider::Kimi, mode, s_ref, e_ref);
@@ -4609,6 +4687,10 @@ mod tests {
             StatsProvider::OpenCode
         );
         assert_eq!(
+            detect_project_provider("grok:///Users/jack/.grok/sessions/%2FUsers%2Fjack%2Frepo"),
+            StatsProvider::Grok
+        );
+        assert_eq!(
             detect_project_provider("kimi:///Users/jack/.kimi/sessions/project-hash"),
             StatsProvider::Kimi
         );
@@ -4663,6 +4745,15 @@ mod tests {
             detect_session_provider("opencode://project/ses_abc"),
             StatsProvider::OpenCode
         );
+        if let Some(root) = providers::grok::get_base_path() {
+            let grok_session = PathBuf::from(root)
+                .join("sessions")
+                .join("%2FUsers%2Fjack%2Frepo")
+                .join("session-id")
+                .to_string_lossy()
+                .to_string();
+            assert_eq!(detect_session_provider(&grok_session), StatsProvider::Grok);
+        }
         if let Some(root) = providers::kimi::get_base_path() {
             let kimi_session = PathBuf::from(root)
                 .join("sessions")
@@ -4736,6 +4827,7 @@ mod tests {
         assert!(providers.contains(&StatsProvider::Codex));
         assert!(providers.contains(&StatsProvider::ForgeCode));
         assert!(providers.contains(&StatsProvider::OpenCode));
+        assert!(providers.contains(&StatsProvider::Grok));
         assert!(providers.contains(&StatsProvider::Kimi));
         assert!(providers.contains(&StatsProvider::Antigravity));
         assert!(providers.contains(&StatsProvider::Copilot));
@@ -4770,6 +4862,14 @@ mod tests {
         let providers = parse_active_stats_providers(Some(vec!["forgecode".to_string()]));
         assert_eq!(providers.len(), 1);
         assert!(providers.contains(&StatsProvider::ForgeCode));
+    }
+
+    #[test]
+    /// Verify parse active stats providers supports Grok.
+    fn test_parse_active_stats_providers_supports_grok() {
+        let providers = parse_active_stats_providers(Some(vec!["grok".to_string()]));
+        assert_eq!(providers.len(), 1);
+        assert!(providers.contains(&StatsProvider::Grok));
     }
 
     #[test]
@@ -4869,6 +4969,96 @@ mod tests {
             false,
             StatsMode::BillingTotal
         ));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_project_stats_summary_accepts_grok_virtual_path() {
+        let temp = TempDir::new().expect("temp dir");
+        let encoded = "%2FUsers%2Ftest%2Fdemo";
+        let session_id = "019fa555-791c-71e2-8c92-ff2e6fa26d6e";
+        let project_dir = temp.path().join("sessions").join(encoded);
+        let session_dir = project_dir.join(session_id);
+        fs::create_dir_all(&session_dir).unwrap();
+
+        fs::write(
+            session_dir.join("summary.json"),
+            serde_json::json!({
+                "info": { "id": session_id, "cwd": "/Users/test/demo" },
+                "generated_title": "Demo",
+                "created_at": "2026-07-27T20:47:50Z",
+                "updated_at": "2026-07-27T21:11:25Z",
+                "num_chat_messages": 2,
+                "current_model_id": "grok-4.5"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        fs::write(
+            session_dir.join("chat_history.jsonl"),
+            r#"{"type":"user","content":"hello"}
+{"type":"assistant","content":"hi","model_id":"grok-4.5"}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            session_dir.join("signals.json"),
+            serde_json::json!({
+                "contextTokensUsed": 42,
+                "primaryModelId": "grok-4.5",
+                "toolCallCount": 0
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let _env = EnvVarGuard::set("GROK_HOME", temp.path());
+        let project_path = format!("grok://{}", project_dir.to_string_lossy());
+
+        assert_eq!(detect_project_provider(&project_path), StatsProvider::Grok);
+
+        let summary = get_project_stats_summary(project_path.clone(), None, None, None)
+            .await
+            .expect("grok virtual project path should load stats");
+        assert_eq!(summary.project_name, "demo");
+        assert!(summary.total_sessions >= 1);
+        assert!(summary.total_messages >= 1);
+        assert_eq!(summary.total_tokens, 42);
+
+        let global = get_global_stats_summary(
+            "/tmp".to_string(),
+            Some(vec!["grok".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("grok should contribute to global stats");
+        assert!(
+            global
+                .provider_distribution
+                .iter()
+                .any(|provider| provider.provider_id == "grok" && provider.tokens >= 42),
+            "expected grok in provider_distribution: {:?}",
+            global.provider_distribution
+        );
+        assert!(
+            global
+                .model_distribution
+                .iter()
+                .any(|model| model.model_name.contains("grok") && model.token_count >= 42),
+            "expected grok model in model_distribution: {:?}",
+            global.model_distribution
+        );
+        assert!(
+            global
+                .top_projects
+                .iter()
+                .any(|project| project.project_name.contains("demo")),
+            "expected grok project in top_projects: {:?}",
+            global.top_projects
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -31,6 +31,7 @@ enum StatsProvider {
     Kimi,
     Antigravity,
     Copilot,
+    Cursor,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +71,7 @@ fn stats_provider_id(provider: StatsProvider) -> &'static str {
         StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
         StatsProvider::Copilot => "copilot",
+        StatsProvider::Cursor => "cursor",
     }
 }
 
@@ -227,6 +229,7 @@ fn all_stats_providers() -> HashSet<StatsProvider> {
         StatsProvider::Kimi,
         StatsProvider::Antigravity,
         StatsProvider::Copilot,
+        StatsProvider::Cursor,
     ]
     .into_iter()
     .collect()
@@ -251,6 +254,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
             "kimi" => Some(StatsProvider::Kimi),
             "antigravity" => Some(StatsProvider::Antigravity),
             "copilot" => Some(StatsProvider::Copilot),
+            "cursor" => Some(StatsProvider::Cursor),
             _ => {
                 unknown.push(provider);
                 None
@@ -280,6 +284,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::Grok
     } else if project_path.starts_with("kimi://") {
         StatsProvider::Kimi
+    } else if project_path.starts_with("cursor://") {
+        StatsProvider::Cursor
     } else if is_antigravity_path(project_path) {
         StatsProvider::Antigravity
     } else if is_codebuddy_path(project_path) {
@@ -299,6 +305,10 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
 fn detect_session_provider(session_path: &str) -> StatsProvider {
     if session_path.starts_with("opencode://") {
         return StatsProvider::OpenCode;
+    }
+
+    if session_path.starts_with("cursor://") {
+        return StatsProvider::Cursor;
     }
 
     if is_grok_path(session_path) {
@@ -416,6 +426,21 @@ fn grok_virtual_paths_match(left: &str, right: &str) -> bool {
     }
     let left_path = left.strip_prefix("grok://").unwrap_or(left);
     let right_path = right.strip_prefix("grok://").unwrap_or(right);
+    match (
+        Path::new(left_path).canonicalize(),
+        Path::new(right_path).canonicalize(),
+    ) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
+fn cursor_virtual_paths_match(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let left_path = left.strip_prefix("cursor://").unwrap_or(left);
+    let right_path = right.strip_prefix("cursor://").unwrap_or(right);
     match (
         Path::new(left_path).canonicalize(),
         Path::new(right_path).canonicalize(),
@@ -1138,6 +1163,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Kimi => providers::kimi::scan_projects().unwrap_or_default(),
         StatsProvider::Antigravity => providers::antigravity::scan_projects().unwrap_or_default(),
         StatsProvider::Copilot => providers::copilot::scan_projects().unwrap_or_default(),
+        StatsProvider::Cursor => providers::cursor::scan_projects().unwrap_or_default(),
         StatsProvider::Claude => Vec::new(),
     };
 
@@ -1150,6 +1176,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
         StatsProvider::Copilot => "copilot",
+        StatsProvider::Cursor => "cursor",
         StatsProvider::Claude => "claude",
     };
 
@@ -1171,6 +1198,7 @@ fn collect_provider_global_file_stats(
                 providers::antigravity::load_sessions(&project.path, false)
             }
             StatsProvider::Copilot => providers::copilot::load_sessions(&project.path, false),
+            StatsProvider::Cursor => providers::cursor::load_sessions(&project.path, false),
             StatsProvider::Claude => Ok(Vec::new()),
         }
         .unwrap_or_default();
@@ -1193,6 +1221,7 @@ fn collect_provider_global_file_stats(
                 StatsProvider::Kimi => providers::kimi::load_messages(file_path),
                 StatsProvider::Antigravity => providers::antigravity::load_messages(file_path),
                 StatsProvider::Copilot => providers::copilot::load_messages(file_path),
+                StatsProvider::Cursor => providers::cursor::load_messages(file_path),
                 StatsProvider::Claude => Ok(Vec::new()),
             }
             .unwrap_or_default();
@@ -1972,6 +2001,27 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                     .map(|project| project.name)
             })
             .unwrap_or_else(|| "Copilot".to_string()),
+        StatsProvider::Cursor => {
+            if let Ok(projects) = providers::cursor::scan_projects() {
+                if let Some(project) = projects
+                    .into_iter()
+                    .find(|p| cursor_virtual_paths_match(&p.path, project_path))
+                {
+                    return project.name;
+                }
+            }
+            if let Some(name) = providers::cursor::display_name_for_project_path(project_path) {
+                return name;
+            }
+            project_path
+                .strip_prefix("cursor://")
+                .and_then(|p| {
+                    PathBuf::from(p)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| "Cursor".to_string())
+        }
     }
 }
 
@@ -2050,6 +2100,18 @@ fn resolve_provider_project_name_from_session(
             }
             "Copilot".to_string()
         }
+        StatsProvider::Cursor => {
+            if let Ok(projects) = providers::cursor::scan_projects() {
+                for project in projects {
+                    if let Ok(sessions) = providers::cursor::load_sessions(&project.path, false) {
+                        if sessions.iter().any(|s| s.file_path == session_path) {
+                            return project.name;
+                        }
+                    }
+                }
+            }
+            "Cursor".to_string()
+        }
         StatsProvider::Claude => "unknown".to_string(),
     }
 }
@@ -2068,6 +2130,7 @@ fn load_provider_sessions_for_stats(
         StatsProvider::Kimi => providers::kimi::load_sessions(project_path, false),
         StatsProvider::Antigravity => providers::antigravity::load_sessions(project_path, false),
         StatsProvider::Copilot => providers::copilot::load_sessions(project_path, false),
+        StatsProvider::Cursor => providers::cursor::load_sessions(project_path, false),
         StatsProvider::Claude => {
             Err("Claude sessions are handled by legacy stats path".to_string())
         }
@@ -2088,6 +2151,7 @@ fn load_provider_messages_for_stats(
         StatsProvider::Kimi => providers::kimi::load_messages(&session.file_path),
         StatsProvider::Antigravity => providers::antigravity::load_messages(&session.file_path),
         StatsProvider::Copilot => providers::copilot::load_messages(&session.file_path),
+        StatsProvider::Cursor => providers::cursor::load_messages(&session.file_path),
         StatsProvider::Claude => {
             Err("Claude messages are handled by legacy stats path".to_string())
         }
@@ -2836,6 +2900,7 @@ pub async fn get_session_token_stats(
             StatsProvider::Kimi => providers::kimi::load_messages(&session_path)?,
             StatsProvider::Antigravity => providers::antigravity::load_messages(&session_path)?,
             StatsProvider::Copilot => providers::copilot::load_messages(&session_path)?,
+            StatsProvider::Cursor => providers::cursor::load_messages(&session_path)?,
             StatsProvider::Claude => Vec::new(),
         };
 
@@ -3792,6 +3857,13 @@ pub async fn get_global_stats_summary(
         file_stats.extend(grok_stats);
     }
 
+    if providers_to_include.contains(&StatsProvider::Cursor) {
+        let (cursor_stats, cursor_projects) =
+            collect_provider_global_file_stats(StatsProvider::Cursor, mode, s_ref, e_ref);
+        project_names.extend(cursor_projects);
+        file_stats.extend(cursor_stats);
+    }
+
     if providers_to_include.contains(&StatsProvider::Kimi) {
         let (kimi_stats, kimi_projects) =
             collect_provider_global_file_stats(StatsProvider::Kimi, mode, s_ref, e_ref);
@@ -4691,6 +4763,12 @@ mod tests {
             StatsProvider::Grok
         );
         assert_eq!(
+            detect_project_provider(
+                "cursor:///Users/jack/Library/Application Support/Cursor/User/workspaceStorage/hash"
+            ),
+            StatsProvider::Cursor
+        );
+        assert_eq!(
             detect_project_provider("kimi:///Users/jack/.kimi/sessions/project-hash"),
             StatsProvider::Kimi
         );
@@ -4744,6 +4822,10 @@ mod tests {
         assert_eq!(
             detect_session_provider("opencode://project/ses_abc"),
             StatsProvider::OpenCode
+        );
+        assert_eq!(
+            detect_session_provider("cursor://composer-id-abc"),
+            StatsProvider::Cursor
         );
         if let Some(root) = providers::grok::get_base_path() {
             let grok_session = PathBuf::from(root)
@@ -4831,6 +4913,7 @@ mod tests {
         assert!(providers.contains(&StatsProvider::Kimi));
         assert!(providers.contains(&StatsProvider::Antigravity));
         assert!(providers.contains(&StatsProvider::Copilot));
+        assert!(providers.contains(&StatsProvider::Cursor));
     }
 
     #[test]
@@ -4870,6 +4953,14 @@ mod tests {
         let providers = parse_active_stats_providers(Some(vec!["grok".to_string()]));
         assert_eq!(providers.len(), 1);
         assert!(providers.contains(&StatsProvider::Grok));
+    }
+
+    #[test]
+    /// Verify parse active stats providers supports Cursor.
+    fn test_parse_active_stats_providers_supports_cursor() {
+        let providers = parse_active_stats_providers(Some(vec!["cursor".to_string()]));
+        assert_eq!(providers.len(), 1);
+        assert!(providers.contains(&StatsProvider::Cursor));
     }
 
     #[test]
@@ -5058,6 +5149,141 @@ mod tests {
                 .any(|project| project.project_name.contains("demo")),
             "expected grok project in top_projects: {:?}",
             global.top_projects
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_project_stats_summary_accepts_cursor_virtual_path() {
+        let temp = TempDir::new().expect("temp dir");
+        let user_dir = temp.path().join("Cursor").join("User");
+        let ws_path = user_dir.join("workspaceStorage").join("hash-demo");
+        fs::create_dir_all(&ws_path).unwrap();
+        fs::create_dir_all(user_dir.join("globalStorage")).unwrap();
+
+        fs::write(
+            ws_path.join("workspace.json"),
+            r#"{"folder":"file:///Users/test/demo"}"#,
+        )
+        .unwrap();
+
+        let ws_conn = rusqlite::Connection::open(ws_path.join("state.vscdb")).unwrap();
+        ws_conn
+            .execute(
+                "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        let composers = json!({
+            "allComposers": [{
+                "composerId": "comp-demo",
+                "name": "Demo chat",
+                "createdAt": 1_700_000_000_000u64,
+                "lastUpdatedAt": 1_700_000_100_000u64,
+                "isArchived": false,
+                "unifiedMode": "agent"
+            }]
+        })
+        .to_string();
+        ws_conn
+            .execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('composer.composerData', ?1)",
+                [&composers],
+            )
+            .unwrap();
+
+        let global_conn =
+            rusqlite::Connection::open(user_dir.join("globalStorage").join("state.vscdb")).unwrap();
+        global_conn
+            .execute(
+                "CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        let composer_data = json!({
+            "fullConversationHeadersOnly": [
+                { "bubbleId": "b1", "type": 1 },
+                { "bubbleId": "b2", "type": 2 }
+            ]
+        })
+        .to_string();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params!["composerData:comp-demo", composer_data],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-demo:b1",
+                    json!({
+                        "bubbleId": "b1",
+                        "type": 1,
+                        "text": "hello cursor",
+                        "createdAt": "2026-07-27T20:00:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-demo:b2",
+                    json!({
+                        "bubbleId": "b2",
+                        "type": 2,
+                        "text": "hi from composer",
+                        "createdAt": "2026-07-27T20:01:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+
+        let _env = EnvVarGuard::set("CURSOR_USER_DIR", &user_dir);
+        let project_path = format!("cursor://{}", ws_path.to_string_lossy());
+
+        assert_eq!(
+            detect_project_provider(&project_path),
+            StatsProvider::Cursor
+        );
+
+        let summary = get_project_stats_summary(project_path.clone(), None, None, None)
+            .await
+            .expect("cursor virtual project path should load stats");
+        assert_eq!(summary.project_name, "demo");
+        assert!(summary.total_sessions >= 1);
+        assert!(summary.total_messages >= 1);
+
+        let global = get_global_stats_summary(
+            "/tmp".to_string(),
+            Some(vec!["cursor".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("cursor should contribute to global stats");
+        assert!(
+            global
+                .provider_distribution
+                .iter()
+                .any(|provider| provider.provider_id == "cursor" && provider.sessions >= 1),
+            "expected cursor in provider_distribution: {:?}",
+            global.provider_distribution
+        );
+        assert!(
+            global
+                .model_distribution
+                .iter()
+                .any(|model| model.model_name == "composer"),
+            "expected composer in model_distribution: {:?}",
+            global.model_distribution
         );
     }
 

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1022,6 +1022,32 @@ fn collect_provider_global_file_stats(
 ) -> (Vec<SessionFileStats>, HashSet<String>) {
     let mut project_keys = HashSet::new();
 
+    if provider == StatsProvider::Cursor {
+        let Ok(sessions) = providers::cursor::collect_global_stats_sessions() else {
+            return (Vec::new(), project_keys);
+        };
+        let mut all_stats = Vec::with_capacity(sessions.len());
+        for (project_display_name, messages) in sessions {
+            project_keys.insert(format!(
+                "cursor:{}",
+                project_display_name
+                    .strip_suffix(" [cursor]")
+                    .unwrap_or(&project_display_name)
+            ));
+            if let Some(stats) = build_global_session_file_stats_from_messages(
+                StatsProvider::Cursor,
+                project_display_name,
+                &messages,
+                mode,
+                s_limit,
+                e_limit,
+            ) {
+                all_stats.push(stats);
+            }
+        }
+        return (all_stats, project_keys);
+    }
+
     if provider == StatsProvider::Antigravity {
         // Use the resolver that honors the external-state override so an
         // external Antigravity root contributes to the global summary
@@ -1221,7 +1247,7 @@ fn collect_provider_global_file_stats(
                 StatsProvider::Kimi => providers::kimi::load_messages(file_path),
                 StatsProvider::Antigravity => providers::antigravity::load_messages(file_path),
                 StatsProvider::Copilot => providers::copilot::load_messages(file_path),
-                StatsProvider::Cursor => providers::cursor::load_messages(file_path),
+                StatsProvider::Cursor => providers::cursor::load_stats_messages(file_path),
                 StatsProvider::Claude => Ok(Vec::new()),
             }
             .unwrap_or_default();
@@ -2151,7 +2177,7 @@ fn load_provider_messages_for_stats(
         StatsProvider::Kimi => providers::kimi::load_messages(&session.file_path),
         StatsProvider::Antigravity => providers::antigravity::load_messages(&session.file_path),
         StatsProvider::Copilot => providers::copilot::load_messages(&session.file_path),
-        StatsProvider::Cursor => providers::cursor::load_messages(&session.file_path),
+        StatsProvider::Cursor => providers::cursor::load_stats_messages(&session.file_path),
         StatsProvider::Claude => {
             Err("Claude messages are handled by legacy stats path".to_string())
         }
@@ -2900,7 +2926,7 @@ pub async fn get_session_token_stats(
             StatsProvider::Kimi => providers::kimi::load_messages(&session_path)?,
             StatsProvider::Antigravity => providers::antigravity::load_messages(&session_path)?,
             StatsProvider::Copilot => providers::copilot::load_messages(&session_path)?,
-            StatsProvider::Cursor => providers::cursor::load_messages(&session_path)?,
+            StatsProvider::Cursor => providers::cursor::load_stats_messages(&session_path)?,
             StatsProvider::Claude => Vec::new(),
         };
 
@@ -5204,7 +5230,8 @@ mod tests {
             "fullConversationHeadersOnly": [
                 { "bubbleId": "b1", "type": 1 },
                 { "bubbleId": "b2", "type": 2 }
-            ]
+            ],
+            "promptTokenBreakdown": { "totalUsedTokens": 4200 }
         })
         .to_string();
         global_conn
@@ -5281,9 +5308,17 @@ mod tests {
             global
                 .model_distribution
                 .iter()
-                .any(|model| model.model_name == "composer"),
-            "expected composer in model_distribution: {:?}",
+                .any(|model| model.model_name == "cursor" && model.token_count >= 4200),
+            "expected cursor in model_distribution: {:?}",
             global.model_distribution
+        );
+        assert!(
+            global
+                .provider_distribution
+                .iter()
+                .any(|provider| provider.provider_id == "cursor" && provider.tokens >= 4200),
+            "expected cursor tokens in provider_distribution: {:?}",
+            global.provider_distribution
         );
     }
 

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -22,6 +22,13 @@ pub fn detect() -> Option<ProviderInfo> {
 
 /// Get Cursor user data path
 pub fn get_base_path() -> Option<PathBuf> {
+    if let Ok(env_val) = std::env::var("CURSOR_USER_DIR") {
+        let path = PathBuf::from(env_val);
+        if path.is_dir() {
+            return Some(path.canonicalize().unwrap_or(path));
+        }
+    }
+
     let home = dirs::home_dir()?;
 
     #[cfg(target_os = "macos")]
@@ -44,6 +51,21 @@ pub fn get_base_path() -> Option<PathBuf> {
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     let base = get_base_path().ok_or("Cursor not found")?;
     scan_projects_in(&base.join("workspaceStorage"))
+}
+
+/// Resolve a human-readable project name from a `cursor://` workspace path
+/// via `workspace.json` (folder basename), without requiring a full scan.
+pub fn display_name_for_project_path(project_path: &str) -> Option<String> {
+    let ws_path = project_path
+        .strip_prefix("cursor://")
+        .unwrap_or(project_path);
+    let workspace_json = PathBuf::from(ws_path).join("workspace.json");
+    read_workspace_folder(&workspace_json).and_then(|folder| {
+        PathBuf::from(&folder)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .filter(|n| !n.is_empty())
+    })
 }
 
 fn scan_projects_in(ws_dir: &Path) -> Result<Vec<ClaudeProject>, String> {
@@ -592,7 +614,7 @@ fn convert_assistant_bubble(
         "assistant",
         Some("assistant"),
         Some(Value::Array(content_blocks)),
-        None,
+        Some("composer".to_string()),
     ))
 }
 
@@ -785,6 +807,19 @@ mod tests {
     fn test_empty_bubble() {
         let bubble = json!({"type": 2, "bubbleId": "empty", "text": ""});
         assert!(convert_cursor_bubble(&bubble, 2, "session-1").is_none());
+    }
+
+    #[test]
+    fn test_assistant_bubble_uses_composer_model() {
+        let bubble = json!({
+            "type": 2,
+            "bubbleId": "a1",
+            "text": "hello",
+            "createdAt": "2026-07-27T20:00:00Z"
+        });
+        let msg = convert_cursor_bubble(&bubble, 2, "session-1").unwrap();
+        assert_eq!(msg.model.as_deref(), Some("composer"));
+        assert_eq!(msg.provider.as_deref(), Some("cursor"));
     }
 
     /// Write a minimal valid Cursor workspace: `workspace.json` + a `state.vscdb`

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -1,4 +1,4 @@
-use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
 use crate::providers::ProviderInfo;
 use crate::utils::{build_provider_message, ms_to_iso, search_json_value_case_insensitive};
 use rusqlite::{Connection, OpenFlags};
@@ -47,10 +47,16 @@ pub fn get_base_path() -> Option<PathBuf> {
     }
 }
 
-/// Scan Cursor projects by reading workspace directories
+/// Scan Cursor projects from migrated global Composer data.
+/// Falls back to legacy workspace `allComposers` only when global storage is empty.
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     let base = get_base_path().ok_or("Cursor not found")?;
-    scan_projects_in(&base.join("workspaceStorage"))
+    let mut projects = scan_projects_from_global(&base)?;
+    if projects.is_empty() {
+        projects = scan_projects_in(&base.join("workspaceStorage"))?;
+    }
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
 }
 
 /// Resolve a human-readable project name from a `cursor://` workspace path
@@ -59,6 +65,16 @@ pub fn display_name_for_project_path(project_path: &str) -> Option<String> {
     let ws_path = project_path
         .strip_prefix("cursor://")
         .unwrap_or(project_path);
+    if let Some(rest) = ws_path.strip_prefix("workspace/") {
+        let id = rest.split('/').next().unwrap_or(rest);
+        if is_orphan_workspace_id(id) {
+            return Some("Cursor".to_string());
+        }
+        if !id.is_empty() {
+            return Some(id.to_string());
+        }
+        return Some("Cursor".to_string());
+    }
     let workspace_json = PathBuf::from(ws_path).join("workspace.json");
     read_workspace_folder(&workspace_json).and_then(|folder| {
         PathBuf::from(&folder)
@@ -90,6 +106,127 @@ fn scan_projects_in(ws_dir: &Path) -> Result<Vec<ClaudeProject>, String> {
 
     projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(projects)
+}
+
+fn scan_projects_from_global(base: &Path) -> Result<Vec<ClaudeProject>, String> {
+    let global_db = base.join("globalStorage/state.vscdb");
+    if !global_db.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(&global_db, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor global DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+        .map_err(|e| format!("Query failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| format!("Query failed: {e}"))?;
+
+    let ws_root = base.join("workspaceStorage");
+    let mut by_workspace: std::collections::HashMap<String, GlobalWorkspaceAcc> =
+        std::collections::HashMap::new();
+
+    for row in rows.flatten() {
+        let (key, value) = row;
+        let Some(composer_id) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        let Ok(composer) = parse_cursor_json(&value) else {
+            continue;
+        };
+        if composer_is_archived(&composer) {
+            continue;
+        }
+        if !composer_has_conversation(&composer) {
+            continue;
+        }
+
+        let (raw_workspace_id, folder_path) = workspace_identity_from_composer(&composer);
+        let workspace_id = normalize_workspace_bucket_id(&raw_workspace_id);
+        let entry =
+            by_workspace
+                .entry(workspace_id.clone())
+                .or_insert_with(|| GlobalWorkspaceAcc {
+                    folder_path: folder_path.clone(),
+                    session_count: 0,
+                    last_modified_ms: 0,
+                });
+        if entry.folder_path.is_empty() && !folder_path.is_empty() {
+            entry.folder_path = folder_path;
+        }
+        entry.session_count += 1;
+        entry.last_modified_ms = entry.last_modified_ms.max(composer_timestamp_ms(&composer));
+        let _ = composer_id;
+    }
+
+    let mut projects = Vec::with_capacity(by_workspace.len());
+    for (workspace_id, acc) in by_workspace {
+        let ws_path = ws_root.join(&workspace_id);
+        let (path, actual_path, name) = if is_orphan_workspace_id(&workspace_id) {
+            (
+                "cursor://workspace/unassigned".to_string(),
+                String::new(),
+                "Cursor".to_string(),
+            )
+        } else if ws_path.is_dir() {
+            let folder = read_workspace_folder(&ws_path.join("workspace.json"))
+                .unwrap_or_else(|| acc.folder_path.clone());
+            let name = PathBuf::from(&folder)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .or_else(|| {
+                    PathBuf::from(&acc.folder_path)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| workspace_id.clone());
+            (
+                format!("cursor://{}", ws_path.to_string_lossy()),
+                folder,
+                name,
+            )
+        } else {
+            let name = PathBuf::from(&acc.folder_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| workspace_id.clone());
+            (
+                format!("cursor://workspace/{workspace_id}"),
+                acc.folder_path.clone(),
+                name,
+            )
+        };
+
+        projects.push(ClaudeProject {
+            name,
+            path,
+            actual_path,
+            session_count: acc.session_count,
+            message_count: 0,
+            last_modified: ms_to_iso(acc.last_modified_ms),
+            git_info: None,
+            provider: Some("cursor".to_string()),
+            storage_type: Some("sqlite".to_string()),
+            custom_directory_label: None,
+        });
+    }
+
+    Ok(projects)
+}
+
+struct GlobalWorkspaceAcc {
+    folder_path: String,
+    session_count: usize,
+    last_modified_ms: u64,
 }
 
 /// One workspace dir → one project, or `None` when the workspace has no
@@ -155,76 +292,236 @@ pub fn load_sessions(
         .strip_prefix("cursor://")
         .unwrap_or(project_path);
 
-    let ws_path_buf = PathBuf::from(ws_path);
-    if !ws_path_buf.is_absolute() {
-        return Err("Cursor workspace path must be absolute".to_string());
-    }
+    let (workspace_id, project_name, legacy_composers) =
+        if let Some(id) = ws_path.strip_prefix("workspace/") {
+            let workspace_id = normalize_workspace_bucket_id(id.split('/').next().unwrap_or(id));
+            let project_name = if is_orphan_workspace_id(&workspace_id) {
+                "Cursor".to_string()
+            } else {
+                display_name_for_project_path(project_path).unwrap_or_else(|| workspace_id.clone())
+            };
+            (workspace_id, project_name, Vec::new())
+        } else {
+            let ws_path_buf = PathBuf::from(ws_path);
+            if !ws_path_buf.is_absolute() {
+                return Err("Cursor workspace path must be absolute".to_string());
+            }
+            let workspace_id = normalize_workspace_bucket_id(
+                &ws_path_buf
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default(),
+            );
+            let workspace_json = ws_path_buf.join("workspace.json");
+            let project_name = read_workspace_folder(&workspace_json)
+                .and_then(|folder| {
+                    PathBuf::from(&folder)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| "Cursor".to_string());
+            let legacy = read_workspace_composers(&ws_path_buf.join("state.vscdb"))?;
+            (workspace_id, project_name, legacy)
+        };
 
-    let ws_db_path = ws_path_buf.join("state.vscdb");
-    let composers = read_workspace_composers(&ws_db_path)?;
-
-    // Read workspace.json to get the real project folder name
-    let workspace_json = PathBuf::from(ws_path).join("workspace.json");
-    let project_name = read_workspace_folder(&workspace_json)
-        .and_then(|folder| {
-            PathBuf::from(&folder)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-        })
-        .unwrap_or_else(|| "Cursor".to_string());
+    let composers = if legacy_composers.is_empty() {
+        read_global_composers_for_workspace(&workspace_id)?
+    } else {
+        legacy_composers
+    };
 
     let mut sessions: Vec<ClaudeSession> = composers
         .iter()
-        .filter_map(|c| {
-            let id = c.get("composerId").and_then(Value::as_str)?;
-            let name = c.get("name").and_then(Value::as_str).unwrap_or("Untitled");
-            let created = c.get("createdAt").and_then(Value::as_f64).unwrap_or(0.0) as u64;
-            let updated = c
-                .get("lastUpdatedAt")
-                .and_then(Value::as_f64)
-                .unwrap_or(0.0) as u64;
-            let mode = c
-                .get("unifiedMode")
-                .and_then(Value::as_str)
-                .unwrap_or("chat");
-            let is_archived = c
-                .get("isArchived")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-
-            if is_archived {
-                return None;
-            }
-
-            Some(ClaudeSession {
-                session_id: format!("cursor://{id}"),
-                actual_session_id: id.to_string(),
-                file_path: format!("cursor://{id}"),
-                project_name: project_name.clone(),
-                message_count: 0, // Loaded on demand
-                first_message_time: ms_to_iso(created),
-                last_message_time: ms_to_iso(updated),
-                last_modified: ms_to_iso(updated),
-                has_tool_use: mode == "agent",
-                has_errors: false,
-                summary: Some(name.to_string()),
-                is_renamed: false,
-                provider: Some("cursor".to_string()),
-                storage_type: Some("sqlite".to_string()),
-                entrypoint: None,
-            })
-        })
+        .filter_map(|c| composer_to_session(c, &project_name))
         .collect();
 
     sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(sessions)
 }
 
+fn composer_to_session(composer: &Value, project_name: &str) -> Option<ClaudeSession> {
+    let id = composer
+        .get("composerId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())?;
+    if composer_is_archived(composer) {
+        return None;
+    }
+    let name = composer
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("Untitled");
+    let created = composer_timestamp_ms(composer);
+    let updated = composer
+        .get("lastUpdatedAt")
+        .and_then(Value::as_f64)
+        .map(|v| v as u64)
+        .filter(|v| *v > 0)
+        .unwrap_or(created);
+    let mode = composer
+        .get("unifiedMode")
+        .and_then(Value::as_str)
+        .unwrap_or("chat");
+
+    Some(ClaudeSession {
+        session_id: format!("cursor://{id}"),
+        actual_session_id: id.to_string(),
+        file_path: format!("cursor://{id}"),
+        project_name: project_name.to_string(),
+        message_count: 0,
+        first_message_time: ms_to_iso(created),
+        last_message_time: ms_to_iso(updated),
+        last_modified: ms_to_iso(updated),
+        has_tool_use: mode == "agent",
+        has_errors: false,
+        summary: Some(name.to_string()),
+        is_renamed: false,
+        provider: Some("cursor".to_string()),
+        storage_type: Some("sqlite".to_string()),
+        entrypoint: None,
+    })
+}
+
+/// Lightweight stats messages: composer headers + token signal (no bubble bodies).
+pub fn load_stats_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let (composer_id, composer) = load_composer_value(session_path)?;
+    Ok(stats_messages_from_composer(&composer_id, &composer))
+}
+
+/// One-pass global stats source: open the Cursor DB once and emit
+/// `(project_display_name, stats_messages)` for every active composer.
+pub fn collect_global_stats_sessions() -> Result<Vec<(String, Vec<ClaudeMessage>)>, String> {
+    let base = get_base_path().ok_or("Cursor not found")?;
+    let global_db = base.join("globalStorage/state.vscdb");
+    if !global_db.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(&global_db, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor global DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+        .map_err(|e| format!("Query failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| format!("Query failed: {e}"))?;
+
+    let ws_root = base.join("workspaceStorage");
+    let mut sessions = Vec::new();
+    for row in rows.flatten() {
+        let (key, value) = row;
+        let Some(composer_id) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        let Ok(composer) = parse_cursor_json(&value) else {
+            continue;
+        };
+        if composer_is_archived(&composer) || !composer_has_conversation(&composer) {
+            continue;
+        }
+
+        let (raw_workspace_id, folder_path) = workspace_identity_from_composer(&composer);
+        let workspace_id = normalize_workspace_bucket_id(&raw_workspace_id);
+        let project_name = resolve_project_display_name(&ws_root, &workspace_id, &folder_path);
+        let project_display_name = format!("{project_name} [cursor]");
+        let messages = stats_messages_from_composer(composer_id, &composer);
+        if !messages.is_empty() {
+            sessions.push((project_display_name, messages));
+        }
+    }
+
+    Ok(sessions)
+}
+
+fn resolve_project_display_name(ws_root: &Path, workspace_id: &str, folder_path: &str) -> String {
+    if is_orphan_workspace_id(workspace_id) {
+        return "Cursor".to_string();
+    }
+    let ws_path = ws_root.join(workspace_id);
+    if ws_path.is_dir() {
+        if let Some(folder) = read_workspace_folder(&ws_path.join("workspace.json")) {
+            if let Some(name) = PathBuf::from(&folder)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+            {
+                return name;
+            }
+        }
+    }
+    PathBuf::from(folder_path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| workspace_id.to_string())
+}
+
+fn stats_messages_from_composer(composer_id: &str, composer: &Value) -> Vec<ClaudeMessage> {
+    let stamp = ms_to_iso(composer_timestamp_ms(composer));
+    let headers = composer
+        .get("fullConversationHeadersOnly")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut messages = Vec::with_capacity(headers.len().max(1));
+    for (index, header) in headers.iter().enumerate() {
+        let bubble_type = header.get("type").and_then(Value::as_u64).unwrap_or(0);
+        let (message_type, role) = match bubble_type {
+            1 => ("user", Some("user")),
+            2 => ("assistant", Some("assistant")),
+            _ => continue,
+        };
+        let bubble_id = header
+            .get("bubbleId")
+            .and_then(Value::as_str)
+            .unwrap_or("stats");
+        messages.push(build_provider_message(
+            "cursor",
+            format!("{composer_id}-{bubble_id}-{index}"),
+            composer_id,
+            stamp.clone(),
+            message_type,
+            role,
+            Some(serde_json::json!([{"type": "text", "text": ""}])),
+            if message_type == "assistant" {
+                Some("cursor".to_string())
+            } else {
+                None
+            },
+        ));
+    }
+
+    if messages
+        .iter()
+        .all(|message| message.message_type != "assistant")
+        && composer_has_conversation(composer)
+    {
+        messages.push(build_provider_message(
+            "cursor",
+            format!("{composer_id}-usage"),
+            composer_id,
+            stamp,
+            "assistant",
+            Some("assistant"),
+            Some(serde_json::json!([{"type": "text", "text": ""}])),
+            Some("cursor".to_string()),
+        ));
+    }
+
+    attach_composer_token_usage(composer, &mut messages);
+    messages
+}
+
 /// Load messages from a Cursor composer
 pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
-    let composer_id = session_path
-        .strip_prefix("cursor://")
-        .unwrap_or(session_path);
+    let (composer_id, composer) = load_composer_value(session_path)?;
 
     let base = get_base_path().ok_or("Cursor not found")?;
     let global_db_path = base.join("globalStorage/state.vscdb");
@@ -233,18 +530,6 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
         .map_err(|e| format!("Failed to open Cursor DB: {e}"))?;
     conn.busy_timeout(std::time::Duration::from_secs(5))
         .map_err(|e| format!("Failed to set busy timeout: {e}"))?;
-
-    // Get composer data (ordered bubble list)
-    let composer_key = format!("composerData:{composer_id}");
-    let composer_data: String = conn
-        .query_row(
-            "SELECT value FROM cursorDiskKV WHERE key = ?1",
-            [&composer_key],
-            |row| row.get(0),
-        )
-        .map_err(|e| format!("Composer not found: {e}"))?;
-
-    let composer: Value = parse_cursor_json(&composer_data)?;
 
     let headers = composer
         .get("fullConversationHeadersOnly")
@@ -292,12 +577,67 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
             Err(_) => continue,
         };
 
-        if let Some(msg) = convert_cursor_bubble(&bubble, bubble_type, composer_id) {
+        if let Some(msg) = convert_cursor_bubble(&bubble, bubble_type, &composer_id) {
             messages.push(msg);
         }
     }
 
+    if messages
+        .iter()
+        .all(|message| message.message_type != "assistant")
+        && composer_has_conversation(&composer)
+    {
+        let stamp = ms_to_iso(composer_timestamp_ms(&composer));
+        messages.push(build_provider_message(
+            "cursor",
+            format!("{composer_id}-usage"),
+            &composer_id,
+            stamp,
+            "assistant",
+            Some("assistant"),
+            Some(serde_json::json!([{"type": "text", "text": ""}])),
+            Some("cursor".to_string()),
+        ));
+    }
+
+    attach_composer_token_usage(&composer, &mut messages);
+
     Ok(messages)
+}
+
+fn attach_composer_token_usage(composer: &Value, messages: &mut [ClaudeMessage]) {
+    if messages.is_empty() {
+        return;
+    }
+
+    let tokens = composer
+        .get("promptTokenBreakdown")
+        .and_then(|v| v.get("totalUsedTokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if tokens == 0 {
+        return;
+    }
+
+    let capped = u32::try_from(tokens.min(u64::from(u32::MAX))).unwrap_or(u32::MAX);
+    let stamp = ms_to_iso(composer_timestamp_ms(composer));
+    if let Some(message) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.message_type == "assistant")
+    {
+        message.model = Some("cursor".to_string());
+        message.usage = Some(TokenUsage {
+            input_tokens: Some(capped),
+            output_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+            service_tier: None,
+        });
+        if !stamp.is_empty() {
+            message.timestamp = stamp;
+        }
+    }
 }
 
 /// Search across all Cursor conversations
@@ -383,6 +723,31 @@ fn read_workspace_folder(workspace_json_path: &Path) -> Option<String> {
     })
 }
 
+fn load_composer_value(session_path: &str) -> Result<(String, Value), String> {
+    let composer_id = session_path
+        .strip_prefix("cursor://")
+        .unwrap_or(session_path)
+        .to_string();
+
+    let base = get_base_path().ok_or("Cursor not found")?;
+    let global_db_path = base.join("globalStorage/state.vscdb");
+    let conn = Connection::open_with_flags(&global_db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let composer_key = format!("composerData:{composer_id}");
+    let composer_data: String = conn
+        .query_row(
+            "SELECT value FROM cursorDiskKV WHERE key = ?1",
+            [&composer_key],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Composer not found: {e}"))?;
+
+    let composer = parse_cursor_json(&composer_data)?;
+    Ok((composer_id, composer))
+}
+
 fn read_workspace_composers(ws_db_path: &Path) -> Result<Vec<Value>, String> {
     if !ws_db_path.is_file() {
         return Ok(Vec::new());
@@ -412,6 +777,128 @@ fn read_workspace_composers(ws_db_path: &Path) -> Result<Vec<Value>, String> {
         .unwrap_or_default();
 
     Ok(composers)
+}
+
+fn read_global_composers_for_workspace(workspace_id: &str) -> Result<Vec<Value>, String> {
+    let base = get_base_path().ok_or("Cursor not found")?;
+    let global_db = base.join("globalStorage/state.vscdb");
+    if !global_db.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(&global_db, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor global DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+        .map_err(|e| format!("Query failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| format!("Query failed: {e}"))?;
+
+    let mut composers = Vec::new();
+    for row in rows.flatten() {
+        let (key, value) = row;
+        let Some(composer_id) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        let Ok(mut composer) = parse_cursor_json(&value) else {
+            continue;
+        };
+        if composer_is_archived(&composer) || !composer_has_conversation(&composer) {
+            continue;
+        }
+        let (raw_id, _) = workspace_identity_from_composer(&composer);
+        let id = normalize_workspace_bucket_id(&raw_id);
+        if id != normalize_workspace_bucket_id(workspace_id) {
+            continue;
+        }
+        if composer.get("composerId").and_then(Value::as_str).is_none() {
+            if let Some(obj) = composer.as_object_mut() {
+                obj.insert(
+                    "composerId".to_string(),
+                    Value::String(composer_id.to_string()),
+                );
+            }
+        }
+        composers.push(composer);
+    }
+
+    Ok(composers)
+}
+
+fn composer_is_archived(composer: &Value) -> bool {
+    composer
+        .get("isArchived")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn composer_has_conversation(composer: &Value) -> bool {
+    let has_headers = composer
+        .get("fullConversationHeadersOnly")
+        .and_then(Value::as_array)
+        .is_some_and(|headers| !headers.is_empty());
+    let has_tokens = composer
+        .get("promptTokenBreakdown")
+        .and_then(|v| v.get("totalUsedTokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        > 0;
+    has_headers || has_tokens
+}
+
+fn workspace_identity_from_composer(composer: &Value) -> (String, String) {
+    let wi = composer.get("workspaceIdentifier");
+    let workspace_id = wi
+        .and_then(|v| v.get("id"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .unwrap_or("unassigned")
+        .to_string();
+    let folder_path = wi
+        .and_then(|v| v.get("uri"))
+        .and_then(|uri| {
+            uri.get("fsPath")
+                .or_else(|| uri.get("path"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("")
+        .to_string();
+    (workspace_id, folder_path)
+}
+
+fn is_orphan_workspace_id(workspace_id: &str) -> bool {
+    workspace_id.is_empty() || workspace_id == "unassigned" || workspace_id == "empty-window"
+}
+
+fn normalize_workspace_bucket_id(workspace_id: &str) -> String {
+    if is_orphan_workspace_id(workspace_id) {
+        "unassigned".to_string()
+    } else {
+        workspace_id.to_string()
+    }
+}
+
+fn composer_timestamp_ms(composer: &Value) -> u64 {
+    composer
+        .get("lastUpdatedAt")
+        .and_then(Value::as_f64)
+        .map(|v| v as u64)
+        .filter(|v| *v > 0)
+        .or_else(|| {
+            composer
+                .get("createdAt")
+                .and_then(Value::as_f64)
+                .map(|v| v as u64)
+                .filter(|v| *v > 0)
+        })
+        .unwrap_or(0)
 }
 
 /// Parse Cursor's JSON which may contain control characters
@@ -614,7 +1101,7 @@ fn convert_assistant_bubble(
         "assistant",
         Some("assistant"),
         Some(Value::Array(content_blocks)),
-        Some("composer".to_string()),
+        Some("cursor".to_string()),
     ))
 }
 
@@ -669,6 +1156,29 @@ fn map_cursor_tool_name(name: &str) -> &str {
 mod tests {
     use super::*;
     use serde_json::json;
+    use serial_test::serial;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value.as_ref());
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn test_percent_decode_basic() {
@@ -818,8 +1328,164 @@ mod tests {
             "createdAt": "2026-07-27T20:00:00Z"
         });
         let msg = convert_cursor_bubble(&bubble, 2, "session-1").unwrap();
-        assert_eq!(msg.model.as_deref(), Some("composer"));
+        assert_eq!(msg.model.as_deref(), Some("cursor"));
         assert_eq!(msg.provider.as_deref(), Some("cursor"));
+    }
+
+    #[test]
+    fn test_attach_composer_token_usage_to_last_assistant() {
+        let mut messages = vec![
+            convert_cursor_bubble(
+                &json!({
+                    "type": 1,
+                    "bubbleId": "u1",
+                    "text": "hi",
+                    "createdAt": "2026-07-27T20:00:00Z"
+                }),
+                1,
+                "session-1",
+            )
+            .unwrap(),
+            convert_cursor_bubble(
+                &json!({
+                    "type": 2,
+                    "bubbleId": "a1",
+                    "text": "hello",
+                    "createdAt": "2026-07-27T20:01:00Z"
+                }),
+                2,
+                "session-1",
+            )
+            .unwrap(),
+        ];
+        attach_composer_token_usage(
+            &json!({ "promptTokenBreakdown": { "totalUsedTokens": 12345 } }),
+            &mut messages,
+        );
+        assert!(messages[0].usage.is_none());
+        assert_eq!(
+            messages[1].usage.as_ref().and_then(|u| u.input_tokens),
+            Some(12345)
+        );
+        assert_eq!(messages[1].model.as_deref(), Some("cursor"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_projects_from_migrated_global_composers() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let user_dir = temp.path().join("User");
+        let ws_hash = "hash-migrated";
+        let ws_path = user_dir.join("workspaceStorage").join(ws_hash);
+        fs::create_dir_all(&ws_path).unwrap();
+        fs::create_dir_all(user_dir.join("globalStorage")).unwrap();
+        fs::write(
+            ws_path.join("workspace.json"),
+            r#"{"folder":"file:///Users/test/demo-cursor"}"#,
+        )
+        .unwrap();
+
+        let ws_conn = Connection::open(ws_path.join("state.vscdb")).unwrap();
+        ws_conn
+            .execute(
+                "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        ws_conn
+            .execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('composer.composerData', ?1)",
+                [r#"{"allComposers":[],"selectedComposerIds":["comp-1"],"hasMigratedComposerData":true}"#],
+            )
+            .unwrap();
+
+        let global_conn =
+            Connection::open(user_dir.join("globalStorage").join("state.vscdb")).unwrap();
+        global_conn
+            .execute(
+                "CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        let composer = json!({
+            "composerId": "comp-1",
+            "name": "Migrated chat",
+            "createdAt": 1_700_000_000_000u64,
+            "lastUpdatedAt": 1_700_000_100_000u64,
+            "isArchived": false,
+            "unifiedMode": "agent",
+            "workspaceIdentifier": {
+                "id": ws_hash,
+                "uri": { "fsPath": "/Users/test/demo-cursor", "path": "/Users/test/demo-cursor" }
+            },
+            "fullConversationHeadersOnly": [
+                { "bubbleId": "b1", "type": 1 },
+                { "bubbleId": "b2", "type": 2 }
+            ],
+            "promptTokenBreakdown": { "totalUsedTokens": 9001 }
+        })
+        .to_string();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params!["composerData:comp-1", composer],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-1:b1",
+                    json!({
+                        "bubbleId": "b1",
+                        "type": 1,
+                        "text": "hello",
+                        "createdAt": "2026-07-27T20:00:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-1:b2",
+                    json!({
+                        "bubbleId": "b2",
+                        "type": 2,
+                        "text": "hi",
+                        "createdAt": "2026-07-27T20:01:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+
+        let _env = EnvVarGuard::set("CURSOR_USER_DIR", &user_dir);
+        let projects = scan_projects().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "demo-cursor");
+        assert!(projects[0].session_count >= 1);
+
+        let sessions = load_sessions(&projects[0].path, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        let messages = load_messages(&sessions[0].file_path).unwrap();
+        assert!(messages.iter().any(|m| {
+            m.model.as_deref() == Some("cursor")
+                && m.usage
+                    .as_ref()
+                    .and_then(|u| u.input_tokens)
+                    .is_some_and(|tokens| tokens == 9001)
+        }));
+        let stats_messages = load_stats_messages(&sessions[0].file_path).unwrap();
+        assert!(stats_messages.iter().any(|m| {
+            m.model.as_deref() == Some("cursor")
+                && m.usage
+                    .as_ref()
+                    .and_then(|u| u.input_tokens)
+                    .is_some_and(|tokens| tokens == 9001)
+        }));
     }
 
     /// Write a minimal valid Cursor workspace: `workspace.json` + a `state.vscdb`

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -1,0 +1,1064 @@
+use super::ProviderInfo;
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
+use crate::utils::{
+    build_provider_message, detect_git_worktree_info, is_symlink,
+    search_json_value_case_insensitive,
+};
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PROVIDER_ID: &str = "grok";
+const SESSIONS_DIR: &str = "sessions";
+const SUMMARY_FILE: &str = "summary.json";
+const CHAT_HISTORY_FILE: &str = "chat_history.jsonl";
+
+pub fn detect() -> Option<ProviderInfo> {
+    let base = get_base_path()?;
+    let sessions_path = Path::new(&base).join(SESSIONS_DIR);
+
+    Some(ProviderInfo {
+        id: PROVIDER_ID.to_string(),
+        display_name: "Grok CLI".to_string(),
+        base_path: base,
+        is_available: sessions_path.exists() && sessions_path.is_dir(),
+    })
+}
+
+pub fn get_base_path() -> Option<String> {
+    if let Ok(env_val) = std::env::var("GROK_HOME") {
+        let path = PathBuf::from(&env_val);
+        let absolute_path = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir().ok()?.join(path)
+        };
+        if absolute_path.exists() {
+            let normalized = absolute_path.canonicalize().unwrap_or(absolute_path);
+            return Some(normalized.to_string_lossy().to_string());
+        }
+    }
+
+    let default = dirs::home_dir()?.join(".grok");
+    if default.exists() {
+        let normalized = default.canonicalize().unwrap_or(default);
+        Some(normalized.to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
+pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
+    crate::utils::require_absolute_path(base_path, "Grok base path")?;
+    let base = Path::new(base_path);
+    let sessions_root = base.join(SESSIONS_DIR);
+
+    if is_symlink(&sessions_root) || !sessions_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    let mut projects = Vec::new();
+
+    for entry in
+        fs::read_dir(&sessions_root).map_err(|e| format!("Failed to read Grok sessions: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Grok project entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let project_dir = entry.path();
+        if !path_is_inside(&project_dir, &canonical_base)? {
+            continue;
+        }
+
+        let mut infos = Vec::new();
+        for session_entry in fs::read_dir(&project_dir)
+            .map_err(|e| format!("Failed to read Grok project dir: {e}"))?
+        {
+            let session_entry =
+                session_entry.map_err(|e| format!("Failed to read Grok session entry: {e}"))?;
+            if session_entry
+                .file_type()
+                .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+            {
+                continue;
+            }
+            if let Some(info) = extract_session_info(&session_entry.path()) {
+                infos.push(info);
+            }
+        }
+
+        if infos.is_empty() {
+            continue;
+        }
+
+        let encoded_name = project_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| "grok".to_string());
+        let actual_path = infos
+            .iter()
+            .find_map(|info| info.cwd.clone())
+            .unwrap_or_else(|| decode_cwd_dirname(&encoded_name));
+        let name = project_name_from_actual_path(&actual_path, &encoded_name);
+        let message_count = infos.iter().map(|info| info.message_count).sum();
+        let last_modified = infos
+            .iter()
+            .map(|info| info.last_modified.as_str())
+            .max()
+            .unwrap_or_default()
+            .to_string();
+
+        let project_uri_path = project_dir
+            .canonicalize()
+            .unwrap_or_else(|_| project_dir.clone());
+
+        projects.push(ClaudeProject {
+            name,
+            path: format!("grok://{}", project_uri_path.to_string_lossy()),
+            actual_path: actual_path.clone(),
+            session_count: infos.len(),
+            message_count,
+            last_modified,
+            git_info: if Path::new(&actual_path).is_absolute() {
+                detect_git_worktree_info(&actual_path)
+            } else {
+                None
+            },
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            custom_directory_label: None,
+        });
+    }
+
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    scan_projects_from_path(&base)
+}
+
+pub fn load_sessions(
+    project_path: &str,
+    exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    load_sessions_from_base_path(&base, project_path, exclude_sidechain)
+}
+
+pub fn load_sessions_from_base_path(
+    base_path: &str,
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    crate::utils::require_absolute_path(base_path, "Grok base path")?;
+    let base = Path::new(base_path);
+    let project_dir = resolve_project_dir(base, project_path)?;
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    if !path_is_inside(&project_dir, &canonical_base)? {
+        return Err("Grok project path is outside Grok base path".to_string());
+    }
+
+    let fallback_project_name = project_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "grok".to_string());
+
+    let mut sessions = Vec::new();
+    for entry in
+        fs::read_dir(&project_dir).map_err(|e| format!("Failed to read Grok project dir: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Grok session entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let session_dir = entry.path();
+        let Some(info) = extract_session_info(&session_dir) else {
+            continue;
+        };
+        let project_name = info
+            .cwd
+            .as_deref()
+            .map(|cwd| project_name_from_actual_path(cwd, &fallback_project_name))
+            .unwrap_or_else(|| {
+                project_name_from_actual_path(
+                    &decode_cwd_dirname(&fallback_project_name),
+                    &fallback_project_name,
+                )
+            });
+
+        sessions.push(ClaudeSession {
+            session_id: session_dir.to_string_lossy().to_string(),
+            actual_session_id: info.session_id.clone(),
+            file_path: session_dir.to_string_lossy().to_string(),
+            project_name,
+            message_count: info.message_count,
+            first_message_time: info.first_message_time,
+            last_message_time: info.last_message_time,
+            last_modified: info.last_modified,
+            has_tool_use: info.has_tool_use,
+            has_errors: false,
+            summary: info.summary,
+            is_renamed: false,
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            entrypoint: None,
+        });
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    load_messages_from_base_path(&base, session_path)
+}
+
+pub fn load_messages_from_base_path(
+    base_path: &str,
+    session_path: &str,
+) -> Result<Vec<ClaudeMessage>, String> {
+    crate::utils::require_absolute_path(base_path, "Grok base path")?;
+    let base = Path::new(base_path);
+    let session_dir = PathBuf::from(session_path);
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    if !session_dir.is_absolute() || !path_is_inside(&session_dir, &canonical_base)? {
+        return Err("Grok session path is outside Grok base path".to_string());
+    }
+    if is_symlink(&session_dir) || !session_dir.is_dir() {
+        return Err("Grok session path is not a directory".to_string());
+    }
+
+    let session_id = session_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let summary = read_json_file(&session_dir.join(SUMMARY_FILE)).unwrap_or(Value::Null);
+    let created_at = summary
+        .get("created_at")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let updated_at = summary
+        .get("updated_at")
+        .or_else(|| summary.get("last_active_at"))
+        .and_then(Value::as_str)
+        .unwrap_or(created_at.as_str())
+        .to_string();
+    let model = summary
+        .get("current_model_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    let mut messages = Vec::new();
+    let mut counter = 0u64;
+
+    for value in read_jsonl_values(&session_dir.join(CHAT_HISTORY_FILE))? {
+        if let Some(message) = convert_chat_message(
+            &value,
+            &session_id,
+            &created_at,
+            model.clone(),
+            &mut counter,
+        ) {
+            messages.push(message);
+        }
+    }
+
+    if let Some(last) = messages.last_mut() {
+        if !updated_at.is_empty() {
+            last.timestamp.clone_from(&updated_at);
+        }
+    }
+
+    attach_session_token_usage(&session_dir, &mut messages);
+
+    if !updated_at.is_empty() {
+        if let Some(message) = messages
+            .iter_mut()
+            .rev()
+            .find(|message| message.usage.is_some())
+        {
+            message.timestamp = updated_at;
+        }
+    }
+
+    Ok(messages)
+}
+
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Grok base path not found")?;
+    search_from_base_path(&base, query, limit)
+}
+
+pub fn search_from_base_path(
+    base_path: &str,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<ClaudeMessage>, String> {
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for project in scan_projects_from_path(base_path)? {
+        for session in load_sessions_from_base_path(base_path, &project.path, false)? {
+            for mut message in load_messages_from_base_path(base_path, &session.file_path)? {
+                if let Some(content) = &message.content {
+                    if search_json_value_case_insensitive(content, &query_lower) {
+                        message.project_name = Some(project.name.clone());
+                        results.push(message);
+                        if results.len() >= limit {
+                            return Ok(results);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[derive(Debug, Clone)]
+struct SessionInfo {
+    session_id: String,
+    cwd: Option<String>,
+    message_count: usize,
+    first_message_time: String,
+    last_message_time: String,
+    last_modified: String,
+    has_tool_use: bool,
+    summary: Option<String>,
+}
+
+fn extract_session_info(session_dir: &Path) -> Option<SessionInfo> {
+    if is_symlink(session_dir) || !session_dir.is_dir() {
+        return None;
+    }
+    let summary_path = session_dir.join(SUMMARY_FILE);
+    let chat_path = session_dir.join(CHAT_HISTORY_FILE);
+    if is_symlink(&summary_path) || !summary_path.is_file() {
+        return None;
+    }
+    if is_symlink(&chat_path) || !chat_path.is_file() {
+        return None;
+    }
+
+    let summary = read_json_file(&summary_path).ok()?;
+    let session_id = summary
+        .pointer("/info/id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            session_dir
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })?;
+
+    let cwd = summary
+        .pointer("/info/cwd")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+        .map(ToOwned::to_owned);
+
+    let title = summary
+        .get("generated_title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .or_else(|| {
+            summary
+                .get("session_summary")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|title| !title.is_empty())
+        })
+        .map(ToOwned::to_owned);
+
+    let created_at = summary
+        .get("created_at")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let updated_at = summary
+        .get("updated_at")
+        .or_else(|| summary.get("last_active_at"))
+        .and_then(Value::as_str)
+        .unwrap_or(created_at.as_str())
+        .to_string();
+
+    let mut message_count = summary
+        .get("num_chat_messages")
+        .or_else(|| summary.get("num_messages"))
+        .and_then(Value::as_u64)
+        .map(|n| n as usize)
+        .unwrap_or(0);
+
+    let signals = read_json_file(&session_dir.join("signals.json")).unwrap_or(Value::Null);
+    let mut has_tool_use = signals
+        .get("toolCallCount")
+        .and_then(Value::as_u64)
+        .is_some_and(|n| n > 0);
+
+    if message_count == 0 {
+        if let Ok(values) = read_jsonl_values(&chat_path) {
+            message_count = values
+                .iter()
+                .filter(|value| {
+                    matches!(
+                        value.get("type").and_then(Value::as_str),
+                        Some("user" | "assistant" | "tool_result" | "reasoning" | "system")
+                    )
+                })
+                .count();
+            if !has_tool_use {
+                has_tool_use = values.iter().any(value_has_tool_use);
+            }
+        }
+    } else if !has_tool_use {
+        has_tool_use = chat_history_has_tool_use(&chat_path);
+    }
+
+    if message_count == 0 {
+        return None;
+    }
+
+    let last_modified = if updated_at.is_empty() {
+        file_modified_iso(&summary_path).unwrap_or_default()
+    } else {
+        updated_at.clone()
+    };
+
+    Some(SessionInfo {
+        session_id,
+        cwd,
+        message_count,
+        first_message_time: created_at,
+        last_message_time: updated_at,
+        last_modified,
+        has_tool_use,
+        summary: title,
+    })
+}
+
+fn convert_chat_message(
+    value: &Value,
+    session_id: &str,
+    timestamp: &str,
+    model: Option<String>,
+    counter: &mut u64,
+) -> Option<ClaudeMessage> {
+    let msg_type = value.get("type").and_then(Value::as_str)?;
+    *counter += 1;
+    let uuid = value
+        .get("id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("{session_id}-{counter}"));
+
+    match msg_type {
+        "system" => {
+            let content = content_to_blocks(value.get("content"));
+            if content_is_empty(&content) {
+                return None;
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp.to_string(),
+                "system",
+                Some("system"),
+                Some(content),
+                None,
+            ))
+        }
+        "user" => Some(build_provider_message(
+            PROVIDER_ID,
+            uuid,
+            session_id,
+            timestamp.to_string(),
+            "user",
+            Some("user"),
+            Some(content_to_blocks(value.get("content"))),
+            None,
+        )),
+        "assistant" => {
+            let mut blocks = content_to_blocks(value.get("content"));
+            if let Some(calls) = value.get("tool_calls").and_then(Value::as_array) {
+                if let Some(arr) = blocks.as_array_mut() {
+                    for call in calls {
+                        arr.push(convert_tool_call(call));
+                    }
+                }
+            }
+            let model_id = value
+                .get("model_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+                .or(model);
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp.to_string(),
+                "assistant",
+                Some("assistant"),
+                Some(blocks),
+                model_id,
+            ))
+        }
+        "reasoning" => {
+            let thinking = extract_reasoning_text(value);
+            if thinking.trim().is_empty() {
+                return None;
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp.to_string(),
+                "assistant",
+                Some("assistant"),
+                Some(json!([{ "type": "thinking", "thinking": thinking }])),
+                model,
+            ))
+        }
+        "tool_result" => Some(build_provider_message(
+            PROVIDER_ID,
+            uuid,
+            session_id,
+            timestamp.to_string(),
+            "user",
+            Some("user"),
+            Some(json!([{
+                "type": "tool_result",
+                "tool_use_id": value.get("tool_call_id").and_then(Value::as_str).unwrap_or(""),
+                "content": value.get("content").cloned().unwrap_or(Value::Null)
+            }])),
+            None,
+        )),
+        "backend_tool_call" => convert_backend_tool_call(value, &uuid, session_id, timestamp),
+        _ => None,
+    }
+}
+
+fn convert_backend_tool_call(
+    value: &Value,
+    uuid: &str,
+    session_id: &str,
+    timestamp: &str,
+) -> Option<ClaudeMessage> {
+    let kind = value.get("kind")?;
+    let name = kind
+        .get("tool_type")
+        .and_then(Value::as_str)
+        .unwrap_or("backend_tool");
+    Some(build_provider_message(
+        PROVIDER_ID,
+        uuid.to_string(),
+        session_id,
+        timestamp.to_string(),
+        "assistant",
+        Some("assistant"),
+        Some(json!([{
+            "type": "tool_use",
+            "id": uuid,
+            "name": name,
+            "input": kind.get("action").cloned().unwrap_or_else(|| kind.clone())
+        }])),
+        None,
+    ))
+}
+
+fn extract_reasoning_text(value: &Value) -> String {
+    if let Some(text) = value.get("content").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    if let Some(text) = value.get("thinking").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    if let Some(items) = value.get("summary").and_then(Value::as_array) {
+        return items
+            .iter()
+            .filter_map(|item| {
+                item.get("text")
+                    .and_then(Value::as_str)
+                    .or_else(|| item.as_str())
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    String::new()
+}
+
+fn content_to_blocks(content: Option<&Value>) -> Value {
+    match content {
+        Some(Value::Array(items)) => {
+            Value::Array(items.iter().map(normalize_content_block).collect())
+        }
+        Some(Value::String(text)) => json!([{ "type": "text", "text": text }]),
+        Some(Value::Null) | None => Value::Array(Vec::new()),
+        Some(other) => json!([{ "type": "text", "text": other.to_string() }]),
+    }
+}
+
+fn normalize_content_block(item: &Value) -> Value {
+    item.clone()
+}
+
+fn content_is_empty(content: &Value) -> bool {
+    match content {
+        Value::Array(items) => {
+            items.is_empty()
+                || items.iter().all(|item| {
+                    item.get("text")
+                        .and_then(Value::as_str)
+                        .map_or(true, |text| text.trim().is_empty())
+                })
+        }
+        Value::String(text) => text.trim().is_empty(),
+        Value::Null => true,
+        _ => false,
+    }
+}
+
+fn convert_tool_call(call: &Value) -> Value {
+    let function = call.get("function").unwrap_or(&Value::Null);
+    let name = function
+        .get("name")
+        .or_else(|| call.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("tool");
+    let input = function
+        .get("arguments")
+        .or_else(|| call.get("arguments"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    json!({
+        "type": "tool_use",
+        "id": call.get("id").and_then(Value::as_str).unwrap_or(""),
+        "name": name,
+        "input": normalize_tool_input(input)
+    })
+}
+
+fn normalize_tool_input(input: Value) -> Value {
+    if let Some(s) = input.as_str() {
+        serde_json::from_str(s).unwrap_or_else(|_| json!({ "input": s }))
+    } else {
+        input
+    }
+}
+
+fn decode_cwd_dirname(encoded: &str) -> String {
+    urlencoding::decode(encoded)
+        .map(std::borrow::Cow::into_owned)
+        .unwrap_or_else(|_| encoded.to_string())
+}
+
+fn attach_session_token_usage(session_dir: &Path, messages: &mut [ClaudeMessage]) {
+    if messages.is_empty() {
+        return;
+    }
+
+    let signals = read_json_file(&session_dir.join("signals.json")).unwrap_or(Value::Null);
+    let tokens = signals
+        .get("contextTokensUsed")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if tokens == 0 {
+        return;
+    }
+
+    let model = signals
+        .get("primaryModelId")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    let capped = u32::try_from(tokens.min(u64::from(u32::MAX))).unwrap_or(u32::MAX);
+    if let Some(message) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.message_type == "assistant")
+    {
+        message.usage = Some(TokenUsage {
+            input_tokens: Some(capped),
+            output_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+            service_tier: None,
+        });
+        if let Some(model) = model {
+            message.model = Some(model);
+        }
+    }
+}
+
+fn read_json_file(path: &Path) -> Result<Value, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Grok JSON file".to_string());
+    }
+    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read JSON file: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON file: {e}"))
+}
+
+fn read_jsonl_values(path: &Path) -> Result<Vec<Value>, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Grok JSONL file".to_string());
+    }
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read JSONL file: {e}"))?;
+    let mut values = Vec::new();
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        if let Ok(value) = serde_json::from_str::<Value>(line) {
+            values.push(value);
+        }
+    }
+    Ok(values)
+}
+
+fn value_has_tool_use(value: &Value) -> bool {
+    matches!(
+        value.get("type").and_then(Value::as_str),
+        Some("tool_result" | "backend_tool_call")
+    ) || value
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .is_some_and(|calls| !calls.is_empty())
+}
+
+fn chat_history_has_tool_use(path: &Path) -> bool {
+    use std::io::{BufRead, BufReader};
+
+    if is_symlink(path) || !path.is_file() {
+        return false;
+    }
+    let Ok(file) = fs::File::open(path) else {
+        return false;
+    };
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<Value>(&line) {
+            if value_has_tool_use(&value) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn file_modified_iso(path: &Path) -> Option<String> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .map(|time| {
+            let dt: DateTime<Utc> = time.into();
+            dt.to_rfc3339()
+        })
+}
+
+fn resolve_project_dir(base: &Path, project_path: &str) -> Result<PathBuf, String> {
+    let raw = project_path.strip_prefix("grok://").unwrap_or(project_path);
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err("Grok project path must be absolute".to_string());
+    }
+    if is_symlink(&path) || !path.is_dir() {
+        return Err("Grok project path is not a directory".to_string());
+    }
+
+    let canonical_base = canonical_existing(base, "Grok base path")?;
+    let sessions_root = canonical_base.join(SESSIONS_DIR);
+    let canonical_sessions = sessions_root
+        .canonicalize()
+        .unwrap_or_else(|_| sessions_root.clone());
+    let canonical_path = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve Grok project path: {e}"))?;
+    if !canonical_path.starts_with(&canonical_sessions) {
+        return Err("Grok project path is outside Grok sessions directory".to_string());
+    }
+    Ok(canonical_path)
+}
+
+fn canonical_existing(path: &Path, label: &str) -> Result<PathBuf, String> {
+    path.canonicalize()
+        .map_err(|e| format!("Failed to resolve {label}: {e}"))
+}
+
+fn path_is_inside(path: &Path, canonical_base: &Path) -> Result<bool, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve path: {e}"))?;
+    Ok(canonical.starts_with(canonical_base))
+}
+
+fn project_name_from_actual_path(actual_path: &str, fallback: &str) -> String {
+    Path::new(actual_path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::fs;
+    use tempfile::TempDir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: std::ffi::OsString) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.original.as_ref() {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn write_fixture(root: &Path) -> (PathBuf, PathBuf) {
+        let encoded = "%2FUsers%2Ftest%2Fdemo";
+        let session_id = "019fa555-791c-71e2-8c92-ff2e6fa26d6e";
+        let project_dir = root.join("sessions").join(encoded);
+        let session_dir = project_dir.join(session_id);
+        fs::create_dir_all(&session_dir).unwrap();
+
+        let summary = json!({
+            "info": {
+                "id": session_id,
+                "cwd": "/Users/test/demo"
+            },
+            "session_summary": "Demo session",
+            "generated_title": "Demo Title",
+            "created_at": "2026-07-27T20:47:50Z",
+            "updated_at": "2026-07-27T21:11:25Z",
+            "num_chat_messages": 4,
+            "current_model_id": "grok-4.5"
+        });
+        fs::write(
+            session_dir.join(SUMMARY_FILE),
+            serde_json::to_string_pretty(&summary).unwrap(),
+        )
+        .unwrap();
+
+        let lines = [
+            r#"{"type":"system","content":"You are Grok."}"#,
+            r#"{"type":"user","content":[{"type":"text","text":"Hello grok"}]}"#,
+            r#"{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"Thinking about hello"}]}"#,
+            r#"{"type":"assistant","content":"Hi there","tool_calls":[{"id":"call-1","name":"read_file","arguments":"{\"target_file\":\"/tmp/a.txt\"}"}],"model_id":"grok-4.5"}"#,
+            r#"{"type":"tool_result","tool_call_id":"call-1","content":"file contents"}"#,
+            r#"{"type":"backend_tool_call","kind":{"tool_type":"web_search","action":{"type":"search","query":"rust"}}}"#,
+            r"not-json",
+        ];
+        fs::write(session_dir.join(CHAT_HISTORY_FILE), lines.join("\n")).unwrap();
+        fs::write(
+            session_dir.join("signals.json"),
+            serde_json::to_string_pretty(&json!({
+                "contextTokensUsed": 12345,
+                "toolCallCount": 3,
+                "primaryModelId": "grok-4.5",
+                "modelsUsed": ["grok-4.5"]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        (project_dir, session_dir)
+    }
+
+    #[test]
+    fn decode_cwd_dirname_percent_decodes_paths() {
+        assert_eq!(
+            decode_cwd_dirname("%2FUsers%2Flucashr%2FDownloads"),
+            "/Users/lucashr/Downloads"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_prefers_grok_home() {
+        let temp = TempDir::new().unwrap();
+        let home_dir = temp.path().join("grok-home");
+        fs::create_dir_all(&home_dir).unwrap();
+        let _env = EnvVarGuard::set("GROK_HOME", home_dir.as_os_str().to_owned());
+        let path = get_base_path().unwrap();
+        assert_eq!(PathBuf::from(path), home_dir.canonicalize().unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_returns_none_when_default_dir_absent() {
+        let _env = EnvVarGuard::remove("GROK_HOME");
+        if dirs::home_dir()
+            .map(|h| h.join(".grok").exists())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        assert!(get_base_path().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn scan_load_and_search_fixture_session() {
+        let temp = TempDir::new().unwrap();
+        let (_project_dir, session_dir) = write_fixture(temp.path());
+        let _env = EnvVarGuard::set("GROK_HOME", temp.path().as_os_str().to_owned());
+
+        let projects = scan_projects().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].provider.as_deref(), Some("grok"));
+        assert_eq!(projects[0].actual_path, "/Users/test/demo");
+        assert_eq!(projects[0].name, "demo");
+        assert!(projects[0].path.starts_with("grok://"));
+
+        let sessions = load_sessions(&projects[0].path, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].actual_session_id,
+            "019fa555-791c-71e2-8c92-ff2e6fa26d6e"
+        );
+        assert_eq!(sessions[0].summary.as_deref(), Some("Demo Title"));
+        assert!(sessions[0].has_tool_use);
+
+        let messages = load_messages(&session_dir.to_string_lossy()).unwrap();
+        assert!(messages.len() >= 5);
+        assert!(messages.iter().any(|m| m.message_type == "user"));
+        assert!(messages.iter().any(|m| {
+            m.content
+                .as_ref()
+                .and_then(|c| c.as_array())
+                .is_some_and(|arr| {
+                    arr.iter()
+                        .any(|item| item.get("type").and_then(Value::as_str) == Some("thinking"))
+                })
+        }));
+        assert!(messages.iter().any(|m| {
+            m.content
+                .as_ref()
+                .and_then(|c| c.as_array())
+                .is_some_and(|arr| {
+                    arr.iter()
+                        .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+                })
+        }));
+        assert!(messages.iter().any(|m| {
+            m.usage
+                .as_ref()
+                .and_then(|usage| usage.input_tokens)
+                .is_some_and(|tokens| tokens == 12345)
+        }));
+
+        let results = search("Hello grok", 10).unwrap();
+        assert!(!results.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn smoke_scan_real_grok_home_when_present() {
+        let _env = EnvVarGuard::remove("GROK_HOME");
+        let Some(base) = dirs::home_dir().map(|h| h.join(".grok")) else {
+            return;
+        };
+        if !base.join("sessions").is_dir() {
+            return;
+        }
+
+        let projects = scan_projects().expect("scan real Grok projects");
+        assert!(
+            !projects.is_empty(),
+            "expected at least one Grok project under ~/.grok/sessions"
+        );
+        assert!(projects
+            .iter()
+            .all(|p| p.provider.as_deref() == Some("grok")));
+
+        let sessions = load_sessions(&projects[0].path, false).expect("load real sessions");
+        assert!(!sessions.is_empty());
+
+        let messages =
+            load_messages(&sessions[0].file_path).expect("load real chat_history messages");
+        assert!(
+            !messages.is_empty(),
+            "expected messages in first real Grok session"
+        );
+    }
+
+    #[test]
+    fn convert_chat_message_maps_tool_result_and_backend_call() {
+        let mut counter = 0u64;
+        let tool_result = json!({
+            "type": "tool_result",
+            "tool_call_id": "call-1",
+            "content": "ok"
+        });
+        let msg = convert_chat_message(
+            &tool_result,
+            "sess",
+            "2026-01-01T00:00:00Z",
+            None,
+            &mut counter,
+        )
+        .unwrap();
+        assert_eq!(msg.message_type, "user");
+
+        let backend = json!({
+            "type": "backend_tool_call",
+            "kind": {
+                "tool_type": "web_search",
+                "action": { "query": "x" }
+            }
+        });
+        let msg =
+            convert_chat_message(&backend, "sess", "2026-01-01T00:00:00Z", None, &mut counter)
+                .unwrap();
+        assert_eq!(msg.message_type, "assistant");
+        let name = msg
+            .content
+            .as_ref()
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|item| item.get("name"))
+            .and_then(Value::as_str);
+        assert_eq!(name, Some("web_search"));
+    }
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -19,6 +19,7 @@ pub mod cursor_agent;
 pub mod forgecode;
 pub mod gemini;
 pub mod goose;
+pub mod grok;
 pub mod kimi;
 pub mod kiro;
 pub mod llm;
@@ -63,6 +64,8 @@ pub enum ProviderId {
     CursorAgent,
     Gemini,
     Goose,
+    /// xAI Grok CLI (`~/.grok/sessions`).
+    Grok,
     Kimi,
     ForgeCode,
     Kiro,
@@ -105,6 +108,7 @@ impl ProviderId {
             Self::CursorAgent => "cursor-agent",
             Self::Gemini => "gemini",
             Self::Goose => "goose",
+            Self::Grok => "grok",
             Self::Kimi => "kimi",
             Self::ForgeCode => "forgecode",
             Self::Kiro => "kiro",
@@ -138,6 +142,7 @@ impl ProviderId {
             "cursor-agent" => Some(Self::CursorAgent),
             "gemini" => Some(Self::Gemini),
             "goose" => Some(Self::Goose),
+            "grok" => Some(Self::Grok),
             "kimi" => Some(Self::Kimi),
             "forgecode" => Some(Self::ForgeCode),
             "kiro" => Some(Self::Kiro),
@@ -172,6 +177,7 @@ impl ProviderId {
             Self::CursorAgent => "Cursor Agent",
             Self::Gemini => "Gemini CLI",
             Self::Goose => "Goose",
+            Self::Grok => "Grok CLI",
             Self::Kimi => "Kimi CLI",
             Self::ForgeCode => "ForgeCode",
             Self::Kiro => "Kiro CLI",
@@ -219,6 +225,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = goose::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = grok::detect() {
         providers.push(info);
     }
     if let Some(info) = kimi::detect() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,6 +271,23 @@ function App() {
     void loadGlobalStats();
   }, [clearProjectSelection, loadGlobalStats, setAnalyticsCurrentView]);
 
+  const activeProvidersKey = useMemo(
+    () => normalizeProviderIds(activeProviders).join(","),
+    [activeProviders]
+  );
+  const prevGlobalProvidersKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isViewingGlobalStats) {
+      prevGlobalProvidersKeyRef.current = activeProvidersKey;
+      return;
+    }
+    if (prevGlobalProvidersKeyRef.current === activeProvidersKey) {
+      return;
+    }
+    prevGlobalProvidersKeyRef.current = activeProvidersKey;
+    void loadGlobalStats();
+  }, [activeProvidersKey, isViewingGlobalStats, loadGlobalStats]);
+
   const handleToggleSidebar = useCallback(() => {
     setIsSidebarCollapsed((prev) => !prev);
   }, []);

--- a/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
+++ b/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
@@ -16,6 +16,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   codex: "var(--metric-green)",
   cursor: "var(--metric-cyan)",
   gemini: "var(--metric-purple)",
+  grok: "var(--metric-red)",
   opencode: "var(--metric-blue)",
 };
 

--- a/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
+++ b/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
@@ -14,7 +14,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   claude: "var(--metric-amber)",
   cline: "var(--metric-teal)",
   codex: "var(--metric-green)",
-  cursor: "var(--metric-cyan)",
+  cursor: "#f54e00",
   gemini: "var(--metric-purple)",
   grok: "var(--metric-red)",
   opencode: "var(--metric-blue)",
@@ -24,9 +24,19 @@ export const ProviderDistributionChart: React.FC<ProviderDistributionChartProps>
   providers,
 }) => {
   const { t } = useTranslation();
-  const sortedProviders = [...providers].sort((a, b) => b.tokens - a.tokens);
+  const sortedProviders = [...providers].sort(
+    (a, b) => b.tokens - a.tokens || b.sessions - a.sessions
+  );
   const totalTokens = sortedProviders.reduce((sum, provider) => sum + provider.tokens, 0);
-  const maxTokens = Math.max(...sortedProviders.map((provider) => provider.tokens), 1);
+  const totalSessions = sortedProviders.reduce((sum, provider) => sum + provider.sessions, 0);
+  const useSessionBars = totalTokens === 0;
+  const totalBarValue = useSessionBars ? totalSessions : totalTokens;
+  const maxBarValue = Math.max(
+    ...(useSessionBars
+      ? sortedProviders.map((provider) => provider.sessions)
+      : sortedProviders.map((provider) => provider.tokens)),
+    1
+  );
 
   if (sortedProviders.length === 0) {
     return (
@@ -42,8 +52,9 @@ export const ProviderDistributionChart: React.FC<ProviderDistributionChartProps>
       {sortedProviders.map((provider) => {
         const normalizedId = getProviderId(provider.provider_id);
         const color = PROVIDER_COLORS[normalizedId] ?? "var(--metric-purple)";
-        const percentage = totalTokens > 0 ? (provider.tokens / totalTokens) * 100 : 0;
-        const barWidth = (provider.tokens / maxTokens) * 100;
+        const barValue = useSessionBars ? provider.sessions : provider.tokens;
+        const percentage = totalBarValue > 0 ? (barValue / totalBarValue) * 100 : 0;
+        const barWidth = (barValue / maxBarValue) * 100;
 
         return (
           <div
@@ -60,7 +71,9 @@ export const ProviderDistributionChart: React.FC<ProviderDistributionChartProps>
                   {getProviderLabel((key, fallback) => t(key, fallback), provider.provider_id)}
                 </span>
                 <span className="font-mono text-px11 font-semibold tabular-nums shrink-0 text-foreground">
-                  {provider.tokens.toLocaleString()}
+                  {useSessionBars
+                    ? provider.sessions.toLocaleString()
+                    : provider.tokens.toLocaleString()}
                 </span>
               </div>
 

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -63,6 +63,11 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   // Google models (OpenCode)
   'gemini-2.5-pro': { input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 },
   'gemini-2.5-flash': { input: 0.15, output: 0.60, cacheWrite: 0, cacheRead: 0 },
+  'grok-4.5-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-4.5': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
+  'grok-4.3': { input: 1.25, output: 2.5, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
+  'grok-4': { input: 3, output: 15, cacheWrite: 0, cacheRead: 0.75 },
 };
 
 const DEFAULT_PRICING: ModelPricing = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 };

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -68,8 +68,8 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'grok-4.3': { input: 1.25, output: 2.5, cacheWrite: 0, cacheRead: 0.20 },
   'grok-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
   'grok-4': { input: 3, output: 15, cacheWrite: 0, cacheRead: 0.75 },
-  // Cursor Composer — product-level label (not underlying Claude/GPT)
-  'composer': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
+  // Cursor product-level label (not underlying Claude/GPT)
+  'cursor': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
 };
 
 const DEFAULT_PRICING: ModelPricing = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 };

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -68,6 +68,8 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'grok-4.3': { input: 1.25, output: 2.5, cacheWrite: 0, cacheRead: 0.20 },
   'grok-build': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
   'grok-4': { input: 3, output: 15, cacheWrite: 0, cacheRead: 0.75 },
+  // Cursor Composer — product-level label (not underlying Claude/GPT)
+  'composer': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
 };
 
 const DEFAULT_PRICING: ModelPricing = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 };

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -151,6 +151,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       forgecode: 0,
       gemini: 0,
       goose: 0,
+      grok: 0,
       kimi: 0,
       kiro: 0,
       llm: 0,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "Failed to detect providers. Using Claude only.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "プロバイダーの検出に失敗しました。Claude のみ使用します。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "프로바이더 감지에 실패했습니다. Claude만 사용합니다.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "检测提供商失败。将仅使用 Claude。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -130,6 +130,7 @@
   "common.provider.forgecode": "ForgeCode",
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
+  "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
   "common.provider.detectError": "偵測提供者失敗。將僅使用 Claude。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-07-19T07:35:41.789Z
- * 총 키 개수: 1877
+ * 생성 시간: 2026-08-01T03:15:38.501Z
+ * 총 키 개수: 1878
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (181개)
+ * common namespace의 번역 키 (182개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -123,6 +123,7 @@ export type CommonKeys =
   | 'common.provider.forgecode'
   | 'common.provider.gemini'
   | 'common.provider.goose'
+  | 'common.provider.grok'
   | 'common.provider.kimi'
   | 'common.provider.kiro'
   | 'common.provider.llm'
@@ -2368,6 +2369,7 @@ export type TranslationKey =
   | 'common.provider.forgecode'
   | 'common.provider.gemini'
   | 'common.provider.goose'
+  | 'common.provider.grok'
   | 'common.provider.kimi'
   | 'common.provider.kiro'
   | 'common.provider.llm'

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -54,6 +54,7 @@ describe("providers utils", () => {
       "forgecode",
       "gemini",
       "goose",
+      "grok",
       "kimi",
       "kiro",
       "llm",

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from "../types";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 const PROVIDER_TRANSLATIONS: Record<
@@ -22,6 +22,7 @@ const PROVIDER_TRANSLATIONS: Record<
   forgecode: { key: "common.provider.forgecode", fallback: "ForgeCode" },
   gemini: { key: "common.provider.gemini", fallback: "Gemini CLI" },
   goose: { key: "common.provider.goose", fallback: "Goose" },
+  grok: { key: "common.provider.grok", fallback: "Grok CLI" },
   kimi: { key: "common.provider.kimi", fallback: "Kimi CLI" },
   kiro: { key: "common.provider.kiro", fallback: "Kiro CLI" },
   llm: { key: "common.provider.llm", fallback: "llm" },
@@ -156,6 +157,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  grok: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   kimi: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
@@ -276,6 +284,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "cursor-agent":
     case "gemini":
     case "goose":
+    case "grok":
     case "kimi":
     case "forgecode":
     case "kiro":
@@ -442,6 +451,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   forgecode: "bg-orange-500/15 text-orange-700 dark:text-orange-300",
   gemini: "bg-purple-500/15 text-purple-600 dark:text-purple-400",
   goose: "bg-red-500/15 text-red-600 dark:text-red-400",
+  grok: "bg-zinc-800/15 text-zinc-800 dark:text-zinc-200",
   kimi: "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-300",
   kiro: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
   llm: "bg-slate-500/15 text-slate-600 dark:text-slate-400",

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -446,7 +446,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   copilot: "bg-[#8250df]/15 text-[#6639ba] dark:text-[#d2a8ff]",
   cline: "bg-teal-500/15 text-teal-600 dark:text-teal-400",
   crush: "bg-pink-500/15 text-pink-600 dark:text-pink-400",
-  cursor: "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",
+  cursor: "bg-[#f54e00]/15 text-[#d04200] dark:text-[#ff6a2a]",
   "cursor-agent": "bg-violet-500/15 text-violet-600 dark:text-violet-400",
   forgecode: "bg-orange-500/15 text-orange-700 dark:text-orange-300",
   gemini: "bg-purple-500/15 text-purple-600 dark:text-purple-400",


### PR DESCRIPTION
## Summary
This PR adds **two new providers** on top of `develop`:

1. **Grok CLI** (`~/.grok` / `$GROK_HOME`) — browse sessions in the project tree, map chat history into the shared message model, and attribute models (`grok-4.5`, `grok-4.5-build`, etc.) in Global Overview.
2. **Cursor IDE** (Composer SQLite under Cursor `User/` + migrated `globalStorage` `composerData`) — include Cursor in Provider Distribution / Model Distribution with product-level model id **`cursor`**, Cursor Orange branding, and a fast one-pass global stats path so large histories do not hang Global Overview.

### Grok
- Backend provider + frontend registration / i18n
- Global stats wiring (provider + model distribution, pricing stubs)

### Cursor
- Scan migrated global `composerData` (legacy workspace `allComposers` only as fallback)
- Bucket orphan / empty-window composers under a single **Cursor** project
- Attribute assistants as model `cursor` (not underlying Claude/GPT)
- Lightweight stats messages + one DB pass for Global Overview (~seconds instead of hanging)
- Chart/badge color `#f54e00`; session-bar fallback when token totals are 0

## Stack note
- Cursor commits sit on the Grok branch. Review can use this PR for the full package; focused Grok-only review remains in [#487](https://github.com/jhlee0409/claude-code-history-viewer/pull/487).

## Out of scope
- Gemini StatsProvider wiring
- Cursor Agent CLI (`cursor-agent`) analytics
- Splitting Cursor usage into underlying Claude/GPT models

## Test plan
- [x] `cargo test --lib providers::grok -- --test-threads=1`
- [x] `cargo test --lib providers::cursor::tests -- --test-threads=1`
- [x] `cargo test --lib get_project_stats_summary_accepts_cursor_virtual_path -- --test-threads=1`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual: Global Overview with All / Cursor selected loads (~2s) and shows Cursor (~13.6M tokens on author machine)
- [ ] Manual: Grok projects appear when `~/.grok` is present; Model Distribution shows Grok model ids
- [ ] Confirm Gemini still absent from Provider Distribution (expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for browsing, loading, searching, and viewing statistics from Grok CLI sessions.
  * Added Cursor and Grok to analytics, project summaries, global statistics, and provider filtering.
  * Added model usage and pricing details for Grok and Cursor Composer.
  * Added Grok provider labels, badges, colors, and translations across supported languages.
  * Global statistics now refresh when active provider selections change.
* **Bug Fixes**
  * Improved Cursor workspace detection, migrated-data support, and display naming.
  * Cursor assistant messages now identify the Composer model and include usage details.
  * Analytics charts now handle tokenless sessions more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->