### PR TITLE
feat(webui): add session and message deep links

### DIFF
--- a/docs/specs/message-deep-linking.md
+++ b/docs/specs/message-deep-linking.md
@@ -43,11 +43,13 @@ Inside `MessageViewer.tsx` (or a `useMessageNavigation` hook):
 4. **Highlight**: Pass a `isTarget` prop to `VirtualizedMessageRow` for a CSS animation (yellow fade-out).
 5. **Cleanup**: Call `clearTargetMessage()` after a short timeout or immediately after scroll initiation.
 
-## 3. URL / Routing (Future "Hypermedia" Phase)
-To support browser back/forward buttons and external links:
-- Sync `selectedSession` and `targetMessageUuid` to URL Query Params.
-- `?session=UUID&msg=UUID`
-- On App mount/URL change: Read params -> Hydrate Store -> Trigger Navigation Flow.
+## 3. WebUI URL Routing
+The browser WebUI supports durable task and message links:
+- `?session=UUID` opens a task.
+- `?session=UUID&msg=UUID` opens, scrolls to, and highlights a message.
+- Task and message selections update browser history.
+- Pasted links and browser Back/Forward hydrate the store and reuse the existing message-navigation flow.
+- The Tauri desktop app does not mutate its URL; this routing is WebUI-only.
 
 ## 4. Implementation Steps
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,9 +152,17 @@ function App() {
   // re-invokes the CLI twice in quick succession, the newer intent wins.
   const pendingHintRef = useRef<SessionHint | null>(null);
   const pendingMessageTargetRef = useRef<string | null>(null);
+  const preloadGenerationRef = useRef(0);
+
+  const invalidatePreload = useCallback(() => {
+    preloadGenerationRef.current += 1;
+  }, []);
 
   const runPreloadWithHint = useCallback(
     (hint: SessionHint, messageId: string | null = null) => {
+      const generation = ++preloadGenerationRef.current;
+      const isCurrent = () => preloadGenerationRef.current === generation;
+
       void preloadSessionFromCli({
         getStartupSessionHint: () => Promise.resolve(hint),
         projects: projectsRef.current,
@@ -163,12 +171,17 @@ function App() {
           selectSession(session, { history: "none" }),
         openSessionPicker,
         t: (key, fallback) => t(key, fallback ?? key),
+        isCurrent,
       }).then(({ matched }) => {
-        if (matched && messageId) {
+        if (isCurrent() && matched && messageId) {
           const state = useAppStore.getState();
           state.setAnalyticsCurrentView("messages");
           state.navigateToMessage(messageId, { history: "none" });
         }
+      }).catch((error) => {
+        if (!isCurrent()) return;
+        console.error("Failed to preload session:", error);
+        toast.error(t("common.error.unexpected", "Failed to open session"));
       });
     },
     [selectProject, selectSession, openSessionPicker, t],
@@ -188,7 +201,11 @@ function App() {
       runPreloadWithHint(queued, messageId);
       return;
     }
+    const startupGeneration = preloadGenerationRef.current;
     void fetchStartupSessionHint().then((hint) => {
+      // A second invocation or deep link may have arrived while the startup
+      // command was resolving. Its newer request owns navigation now.
+      if (preloadGenerationRef.current !== startupGeneration) return;
       if (hint) {
         runPreloadWithHint(hint, readWebUIDeepLink().messageId);
       }
@@ -211,6 +228,7 @@ function App() {
         if (cancelled) return;
         unlisten = await listen<SessionHint>("cli-session-hint", (event) => {
           const hint = event.payload;
+          invalidatePreload();
           // Projects not yet loaded: stash and let the first-load effect
           // consume the latest hint. This handles the race where the user
           // re-invokes the CLI before the initial project scan finishes.
@@ -232,11 +250,12 @@ function App() {
       cancelled = true;
       unlisten?.();
     };
-  }, [runPreloadWithHint]);
+  }, [invalidatePreload, runPreloadWithHint]);
 
   useEffect(
     () =>
       listenForWebUIDeepLinks((deepLink) => {
+        invalidatePreload();
         if (!deepLink.sessionId) {
           pendingHintRef.current = null;
           pendingMessageTargetRef.current = null;
@@ -274,7 +293,7 @@ function App() {
           deepLink.messageId,
         );
       }),
-    [clearProjectSelection, runPreloadWithHint],
+    [clearProjectSelection, invalidatePreload, runPreloadWithHint],
   );
 
   // Local state

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,11 @@ import {
   preloadSessionFromCli,
   type SessionHint,
 } from "./lib/preloadSession";
+import {
+  listenForWebUIDeepLinks,
+  readWebUIDeepLink,
+  writeWebUIDeepLink,
+} from "./utils/webuiDeepLink";
 
 import "./App.css";
 
@@ -146,16 +151,24 @@ function App() {
   // load path can pick it up. Only the *latest* hint is kept — if the user
   // re-invokes the CLI twice in quick succession, the newer intent wins.
   const pendingHintRef = useRef<SessionHint | null>(null);
+  const pendingMessageTargetRef = useRef<string | null>(null);
 
   const runPreloadWithHint = useCallback(
-    (hint: SessionHint) => {
+    (hint: SessionHint, messageId: string | null = null) => {
       void preloadSessionFromCli({
         getStartupSessionHint: () => Promise.resolve(hint),
         projects: projectsRef.current,
         selectProject,
-        selectSession,
+        selectSession: (session) =>
+          selectSession(session, { history: "none" }),
         openSessionPicker,
         t: (key, fallback) => t(key, fallback ?? key),
+      }).then(({ matched }) => {
+        if (matched && messageId) {
+          const state = useAppStore.getState();
+          state.setAnalyticsCurrentView("messages");
+          state.navigateToMessage(messageId, { history: "none" });
+        }
       });
     },
     [selectProject, selectSession, openSessionPicker, t],
@@ -170,18 +183,17 @@ function App() {
     const queued = pendingHintRef.current;
     if (queued) {
       pendingHintRef.current = null;
-      runPreloadWithHint(queued);
+      const messageId = pendingMessageTargetRef.current;
+      pendingMessageTargetRef.current = null;
+      runPreloadWithHint(queued, messageId);
       return;
     }
-    void preloadSessionFromCli({
-      getStartupSessionHint: fetchStartupSessionHint,
-      projects,
-      selectProject,
-      selectSession,
-      openSessionPicker,
-      t: (key, fallback) => t(key, fallback ?? key),
+    void fetchStartupSessionHint().then((hint) => {
+      if (hint) {
+        runPreloadWithHint(hint, readWebUIDeepLink().messageId);
+      }
     });
-  }, [isLoadingProjects, projects, selectProject, selectSession, openSessionPicker, t, runPreloadWithHint]);
+  }, [isLoadingProjects, projects, runPreloadWithHint]);
 
   // Second-invocation routing. `tauri-plugin-single-instance` (CLI re-exec)
   // and macOS `RunEvent::Opened` (Spotlight/Dock/Finder) both emit
@@ -204,6 +216,7 @@ function App() {
           // re-invokes the CLI before the initial project scan finishes.
           if (!cliPreloadAttempted.current || projectsRef.current.length === 0) {
             pendingHintRef.current = hint;
+            pendingMessageTargetRef.current = null;
             return;
           }
           runPreloadWithHint(hint);
@@ -220,6 +233,49 @@ function App() {
       unlisten?.();
     };
   }, [runPreloadWithHint]);
+
+  useEffect(
+    () =>
+      listenForWebUIDeepLinks((deepLink) => {
+        if (!deepLink.sessionId) {
+          pendingHintRef.current = null;
+          pendingMessageTargetRef.current = null;
+          clearProjectSelection({ history: "none" });
+          return;
+        }
+
+        if (!cliPreloadAttempted.current || projectsRef.current.length === 0) {
+          pendingHintRef.current = {
+            kind: "uuid",
+            value: deepLink.sessionId,
+          };
+          pendingMessageTargetRef.current = deepLink.messageId;
+          return;
+        }
+
+        const state = useAppStore.getState();
+        const currentSessionId =
+          state.selectedSession?.actual_session_id ||
+          state.selectedSession?.session_id;
+
+        if (currentSessionId === deepLink.sessionId) {
+          if (deepLink.messageId) {
+            state.setAnalyticsCurrentView("messages");
+            state.navigateToMessage(deepLink.messageId, { history: "none" });
+          } else {
+            state.clearTargetMessage();
+          }
+          return;
+        }
+
+        clearProjectSelection({ history: "none" });
+        runPreloadWithHint(
+          { kind: "uuid", value: deepLink.sessionId },
+          deepLink.messageId,
+        );
+      }),
+    [clearProjectSelection, runPreloadWithHint],
+  );
 
   // Local state
   const [isViewingGlobalStats, setIsViewingGlobalStats] = useState(false);
@@ -387,6 +443,7 @@ function App() {
       setDateFilter({ start: null, end: null });
 
       await selectProject(project);
+      writeWebUIDeepLink({ sessionId: null, messageId: null });
 
       try {
         if (activeView === "tokenStats") {

--- a/src/components/modals/globalSearch/GlobalSearchModal.tsx
+++ b/src/components/modals/globalSearch/GlobalSearchModal.tsx
@@ -173,8 +173,10 @@ export const GlobalSearchModal = ({
                     // a result clicked while in analytics/tokenStats/etc. loads the
                     // session but stays hidden behind the other view (issue #390).
                     setAnalyticsCurrentView("messages");
-                    if (result.uuid) navigateToMessage(result.uuid);
                     await selectSession(targetSession);
+                    if (result.uuid) {
+                        navigateToMessage(result.uuid, { history: "replace" });
+                    }
                     onClose();
                     return;
                 }
@@ -243,9 +245,11 @@ export const GlobalSearchModal = ({
                     if (token !== resolveTokenRef.current) return; // cancelled
                     if (found) {
                         setAnalyticsCurrentView("messages");
-                        if (result.uuid) navigateToMessage(result.uuid);
                         await selectProject(found.project);
                         await selectSession(found.session);
+                        if (result.uuid) {
+                            navigateToMessage(result.uuid, { history: "replace" });
+                        }
                         onClose();
                         return;
                     }

--- a/src/lib/preloadSession.test.ts
+++ b/src/lib/preloadSession.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import type { ClaudeProject, ClaudeSession } from "@/types";
 import {
+  fetchStartupSessionHint,
   preloadSessionFromCli,
   type PreloadDependencies,
   type SessionHint,
@@ -79,6 +80,8 @@ describe("preloadSessionFromCli", () => {
     mockStoreState.excludeSidechain = false;
     mockStoreState.selectedSession = null;
     mockStoreState.getSessionDisplayName = (_id: string, fallback?: string) => fallback;
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    window.history.replaceState({}, "", "/");
   });
 
   afterEach(() => {
@@ -92,6 +95,21 @@ describe("preloadSessionFromCli", () => {
     expect(deps.selectProject).not.toHaveBeenCalled();
     expect(deps.selectSession).not.toHaveBeenCalled();
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("uses a WebUI session query as the startup hint", async () => {
+    window.history.replaceState({}, "", `/?session=${UUID}&msg=message-123`);
+
+    await expect(fetchStartupSessionHint()).resolves.toEqual({
+      kind: "uuid",
+      value: UUID,
+    });
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it("does not call the desktop startup-hint command in WebUI mode", async () => {
+    await expect(fetchStartupSessionHint()).resolves.toBeNull();
+    expect(api).not.toHaveBeenCalled();
   });
 
   it("opens a matching session across projects", async () => {

--- a/src/lib/preloadSession.test.ts
+++ b/src/lib/preloadSession.test.ts
@@ -409,6 +409,33 @@ describe("preloadSessionFromCli", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it("skips a resolved match when a newer preload supersedes it", async () => {
+    vi.mocked(api).mockResolvedValueOnce([session] as unknown as never);
+    let isCurrent = true;
+    const selectProject = vi.fn().mockImplementation(async () => {
+      // Simulate a newer CLI/deep-link request arriving while the project
+      // selection is loading.
+      isCurrent = false;
+    });
+
+    const deps = makeDeps({
+      getStartupSessionHint: vi.fn().mockResolvedValue({
+        kind: "uuid",
+        value: UUID,
+      } as SessionHint),
+      projects: [project],
+      selectProject,
+      isCurrent: () => isCurrent,
+    });
+
+    const result = await preloadSessionFromCli(deps);
+
+    expect(result).toEqual({ handled: true, matched: false });
+    expect(selectProject).toHaveBeenCalledWith(project);
+    expect(deps.selectSession).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   // Real race simulation: user clicks a session mid-scan. Exercises the
   // per-loop guard inside scan helpers, not just the final guard.
   it("aborts scan loop when selectedSession mutates mid-scan", async () => {

--- a/src/lib/preloadSession.ts
+++ b/src/lib/preloadSession.ts
@@ -51,6 +51,12 @@ export interface PreloadDependencies {
   openSessionPicker: (candidates: SessionPickerCandidate[], hintValue: string) => void;
   /** i18n translator for the not-found toast. */
   t: Translator;
+  /**
+   * Returns false when a newer navigation request superseded this preload.
+   * Optional so callers that do not have concurrent navigation can use the
+   * resolver without maintaining a request token.
+   */
+  isCurrent?: () => boolean;
 }
 
 /**
@@ -169,16 +175,22 @@ async function loadSessionsFor(
  * Returns `null` when the race guard fires so callers can distinguish "user
  * picked something" from "no matches."
  */
-async function scanAllProjects(projects: ClaudeProject[]): Promise<ProjectSessionsPair[] | null> {
+async function scanAllProjects(
+  projects: ClaudeProject[],
+  isCurrent: () => boolean,
+): Promise<ProjectSessionsPair[] | null> {
   const { excludeSidechain } = useAppStore.getState();
   const out: ProjectSessionsPair[] = [];
 
   for (const project of projects) {
-    if (useAppStore.getState().selectedSession) {
+    if (!isCurrent() || useAppStore.getState().selectedSession) {
       return null;
     }
     try {
       const sessions = await loadSessionsFor(project, excludeSidechain);
+      if (!isCurrent() || useAppStore.getState().selectedSession) {
+        return null;
+      }
       out.push({ project, sessions });
     } catch (error) {
       console.warn(`preloadSession: failed to scan project ${project.name}:`, error);
@@ -194,12 +206,14 @@ async function scanAllProjects(projects: ClaudeProject[]): Promise<ProjectSessio
 async function resolveUuid(
   uuid: string,
   projects: ClaudeProject[],
+  isCurrent: () => boolean,
 ): Promise<SessionPickerCandidate | null> {
   const { excludeSidechain } = useAppStore.getState();
   for (const project of projects) {
-    if (useAppStore.getState().selectedSession) return null;
+    if (!isCurrent() || useAppStore.getState().selectedSession) return null;
     try {
       const sessions = await loadSessionsFor(project, excludeSidechain);
+      if (!isCurrent() || useAppStore.getState().selectedSession) return null;
       const session = matchByUuid(sessions, uuid);
       if (session) return { project, session };
     } catch (error) {
@@ -212,12 +226,14 @@ async function resolveUuid(
 async function resolvePath(
   absPath: string,
   projects: ClaudeProject[],
+  isCurrent: () => boolean,
 ): Promise<SessionPickerCandidate | null> {
   const { excludeSidechain } = useAppStore.getState();
   for (const project of projects) {
-    if (useAppStore.getState().selectedSession) return null;
+    if (!isCurrent() || useAppStore.getState().selectedSession) return null;
     try {
       const sessions = await loadSessionsFor(project, excludeSidechain);
+      if (!isCurrent() || useAppStore.getState().selectedSession) return null;
       const session = matchByPath(sessions, absPath);
       if (session) return { project, session };
     } catch (error) {
@@ -230,6 +246,7 @@ async function resolvePath(
 async function resolveFolder(
   folderName: string,
   projects: ClaudeProject[],
+  isCurrent: () => boolean,
 ): Promise<SessionPickerCandidate | null> {
   // Folder name matches the project directory name, not the full path.
   const lower = folderName.toLowerCase();
@@ -239,13 +256,14 @@ async function resolveFolder(
     const name = parts[parts.length - 1] ?? "";
     return name.toLowerCase() === lower;
   });
-  if (!target) return null;
+  if (!target || !isCurrent()) return null;
 
   if (useAppStore.getState().selectedSession) return null;
 
   try {
     const { excludeSidechain } = useAppStore.getState();
     const sessions = await loadSessionsFor(target, excludeSidechain);
+    if (!isCurrent() || useAppStore.getState().selectedSession) return null;
     // Pick the most recently modified session as the "default" for a folder hint.
     const sorted = [...sessions].sort((a, b) => {
       const at = a.last_modified ?? "";
@@ -270,12 +288,14 @@ async function resolveFolder(
 async function resolveTitle(
   substring: string,
   projects: ClaudeProject[],
+  isCurrent: () => boolean,
 ): Promise<SessionPickerCandidate[] | null> {
-  const scanned = await scanAllProjects(projects);
+  const scanned = await scanAllProjects(projects, isCurrent);
   if (scanned === null) return null;
 
   const candidates: SessionPickerCandidate[] = [];
   for (const { project, sessions } of scanned) {
+    if (!isCurrent() || useAppStore.getState().selectedSession) return null;
     for (const session of matchByTitle(sessions, substring)) {
       candidates.push({ project, session });
     }
@@ -290,24 +310,41 @@ async function resolveTitle(
 export async function preloadSessionFromCli(
   deps: PreloadDependencies,
 ): Promise<{ handled: boolean; matched: boolean }> {
+  const isCurrent = () => deps.isCurrent?.() ?? true;
+  if (!isCurrent()) {
+    return { handled: true, matched: false };
+  }
+
   const hint = await deps.getStartupSessionHint();
-  if (!hint) {
+  if (!hint || !isCurrent()) {
     return { handled: false, matched: false };
   }
 
   // Dispatch per kind.
   if (hint.kind === "uuid") {
-    return commitSingleMatch(await resolveUuid(hint.value, deps.projects), deps);
+    return commitSingleMatch(
+      await resolveUuid(hint.value, deps.projects, isCurrent),
+      deps,
+      isCurrent,
+    );
   }
   if (hint.kind === "path") {
-    return commitSingleMatch(await resolvePath(hint.value, deps.projects), deps);
+    return commitSingleMatch(
+      await resolvePath(hint.value, deps.projects, isCurrent),
+      deps,
+      isCurrent,
+    );
   }
   if (hint.kind === "folder") {
-    return commitSingleMatch(await resolveFolder(hint.value, deps.projects), deps);
+    return commitSingleMatch(
+      await resolveFolder(hint.value, deps.projects, isCurrent),
+      deps,
+      isCurrent,
+    );
   }
   if (hint.kind === "title") {
-    const matches = await resolveTitle(hint.value, deps.projects);
-    if (matches === null) {
+    const matches = await resolveTitle(hint.value, deps.projects, isCurrent);
+    if (matches === null || !isCurrent()) {
       // Race guard tripped during scan — user chose something else.
       return { handled: true, matched: false };
     }
@@ -319,10 +356,10 @@ export async function preloadSessionFromCli(
       return { handled: true, matched: false };
     }
     if (matches.length === 1) {
-      return commitSingleMatch(matches[0] ?? null, deps);
+      return commitSingleMatch(matches[0] ?? null, deps, isCurrent);
     }
     // Multi-match: delegate to the picker modal.
-    if (useAppStore.getState().selectedSession) {
+    if (!isCurrent() || useAppStore.getState().selectedSession) {
       return { handled: true, matched: false };
     }
     deps.openSessionPicker(matches, hint.value);
@@ -340,24 +377,28 @@ export async function preloadSessionFromCli(
 async function commitSingleMatch(
   match: SessionPickerCandidate | null,
   deps: PreloadDependencies,
+  isCurrent: () => boolean,
 ): Promise<{ handled: boolean; matched: boolean }> {
+  if (!isCurrent()) {
+    return { handled: true, matched: false };
+  }
   if (!match) {
-    if (useAppStore.getState().selectedSession) {
+    if (!isCurrent() || useAppStore.getState().selectedSession) {
       return { handled: true, matched: false };
     }
     toast.error(deps.t("globalSearch.sessionNotFound", "Session not found"));
     return { handled: true, matched: false };
   }
-  if (useAppStore.getState().selectedSession) {
+  if (!isCurrent() || useAppStore.getState().selectedSession) {
     return { handled: true, matched: false };
   }
   await deps.selectProject(match.project);
   // Re-check after the project-load await: the user may have clicked a
   // session while selectProject was loading. Skipping this check lets the
   // CLI hint clobber their manual choice.
-  if (useAppStore.getState().selectedSession) {
+  if (!isCurrent() || useAppStore.getState().selectedSession) {
     return { handled: true, matched: false };
   }
   await deps.selectSession(match.session);
-  return { handled: true, matched: true };
+  return { handled: true, matched: isCurrent() };
 }

--- a/src/lib/preloadSession.ts
+++ b/src/lib/preloadSession.ts
@@ -20,6 +20,8 @@
 import { toast } from "sonner";
 import { api } from "@/services/api";
 import { useAppStore } from "@/store/useAppStore";
+import { isWebUI } from "@/utils/platform";
+import { readWebUIDeepLink } from "@/utils/webuiDeepLink";
 import type { SessionPickerCandidate } from "@/store/slices/sessionPickerSlice";
 import type { ClaudeProject, ClaudeSession } from "@/types";
 
@@ -56,6 +58,11 @@ export interface PreloadDependencies {
  * that calls the Tauri / WebUI backend.
  */
 export async function fetchStartupSessionHint(): Promise<SessionHint | null> {
+  if (isWebUI()) {
+    const { sessionId } = readWebUIDeepLink();
+    return sessionId ? { kind: "uuid", value: sessionId } : null;
+  }
+
   try {
     return await api<SessionHint | null>("get_startup_session_hint");
   } catch (error) {

--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -36,6 +36,11 @@ import { nextRequestId, getRequestId } from "../../utils/requestId";
 import { supportsConversationBreakdown } from "../../utils/providers";
 import { normalizeDateFilterOptions } from "../../utils/date";
 import { getAgentIdFromProgress } from "../../components/MessageViewer/helpers/agentProgressHelpers";
+import {
+  type WebUINavigationOptions,
+  readWebUIDeepLink,
+  writeWebUIDeepLink,
+} from "../../utils/webuiDeepLink";
 
 // ============================================================================
 // State Interface
@@ -64,7 +69,10 @@ export interface MessageSliceState {
 }
 
 export interface MessageSliceActions {
-  selectSession: (session: ClaudeSession) => Promise<void>;
+  selectSession: (
+    session: ClaudeSession,
+    options?: WebUINavigationOptions,
+  ) => Promise<void>;
   /** Load the next (older) page of the current session and prepend it. */
   loadMoreMessages: () => Promise<void>;
   /**
@@ -402,7 +410,7 @@ export const createMessageSlice: StateCreator<
   return {
     ...initialMessageState,
 
-  selectSession: async (session: ClaudeSession) => {
+  selectSession: async (session: ClaudeSession, options) => {
     // In-place reloads share a file_path, so the path guard alone cannot drop
     // a stale overlapping reload (e.g. two quick filter toggles) — the epoch
     // does. Captured before any await.
@@ -439,6 +447,18 @@ export const createMessageSlice: StateCreator<
     }
 
     get().setSelectedSession(session);
+    const sessionId = session.actual_session_id || session.session_id;
+    const currentDeepLink = readWebUIDeepLink();
+    writeWebUIDeepLink(
+      {
+        sessionId,
+        messageId:
+          currentDeepLink.sessionId === sessionId
+            ? currentDeepLink.messageId
+            : null,
+      },
+      options?.history,
+    );
     // Note: sessionSearch state reset is handled by searchSlice
 
     // The session file may have changed (or the session did) — the cached

--- a/src/store/slices/navigationSlice.test.ts
+++ b/src/store/slices/navigationSlice.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClaudeSession } from "@/types";
+import { createNavigationSlice } from "./navigationSlice";
+
+const session: ClaudeSession = {
+  session_id: "display-session",
+  actual_session_id: "canonical-session",
+  file_path: "/tmp/session.jsonl",
+  project_name: "demo",
+  message_count: 1,
+  first_message_time: "2026-08-09T00:00:00Z",
+  last_message_time: "2026-08-09T00:00:00Z",
+  last_modified: "2026-08-09T00:00:00Z",
+  has_tool_use: false,
+  has_errors: false,
+};
+
+describe("navigationSlice WebUI history", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("pushes the selected session and target message into the URL", () => {
+    const set = vi.fn();
+    const get = () => ({ selectedSession: session });
+    const slice = createNavigationSlice(set as never, get as never, {} as never);
+
+    slice.navigateToMessage("message-123");
+
+    expect(set).toHaveBeenCalledWith({
+      targetMessageUuid: "message-123",
+      shouldHighlightTarget: true,
+    });
+    expect(readLocation()).toEqual({
+      session: "canonical-session",
+      message: "message-123",
+    });
+  });
+
+  it("can replace or suppress browser-history updates", () => {
+    const set = vi.fn();
+    const get = () => ({ selectedSession: session });
+    const slice = createNavigationSlice(set as never, get as never, {} as never);
+    const replaceState = vi.spyOn(window.history, "replaceState");
+
+    slice.navigateToMessage("message-123", { history: "replace" });
+    slice.navigateToMessage("message-456", { history: "none" });
+
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    expect(readLocation()).toEqual({
+      session: "canonical-session",
+      message: "message-123",
+    });
+  });
+});
+
+function readLocation() {
+  const url = new URL(window.location.href);
+  return {
+    session: url.searchParams.get("session"),
+    message: url.searchParams.get("msg"),
+  };
+}

--- a/src/store/slices/navigationSlice.ts
+++ b/src/store/slices/navigationSlice.ts
@@ -1,5 +1,9 @@
 import type { StateCreator } from "zustand";
 import type { FullAppStore } from "./types";
+import {
+    type WebUINavigationOptions,
+    writeWebUIDeepLink,
+} from "@/utils/webuiDeepLink";
 
 export interface NavigationSliceState {
     targetMessageUuid: string | null;
@@ -7,7 +11,7 @@ export interface NavigationSliceState {
 }
 
 export interface NavigationSliceActions {
-    navigateToMessage: (uuid: string) => void;
+    navigateToMessage: (uuid: string, options?: WebUINavigationOptions) => void;
     clearTargetMessage: () => void;
 }
 
@@ -18,14 +22,25 @@ export const createNavigationSlice: StateCreator<
     [],
     [],
     NavigationSlice
-> = (set) => ({
+> = (set, get) => ({
     targetMessageUuid: null,
     shouldHighlightTarget: false,
 
-    navigateToMessage: (uuid) => set({
-        targetMessageUuid: uuid,
-        shouldHighlightTarget: true
-    }),
+    navigateToMessage: (uuid, options) => {
+        set({
+            targetMessageUuid: uuid,
+            shouldHighlightTarget: true
+        });
+
+        const session = get().selectedSession;
+        const sessionId = session?.actual_session_id || session?.session_id;
+        if (sessionId) {
+            writeWebUIDeepLink(
+                { sessionId, messageId: uuid },
+                options?.history ?? "push",
+            );
+        }
+    },
 
     clearTargetMessage: () => set({
         targetMessageUuid: null,

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -21,6 +21,10 @@ import type { GroupingMode } from "../../types/metadata.types";
 import { DEFAULT_PROVIDER_ID, getProviderId, PROVIDER_IDS } from "../../utils/providers";
 import { INITIAL_PAGINATION } from "./messageSlice";
 import { nextRequestId, getRequestId } from "../../utils/requestId";
+import {
+  type WebUINavigationOptions,
+  writeWebUIDeepLink,
+} from "../../utils/webuiDeepLink";
 
 // ============================================================================
 // State Interface
@@ -49,7 +53,7 @@ export interface ProjectSliceActions {
   refreshAllConversations: () => Promise<void>;
   selectProject: (project: ClaudeProject) => Promise<void>;
   loadMoreSessions: () => Promise<void>;
-  clearProjectSelection: () => void;
+  clearProjectSelection: (options?: WebUINavigationOptions) => void;
   setClaudePath: (path: string) => Promise<void>;
   setError: (error: AppError | null) => void;
   setSelectedSession: (session: ClaudeSession | null) => void;
@@ -673,7 +677,7 @@ export const createProjectSlice: StateCreator<
     }
   },
 
-  clearProjectSelection: () => {
+  clearProjectSelection: (options) => {
     nextRequestId("selectProject");
 
     set({
@@ -699,6 +703,10 @@ export const createProjectSlice: StateCreator<
     get().setDateFilter({ start: null, end: null });
     get().clearTargetMessage();
     get().exitSessionSelectionMode();
+    writeWebUIDeepLink(
+      { sessionId: null, messageId: null },
+      options?.history,
+    );
   },
 
   setClaudePath: async (path: string) => {

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -217,7 +217,10 @@ export interface AppStoreState {
 
 export interface AppStoreActions {
   // Navigation actions
-  navigateToMessage: (uuid: string) => void;
+  navigateToMessage: (
+    uuid: string,
+    options?: import("@/utils/webuiDeepLink").WebUINavigationOptions,
+  ) => void;
   clearTargetMessage: () => void;
 
   // Project actions
@@ -226,14 +229,19 @@ export interface AppStoreActions {
   refreshAllConversations: () => Promise<void>;
   selectProject: (project: ClaudeProject) => Promise<void>;
   loadMoreSessions: () => Promise<void>;
-  clearProjectSelection: () => void;
+  clearProjectSelection: (
+    options?: import("@/utils/webuiDeepLink").WebUINavigationOptions,
+  ) => void;
   setClaudePath: (path: string) => Promise<void>;
   setError: (error: AppError | null) => void;
   setSelectedSession: (session: ClaudeSession | null) => void;
   setSessions: (sessions: ClaudeSession[]) => void;
 
   // Message actions
-  selectSession: (session: ClaudeSession) => Promise<void>;
+  selectSession: (
+    session: ClaudeSession,
+    options?: import("@/utils/webuiDeepLink").WebUINavigationOptions,
+  ) => Promise<void>;
   loadMoreMessages: () => Promise<void>;
   ensureMessageLoaded: (uuid: string) => Promise<boolean>;
   fetchFullSessionMessages: () => Promise<ClaudeMessage[]>;

--- a/src/test/App.accessibility.test.tsx
+++ b/src/test/App.accessibility.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import App from "@/App";
 
 const { useAppStoreMock } = vi.hoisted(() => {
@@ -44,6 +44,8 @@ const { useAppStoreMock } = vi.hoisted(() => {
     selectProject: vi.fn(async () => {}),
     selectSession: vi.fn(async () => {}),
     clearProjectSelection: vi.fn(),
+    navigateToMessage: vi.fn(),
+    clearTargetMessage: vi.fn(),
     setSessionSearchQuery: vi.fn(),
     setSearchFilterType: vi.fn(),
     goToNextMatch: vi.fn(),
@@ -268,6 +270,11 @@ vi.mock("react-i18next", async (importOriginal) => {
 });
 
 describe("App accessibility smoke", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+    vi.clearAllMocks();
+  });
+
   it("renders skip links and landmark targets", () => {
     render(<App />);
 
@@ -288,5 +295,23 @@ describe("App accessibility smoke", () => {
     expect(document.getElementById("main-content")).not.toBeNull();
     expect(document.getElementById("message-navigator")).not.toBeNull();
     expect(document.getElementById("app-settings-button")).not.toBeNull();
+  });
+
+  it("replays a WebUI message link from browser history", async () => {
+    render(<App />);
+
+    window.history.replaceState(
+      {},
+      "",
+      "/?session=session-1&msg=message-2",
+    );
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    await waitFor(() => {
+      expect(useAppStoreMock.getState().navigateToMessage).toHaveBeenCalledWith(
+        "message-2",
+        { history: "none" },
+      );
+    });
   });
 });

--- a/src/test/messageSlice.pagination.test.ts
+++ b/src/test/messageSlice.pagination.test.ts
@@ -161,6 +161,35 @@ describe("messageSlice — chat-style pagination", () => {
   beforeEach(() => {
     mockApi.mockReset();
     mockToastError.mockReset();
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("writes the selected session to the WebUI URL", async () => {
+    const store = createTestStore();
+    installBackend(makeBackend(1));
+
+    await store.getState().selectSession(makeSession());
+
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("session")).toBe("session-1");
+    expect(url.searchParams.get("msg")).toBeNull();
+  });
+
+  it("preserves a message target when loading the session from that deep link", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?session=session-1&msg=uuid-1",
+    );
+    const store = createTestStore();
+    installBackend(makeBackend(1));
+
+    await store.getState().selectSession(makeSession());
+
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("session")).toBe("session-1");
+    expect(url.searchParams.get("msg")).toBe("uuid-1");
   });
 
   it("selectSession loads only the newest window", async () => {

--- a/src/test/projectSlice.scanProjects.test.ts
+++ b/src/test/projectSlice.scanProjects.test.ts
@@ -146,6 +146,19 @@ const createTestStore = () =>
 describe("projectSlice scanProjects", () => {
   beforeEach(() => {
     vi.mocked(api).mockReset();
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("clears the WebUI deep link with browser history control", () => {
+    window.history.replaceState({}, "", "/?session=session-1&msg=message-1");
+    const store = createTestStore();
+
+    store.getState().clearProjectSelection({ history: "replace" });
+
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("session")).toBeNull();
+    expect(url.searchParams.get("msg")).toBeNull();
   });
 
   it("publishes each provider as soon as that provider scan completes", async () => {

--- a/src/utils/webuiDeepLink.test.ts
+++ b/src/utils/webuiDeepLink.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  listenForWebUIDeepLinks,
+  readWebUIDeepLink,
+  writeWebUIDeepLink,
+} from "./webuiDeepLink";
+
+describe("WebUI deep links", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    window.history.replaceState({}, "", "/viewer/?foo=kept");
+  });
+
+  it("reads session and message identifiers from the current URL", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/viewer/?session=session-123&msg=message-456&foo=kept",
+    );
+
+    expect(readWebUIDeepLink()).toEqual({
+      sessionId: "session-123",
+      messageId: "message-456",
+    });
+  });
+
+  it("ignores a message identifier when no session is present", () => {
+    window.history.replaceState({}, "", "/viewer/?msg=message-456");
+
+    expect(readWebUIDeepLink()).toEqual({
+      sessionId: null,
+      messageId: null,
+    });
+  });
+
+  it("pushes a session link while preserving unrelated query parameters", () => {
+    const pushState = vi.spyOn(window.history, "pushState");
+
+    writeWebUIDeepLink(
+      { sessionId: "session-123", messageId: "message-456" },
+      "push",
+    );
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+    const url = new URL(window.location.href);
+    expect(url.pathname).toBe("/viewer/");
+    expect(url.searchParams.get("foo")).toBe("kept");
+    expect(url.searchParams.get("session")).toBe("session-123");
+    expect(url.searchParams.get("msg")).toBe("message-456");
+  });
+
+  it("replaces the current entry and removes a stale message identifier", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/viewer/?session=old-session&msg=old-message&foo=kept",
+    );
+    const replaceState = vi.spyOn(window.history, "replaceState");
+
+    writeWebUIDeepLink(
+      { sessionId: "new-session", messageId: null },
+      "replace",
+    );
+
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get("session")).toBe("new-session");
+    expect(url.searchParams.get("msg")).toBeNull();
+    expect(url.searchParams.get("foo")).toBe("kept");
+  });
+
+  it("does not add a duplicate browser-history entry", () => {
+    window.history.replaceState({}, "", "/viewer/?session=session-123");
+    const pushState = vi.spyOn(window.history, "pushState");
+
+    writeWebUIDeepLink(
+      { sessionId: "session-123", messageId: null },
+      "push",
+    );
+
+    expect(pushState).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate browser history inside the Tauri desktop app", () => {
+    (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    const pushState = vi.spyOn(window.history, "pushState");
+
+    writeWebUIDeepLink(
+      { sessionId: "session-123", messageId: null },
+      "push",
+    );
+
+    expect(pushState).not.toHaveBeenCalled();
+  });
+
+  it("reports browser back and forward navigation", () => {
+    const listener = vi.fn();
+    const stopListening = listenForWebUIDeepLinks(listener);
+    window.history.replaceState(
+      {},
+      "",
+      "/viewer/?session=session-123&msg=message-456",
+    );
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    expect(listener).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      messageId: "message-456",
+    });
+    stopListening();
+  });
+});

--- a/src/utils/webuiDeepLink.ts
+++ b/src/utils/webuiDeepLink.ts
@@ -1,0 +1,78 @@
+import { isWebUI } from "./platform";
+
+export const WEBUI_SESSION_PARAM = "session";
+export const WEBUI_MESSAGE_PARAM = "msg";
+
+export type WebUIHistoryMode = "push" | "replace" | "none";
+
+export interface WebUINavigationOptions {
+  history?: WebUIHistoryMode;
+}
+
+export interface WebUIDeepLink {
+  sessionId: string | null;
+  messageId: string | null;
+}
+
+const normalizedParam = (value: string | null): string | null => {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+};
+
+export function readWebUIDeepLink(): WebUIDeepLink {
+  if (!isWebUI()) {
+    return { sessionId: null, messageId: null };
+  }
+
+  const url = new URL(window.location.href);
+  const sessionId = normalizedParam(url.searchParams.get(WEBUI_SESSION_PARAM));
+  if (!sessionId) {
+    return { sessionId: null, messageId: null };
+  }
+
+  return {
+    sessionId,
+    messageId: normalizedParam(url.searchParams.get(WEBUI_MESSAGE_PARAM)),
+  };
+}
+
+export function writeWebUIDeepLink(
+  deepLink: WebUIDeepLink,
+  historyMode: WebUIHistoryMode = "push",
+): void {
+  if (!isWebUI() || historyMode === "none") return;
+
+  const url = new URL(window.location.href);
+  const sessionId = normalizedParam(deepLink.sessionId);
+  const messageId = sessionId ? normalizedParam(deepLink.messageId) : null;
+
+  if (sessionId) {
+    url.searchParams.set(WEBUI_SESSION_PARAM, sessionId);
+  } else {
+    url.searchParams.delete(WEBUI_SESSION_PARAM);
+  }
+
+  if (messageId) {
+    url.searchParams.set(WEBUI_MESSAGE_PARAM, messageId);
+  } else {
+    url.searchParams.delete(WEBUI_MESSAGE_PARAM);
+  }
+
+  if (url.href === window.location.href) return;
+
+  if (historyMode === "replace") {
+    window.history.replaceState(window.history.state, "", url);
+  } else {
+    window.history.pushState(window.history.state, "", url);
+  }
+}
+
+export function listenForWebUIDeepLinks(
+  listener: (deepLink: WebUIDeepLink) => void,
+): () => void {
+  if (!isWebUI()) return () => {};
+
+  const handlePopState = () => listener(readWebUIDeepLink());
+  window.addEventListener("popstate", handlePopState);
+  return () => window.removeEventListener("popstate", handlePopState);
+}


### PR DESCRIPTION
## TL;DR

- Give every WebUI task a stable `?session=...` URL and every message a stable `?session=...&msg=...` URL.
- Restore pasted links and browser Back/Forward through the viewer's existing task preload, pagination, scroll, and highlight flows.
- Keep the Tauri desktop app's URL behavior unchanged.

## Paper Trail

| Type | Link / Value | Role |
|---|---|---|
| Spec | [Message Deep Linking & Navigation](https://github.com/owensantoso/claude-code-history-viewer/blob/57782adde8d4f03d1ea494e4b6a3390170c35a73/docs/specs/message-deep-linking.md) | existing design and routing contract |
| Codex thread | `019fe1be-1dce-78b2-a2fa-67caf6b9ae76` | implementation and live-test provenance |
| Model | Codex (GPT-5.6-sol) | implementation assistance |

## Why

The WebUI already knows how to select tasks, page older messages into memory, scroll to a message, and highlight it. That state was not represented in the browser URL, so a specific task or message could not be shared, bookmarked, refreshed, or revisited with Back/Forward.

## What Changed

- Added a small WebUI URL adapter for reading and writing task/message query parameters while preserving base paths, unrelated parameters, and browser history semantics.
- Synced task selection, message navigation, project clearing, and global-search navigation with the URL.
- Reused the existing startup task resolver for pasted task URLs, then passed message targets into the existing pagination/scroll/highlight path.
- Added a `popstate` listener so Back/Forward replays navigation without writing another history entry.
- Kept URL mutations disabled in Tauri desktop mode.
- Updated the existing deep-linking spec and added regression coverage at utility, store, preload, pagination, and app boundaries.

## Rationale By Area

- [WebUI URL adapter](https://github.com/owensantoso/claude-code-history-viewer/blob/57782adde8d4f03d1ea494e4b6a3390170c35a73/src/utils/webuiDeepLink.ts): owns query parsing and browser-history writes so store slices do not duplicate URL mechanics.
- [App hydration and Back/Forward routing](https://github.com/owensantoso/claude-code-history-viewer/blob/57782adde8d4f03d1ea494e4b6a3390170c35a73/src/App.tsx): connects pasted URLs and history events to the existing task preload and message-navigation flows.
- [Task and message selection](https://github.com/owensantoso/claude-code-history-viewer/blob/57782adde8d4f03d1ea494e4b6a3390170c35a73/src/store/slices/messageSlice.ts): records canonical task IDs while preserving a matching message target during reloads.
- [Global search ordering](https://github.com/owensantoso/claude-code-history-viewer/blob/57782adde8d4f03d1ea494e4b6a3390170c35a73/src/components/modals/globalSearch/GlobalSearchModal.tsx): selects the destination task before replacing its URL with the matched message, avoiding a transient old-task/new-message pairing.

## How To Review

1. Review `src/utils/webuiDeepLink.ts` for the URL contract and WebUI/Tauri boundary.
2. Review `src/App.tsx` for startup hydration and `popstate` behavior.
3. Review the three store-slice changes for where history entries are pushed, replaced, or suppressed.
4. Review the focused tests, especially the utility matrix and app-level browser-history regression.

## Validation

- `npx --yes pnpm@10.13.1 tsc --build .`
- `npx --yes pnpm@10.13.1 vitest run --reporter=dot` — 81 files, 953 tests passed
- `npx --yes pnpm@10.13.1 lint`
- `npx --yes pnpm@10.13.1 build`
- Live read-only WebUI check with real Codex data:
  - pasted a task-only URL and restored the task
  - pasted a task-plus-message URL and rendered the exact target
  - targeted an older message outside the initial visible window
  - navigated between messages and verified same-page Back restoration

## Risks / Follow-Ups

- Deep-link startup still waits for the viewer's normal project scan before resolving the task.
- This PR intentionally does not add an `Open in Codex` button, enlarge global search, or add a running-task dashboard. Those can remain independent follow-up PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WebUI deep links for opening specific sessions and messages directly from URLs.
  - Added support for restoring session and message selections with browser back and forward navigation.
  - Deep links stay synchronized when selecting sessions, projects, or messages.

- **Bug Fixes**
  - Improved global search navigation by selecting the correct session or project before opening a message.
  - Prevented search-result navigation from cluttering browser history.
  - Cleared outdated message targets when switching sessions or projects.
  - Prevented stale links from opening the wrong session or message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->