### PR TITLE
feat(markdown): render LaTeX math formulas via KaTeX

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "html-to-image": "^1.11.13",
     "i18next": "^25.3.0",
     "i18next-browser-languagedetector": "^8.2.0",
+    "katex": "^0.18.1",
     "lucide-react": "^0.300.0",
     "marked": "^17.0.4",
     "overlayscrollbars": "^2.13.0",
@@ -61,7 +62,9 @@
     "react-i18next": "^15.5.3",
     "react-markdown": "^10.1.0",
     "react-window": "1.8.11",
+    "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.0.0",
     "zustand": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "html-to-image": "^1.11.13",
     "i18next": "^25.3.0",
     "i18next-browser-languagedetector": "^8.2.0",
-    "katex": "^0.18.1",
+    "katex": "^0.16.47",
     "lucide-react": "^0.300.0",
     "marked": "^17.0.4",
     "overlayscrollbars": "^2.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.2.0
         version: 8.2.0
+      katex:
+        specifier: ^0.18.1
+        version: 0.18.1
       lucide-react:
         specifier: ^0.300.0
         version: 0.300.0(react@19.2.3)
@@ -142,9 +145,15 @@ importers:
       react-window:
         specifier: 1.8.11
         version: 1.8.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      rehype-katex:
+        specifier: ^7.0.1
+        version: 7.0.1
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-math:
+        specifier: ^6.0.0
+        version: 6.0.0
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1625,6 +1634,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1965,6 +1977,10 @@ packages:
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -2354,11 +2370,35 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -2615,6 +2655,14 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  katex@0.18.1:
+    resolution: {integrity: sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2791,6 +2839,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
@@ -2845,6 +2896,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -3201,8 +3255,14 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  rehype-katex@7.0.1:
+    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -3504,11 +3564,17 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -3562,6 +3628,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -3654,6 +3723,9 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -5088,6 +5160,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/katex@0.16.8': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -5467,6 +5541,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@14.0.2: {}
+
+  commander@8.3.0: {}
 
   concat-map@0.0.1: {}
 
@@ -5891,6 +5967,47 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -5911,9 +6028,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   hermes-estree@0.25.1: {}
 
@@ -6159,6 +6291,14 @@ snapshots:
 
   json5@2.2.3: {}
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  katex@0.18.1:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6388,6 +6528,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -6541,6 +6693,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.47
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -6964,6 +7126,16 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  rehype-katex@7.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/katex': 0.16.8
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      katex: 0.16.47
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6971,6 +7143,15 @@ snapshots:
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -7296,6 +7477,11 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -7303,6 +7489,11 @@ snapshots:
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.0.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -7356,6 +7547,11 @@ snapshots:
       react: 19.2.3
 
   util-deprecate@1.0.2: {}
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
 
   vfile-message@4.0.3:
     dependencies:
@@ -7427,6 +7623,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
+
+  web-namespaces@2.0.1: {}
 
   webidl-conversions@7.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       katex:
-        specifier: ^0.18.1
-        version: 0.18.1
+        specifier: ^0.16.47
+        version: 0.16.47
       lucide-react:
         specifier: ^0.300.0
         version: 0.300.0(react@19.2.3)
@@ -2657,10 +2657,6 @@ packages:
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
-    hasBin: true
-
-  katex@0.18.1:
-    resolution: {integrity: sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==}
     hasBin: true
 
   keyv@4.5.4:
@@ -6292,10 +6288,6 @@ snapshots:
   json5@2.2.3: {}
 
   katex@0.16.47:
-    dependencies:
-      commander: 8.3.0
-
-  katex@0.18.1:
     dependencies:
       commander: 8.3.0
 

--- a/src/components/FileContent.tsx
+++ b/src/components/FileContent.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { FileText } from "lucide-react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { Highlight, themes } from "prism-react-renderer";
 import { useCopyButton } from "../hooks/useCopyButton";
 import { useTheme } from "@/contexts/theme";
@@ -257,7 +257,7 @@ export const FileContent = ({
               </div>
               {language === "markdown" ? (
                 <div className={`p-4 bg-tool-file/5 text-foreground ${layout.prose}`}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                     {displayContent}
                   </ReactMarkdown>
                 </div>

--- a/src/components/common/Markdown.tsx
+++ b/src/components/common/Markdown.tsx
@@ -12,16 +12,9 @@
 
 import { memo } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
-import rehypeKatex from "rehype-katex";
-import "katex/dist/katex.min.css";
 import { layout } from "@/components/renderers";
 import { cn } from "@/lib/utils";
-
-/** Module-level plugin arrays for stable reference across renders. */
-const REMARK_PLUGINS = [remarkGfm, remarkMath];
-const REHYPE_PLUGINS = [rehypeKatex];
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 
 interface MarkdownProps {
   children: string;

--- a/src/components/common/Markdown.tsx
+++ b/src/components/common/Markdown.tsx
@@ -1,21 +1,27 @@
 /**
  * Shared Markdown renderer with centralized plugin configuration.
  *
- * Wraps ReactMarkdown with remarkGfm and a consistent `layout.prose` wrapper.
- * Use this for all simple markdown rendering across the app.
+ * Wraps ReactMarkdown with remarkGfm + remarkMath/rehypeKatex (renders
+ * `$inline$` and `$$block$$` LaTeX as formulas) and a consistent
+ * `layout.prose` wrapper. Use this for all simple markdown rendering across
+ * the app.
  *
  * For advanced use cases (custom components like CollapsibleTable, custom prose
- * classes), use ReactMarkdown directly with remarkGfm.
+ * classes), use ReactMarkdown directly with the same plugin set.
  */
 
 import { memo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import "katex/dist/katex.min.css";
 import { layout } from "@/components/renderers";
 import { cn } from "@/lib/utils";
 
-/** Module-level plugin array for stable reference across renders. */
-const REMARK_PLUGINS = [remarkGfm];
+/** Module-level plugin arrays for stable reference across renders. */
+const REMARK_PLUGINS = [remarkGfm, remarkMath];
+const REHYPE_PLUGINS = [rehypeKatex];
 
 interface MarkdownProps {
   children: string;
@@ -26,7 +32,7 @@ interface MarkdownProps {
 export const Markdown = memo(function Markdown({ children, className }: MarkdownProps) {
   return (
     <div className={cn(layout.prose, className)}>
-      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} skipHtml>
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
         {children}
       </ReactMarkdown>
     </div>

--- a/src/components/contentRenderer/CommandRenderer.tsx
+++ b/src/components/contentRenderer/CommandRenderer.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Terminal, CheckCircle, AlertCircle, Info, ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { cn } from "@/lib/utils";
 import { layout } from "@/components/renderers";
 import { useCaptureExpandState } from "@/contexts/CaptureExpandContext";
@@ -331,7 +331,7 @@ export const CommandRenderer = ({
                 isError ? "bg-destructive/5 text-destructive" : "bg-success/5 text-success"
               )}
             >
-              <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>{output.content}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>{output.content}</ReactMarkdown>
             </div>
           </div>
         );
@@ -389,7 +389,7 @@ export const CommandRenderer = ({
       {/* Remaining Text */}
       {withoutCommands && (
         <div className={layout.prose}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+          <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
             {withoutCommands}
           </ReactMarkdown>
         </div>

--- a/src/components/contentRenderer/TaskNotificationRenderer.tsx
+++ b/src/components/contentRenderer/TaskNotificationRenderer.tsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { cn } from "@/lib/utils";
 import { layout, getVariantStyles } from "@/components/renderers";
 import { useCaptureExpandState } from "@/contexts/CaptureExpandContext";
@@ -192,7 +192,7 @@ const TaskRow = memo(function TaskRow({
             )}>
               {notification.result ? (
                 <div className={cn(layout.prose, "text-2xs")}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                     {notification.result}
                   </ReactMarkdown>
                 </div>
@@ -442,7 +442,7 @@ export const TaskNotificationRenderer = memo(function TaskNotificationRenderer({
               {isDetailsExpanded ? (
                 // Full content
                 <div className={cn(layout.prose, "text-2xs animate-fade-in")}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                     {remainingText}
                   </ReactMarkdown>
                 </div>
@@ -457,7 +457,7 @@ export const TaskNotificationRenderer = memo(function TaskNotificationRenderer({
                     "text-2xs",
                     "line-clamp-3 text-muted-foreground"
                   )}>
-                    <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                    <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                       {getPreviewLines(remainingText, 3)}
                     </ReactMarkdown>
                   </div>

--- a/src/components/messageRenderer/MessageContentDisplay.tsx
+++ b/src/components/messageRenderer/MessageContentDisplay.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo, Children, isValidElement } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
-import rehypeKatex from "rehype-katex";
-import "katex/dist/katex.min.css";
 import { Copy, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CommandRenderer, ImageRenderer, TaskNotificationRenderer, hasTaskNotification } from "../contentRenderer";
@@ -12,14 +8,11 @@ import { TooltipButton } from "../../shared/TooltipButton";
 import { HighlightedText } from "../common";
 import { layout } from "@/components/renderers";
 import { cn } from "@/lib/utils";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { useCaptureExpandState } from "@/contexts/CaptureExpandContext";
 
 const LINE_LIMIT = 3;
 const TABLE_ROW_LIMIT = 2;
-
-/** Module-level plugin arrays for stable reference across renders. */
-const REMARK_PLUGINS = [remarkGfm, remarkMath];
-const REHYPE_PLUGINS = [rehypeKatex];
 
 // Get line count and preview text
 const getTextInfo = (text: string) => {

--- a/src/components/messageRenderer/MessageContentDisplay.tsx
+++ b/src/components/messageRenderer/MessageContentDisplay.tsx
@@ -1,6 +1,9 @@
 import React, { useMemo, Children, isValidElement } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import "katex/dist/katex.min.css";
 import { Copy, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CommandRenderer, ImageRenderer, TaskNotificationRenderer, hasTaskNotification } from "../contentRenderer";
@@ -13,6 +16,10 @@ import { useCaptureExpandState } from "@/contexts/CaptureExpandContext";
 
 const LINE_LIMIT = 3;
 const TABLE_ROW_LIMIT = 2;
+
+/** Module-level plugin arrays for stable reference across renders. */
+const REMARK_PLUGINS = [remarkGfm, remarkMath];
+const REHYPE_PLUGINS = [rehypeKatex];
 
 // Get line count and preview text
 const getTextInfo = (text: string) => {
@@ -279,7 +286,8 @@ export const MessageContentDisplay: React.FC<MessageContentDisplayProps> = ({
               "prose-ul:text-foreground prose-ol:text-foreground prose-li:text-foreground"
             )}>
               <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
+                remarkPlugins={REMARK_PLUGINS}
+                rehypePlugins={REHYPE_PLUGINS}
                 skipHtml
                 components={{
                   table: CollapsibleTable,

--- a/src/components/toolResultRenderer/ClaudeSessionHistoryRenderer.tsx
+++ b/src/components/toolResultRenderer/ClaudeSessionHistoryRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { MessageCircle, User, Bot, Wrench, X, ChevronRight } from "lucide-react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { useTranslation } from "react-i18next";
 import { formatTime } from "../../utils/time";
 import { layout } from "@/components/renderers";
@@ -108,7 +108,7 @@ export const ClaudeSessionHistoryRenderer = ({ content }: Props) => {
                 "content" in msg.message ? (
                   typeof msg.message.content === "string" ? (
                     <div className="prose prose-sm max-w-none prose-gray">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                         {msg.message.content}
                       </ReactMarkdown>
                     </div>
@@ -120,7 +120,7 @@ export const ClaudeSessionHistoryRenderer = ({ content }: Props) => {
                             {item.type === "text" &&
                               typeof item.text === "string" && (
                                 <div className="prose prose-sm max-w-none prose-gray">
-                                  <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                                  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                                     {item.text}
                                   </ReactMarkdown>
                                 </div>

--- a/src/components/toolResultRenderer/ClaudeToolResultItem.tsx
+++ b/src/components/toolResultRenderer/ClaudeToolResultItem.tsx
@@ -14,7 +14,7 @@ import { memo } from "react";
 import { Check, FileText, AlertTriangle, Folder, File, Wrench } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { Highlight, themes } from "prism-react-renderer";
 import { useCopyButton } from "../../hooks/useCopyButton";
 import { Renderer } from "../../shared/RendererHeader";
@@ -290,7 +290,7 @@ export const ClaudeToolResultItem = memo(function ClaudeToolResultItem({
         <div className={layout.bodyText}>
           {typeof content === "string" ? (
             <div className={layout.prose}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+              <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                 {content}
               </ReactMarkdown>
             </div>
@@ -304,7 +304,7 @@ export const ClaudeToolResultItem = memo(function ClaudeToolResultItem({
                   if (contentItem.type === "text" && typeof contentItem.text === "string") {
                     return (
                       <div key={idx} className={layout.prose}>
-                        <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                           {contentItem.text}
                         </ReactMarkdown>
                       </div>

--- a/src/components/toolResultRenderer/ContentArrayRenderer.tsx
+++ b/src/components/toolResultRenderer/ContentArrayRenderer.tsx
@@ -8,7 +8,7 @@
 import { Bot } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { ThinkingRenderer, ToolUseRenderer } from "../contentRenderer";
 import { ClaudeToolResultItem } from "./ClaudeToolResultItem";
 import { cn } from "@/lib/utils";
@@ -158,7 +158,7 @@ export const ContentArrayRenderer = ({ toolResult, searchQuery }: ContentArrayRe
                       itemObj.text.includes("</thinking>") ? (
                         <ThinkingRenderer thinking={itemObj.text} searchQuery={searchQuery} />
                       ) : (
-                        <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                           {itemObj.text}
                         </ReactMarkdown>
                       )}

--- a/src/components/toolResultRenderer/ErrorRenderer.tsx
+++ b/src/components/toolResultRenderer/ErrorRenderer.tsx
@@ -1,7 +1,7 @@
 import { X } from "lucide-react";
 import { Renderer } from "../../shared/RendererHeader";
 import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { useTranslation } from "react-i18next";
 import { layout } from "@/components/renderers";
 import { cn } from "@/lib/utils";
@@ -41,7 +41,7 @@ export const ErrorRenderer = ({
               currentMatchIndex={currentMatchIndex}
             />
           ) : (
-            <Markdown remarkPlugins={[remarkGfm]}>{errorMessage}</Markdown>
+            <Markdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>{errorMessage}</Markdown>
           )}
         </div>
       </Renderer.Content>

--- a/src/components/toolResultRenderer/StringRenderer.tsx
+++ b/src/components/toolResultRenderer/StringRenderer.tsx
@@ -4,7 +4,7 @@ import { memo, useEffect } from "react";
 import { Folder, Check, FileText } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { Renderer } from "../../shared/RendererHeader";
 import { layout } from "@/components/renderers";
 import { cn } from "@/lib/utils";
@@ -80,7 +80,7 @@ export const StringRenderer = memo(function StringRenderer({ result, searchQuery
             </div>
           ) : (
             <div className={`p-3 ${layout.prose}`}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+              <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                 {displayResult}
               </ReactMarkdown>
             </div>

--- a/src/components/toolResultRenderer/WebSearchRenderer.tsx
+++ b/src/components/toolResultRenderer/WebSearchRenderer.tsx
@@ -2,7 +2,7 @@
 
 import { Globe } from "lucide-react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS, REHYPE_PLUGINS } from "@/lib/markdownPlugins";
 import { useTranslation } from "react-i18next";
 import { Renderer } from "../../shared/RendererHeader";
 import { layout } from "@/components/renderers";
@@ -105,7 +105,7 @@ export const WebSearchRenderer = ({
 
                       return (
                         <div className={layout.prose}>
-                          <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                          <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                             {result}
                           </ReactMarkdown>
                         </div>
@@ -129,7 +129,7 @@ export const WebSearchRenderer = ({
                               <div key={idx}>
                                 {item && typeof item === "object" && "text" in item && typeof item.text === "string" ? (
                                   <div className={layout.prose}>
-                                    <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                                    <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
                                       {item.text}
                                     </ReactMarkdown>
                                   </div>
@@ -197,7 +197,7 @@ const SearchResultItem = ({
     )}
     {description && (
       <div className={`${layout.bodyText} leading-relaxed text-foreground/80`}>
-        <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} skipHtml>
           {description}
         </ReactMarkdown>
       </div>

--- a/src/lib/markdownPlugins.ts
+++ b/src/lib/markdownPlugins.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared remark/rehype plugin configuration for every ReactMarkdown instance
+ * in the app (GFM + LaTeX math via KaTeX). Import this instead of
+ * constructing a local plugin array so the renderers can't drift apart when
+ * a plugin or option changes.
+ */
+
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import "katex/dist/katex.min.css";
+
+/** Module-level plugin arrays for stable reference across renders. */
+export const REMARK_PLUGINS = [remarkGfm, remarkMath];
+export const REHYPE_PLUGINS = [rehypeKatex];


### PR DESCRIPTION
## What this does

Assistant messages already rendered as Markdown (GFM tables, code blocks, etc. via `react-markdown` + `remark-gfm`), but `$inline$` and `$$block$$` LaTeX was left as plain text — no math plugin was wired up.

Split out from #491 at the maintainer's request to keep scope separated from the session-continuation change (merged in #496).

## Changes

- Added `remark-math` + `rehype-katex` (+ `katex` for the stylesheet) to:
  - the shared `Markdown` component (`src/components/common/Markdown.tsx`)
  - the assistant-message renderer's inline `ReactMarkdown` instance (`MessageContentDisplay.tsx`)
- `skipHtml` stays on both — `rehype-katex` operates on the mdast tree produced by `remark-math`, not on raw HTML strings, so this doesn't reopen any HTML-injection surface.

## Testing

- `pnpm tsc --build .`, `pnpm lint`, `pnpm exec vitest run`: clean (987 tests passing).

## Test plan

- [ ] Send a message containing `$E = mc^2$` and confirm it renders as an inline formula, not literal text
- [ ] Send a message containing a `$$...$$` block and confirm it renders as a display-mode formula
- [ ] Confirm existing Markdown (tables, code blocks, GFM) still renders unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for rendering mathematical notation in Markdown using LaTeX.
  * Enhanced Markdown rendering with GitHub Flavored Markdown features and properly formatted equations.
  * Added KaTeX styling for clear, consistent display of mathematical expressions.
  * Applied consistent Markdown and math rendering across messages, files, task results, tool outputs, errors, and search content.
  * Raw HTML rendering remains disabled for improved safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->