### PR TITLE
feat(providers): add Cursor global stats support

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -34,6 +34,7 @@ enum StatsProvider {
     Ompi,
     Pi,
     Gemini,
+    Cursor,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +77,7 @@ fn stats_provider_id(provider: StatsProvider) -> &'static str {
         StatsProvider::Ompi => "ompi",
         StatsProvider::Pi => "pi",
         StatsProvider::Gemini => "gemini",
+        StatsProvider::Cursor => "cursor",
     }
 }
 
@@ -236,6 +238,7 @@ fn all_stats_providers() -> HashSet<StatsProvider> {
         StatsProvider::Ompi,
         StatsProvider::Pi,
         StatsProvider::Gemini,
+        StatsProvider::Cursor,
     ]
     .into_iter()
     .collect()
@@ -263,6 +266,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
             "ompi" => Some(StatsProvider::Ompi),
             "pi" => Some(StatsProvider::Pi),
             "gemini" => Some(StatsProvider::Gemini),
+            "cursor" => Some(StatsProvider::Cursor),
             _ => {
                 unknown.push(provider);
                 None
@@ -294,6 +298,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::Kimi
     } else if project_path.starts_with("gemini://") {
         StatsProvider::Gemini
+    } else if project_path.starts_with("cursor://") {
+        StatsProvider::Cursor
     } else if is_antigravity_path(project_path) {
         StatsProvider::Antigravity
     } else if is_ompi_path(project_path) {
@@ -317,6 +323,10 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
 fn detect_session_provider(session_path: &str) -> StatsProvider {
     if session_path.starts_with("opencode://") {
         return StatsProvider::OpenCode;
+    }
+
+    if session_path.starts_with("cursor://") {
+        return StatsProvider::Cursor;
     }
 
     if is_grok_path(session_path) {
@@ -503,6 +513,21 @@ fn grok_virtual_paths_match(left: &str, right: &str) -> bool {
     }
     let left_path = left.strip_prefix("grok://").unwrap_or(left);
     let right_path = right.strip_prefix("grok://").unwrap_or(right);
+    match (
+        Path::new(left_path).canonicalize(),
+        Path::new(right_path).canonicalize(),
+    ) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
+fn cursor_virtual_paths_match(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let left_path = left.strip_prefix("cursor://").unwrap_or(left);
+    let right_path = right.strip_prefix("cursor://").unwrap_or(right);
     match (
         Path::new(left_path).canonicalize(),
         Path::new(right_path).canonicalize(),
@@ -1084,6 +1109,32 @@ fn collect_provider_global_file_stats(
 ) -> (Vec<SessionFileStats>, HashSet<String>) {
     let mut project_keys = HashSet::new();
 
+    if provider == StatsProvider::Cursor {
+        let Ok(sessions) = providers::cursor::collect_global_stats_sessions() else {
+            return (Vec::new(), project_keys);
+        };
+        let mut all_stats = Vec::with_capacity(sessions.len());
+        for (project_display_name, messages) in sessions {
+            project_keys.insert(format!(
+                "cursor:{}",
+                project_display_name
+                    .strip_suffix(" [cursor]")
+                    .unwrap_or(&project_display_name)
+            ));
+            if let Some(stats) = build_global_session_file_stats_from_messages(
+                StatsProvider::Cursor,
+                project_display_name,
+                &messages,
+                mode,
+                s_limit,
+                e_limit,
+            ) {
+                all_stats.push(stats);
+            }
+        }
+        return (all_stats, project_keys);
+    }
+
     if provider == StatsProvider::Antigravity {
         // Use the resolver that honors the external-state override so an
         // external Antigravity root contributes to the global summary
@@ -1228,6 +1279,7 @@ fn collect_provider_global_file_stats(
         StatsProvider::Ompi => providers::ompi::scan_projects().unwrap_or_default(),
         StatsProvider::Pi => providers::pi::scan_projects().unwrap_or_default(),
         StatsProvider::Gemini => providers::gemini::scan_projects().unwrap_or_default(),
+        StatsProvider::Cursor => providers::cursor::scan_projects().unwrap_or_default(),
         StatsProvider::Claude => Vec::new(),
     };
 
@@ -1254,6 +1306,7 @@ fn collect_provider_global_file_stats(
             StatsProvider::Ompi => providers::ompi::load_sessions(&project.path, false),
             StatsProvider::Pi => providers::pi::load_sessions(&project.path, false),
             StatsProvider::Gemini => providers::gemini::load_sessions(&project.path, false),
+            StatsProvider::Cursor => providers::cursor::load_sessions(&project.path, false),
             StatsProvider::Claude => Ok(Vec::new()),
         }
         .unwrap_or_default();
@@ -1279,6 +1332,7 @@ fn collect_provider_global_file_stats(
                 StatsProvider::Ompi => providers::ompi::load_messages(file_path),
                 StatsProvider::Pi => providers::pi::load_messages(file_path),
                 StatsProvider::Gemini => providers::gemini::load_messages(file_path),
+                StatsProvider::Cursor => providers::cursor::load_stats_messages(file_path),
                 StatsProvider::Claude => Ok(Vec::new()),
             }
             .unwrap_or_default();
@@ -2088,6 +2142,27 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                 })
                 .unwrap_or_else(|| "Gemini".to_string())
         }
+        StatsProvider::Cursor => {
+            if let Ok(projects) = providers::cursor::scan_projects() {
+                if let Some(project) = projects
+                    .into_iter()
+                    .find(|p| cursor_virtual_paths_match(&p.path, project_path))
+                {
+                    return project.name;
+                }
+            }
+            if let Some(name) = providers::cursor::display_name_for_project_path(project_path) {
+                return name;
+            }
+            project_path
+                .strip_prefix("cursor://")
+                .and_then(|p| {
+                    PathBuf::from(p)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| "Cursor".to_string())
+        }
     }
 }
 
@@ -2202,6 +2277,18 @@ fn resolve_provider_project_name_from_session(
             }
             "Gemini".to_string()
         }
+        StatsProvider::Cursor => {
+            if let Ok(projects) = providers::cursor::scan_projects() {
+                for project in projects {
+                    if let Ok(sessions) = providers::cursor::load_sessions(&project.path, false) {
+                        if sessions.iter().any(|s| s.file_path == session_path) {
+                            return project.name;
+                        }
+                    }
+                }
+            }
+            "Cursor".to_string()
+        }
         StatsProvider::Claude => "unknown".to_string(),
     }
 }
