### PR TITLE
feat(sessions): merge cross-file Claude session continuations

### DIFF
--- a/src-tauri/src/commands/session/chain.rs
+++ b/src-tauri/src/commands/session/chain.rs
@@ -1,0 +1,401 @@
+//! Cross-file session chain resolution.
+//!
+//! Claude Code sometimes auto-continues a conversation that ran out of context
+//! by starting a brand-new session file rather than compacting in place: the
+//! new file's `compact_boundary` system event carries a `logicalParentUuid`
+//! that points at the last message of the OLD file, not at anything in the
+//! new one. The rest of the app (session list, message loading) only ever
+//! looks at one file at a time, so that earlier half of the conversation was
+//! invisible in the viewer even though it's still on disk.
+//!
+//! This module detects that dangling link and walks it backward to the
+//! originating file(s), purely for display — nothing here reads or writes
+//! anything on disk beyond the existing `.jsonl` files.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use once_cell::sync::Lazy;
+
+/// Hard cap on how many hops `resolve_session_chain` will follow. Guards
+/// against a pathological or corrupted `logicalParentUuid` cycle; no real
+/// Claude Code conversation should ever chain this deep.
+const MAX_CHAIN_HOPS: usize = 50;
+
+/// A cheap fingerprint that changes when a session file is appended or
+/// replaced. The directory snapshot below also notices new/deleted candidate
+/// files, which matters when an orphaned boundary is completed later.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FileSignature {
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+type ProjectSnapshot = Vec<(PathBuf, FileSignature)>;
+
+#[derive(Clone)]
+struct CachedChain {
+    project_snapshot: ProjectSnapshot,
+    chain: Vec<PathBuf>,
+}
+
+/// Resolved chains are cheap to recompute but not free (each hop scans every
+/// `.jsonl` file in the project directory once), and the same session is
+/// re-resolved on every pagination page as the user scrolls. Cache for the
+/// life of the process, keyed by the leaf (most recent) session file path, but
+/// invalidate it whenever any candidate file changes.
+static SESSION_CHAIN_CACHE: Lazy<Mutex<HashMap<String, CachedChain>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn file_signature(path: &Path) -> Option<FileSignature> {
+    let metadata = fs::metadata(path).ok()?;
+    Some(FileSignature {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+fn project_snapshot(project_dir: &Path) -> Option<ProjectSnapshot> {
+    let mut snapshot = Vec::new();
+    for entry in fs::read_dir(project_dir).ok()? {
+        let entry = entry.ok()?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        snapshot.push((path.clone(), file_signature(&path)?));
+    }
+    snapshot.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    Some(snapshot)
+}
+
+#[derive(serde::Deserialize)]
+struct BoundaryClassifier {
+    #[serde(rename = "type")]
+    message_type: String,
+    subtype: Option<String>,
+    uuid: Option<String>,
+    #[serde(rename = "logicalParentUuid")]
+    logical_parent_uuid: Option<String>,
+}
+
+/// Scan a session file for the first `compact_boundary` event whose
+/// `logicalParentUuid` is NOT among this file's own message uuids. That
+/// absence is exactly what marks "this file's history starts abruptly here;
+/// the messages before it live in a different file."
+fn find_dangling_parent_uuid(path: &Path) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
+
+    let mut own_uuids: HashSet<String> = HashSet::new();
+    let mut boundary_parents: Vec<String> = Vec::new();
+
+    for line in reader.lines() {
+        let Ok(line) = line else { continue };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(entry) = serde_json::from_str::<BoundaryClassifier>(trimmed) else {
+            continue;
+        };
+        if let Some(uuid) = entry.uuid {
+            own_uuids.insert(uuid);
+        }
+        if entry.message_type == "system" && entry.subtype.as_deref() == Some("compact_boundary") {
+            if let Some(parent) = entry.logical_parent_uuid {
+                boundary_parents.push(parent);
+            }
+        }
+    }
+
+    boundary_parents
+        .into_iter()
+        .find(|parent| !own_uuids.contains(parent))
+}
+
+/// Fast (non-JSON-parsing) check for whether `path` contains a message with
+/// the given `uuid`. A plain substring search is sufficient: uuids are random
+/// v4 strings, so an accidental match elsewhere in the file is not a realistic
+/// concern, and this avoids parsing every line of every candidate file.
+fn file_contains_uuid(path: &Path, target_uuid: &str) -> bool {
+    let Ok(content) = fs::read(path) else {
+        return false;
+    };
+    let needle = format!("\"uuid\":\"{target_uuid}\"");
+    memchr::memmem::find(&content, needle.as_bytes()).is_some()
+}
+
+/// Search the (flat) project directory for a session file containing a
+/// message with `target_uuid`, skipping anything in `skip`. Only looks at the
+/// project root, not `subagents/` or other nested dirs — a session chain's
+/// predecessor is always another top-level session file.
+fn find_file_containing_uuid(
+    project_dir: &Path,
+    target_uuid: &str,
+    skip: &HashSet<PathBuf>,
+) -> Option<PathBuf> {
+    let entries = fs::read_dir(project_dir).ok()?;
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        if skip.contains(&path) {
+            continue;
+        }
+        if file_contains_uuid(&path, target_uuid) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Resolve the full chain of session files that make up one logical
+/// conversation, oldest first, ending with `session_path` itself. For a
+/// session with no cross-file continuation this is just `[session_path]`.
+pub fn resolve_session_chain(session_path: &Path) -> Vec<PathBuf> {
+    let key = session_path.to_string_lossy().to_string();
+    let cached_snapshot = session_path.parent().and_then(project_snapshot);
+    if let Some(snapshot) = cached_snapshot.as_ref() {
+        if let Some(cached) = SESSION_CHAIN_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&key)
+        {
+            if cached.project_snapshot == *snapshot {
+                return cached.chain.clone();
+            }
+        }
+    }
+
+    let mut chain: Vec<PathBuf> = vec![session_path.to_path_buf()];
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    visited.insert(session_path.to_path_buf());
+
+    let mut current = session_path.to_path_buf();
+    for _ in 0..MAX_CHAIN_HOPS {
+        let Some(parent_uuid) = find_dangling_parent_uuid(&current) else {
+            break;
+        };
+        let Some(project_dir) = current.parent() else {
+            break;
+        };
+        let Some(predecessor) = find_file_containing_uuid(project_dir, &parent_uuid, &visited)
+        else {
+            break;
+        };
+        chain.insert(0, predecessor.clone());
+        visited.insert(predecessor.clone());
+        current = predecessor;
+    }
+
+    if let Some(snapshot) = session_path.parent().and_then(project_snapshot) {
+        SESSION_CHAIN_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(
+                key,
+                CachedChain {
+                    project_snapshot: snapshot,
+                    chain: chain.clone(),
+                },
+            );
+    }
+
+    chain
+}
+
+/// Every file in `project_root` that is a non-final link in some OTHER
+/// file's resolved chain — i.e. an earlier half of a conversation that a
+/// newer session file already supersedes. The session list hides these by
+/// default so a Claude Code auto-continuation shows as one entry, not two;
+/// as a chain grows another hop, the file that used to be the leaf becomes
+/// superseded in turn and drops out on the next list refresh.
+pub fn superseded_chain_paths(project_root: &Path) -> HashSet<PathBuf> {
+    let mut superseded = HashSet::new();
+    let Ok(entries) = fs::read_dir(project_root) else {
+        return superseded;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let chain = resolve_session_chain(&path);
+        if chain.len() > 1 {
+            for predecessor in &chain[..chain.len() - 1] {
+                superseded.insert(predecessor.clone());
+            }
+        }
+    }
+    superseded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn no_chain_for_a_normal_session() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "a.jsonl",
+            "{\"uuid\":\"u1\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+        );
+        let chain = resolve_session_chain(&path);
+        assert_eq!(chain, vec![path]);
+    }
+
+    #[test]
+    fn resolves_a_two_hop_chain() {
+        let dir = TempDir::new().unwrap();
+        let older = write_file(
+            &dir,
+            "older.jsonl",
+            "{\"uuid\":\"tail-uuid\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[]}}\n",
+        );
+        let newer = write_file(
+            &dir,
+            "newer.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-1\",",
+                "\"logicalParentUuid\":\"tail-uuid\"}\n",
+                "{\"uuid\":\"u2\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"continuing\"}}\n",
+            ),
+        );
+
+        let chain = resolve_session_chain(&newer);
+        assert_eq!(chain, vec![older, newer]);
+    }
+
+    #[test]
+    fn stops_when_the_parent_uuid_is_nowhere_to_be_found() {
+        let dir = TempDir::new().unwrap();
+        let newer = write_file(
+            &dir,
+            "orphan.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-1\",",
+                "\"logicalParentUuid\":\"missing-uuid\"}\n",
+                "{\"uuid\":\"u2\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+            ),
+        );
+
+        let chain = resolve_session_chain(&newer);
+        assert_eq!(chain, vec![newer]);
+    }
+
+    #[test]
+    fn invalidates_cache_when_a_missing_predecessor_appears() {
+        let dir = TempDir::new().unwrap();
+        let newer = write_file(
+            &dir,
+            "newer.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-1\",",
+                "\"logicalParentUuid\":\"tail-uuid\"}\n",
+                "{\"uuid\":\"u2\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"continuing\"}}\n",
+            ),
+        );
+
+        assert_eq!(resolve_session_chain(&newer), vec![newer.clone()]);
+
+        let older = write_file(
+            &dir,
+            "older.jsonl",
+            "{\"uuid\":\"tail-uuid\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[]}}\n",
+        );
+
+        assert_eq!(resolve_session_chain(&newer), vec![older, newer]);
+    }
+
+    #[test]
+    fn stops_at_a_cycle_without_repeating_files() {
+        let dir = TempDir::new().unwrap();
+        let first = write_file(
+            &dir,
+            "first.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-a\",",
+                "\"logicalParentUuid\":\"uuid-b\"}\n",
+                "{\"uuid\":\"uuid-a\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"a\"}}\n",
+            ),
+        );
+        let second = write_file(
+            &dir,
+            "second.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-b\",",
+                "\"logicalParentUuid\":\"uuid-a\"}\n",
+                "{\"uuid\":\"uuid-b\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"b\"}}\n",
+            ),
+        );
+
+        assert_eq!(resolve_session_chain(&second), vec![first, second]);
+    }
+
+    #[test]
+    fn respects_the_maximum_chain_hop_limit() {
+        let dir = TempDir::new().unwrap();
+        let mut paths = Vec::new();
+        for index in 0..=MAX_CHAIN_HOPS {
+            let boundary = if index == 0 {
+                String::new()
+            } else {
+                format!(
+                    "{{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-{index}\",\"logicalParentUuid\":\"uuid-{}\"}}\n",
+                    index - 1
+                )
+            };
+            let content = format!(
+                "{boundary}{{\"uuid\":\"uuid-{index}\",\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\"{index}\"}}}}\n"
+            );
+            paths.push(write_file(&dir, &format!("chain-{index}.jsonl"), &content));
+        }
+
+        let chain = resolve_session_chain(paths.last().unwrap());
+        assert_eq!(chain.len(), MAX_CHAIN_HOPS + 1);
+    }
+
+    #[test]
+    fn superseded_paths_hides_only_non_leaf_files() {
+        let dir = TempDir::new().unwrap();
+        let older = write_file(
+            &dir,
+            "older.jsonl",
+            "{\"uuid\":\"tail-uuid\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[]}}\n",
+        );
+        let newer = write_file(
+            &dir,
+            "newer.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-1\",",
+                "\"logicalParentUuid\":\"tail-uuid\"}\n",
+                "{\"uuid\":\"u2\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"continuing\"}}\n",
+            ),
+        );
+        let unrelated = write_file(
+            &dir,
+            "unrelated.jsonl",
+            "{\"uuid\":\"u3\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+        );
+
+        let superseded = superseded_chain_paths(dir.path());
+        assert!(superseded.contains(&older));
+        assert!(!superseded.contains(&newer));
+        assert!(!superseded.contains(&unrelated));
+    }
+}

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -846,7 +846,11 @@ fn session_with_sidechain_filter(
     mut session: ClaudeSession,
     sidechain_count: usize,
     exclude: bool,
+    superseded: &std::collections::HashSet<PathBuf>,
 ) -> Option<ClaudeSession> {
+    if superseded.contains(Path::new(&session.file_path)) {
+        return None;
+    }
     if exclude {
         session.message_count = session.message_count.saturating_sub(sidechain_count);
         if session.message_count == 0 {
@@ -1090,6 +1094,12 @@ pub async fn load_project_sessions_page(
     let mut cache = load_cache(&project_path);
     let mut cache_updated = false;
 
+    // Hide files that are a non-leaf link in some other session's resolved
+    // continuation chain (see `chain.rs`) — a Claude Code auto-continuation
+    // shows as one entry (the leaf, which now renders the full merged
+    // history) instead of one entry per file.
+    let superseded = super::chain::superseded_chain_paths(project_root);
+
     let mut candidates: Vec<SessionPageCandidate> = Vec::new();
     let mut known_dropped_candidates = 0usize;
 
@@ -1122,6 +1132,7 @@ pub async fn load_project_sessions_page(
                         session.clone(),
                         cached.sidechain_count,
                         exclude,
+                        &superseded,
                     )
                     .is_some()
                     {
@@ -1212,9 +1223,12 @@ pub async fn load_project_sessions_page(
         for (source, result_opt) in results {
             match source {
                 SessionPageCandidateSource::Cached(session, sidechain_count) => {
-                    if let Some(session) =
-                        session_with_sidechain_filter(*session, sidechain_count, exclude)
-                    {
+                    if let Some(session) = session_with_sidechain_filter(
+                        *session,
+                        sidechain_count,
+                        exclude,
+                        &superseded,
+                    ) {
                         sessions.push(session);
                     } else {
                         newly_dropped_candidates = newly_dropped_candidates.saturating_add(1);
@@ -1274,6 +1288,7 @@ pub async fn load_project_sessions_page(
                             result.session,
                             result.sidechain_count,
                             exclude,
+                            &superseded,
                         ) {
                             sessions.push(session);
                         } else {
@@ -1518,6 +1533,15 @@ pub async fn load_project_sessions(
 
     // 6. Sort by last message time (conversation time) instead of filesystem modification time
     sessions.sort_by(|a, b| b.last_message_time.cmp(&a.last_message_time));
+
+    // 7. Hide files that are a non-leaf link in some other session's resolved
+    // continuation chain (see `chain.rs`) — a Claude Code auto-continuation
+    // shows as one entry (the leaf, which now renders the full merged
+    // history) instead of one entry per file.
+    let superseded = super::chain::superseded_chain_paths(Path::new(&project_path));
+    if !superseded.is_empty() {
+        sessions.retain(|s| !superseded.contains(Path::new(&s.file_path)));
+    }
 
     // 8. Summary propagation
     propagate_session_summaries(&mut sessions);
@@ -1816,9 +1840,52 @@ pub async fn load_session_messages(session_path: String) -> Result<Vec<ClaudeMes
     #[cfg(debug_assertions)]
     let start_time = std::time::Instant::now();
 
+    // Resolve any cross-file continuation chain (see `chain.rs`) and load
+    // every file in it, oldest first, so a session that Claude Code split
+    // across files after running out of context still reads as one
+    // conversation. For the common case (no chain) this is just `[session_path]`.
+    let chain = super::chain::resolve_session_chain(Path::new(&session_path));
+    let mut messages: Vec<ClaudeMessage> = Vec::new();
+    for (index, path) in chain.iter().enumerate() {
+        let is_leaf = index + 1 == chain.len();
+        match load_all_messages_from_file(path) {
+            Ok(file_messages) => messages.extend(file_messages),
+            Err(error) if is_leaf => return Err(error),
+            Err(error) => {
+                // A predecessor can disappear while Claude Code is rotating
+                // files. Preserve the readable part of the conversation and
+                // make the leaf failure fatal because it is the requested
+                // session itself.
+                log::warn!(
+                    "Skipping unreadable predecessor in session chain {}: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    {
+        let elapsed = start_time.elapsed();
+        eprintln!(
+            "📤 [load_session_messages] {} messages across {} file(s), {}ms elapsed (simd-json + mmap optimized)",
+            messages.len(),
+            chain.len(),
+            elapsed.as_millis()
+        );
+    }
+
+    Ok(messages)
+}
+
+/// Load every viewer-visible message from a single `.jsonl` file, in order.
+/// Factored out of `load_session_messages` so it can be called once per file
+/// in a resolved continuation chain.
+#[allow(unsafe_code)] // Required for mmap performance optimization
+fn load_all_messages_from_file(session_path: &Path) -> Result<Vec<ClaudeMessage>, String> {
     // Use memory-mapped file for faster I/O
     let file =
-        fs::File::open(&session_path).map_err(|e| format!("Failed to open session file: {e}"))?;
+        fs::File::open(session_path).map_err(|e| format!("Failed to open session file: {e}"))?;
 
     // SAFETY: We're only reading the file, and the file handle is kept open
     // for the duration of the mmap's lifetime. No concurrent modifications expected
@@ -1858,19 +1925,7 @@ pub async fn load_session_messages(session_path: String) -> Result<Vec<ClaudeMes
 
     // Sort by line number to maintain original order
     messages.sort_by_key(|(line_num, _)| *line_num);
-    let messages: Vec<ClaudeMessage> = messages.into_iter().map(|(_, msg)| msg).collect();
-
-    #[cfg(debug_assertions)]
-    {
-        let elapsed = start_time.elapsed();
-        eprintln!(
-            "📤 [load_session_messages] {} messages, {}ms elapsed (simd-json + mmap optimized)",
-            messages.len(),
-            elapsed.as_millis()
-        );
-    }
-
-    Ok(messages)
+    Ok(messages.into_iter().map(|(_, msg)| msg).collect())
 }
 
 // ============================================================================
@@ -2187,20 +2242,22 @@ pub fn get_session_message_offset(
     Ok(None)
 }
 
-#[tauri::command]
+/// Load a chat-style window of messages from a SINGLE file (the pre-chain
+/// pagination algorithm, unchanged). `offset_from_end` counts messages
+/// already consumed from the newest end of this file.
+///
+/// Returns the window's messages (oldest-to-newest), this file's own total
+/// viewer-visible message count, and whether the window reached line 0 of
+/// the file (i.e. there is nothing older left to read from this file).
 #[allow(unsafe_code)] // Required for mmap performance optimization
-pub async fn load_session_messages_paginated(
-    session_path: String,
-    offset: usize,
+fn load_message_window_from_file(
+    session_path: &Path,
+    offset_from_end: usize,
     limit: usize,
-    exclude_sidechain: Option<bool>,
-) -> Result<MessagePage, String> {
-    #[cfg(debug_assertions)]
-    let start_time = std::time::Instant::now();
-
-    // Use memory-mapped file for faster I/O
+    exclude: bool,
+) -> Result<(Vec<ClaudeMessage>, usize, bool), String> {
     let file =
-        fs::File::open(&session_path).map_err(|e| format!("Failed to open session file: {e}"))?;
+        fs::File::open(session_path).map_err(|e| format!("Failed to open session file: {e}"))?;
 
     // SAFETY: We're only reading the file, and the file handle is kept open
     // for the duration of the mmap's lifetime. No concurrent modifications expected
@@ -2208,47 +2265,25 @@ pub async fn load_session_messages_paginated(
     let mmap = unsafe { Mmap::map(&file) }
         .map_err(|e| format!("Failed to memory-map session file: {e}"))?;
 
-    let exclude = exclude_sidechain.unwrap_or(false);
-
-    // Find line boundaries efficiently using SIMD-accelerated memchr
     let line_ranges = find_line_ranges(&mmap);
 
-    // Phase 1: Build valid line indices (fast classification)
     let valid_indices: Vec<usize> = line_ranges
         .iter()
         .enumerate()
-        .filter(|(_, &(start, end))| {
-            let line = &mmap[start..end];
-            classify_line_fast(line, exclude)
-        })
+        .filter(|(_, &(start, end))| classify_line_fast(&mmap[start..end], exclude))
         .map(|(idx, _)| idx)
         .collect();
 
     let total_count = valid_indices.len();
-
-    // Chat-style pagination: offset=0 means newest messages (at the end)
-    if total_count == 0 {
-        return Ok(MessagePage {
-            messages: vec![],
-            total_count: 0,
-            has_more: false,
-            next_offset: 0,
-        });
+    if total_count == 0 || offset_from_end >= total_count {
+        return Ok((vec![], total_count, offset_from_end >= total_count));
     }
 
-    let already_loaded = offset;
-    let remaining_messages = total_count.saturating_sub(already_loaded);
-    let messages_to_load = std::cmp::min(limit, remaining_messages);
+    let remaining_messages = total_count - offset_from_end;
+    let messages_to_load = limit.min(remaining_messages);
+    let start_idx = total_count - offset_from_end - messages_to_load;
+    let end_idx = total_count - offset_from_end;
 
-    let (start_idx, end_idx) = if remaining_messages == 0 {
-        (0, 0)
-    } else {
-        let start = total_count - already_loaded - messages_to_load;
-        let end = total_count - already_loaded;
-        (start, end)
-    };
-
-    // Phase 2: Parse only the target lines (parallel with simd-json)
     let target_indices = &valid_indices[start_idx..end_idx];
     let mut parsed: Vec<(usize, ClaudeMessage)> = target_indices
         .par_iter()
@@ -2260,37 +2295,17 @@ pub async fn load_session_messages_paginated(
         })
         .collect();
 
-    // Sort by line number to maintain original order
     parsed.sort_by_key(|(line_num, _)| *line_num);
     let messages: Vec<ClaudeMessage> = parsed.into_iter().map(|(_, msg)| msg).collect();
 
-    let has_more = start_idx > 0;
-    let next_offset = offset + messages.len();
-
-    #[cfg(debug_assertions)]
-    {
-        let elapsed = start_time.elapsed();
-        eprintln!("📊 load_session_messages_paginated performance: {}/{} messages, {}ms elapsed (simd-json + mmap)",
-                 messages.len(), total_count, elapsed.as_millis());
-    }
-
-    Ok(MessagePage {
-        messages,
-        total_count,
-        has_more,
-        next_offset,
-    })
+    Ok((messages, total_count, start_idx == 0))
 }
 
-#[tauri::command]
+/// Count viewer-visible messages in a single file (the pre-chain algorithm).
 #[allow(unsafe_code)] // Required for mmap performance optimization
-pub async fn get_session_message_count(
-    session_path: String,
-    exclude_sidechain: Option<bool>,
-) -> Result<usize, String> {
-    // Use memory-mapped file for faster I/O
+fn count_valid_messages_in_file(session_path: &Path, exclude: bool) -> Result<usize, String> {
     let file =
-        fs::File::open(&session_path).map_err(|e| format!("Failed to open session file: {e}"))?;
+        fs::File::open(session_path).map_err(|e| format!("Failed to open session file: {e}"))?;
 
     // SAFETY: We're only reading the file, and the file handle is kept open
     // for the duration of the mmap's lifetime. No concurrent modifications expected
@@ -2298,21 +2313,129 @@ pub async fn get_session_message_count(
     let mmap = unsafe { Mmap::map(&file) }
         .map_err(|e| format!("Failed to memory-map session file: {e}"))?;
 
-    let exclude = exclude_sidechain.unwrap_or(false);
-
-    // Find line boundaries and count valid lines using SIMD-accelerated memchr
     let line_ranges = find_line_ranges(&mmap);
-
-    // Parallel counting with fast classification
-    let count: usize = line_ranges
+    Ok(line_ranges
         .par_iter()
-        .filter(|&&(start, end)| {
-            let line = &mmap[start..end];
-            classify_line_fast(line, exclude)
-        })
-        .count();
+        .filter(|&&(start, end)| classify_line_fast(&mmap[start..end], exclude))
+        .count())
+}
 
-    Ok(count)
+#[tauri::command]
+#[allow(unsafe_code)] // Required for mmap performance optimization
+pub async fn load_session_messages_paginated(
+    session_path: String,
+    offset: usize,
+    limit: usize,
+    exclude_sidechain: Option<bool>,
+) -> Result<MessagePage, String> {
+    #[cfg(debug_assertions)]
+    let start_time = std::time::Instant::now();
+
+    let exclude = exclude_sidechain.unwrap_or(false);
+    let chain = super::chain::resolve_session_chain(Path::new(&session_path));
+
+    let page = if chain.len() <= 1 {
+        // Common case: no cross-file continuation. Same algorithm and
+        // performance characteristics as before this feature existed.
+        let (messages, total_count, _) =
+            load_message_window_from_file(Path::new(&session_path), offset, limit, exclude)?;
+        let next_offset = offset + messages.len();
+        MessagePage {
+            messages,
+            total_count,
+            has_more: next_offset < total_count,
+            next_offset,
+        }
+    } else {
+        // Chained session: walk the files newest -> oldest, consuming the
+        // requested chat-style window, then present them oldest -> newest.
+        let mut skip = offset;
+        let mut remaining = limit;
+        let mut chunks: Vec<Vec<ClaudeMessage>> = Vec::new();
+        let mut total_count = 0usize;
+
+        for idx in (0..chain.len()).rev() {
+            let is_leaf = idx + 1 == chain.len();
+            // Keep scanning older files after the requested page is full so
+            // total_count remains exact, but pass limit=0 to avoid parsing
+            // message payloads a second time.
+            let requested_limit = if remaining == 0 { 0 } else { remaining };
+            let requested_offset = if remaining == 0 { 0 } else { skip };
+            let result = load_message_window_from_file(
+                &chain[idx],
+                requested_offset,
+                requested_limit,
+                exclude,
+            );
+            let (messages, file_total, _) = match result {
+                Ok(result) => result,
+                Err(error) if is_leaf => return Err(error),
+                Err(error) => {
+                    log::warn!(
+                        "Skipping unreadable predecessor in paginated session chain {}: {error}",
+                        chain[idx].display()
+                    );
+                    continue;
+                }
+            };
+
+            total_count += file_total;
+            if remaining == 0 {
+                continue;
+            }
+            if skip >= file_total {
+                skip -= file_total;
+                continue;
+            }
+            remaining -= messages.len();
+            chunks.push(messages);
+            skip = 0;
+        }
+
+        chunks.reverse();
+        let messages: Vec<ClaudeMessage> = chunks.into_iter().flatten().collect();
+        let next_offset = offset + messages.len();
+        MessagePage {
+            messages,
+            total_count,
+            has_more: next_offset < total_count,
+            next_offset,
+        }
+    };
+
+    #[cfg(debug_assertions)]
+    {
+        let elapsed = start_time.elapsed();
+        eprintln!("📊 load_session_messages_paginated performance: {}/{} messages across {} file(s), {}ms elapsed (simd-json + mmap)",
+                 page.messages.len(), page.total_count, chain.len(), elapsed.as_millis());
+    }
+
+    Ok(page)
+}
+
+#[tauri::command]
+pub async fn get_session_message_count(
+    session_path: String,
+    exclude_sidechain: Option<bool>,
+) -> Result<usize, String> {
+    let exclude = exclude_sidechain.unwrap_or(false);
+    let chain = super::chain::resolve_session_chain(Path::new(&session_path));
+
+    let mut total = 0usize;
+    for (index, path) in chain.iter().enumerate() {
+        let is_leaf = index + 1 == chain.len();
+        match count_valid_messages_in_file(path, exclude) {
+            Ok(file_total) => total += file_total,
+            Err(error) if is_leaf => return Err(error),
+            Err(error) => {
+                log::warn!(
+                    "Skipping unreadable predecessor in session count chain {}: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(total)
 }
 
 #[cfg(test)]
@@ -2489,6 +2612,50 @@ mod tests {
         assert_eq!(page.total_count, 5);
         assert_eq!(page.messages.len(), 3);
         assert!(page.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_load_session_messages_paginated_merges_continuation_chain() {
+        let temp_dir = TempDir::new().unwrap();
+        let older_content = format!(
+            "{}\n{}\n",
+            create_sample_user_message("uuid-1", "session-1", "Before"),
+            create_sample_assistant_message("tail-uuid", "session-1", "Earlier reply")
+        );
+        create_test_jsonl_file(&temp_dir, "older.jsonl", &older_content);
+
+        let newer_content = format!(
+            "{{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-1\",\"logicalParentUuid\":\"tail-uuid\",\"sessionId\":\"session-2\",\"timestamp\":\"2025-06-26T10:02:00Z\"}}\n{}\n{}\n",
+            create_sample_user_message("uuid-3", "session-2", "After"),
+            create_sample_assistant_message("uuid-4", "session-2", "Latest reply")
+        );
+        let newer_path = create_test_jsonl_file(&temp_dir, "newer.jsonl", &newer_content);
+        let newer_path_string = newer_path.to_string_lossy().to_string();
+
+        let all_messages = load_session_messages(newer_path_string.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            all_messages
+                .iter()
+                .map(|message| message.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["uuid-1", "tail-uuid", "boundary-1", "uuid-3", "uuid-4"]
+        );
+        assert_eq!(
+            get_session_message_count(newer_path_string.clone(), None)
+                .await
+                .unwrap(),
+            5
+        );
+
+        let first_page = load_session_messages_paginated(newer_path_string, 0, 3, None)
+            .await
+            .unwrap();
+        assert_eq!(first_page.total_count, 5);
+        assert_eq!(first_page.messages.len(), 3);
+        assert_eq!(first_page.messages[0].uuid, "boundary-1");
+        assert!(first_page.has_more);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -7,6 +7,7 @@
 //! - `rename`: Native session renaming functions
 //! - `delete`: Session deletion
 
+mod chain;
 mod delete;
 mod edits;
 mod load;
@@ -15,6 +16,7 @@ mod resume;
 mod search;
 
 // Re-export all commands
+pub use chain::{resolve_session_chain, superseded_chain_paths};
 pub use delete::*;
 pub use edits::*;
 pub use load::*;

--- a/src/store/slices/watcherSlice.ts
+++ b/src/store/slices/watcherSlice.ts
@@ -69,7 +69,13 @@ export const createWatcherSlice: StateCreator<
 
     const timer = setTimeout(() => {
       projectUpdateTimers.delete(projectPath);
-      get().markProjectUpdated(projectPath);
+      // Reload the project's session list (not just a timestamp) so that a
+      // newly-created session file — e.g. a Claude Code auto-continuation —
+      // shows up, and superseded-chain-predecessor filtering on the backend
+      // re-runs with the new file present. `triggerProjectRefresh` is a
+      // no-op beyond marking the timestamp when `projectPath` isn't the
+      // currently selected project, so this is safe to call unconditionally.
+      void get().triggerProjectRefresh(projectPath);
     }, PROJECT_UPDATE_DEBOUNCE_MS);
 
     projectUpdateTimers.set(projectPath, timer);


### PR DESCRIPTION
Split from #491 to isolate the session-continuation implementation.

Scope:
- Resolve Claude compact-boundary logicalParentUuid links across top-level JSONL files.
- Cache safely with file/directory signature invalidation, cycle and hop guards.
- Hide superseded predecessor files and merge full and paginated message loading.
- Refresh the selected project when a new continuation file appears.

Intentionally excludes the original PR’s KaTeX/Markdown rendering, window-size, and Tauri config changes.

Verification: Rust 897 tests passed serially; integration 4 passed/5 ignored; clippy and fmt passed; frontend tsc, ESLint, Vitest 83 files/960 tests, and i18n validation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions split across multiple conversation files are now combined into a single chronological conversation.
  * Session messages, pagination, and message counts now include linked continuation files.
  * Superseded session files are hidden from project session lists.

* **Bug Fixes**
  * Project session lists now refresh automatically after detected project changes.
  * Missing or unreadable predecessor files are handled gracefully while preserving access to valid conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->