### PR TITLE
Update MiniMax analytics pricing

### DIFF
--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -22,12 +22,12 @@ export const formatNumber = (num: number): string => {
 };
 
 /**
- * Claude API pricing configuration
+ * Model API pricing configuration
  */
 interface ModelPricing {
   input: number;
   output: number;
-  cacheWrite: number;
+  cacheWrite: number | null;
   cacheRead: number;
 }
 
@@ -47,6 +47,9 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'claude-3-5-sonnet': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
   'claude-3-5-haiku': { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.10 },
   'claude-3-haiku': { input: 0.25, output: 1.25, cacheWrite: 0.30, cacheRead: 0.03 },
+  // MiniMax models
+  'minimax-m3': { input: 0.6, output: 2.4, cacheWrite: null, cacheRead: 0.12 },
+  'minimax-m2.7': { input: 0.3, output: 1.2, cacheWrite: 0.375, cacheRead: 0.06 },
   // OpenAI models (Codex CLI) - specific keys must precede prefix matches
   // cacheWrite is 0 (OpenAI does not charge for cache writes)
   // cacheRead is input_rate * 0.1 (90% discount on cached input)
@@ -84,7 +87,7 @@ export const hasExplicitModelPricing = (modelName: string): boolean =>
   findModelPricing(modelName) != null;
 
 /**
- * Calculate Claude API pricing for a model
+ * Calculate API pricing for a model
  */
 export const calculateModelPrice = (
   modelName: string,
@@ -97,7 +100,9 @@ export const calculateModelPrice = (
 
   const inputCost = (inputTokens / 1000000) * modelPricing.input;
   const outputCost = (outputTokens / 1000000) * modelPricing.output;
-  const cacheWriteCost = (cacheCreationTokens / 1000000) * modelPricing.cacheWrite;
+  const cacheWriteCost = modelPricing.cacheWrite == null
+    ? 0
+    : (cacheCreationTokens / 1000000) * modelPricing.cacheWrite;
   const cacheReadCost = (cacheReadTokens / 1000000) * modelPricing.cacheRead;
 
   return inputCost + outputCost + cacheWriteCost + cacheReadCost;

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -47,7 +47,9 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'claude-3-5-sonnet': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
   'claude-3-5-haiku': { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.10 },
   'claude-3-haiku': { input: 0.25, output: 1.25, cacheWrite: 0.30, cacheRead: 0.03 },
-  // MiniMax models
+  // MiniMax models. M3 uses the Standard <=512K context tier; this calculator
+  // has no context-length input, and the current tier publishes no separate
+  // cache-write charge, so cache creation is intentionally treated as free.
   'minimax-m3': { input: 0.6, output: 2.4, cacheWrite: null, cacheRead: 0.12 },
   'minimax-m2.7': { input: 0.3, output: 1.2, cacheWrite: 0.375, cacheRead: 0.06 },
   // OpenAI models (Codex CLI) - specific keys must precede prefix matches

--- a/src/test/analyticsCalculations.test.ts
+++ b/src/test/analyticsCalculations.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateModelPrice,
+  hasExplicitModelPricing,
+} from "../components/AnalyticsDashboard/utils/calculations";
+
+const ONE_MILLION_TOKENS = 1_000_000;
+
+describe("MiniMax analytics pricing", () => {
+  it("recognizes both explicit model pricing entries", () => {
+    expect(hasExplicitModelPricing("MiniMax-M3")).toBe(true);
+    expect(hasExplicitModelPricing("MiniMax-M2.7")).toBe(true);
+  });
+
+  it("calculates MiniMax-M3 pricing without an unavailable cache-write rate", () => {
+    expect(
+      calculateModelPrice(
+        "MiniMax-M3",
+        ONE_MILLION_TOKENS,
+        ONE_MILLION_TOKENS,
+        ONE_MILLION_TOKENS,
+        ONE_MILLION_TOKENS
+      )
+    ).toBeCloseTo(3.12);
+  });
+
+  it("calculates MiniMax-M2.7 pricing with cache read and write rates", () => {
+    expect(
+      calculateModelPrice(
+        "MiniMax-M2.7",
+        ONE_MILLION_TOKENS,
+        ONE_MILLION_TOKENS,
+        ONE_MILLION_TOKENS,
+        ONE_MILLION_TOKENS
+      )
+    ).toBeCloseTo(1.935);
+  });
+});


### PR DESCRIPTION
Reason: Add current MiniMax pricing and cache rates so analytics reports accurate estimated costs.

- Add explicit pricing entries for MiniMax-M3 and MiniMax-M2.7.
- Handle an unavailable cache-write rate without adding a cache-write charge.
- Add focused pricing recognition and calculation tests for both model IDs.

Checks:
- `pnpm exec vitest run src/test/analyticsCalculations.test.ts --reporter=verbose`
- `pnpm exec eslint src/components/AnalyticsDashboard/utils/calculations.ts src/test/analyticsCalculations.test.ts`
- `pnpm exec tsc --build .`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics cost calculations for MiniMax models.
  * Corrected handling of models without cache-write pricing.
  * Updated pricing metadata to support broader API pricing terminology.

* **Tests**
  * Added coverage for MiniMax-M3 and MiniMax-M2.7 pricing calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->