@@ -2223,6 +2310,7 @@ fn load_provider_sessions_for_stats(
         StatsProvider::Ompi => providers::ompi::load_sessions(project_path, false),
         StatsProvider::Pi => providers::pi::load_sessions(project_path, false),
         StatsProvider::Gemini => providers::gemini::load_sessions(project_path, false),
+        StatsProvider::Cursor => providers::cursor::load_sessions(project_path, false),
         StatsProvider::Claude => {
             Err("Claude sessions are handled by legacy stats path".to_string())
         }
@@ -2246,6 +2334,7 @@ fn load_provider_messages_for_stats(
         StatsProvider::Ompi => providers::ompi::load_messages(&session.file_path),
         StatsProvider::Pi => providers::pi::load_messages(&session.file_path),
         StatsProvider::Gemini => providers::gemini::load_messages(&session.file_path),
+        StatsProvider::Cursor => providers::cursor::load_stats_messages(&session.file_path),
         StatsProvider::Claude => {
             Err("Claude messages are handled by legacy stats path".to_string())
         }
@@ -2997,6 +3086,7 @@ pub async fn get_session_token_stats(
             StatsProvider::Ompi => providers::ompi::load_messages(&session_path)?,
             StatsProvider::Pi => providers::pi::load_messages(&session_path)?,
             StatsProvider::Gemini => providers::gemini::load_messages(&session_path)?,
+            StatsProvider::Cursor => providers::cursor::load_stats_messages(&session_path)?,
             StatsProvider::Claude => Vec::new(),
         };
 
@@ -3953,6 +4043,13 @@ pub async fn get_global_stats_summary(
         file_stats.extend(grok_stats);
     }
 
+    if providers_to_include.contains(&StatsProvider::Cursor) {
+        let (cursor_stats, cursor_projects) =
+            collect_provider_global_file_stats(StatsProvider::Cursor, mode, s_ref, e_ref);
+        project_names.extend(cursor_projects);
+        file_stats.extend(cursor_stats);
+    }
+
     if providers_to_include.contains(&StatsProvider::Kimi) {
         let (kimi_stats, kimi_projects) =
             collect_provider_global_file_stats(StatsProvider::Kimi, mode, s_ref, e_ref);
@@ -4880,6 +4977,12 @@ mod tests {
             StatsProvider::Grok
         );
         assert_eq!(
+            detect_project_provider(
+                "cursor:///Users/jack/Library/Application Support/Cursor/User/workspaceStorage/hash"
+            ),
+            StatsProvider::Cursor
+        );
+        assert_eq!(
             detect_project_provider("kimi:///Users/jack/.kimi/sessions/project-hash"),
             StatsProvider::Kimi
         );
@@ -4933,6 +5036,10 @@ mod tests {
         assert_eq!(
             detect_session_provider("opencode://project/ses_abc"),
             StatsProvider::OpenCode
+        );
+        assert_eq!(
+            detect_session_provider("cursor://composer-id-abc"),
+            StatsProvider::Cursor
         );
         if let Some(root) = providers::grok::get_base_path() {
             let grok_session = PathBuf::from(root)
@@ -5020,6 +5127,7 @@ mod tests {
         assert!(providers.contains(&StatsProvider::Kimi));
         assert!(providers.contains(&StatsProvider::Antigravity));
         assert!(providers.contains(&StatsProvider::Copilot));
+        assert!(providers.contains(&StatsProvider::Cursor));
     }
 
     #[test]
@@ -5059,6 +5167,14 @@ mod tests {
         let providers = parse_active_stats_providers(Some(vec!["grok".to_string()]));
         assert_eq!(providers.len(), 1);
         assert!(providers.contains(&StatsProvider::Grok));
+    }
+
+    #[test]
+    /// Verify parse active stats providers supports Cursor.
+    fn test_parse_active_stats_providers_supports_cursor() {
+        let providers = parse_active_stats_providers(Some(vec!["cursor".to_string()]));
+        assert_eq!(providers.len(), 1);
+        assert!(providers.contains(&StatsProvider::Cursor));
     }
 
     #[test]
@@ -5247,6 +5363,150 @@ mod tests {
                 .any(|project| project.project_name.contains("demo")),
             "expected grok project in top_projects: {:?}",
             global.top_projects
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_project_stats_summary_accepts_cursor_virtual_path() {
+        let temp = TempDir::new().expect("temp dir");
+        let user_dir = temp.path().join("Cursor").join("User");
+        let ws_path = user_dir.join("workspaceStorage").join("hash-demo");
+        fs::create_dir_all(&ws_path).unwrap();
+        fs::create_dir_all(user_dir.join("globalStorage")).unwrap();
+
+        fs::write(
+            ws_path.join("workspace.json"),
+            r#"{"folder":"file:///Users/test/demo"}"#,
+        )
+        .unwrap();
+
+        let ws_conn = rusqlite::Connection::open(ws_path.join("state.vscdb")).unwrap();
+        ws_conn
+            .execute(
+                "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        let composers = json!({
+            "allComposers": [{
+                "composerId": "comp-demo",
+                "name": "Demo chat",
+                "createdAt": 1_700_000_000_000u64,
+                "lastUpdatedAt": 1_700_000_100_000u64,
+                "isArchived": false,
+                "unifiedMode": "agent"
+            }]
+        })
+        .to_string();
+        ws_conn
+            .execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('composer.composerData', ?1)",
+                [&composers],
+            )
+            .unwrap();
+
+        let global_conn =
+            rusqlite::Connection::open(user_dir.join("globalStorage").join("state.vscdb")).unwrap();
+        global_conn
+            .execute(
+                "CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        let composer_data = json!({
+            "fullConversationHeadersOnly": [
+                { "bubbleId": "b1", "type": 1 },
+                { "bubbleId": "b2", "type": 2 }
+            ],
+            "promptTokenBreakdown": { "totalUsedTokens": 4200 }
+        })
+        .to_string();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params!["composerData:comp-demo", composer_data],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-demo:b1",
+                    json!({
+                        "bubbleId": "b1",
+                        "type": 1,
+                        "text": "hello cursor",
+                        "createdAt": "2026-07-27T20:00:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-demo:b2",
+                    json!({
+                        "bubbleId": "b2",
+                        "type": 2,
+                        "text": "hi from composer",
+                        "createdAt": "2026-07-27T20:01:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+
+        let _env = EnvVarGuard::set("CURSOR_USER_DIR", &user_dir);
+        let project_path = format!("cursor://{}", ws_path.to_string_lossy());
+
+        assert_eq!(
+            detect_project_provider(&project_path),
+            StatsProvider::Cursor
+        );
+
+        let summary = get_project_stats_summary(project_path.clone(), None, None, None)
+            .await
+            .expect("cursor virtual project path should load stats");
+        assert_eq!(summary.project_name, "demo");
+        assert!(summary.total_sessions >= 1);
+        assert!(summary.total_messages >= 1);
+
+        let global = get_global_stats_summary(
+            "/tmp".to_string(),
+            Some(vec!["cursor".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("cursor should contribute to global stats");
+        assert!(
+            global
+                .provider_distribution
+                .iter()
+                .any(|provider| provider.provider_id == "cursor" && provider.sessions >= 1),
+            "expected cursor in provider_distribution: {:?}",
+            global.provider_distribution
+        );
+        assert!(
+            global
+                .model_distribution
+                .iter()
+                .any(|model| model.model_name == "cursor" && model.token_count >= 4200),
+            "expected cursor in model_distribution: {:?}",
+            global.model_distribution
+        );
+        assert!(
+            global
+                .provider_distribution
+                .iter()
+                .any(|provider| provider.provider_id == "cursor" && provider.tokens >= 4200),
+            "expected cursor tokens in provider_distribution: {:?}",
+            global.provider_distribution
         );
     }
 

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -1,4 +1,4 @@
-use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
 use crate::providers::ProviderInfo;
 use crate::utils::{build_provider_message, ms_to_iso, search_json_value_case_insensitive};
 use rusqlite::{Connection, OpenFlags};
@@ -22,6 +22,13 @@ pub fn detect() -> Option<ProviderInfo> {
 
 /// Get Cursor user data path
 pub fn get_base_path() -> Option<PathBuf> {
+    if let Ok(env_val) = std::env::var("CURSOR_USER_DIR") {
+        let path = PathBuf::from(env_val);
+        if path.is_dir() {
+            return Some(path.canonicalize().unwrap_or(path));
+        }
+    }
+
     let home = dirs::home_dir()?;
 
     #[cfg(target_os = "macos")]
@@ -40,10 +47,41 @@ pub fn get_base_path() -> Option<PathBuf> {
     }
 }
 
-/// Scan Cursor projects by reading workspace directories
+/// Scan Cursor projects from migrated global Composer data.
+/// Falls back to legacy workspace `allComposers` only when global storage is empty.
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     let base = get_base_path().ok_or("Cursor not found")?;
-    scan_projects_in(&base.join("workspaceStorage"))
+    let mut projects = scan_projects_from_global(&base)?;
+    if projects.is_empty() {
+        projects = scan_projects_in(&base.join("workspaceStorage"))?;
+    }
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+/// Resolve a human-readable project name from a `cursor://` workspace path
+/// via `workspace.json` (folder basename), without requiring a full scan.
+pub fn display_name_for_project_path(project_path: &str) -> Option<String> {
+    let ws_path = project_path
+        .strip_prefix("cursor://")
+        .unwrap_or(project_path);
+    if let Some(rest) = ws_path.strip_prefix("workspace/") {
+        let id = rest.split('/').next().unwrap_or(rest);
+        if is_orphan_workspace_id(id) {
+            return Some("Cursor".to_string());
+        }
+        if !id.is_empty() {
+            return Some(id.to_string());
+        }
+        return Some("Cursor".to_string());
+    }
+    let workspace_json = PathBuf::from(ws_path).join("workspace.json");
+    read_workspace_folder(&workspace_json).and_then(|folder| {
+        PathBuf::from(&folder)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .filter(|n| !n.is_empty())
+    })
 }
 
 fn scan_projects_in(ws_dir: &Path) -> Result<Vec<ClaudeProject>, String> {
@@ -68,6 +106,127 @@ fn scan_projects_in(ws_dir: &Path) -> Result<Vec<ClaudeProject>, String> {
 
     projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(projects)
+}
+
+fn scan_projects_from_global(base: &Path) -> Result<Vec<ClaudeProject>, String> {
+    let global_db = base.join("globalStorage/state.vscdb");
+    if !global_db.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(&global_db, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor global DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+        .map_err(|e| format!("Query failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| format!("Query failed: {e}"))?;
+
+    let ws_root = base.join("workspaceStorage");
+    let mut by_workspace: std::collections::HashMap<String, GlobalWorkspaceAcc> =
+        std::collections::HashMap::new();
+
+    for row in rows.flatten() {
+        let (key, value) = row;
+        let Some(composer_id) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        let Ok(composer) = parse_cursor_json(&value) else {
+            continue;
+        };
+        if composer_is_archived(&composer) {
+            continue;
+        }
+        if !composer_has_conversation(&composer) {
+            continue;
+        }
+
+        let (raw_workspace_id, folder_path) = workspace_identity_from_composer(&composer);
+        let workspace_id = normalize_workspace_bucket_id(&raw_workspace_id);
+        let entry =
+            by_workspace
+                .entry(workspace_id.clone())
+                .or_insert_with(|| GlobalWorkspaceAcc {
+                    folder_path: folder_path.clone(),
+                    session_count: 0,
+                    last_modified_ms: 0,
+                });
+        if entry.folder_path.is_empty() && !folder_path.is_empty() {
+            entry.folder_path = folder_path;
+        }
+        entry.session_count += 1;
+        entry.last_modified_ms = entry.last_modified_ms.max(composer_timestamp_ms(&composer));
+        let _ = composer_id;
+    }
+
+    let mut projects = Vec::with_capacity(by_workspace.len());
+    for (workspace_id, acc) in by_workspace {
+        let ws_path = ws_root.join(&workspace_id);
+        let (path, actual_path, name) = if is_orphan_workspace_id(&workspace_id) {
+            (
+                "cursor://workspace/unassigned".to_string(),
+                String::new(),
+                "Cursor".to_string(),
+            )
+        } else if ws_path.is_dir() {
+            let folder = read_workspace_folder(&ws_path.join("workspace.json"))
+                .unwrap_or_else(|| acc.folder_path.clone());
+            let name = PathBuf::from(&folder)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .or_else(|| {
+                    PathBuf::from(&acc.folder_path)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| workspace_id.clone());
+            (
+                format!("cursor://{}", ws_path.to_string_lossy()),
+                folder,
+                name,
+            )
+        } else {
+            let name = PathBuf::from(&acc.folder_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| workspace_id.clone());
+            (
+                format!("cursor://workspace/{workspace_id}"),
+                acc.folder_path.clone(),
+                name,
+            )
+        };
+
+        projects.push(ClaudeProject {
+            name,
+            path,
+            actual_path,
+            session_count: acc.session_count,
+            message_count: 0,
+            last_modified: ms_to_iso(acc.last_modified_ms),
+            git_info: None,
+            provider: Some("cursor".to_string()),
+            storage_type: Some("sqlite".to_string()),
+            custom_directory_label: None,
+        });
+    }
+
+    Ok(projects)
+}
+
+struct GlobalWorkspaceAcc {
+    folder_path: String,
+    session_count: usize,
+    last_modified_ms: u64,
 }
 
 /// One workspace dir → one project, or `None` when the workspace has no
@@ -133,76 +292,236 @@ pub fn load_sessions(
         .strip_prefix("cursor://")
         .unwrap_or(project_path);
 
-    let ws_path_buf = PathBuf::from(ws_path);
-    if !ws_path_buf.is_absolute() {
-        return Err("Cursor workspace path must be absolute".to_string());
-    }
+    let (workspace_id, project_name, legacy_composers) =
+        if let Some(id) = ws_path.strip_prefix("workspace/") {
+            let workspace_id = normalize_workspace_bucket_id(id.split('/').next().unwrap_or(id));
+            let project_name = if is_orphan_workspace_id(&workspace_id) {
+                "Cursor".to_string()
+            } else {
+                display_name_for_project_path(project_path).unwrap_or_else(|| workspace_id.clone())
+            };
+            (workspace_id, project_name, Vec::new())
+        } else {
+            let ws_path_buf = PathBuf::from(ws_path);
+            if !ws_path_buf.is_absolute() {
+                return Err("Cursor workspace path must be absolute".to_string());
+            }
+            let workspace_id = normalize_workspace_bucket_id(
+                &ws_path_buf
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default(),
+            );
+            let workspace_json = ws_path_buf.join("workspace.json");
+            let project_name = read_workspace_folder(&workspace_json)
+                .and_then(|folder| {
+                    PathBuf::from(&folder)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| "Cursor".to_string());
+            let legacy = read_workspace_composers(&ws_path_buf.join("state.vscdb"))?;
+            (workspace_id, project_name, legacy)
+        };
 
-    let ws_db_path = ws_path_buf.join("state.vscdb");
-    let composers = read_workspace_composers(&ws_db_path)?;
-
-    // Read workspace.json to get the real project folder name
-    let workspace_json = PathBuf::from(ws_path).join("workspace.json");
-    let project_name = read_workspace_folder(&workspace_json)
-        .and_then(|folder| {
-            PathBuf::from(&folder)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-        })
-        .unwrap_or_else(|| "Cursor".to_string());
+    let composers = if legacy_composers.is_empty() {
+        read_global_composers_for_workspace(&workspace_id)?
+    } else {
+        legacy_composers
+    };
 
     let mut sessions: Vec<ClaudeSession> = composers
         .iter()
-        .filter_map(|c| {
-            let id = c.get("composerId").and_then(Value::as_str)?;
-            let name = c.get("name").and_then(Value::as_str).unwrap_or("Untitled");
-            let created = c.get("createdAt").and_then(Value::as_f64).unwrap_or(0.0) as u64;
-            let updated = c
-                .get("lastUpdatedAt")
-                .and_then(Value::as_f64)
-                .unwrap_or(0.0) as u64;
-            let mode = c
-                .get("unifiedMode")
-                .and_then(Value::as_str)
-                .unwrap_or("chat");
-            let is_archived = c
-                .get("isArchived")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
-
-            if is_archived {
-                return None;
-            }
-
-            Some(ClaudeSession {
-                session_id: format!("cursor://{id}"),
-                actual_session_id: id.to_string(),
-                file_path: format!("cursor://{id}"),
-                project_name: project_name.clone(),
-                message_count: 0, // Loaded on demand
-                first_message_time: ms_to_iso(created),
-                last_message_time: ms_to_iso(updated),
-                last_modified: ms_to_iso(updated),
-                has_tool_use: mode == "agent",
-                has_errors: false,
-                summary: Some(name.to_string()),
-                is_renamed: false,
-                provider: Some("cursor".to_string()),
-                storage_type: Some("sqlite".to_string()),
-                entrypoint: None,
-            })
-        })
+        .filter_map(|c| composer_to_session(c, &project_name))
         .collect();
 
     sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
     Ok(sessions)
 }
 
+fn composer_to_session(composer: &Value, project_name: &str) -> Option<ClaudeSession> {
+    let id = composer
+        .get("composerId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())?;
+    if composer_is_archived(composer) {
+        return None;
+    }
+    let name = composer
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("Untitled");
+    let created = composer_timestamp_ms(composer);
+    let updated = composer
+        .get("lastUpdatedAt")
+        .and_then(Value::as_f64)
+        .map(|v| v as u64)
+        .filter(|v| *v > 0)
+        .unwrap_or(created);
+    let mode = composer
+        .get("unifiedMode")
+        .and_then(Value::as_str)
+        .unwrap_or("chat");
+
+    Some(ClaudeSession {
+        session_id: format!("cursor://{id}"),
+        actual_session_id: id.to_string(),
+        file_path: format!("cursor://{id}"),
+        project_name: project_name.to_string(),
+        message_count: 0,
+        first_message_time: ms_to_iso(created),
+        last_message_time: ms_to_iso(updated),
+        last_modified: ms_to_iso(updated),
+        has_tool_use: mode == "agent",
+        has_errors: false,
+        summary: Some(name.to_string()),
+        is_renamed: false,
+        provider: Some("cursor".to_string()),
+        storage_type: Some("sqlite".to_string()),
+        entrypoint: None,
+    })
+}
+
+/// Lightweight stats messages: composer headers + token signal (no bubble bodies).
+pub fn load_stats_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let (composer_id, composer) = load_composer_value(session_path)?;
+    Ok(stats_messages_from_composer(&composer_id, &composer))
+}
+
+/// One-pass global stats source: open the Cursor DB once and emit
+/// `(project_display_name, stats_messages)` for every active composer.
+pub fn collect_global_stats_sessions() -> Result<Vec<(String, Vec<ClaudeMessage>)>, String> {
+    let base = get_base_path().ok_or("Cursor not found")?;
+    let global_db = base.join("globalStorage/state.vscdb");
+    if !global_db.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(&global_db, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor global DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+        .map_err(|e| format!("Query failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| format!("Query failed: {e}"))?;
+
+    let ws_root = base.join("workspaceStorage");
+    let mut sessions = Vec::new();
+    for row in rows.flatten() {
+        let (key, value) = row;
+        let Some(composer_id) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        let Ok(composer) = parse_cursor_json(&value) else {
+            continue;
+        };
+        if composer_is_archived(&composer) || !composer_has_conversation(&composer) {
+            continue;
+        }
+
+        let (raw_workspace_id, folder_path) = workspace_identity_from_composer(&composer);
+        let workspace_id = normalize_workspace_bucket_id(&raw_workspace_id);
+        let project_name = resolve_project_display_name(&ws_root, &workspace_id, &folder_path);
+        let project_display_name = format!("{project_name} [cursor]");
+        let messages = stats_messages_from_composer(composer_id, &composer);
+        if !messages.is_empty() {
+            sessions.push((project_display_name, messages));
+        }
+    }
+
+    Ok(sessions)
+}
+
+fn resolve_project_display_name(ws_root: &Path, workspace_id: &str, folder_path: &str) -> String {
+    if is_orphan_workspace_id(workspace_id) {
+        return "Cursor".to_string();
+    }
+    let ws_path = ws_root.join(workspace_id);
+    if ws_path.is_dir() {
+        if let Some(folder) = read_workspace_folder(&ws_path.join("workspace.json")) {
+            if let Some(name) = PathBuf::from(&folder)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+            {
+                return name;
+            }
+        }
+    }
+    PathBuf::from(folder_path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| workspace_id.to_string())
+}
+
+fn stats_messages_from_composer(composer_id: &str, composer: &Value) -> Vec<ClaudeMessage> {
+    let stamp = ms_to_iso(composer_timestamp_ms(composer));
+    let headers = composer
+        .get("fullConversationHeadersOnly")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut messages = Vec::with_capacity(headers.len().max(1));
+    for (index, header) in headers.iter().enumerate() {
+        let bubble_type = header.get("type").and_then(Value::as_u64).unwrap_or(0);
+        let (message_type, role) = match bubble_type {
+            1 => ("user", Some("user")),
+            2 => ("assistant", Some("assistant")),
+            _ => continue,
+        };
+        let bubble_id = header
+            .get("bubbleId")
+            .and_then(Value::as_str)
+            .unwrap_or("stats");
+        messages.push(build_provider_message(
+            "cursor",
+            format!("{composer_id}-{bubble_id}-{index}"),
+            composer_id,
+            stamp.clone(),
+            message_type,
+            role,
+            Some(serde_json::json!([{"type": "text", "text": ""}])),
+            if message_type == "assistant" {
+                Some("cursor".to_string())
+            } else {
+                None
+            },
+        ));
+    }
+
+    if messages
+        .iter()
+        .all(|message| message.message_type != "assistant")
+        && composer_has_conversation(composer)
+    {
+        messages.push(build_provider_message(
+            "cursor",
+            format!("{composer_id}-usage"),
+            composer_id,
+            stamp,
+            "assistant",
+            Some("assistant"),
+            Some(serde_json::json!([{"type": "text", "text": ""}])),
+            Some("cursor".to_string()),
+        ));
+    }
+
+    attach_composer_token_usage(composer, &mut messages);
+    messages
+}
+
 /// Load messages from a Cursor composer
 pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
-    let composer_id = session_path
-        .strip_prefix("cursor://")
-        .unwrap_or(session_path);
+    let (composer_id, composer) = load_composer_value(session_path)?;
 
     let base = get_base_path().ok_or("Cursor not found")?;
     let global_db_path = base.join("globalStorage/state.vscdb");
@@ -211,18 +530,6 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
         .map_err(|e| format!("Failed to open Cursor DB: {e}"))?;
     conn.busy_timeout(std::time::Duration::from_secs(5))
         .map_err(|e| format!("Failed to set busy timeout: {e}"))?;
-
-    // Get composer data (ordered bubble list)
-    let composer_key = format!("composerData:{composer_id}");
-    let composer_data: String = conn
-        .query_row(
-            "SELECT value FROM cursorDiskKV WHERE key = ?1",
-            [&composer_key],
-            |row| row.get(0),
-        )
-        .map_err(|e| format!("Composer not found: {e}"))?;
-
-    let composer: Value = parse_cursor_json(&composer_data)?;
 
     let headers = composer
         .get("fullConversationHeadersOnly")
@@ -270,12 +577,67 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
             Err(_) => continue,
         };
 
-        if let Some(msg) = convert_cursor_bubble(&bubble, bubble_type, composer_id) {
+        if let Some(msg) = convert_cursor_bubble(&bubble, bubble_type, &composer_id) {
             messages.push(msg);
         }
     }
 
+    if messages
+        .iter()
+        .all(|message| message.message_type != "assistant")
+        && composer_has_conversation(&composer)
+    {
+        let stamp = ms_to_iso(composer_timestamp_ms(&composer));
+        messages.push(build_provider_message(
+            "cursor",
+            format!("{composer_id}-usage"),
+            &composer_id,
+            stamp,
+            "assistant",
+            Some("assistant"),
+            Some(serde_json::json!([{"type": "text", "text": ""}])),
+            Some("cursor".to_string()),
+        ));
+    }
+
+    attach_composer_token_usage(&composer, &mut messages);
+
     Ok(messages)
+}
+
+fn attach_composer_token_usage(composer: &Value, messages: &mut [ClaudeMessage]) {
+    if messages.is_empty() {
+        return;
+    }
+
+    let tokens = composer
+        .get("promptTokenBreakdown")
+        .and_then(|v| v.get("totalUsedTokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if tokens == 0 {
+        return;
+    }
+
+    let capped = u32::try_from(tokens.min(u64::from(u32::MAX))).unwrap_or(u32::MAX);
+    let stamp = ms_to_iso(composer_timestamp_ms(composer));
+    if let Some(message) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.message_type == "assistant")
+    {
+        message.model = Some("cursor".to_string());
+        message.usage = Some(TokenUsage {
+            input_tokens: Some(capped),
+            output_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+            service_tier: None,
+        });
+        if !stamp.is_empty() {
+            message.timestamp = stamp;
+        }
+    }
 }
 
 /// Search across all Cursor conversations
@@ -361,6 +723,31 @@ fn read_workspace_folder(workspace_json_path: &Path) -> Option<String> {
     })
 }
 
+fn load_composer_value(session_path: &str) -> Result<(String, Value), String> {
+    let composer_id = session_path
+        .strip_prefix("cursor://")
+        .unwrap_or(session_path)
+        .to_string();
+
+    let base = get_base_path().ok_or("Cursor not found")?;
+    let global_db_path = base.join("globalStorage/state.vscdb");
+    let conn = Connection::open_with_flags(&global_db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let composer_key = format!("composerData:{composer_id}");
+    let composer_data: String = conn
+        .query_row(
+            "SELECT value FROM cursorDiskKV WHERE key = ?1",
+            [&composer_key],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Composer not found: {e}"))?;
+
+    let composer = parse_cursor_json(&composer_data)?;
+    Ok((composer_id, composer))
+}
+
 fn read_workspace_composers(ws_db_path: &Path) -> Result<Vec<Value>, String> {
     if !ws_db_path.is_file() {
         return Ok(Vec::new());
@@ -390,6 +777,128 @@ fn read_workspace_composers(ws_db_path: &Path) -> Result<Vec<Value>, String> {
         .unwrap_or_default();
 
     Ok(composers)
+}
+
+fn read_global_composers_for_workspace(workspace_id: &str) -> Result<Vec<Value>, String> {
+    let base = get_base_path().ok_or("Cursor not found")?;
+    let global_db = base.join("globalStorage/state.vscdb");
+    if !global_db.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(&global_db, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Cursor global DB: {e}"))?;
+    let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
+
+    let mut stmt = conn
+        .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+        .map_err(|e| format!("Query failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })
+        .map_err(|e| format!("Query failed: {e}"))?;
+
+    let mut composers = Vec::new();
+    for row in rows.flatten() {
+        let (key, value) = row;
+        let Some(composer_id) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        let Ok(mut composer) = parse_cursor_json(&value) else {
+            continue;
+        };
+        if composer_is_archived(&composer) || !composer_has_conversation(&composer) {
+            continue;
+        }
+        let (raw_id, _) = workspace_identity_from_composer(&composer);
+        let id = normalize_workspace_bucket_id(&raw_id);
+        if id != normalize_workspace_bucket_id(workspace_id) {
+            continue;
+        }
+        if composer.get("composerId").and_then(Value::as_str).is_none() {
+            if let Some(obj) = composer.as_object_mut() {
+                obj.insert(
+                    "composerId".to_string(),
+                    Value::String(composer_id.to_string()),
+                );
+            }
+        }
+        composers.push(composer);
+    }
+
+    Ok(composers)
+}
+
+fn composer_is_archived(composer: &Value) -> bool {
+    composer
+        .get("isArchived")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn composer_has_conversation(composer: &Value) -> bool {
+    let has_headers = composer
+        .get("fullConversationHeadersOnly")
+        .and_then(Value::as_array)
+        .is_some_and(|headers| !headers.is_empty());
+    let has_tokens = composer
+        .get("promptTokenBreakdown")
+        .and_then(|v| v.get("totalUsedTokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        > 0;
+    has_headers || has_tokens
+}
+
+fn workspace_identity_from_composer(composer: &Value) -> (String, String) {
+    let wi = composer.get("workspaceIdentifier");
+    let workspace_id = wi
+        .and_then(|v| v.get("id"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .unwrap_or("unassigned")
+        .to_string();
+    let folder_path = wi
+        .and_then(|v| v.get("uri"))
+        .and_then(|uri| {
+            uri.get("fsPath")
+                .or_else(|| uri.get("path"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("")
+        .to_string();
+    (workspace_id, folder_path)
+}
+
+fn is_orphan_workspace_id(workspace_id: &str) -> bool {
+    workspace_id.is_empty() || workspace_id == "unassigned" || workspace_id == "empty-window"
+}
+
+fn normalize_workspace_bucket_id(workspace_id: &str) -> String {
+    if is_orphan_workspace_id(workspace_id) {
+        "unassigned".to_string()
+    } else {
+        workspace_id.to_string()
+    }
+}
+
+fn composer_timestamp_ms(composer: &Value) -> u64 {
+    composer
+        .get("lastUpdatedAt")
+        .and_then(Value::as_f64)
+        .map(|v| v as u64)
+        .filter(|v| *v > 0)
+        .or_else(|| {
+            composer
+                .get("createdAt")
+                .and_then(Value::as_f64)
+                .map(|v| v as u64)
+                .filter(|v| *v > 0)
+        })
+        .unwrap_or(0)
 }
 
 /// Parse Cursor's JSON which may contain control characters
@@ -592,7 +1101,7 @@ fn convert_assistant_bubble(
         "assistant",
         Some("assistant"),
         Some(Value::Array(content_blocks)),
-        None,
+        Some("cursor".to_string()),
     ))
 }
 
@@ -647,6 +1156,29 @@ fn map_cursor_tool_name(name: &str) -> &str {
 mod tests {
     use super::*;
     use serde_json::json;
+    use serial_test::serial;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value.as_ref());
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn test_percent_decode_basic() {
@@ -785,6 +1317,175 @@ mod tests {
     fn test_empty_bubble() {
         let bubble = json!({"type": 2, "bubbleId": "empty", "text": ""});
         assert!(convert_cursor_bubble(&bubble, 2, "session-1").is_none());
+    }
+
+    #[test]
+    fn test_assistant_bubble_uses_composer_model() {
+        let bubble = json!({
+            "type": 2,
+            "bubbleId": "a1",
+            "text": "hello",
+            "createdAt": "2026-07-27T20:00:00Z"
+        });
+        let msg = convert_cursor_bubble(&bubble, 2, "session-1").unwrap();
+        assert_eq!(msg.model.as_deref(), Some("cursor"));
+        assert_eq!(msg.provider.as_deref(), Some("cursor"));
+    }
+
+    #[test]
+    fn test_attach_composer_token_usage_to_last_assistant() {
+        let mut messages = vec![
+            convert_cursor_bubble(
+                &json!({
+                    "type": 1,
+                    "bubbleId": "u1",
+                    "text": "hi",
+                    "createdAt": "2026-07-27T20:00:00Z"
+                }),
+                1,
+                "session-1",
+            )
+            .unwrap(),
+            convert_cursor_bubble(
+                &json!({
+                    "type": 2,
+                    "bubbleId": "a1",
+                    "text": "hello",
+                    "createdAt": "2026-07-27T20:01:00Z"
+                }),
+                2,
+                "session-1",
+            )
+            .unwrap(),
+        ];
+        attach_composer_token_usage(
+            &json!({ "promptTokenBreakdown": { "totalUsedTokens": 12345 } }),
+            &mut messages,
+        );
+        assert!(messages[0].usage.is_none());
+        assert_eq!(
+            messages[1].usage.as_ref().and_then(|u| u.input_tokens),
+            Some(12345)
+        );
+        assert_eq!(messages[1].model.as_deref(), Some("cursor"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_projects_from_migrated_global_composers() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let user_dir = temp.path().join("User");
+        let ws_hash = "hash-migrated";
+        let ws_path = user_dir.join("workspaceStorage").join(ws_hash);
+        fs::create_dir_all(&ws_path).unwrap();
+        fs::create_dir_all(user_dir.join("globalStorage")).unwrap();
+        fs::write(
+            ws_path.join("workspace.json"),
+            r#"{"folder":"file:///Users/test/demo-cursor"}"#,
+        )
+        .unwrap();
+
+        let ws_conn = Connection::open(ws_path.join("state.vscdb")).unwrap();
+        ws_conn
+            .execute(
+                "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        ws_conn
+            .execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('composer.composerData', ?1)",
+                [r#"{"allComposers":[],"selectedComposerIds":["comp-1"],"hasMigratedComposerData":true}"#],
+            )
+            .unwrap();
+
+        let global_conn =
+            Connection::open(user_dir.join("globalStorage").join("state.vscdb")).unwrap();
+        global_conn
+            .execute(
+                "CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value TEXT)",
+                [],
+            )
+            .unwrap();
+        let composer = json!({
+            "composerId": "comp-1",
+            "name": "Migrated chat",
+            "createdAt": 1_700_000_000_000u64,
+            "lastUpdatedAt": 1_700_000_100_000u64,
+            "isArchived": false,
+            "unifiedMode": "agent",
+            "workspaceIdentifier": {
+                "id": ws_hash,
+                "uri": { "fsPath": "/Users/test/demo-cursor", "path": "/Users/test/demo-cursor" }
+            },
+            "fullConversationHeadersOnly": [
+                { "bubbleId": "b1", "type": 1 },
+                { "bubbleId": "b2", "type": 2 }
+            ],
+            "promptTokenBreakdown": { "totalUsedTokens": 9001 }
+        })
+        .to_string();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params!["composerData:comp-1", composer],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-1:b1",
+                    json!({
+                        "bubbleId": "b1",
+                        "type": 1,
+                        "text": "hello",
+                        "createdAt": "2026-07-27T20:00:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+        global_conn
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    "bubbleId:comp-1:b2",
+                    json!({
+                        "bubbleId": "b2",
+                        "type": 2,
+                        "text": "hi",
+                        "createdAt": "2026-07-27T20:01:00Z"
+                    })
+                    .to_string()
+                ],
+            )
+            .unwrap();
+
+        let _env = EnvVarGuard::set("CURSOR_USER_DIR", &user_dir);
+        let projects = scan_projects().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "demo-cursor");
+        assert!(projects[0].session_count >= 1);
+
+        let sessions = load_sessions(&projects[0].path, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        let messages = load_messages(&sessions[0].file_path).unwrap();
+        assert!(messages.iter().any(|m| {
+            m.model.as_deref() == Some("cursor")
+                && m.usage
+                    .as_ref()
+                    .and_then(|u| u.input_tokens)
+                    .is_some_and(|tokens| tokens == 9001)
+        }));
+        let stats_messages = load_stats_messages(&sessions[0].file_path).unwrap();
+        assert!(stats_messages.iter().any(|m| {
+            m.model.as_deref() == Some("cursor")
+                && m.usage
+                    .as_ref()
+                    .and_then(|u| u.input_tokens)
+                    .is_some_and(|tokens| tokens == 9001)
+        }));
     }
 
     /// Write a minimal valid Cursor workspace: `workspace.json` + a `state.vscdb`

--- a/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
+++ b/src/components/AnalyticsDashboard/components/ProviderDistributionChart.tsx
@@ -14,7 +14,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   claude: "var(--metric-amber)",
   cline: "var(--metric-teal)",
   codex: "var(--metric-green)",
-  cursor: "var(--metric-cyan)",
+  cursor: "#f54e00",
   gemini: "var(--metric-purple)",
   grok: "var(--metric-red)",
   opencode: "var(--metric-blue)",
@@ -24,9 +24,19 @@ export const ProviderDistributionChart: React.FC<ProviderDistributionChartProps>
   providers,
 }) => {
   const { t } = useTranslation();
-  const sortedProviders = [...providers].sort((a, b) => b.tokens - a.tokens);
+  const sortedProviders = [...providers].sort(
+    (a, b) => b.tokens - a.tokens || b.sessions - a.sessions
+  );
   const totalTokens = sortedProviders.reduce((sum, provider) => sum + provider.tokens, 0);
-  const maxTokens = Math.max(...sortedProviders.map((provider) => provider.tokens), 1);
+  const totalSessions = sortedProviders.reduce((sum, provider) => sum + provider.sessions, 0);
+  const useSessionBars = totalTokens === 0;
+  const totalBarValue = useSessionBars ? totalSessions : totalTokens;
+  const maxBarValue = Math.max(
+    ...(useSessionBars
+      ? sortedProviders.map((provider) => provider.sessions)
+      : sortedProviders.map((provider) => provider.tokens)),
+    1
+  );
 
   if (sortedProviders.length === 0) {
     return (
@@ -42,8 +52,9 @@ export const ProviderDistributionChart: React.FC<ProviderDistributionChartProps>
       {sortedProviders.map((provider) => {
         const normalizedId = getProviderId(provider.provider_id);
         const color = PROVIDER_COLORS[normalizedId] ?? "var(--metric-purple)";
-        const percentage = totalTokens > 0 ? (provider.tokens / totalTokens) * 100 : 0;
-        const barWidth = (provider.tokens / maxTokens) * 100;
+        const barValue = useSessionBars ? provider.sessions : provider.tokens;
+        const percentage = totalBarValue > 0 ? (barValue / totalBarValue) * 100 : 0;
+        const barWidth = (barValue / maxBarValue) * 100;
 
         return (
           <div
@@ -60,7 +71,9 @@ export const ProviderDistributionChart: React.FC<ProviderDistributionChartProps>
                   {getProviderLabel((key, fallback) => t(key, fallback), provider.provider_id)}
                 </span>
                 <span className="font-mono text-px11 font-semibold tabular-nums shrink-0 text-foreground">
-                  {provider.tokens.toLocaleString()}
+                  {useSessionBars
+                    ? provider.sessions.toLocaleString()
+                    : provider.tokens.toLocaleString()}
                 </span>
               </div>
 

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -80,6 +80,8 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'grok-4.3': { input: 1.25, output: 2.5, cacheWrite: 0, cacheRead: 0.20 },
   'grok-build': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
   'grok-4': { input: 3, output: 15, cacheWrite: 0, cacheRead: 0.75 },
+  // Cursor product-level label (not underlying Claude/GPT)
+  'cursor': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
 };
 
 const DEFAULT_PRICING: ModelPricing = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 };

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -446,7 +446,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   copilot: "bg-[#8250df]/15 text-[#6639ba] dark:text-[#d2a8ff]",
   cline: "bg-teal-500/15 text-teal-600 dark:text-teal-400",
   crush: "bg-pink-500/15 text-pink-600 dark:text-pink-400",
-  cursor: "bg-cyan-500/15 text-cyan-700 dark:text-cyan-300",
+  cursor: "bg-[#f54e00]/15 text-[#d04200] dark:text-[#ff6a2a]",
   "cursor-agent": "bg-violet-500/15 text-violet-600 dark:text-violet-400",
   forgecode: "bg-orange-500/15 text-orange-700 dark:text-orange-300",
   gemini: "bg-purple-500/15 text-purple-600 dark:text-purple-400",


### PR DESCRIPTION
## Summary

- split the Cursor-only provider work out of stacked PR #488
- support migrated global Composer data and legacy workspace Composer data
- include Cursor in provider detection, session/project stats, global provider/model distribution, and charts
- add Composer token attribution for global stats without loading full bubble bodies

## Verification

- Rust: 889 unit tests passed; integration: 4 passed, 5 environment-dependent tests ignored
- cargo fmt, clippy with all features
- frontend typecheck, lint, 83 test files / 960 tests, i18n validation

Original stacked PR: #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cursor as a supported analytics and statistics provider.
  * Added support for migrated and legacy Cursor session data, including workspace detection and project names.
  * Cursor session details now include model and token usage information.

* **Bug Fixes**
  * Provider distribution charts now remain informative when token usage is unavailable by using session counts.
  * Improved provider sorting and metric-based chart calculations.

* **Style**
  * Updated Cursor branding to use orange consistently across charts and provider badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->