### PR TITLE
fix(stats): correct provider model pricing and token accounting

### DIFF
--- a/src-tauri/src/commands/proptest_examples.rs
+++ b/src-tauri/src/commands/proptest_examples.rs
@@ -130,7 +130,9 @@ proptest! {
             output_tokens: Some(output),
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: None,
             service_tier: None,
+            ..Default::default()
         };
 
         // Verify tokens are set correctly (no need to check >= 0 for u32)
@@ -149,7 +151,9 @@ proptest! {
             output_tokens: output,
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: None,
             service_tier: None,
+            ..Default::default()
         };
 
         let serialized = serde_json::to_string(&original).unwrap();

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 use crate::models::MessageContent;
 use crate::models::{
-    ActivityHeatmap, ClaudeMessage, DailyStats, GlobalStatsSummary, ModelStats, ProjectRanking,
-    ProjectStatsSummary, ProviderUsageStats, RawLogEntry, SessionComparison, SessionTokenStats,
-    TokenDistribution, TokenUsage, ToolUsageStats,
+    ActivityHeatmap, ClaudeMessage, DailyStats, GlobalStatsSummary, ModelContextStats, ModelStats,
+    ProjectRanking, ProjectStatsSummary, ProviderUsageStats, RawLogEntry, SessionComparison,
+    SessionTokenStats, TokenDistribution, TokenUsage, ToolUsageStats,
 };
 use crate::providers;
 use crate::utils::find_line_ranges;
@@ -23,10 +23,26 @@ mod cache;
 enum StatsProvider {
     #[default]
     Claude,
+    Aider,
+    AmazonQ,
+    Cline,
     Codebuddy,
     Codex,
+    Continue,
     ForgeCode,
     OpenCode,
+    OpenHands,
+    OpenInterpreter,
+    PearAI,
+    Qwen,
+    Trae,
+    Vibe,
+    Zed,
+    Crush,
+    CursorAgent,
+    Goose,
+    Kiro,
+    Llm,
     Grok,
     Kimi,
     Antigravity,
@@ -66,10 +82,26 @@ fn parse_stats_mode(stats_mode: Option<String>) -> StatsMode {
 fn stats_provider_id(provider: StatsProvider) -> &'static str {
     match provider {
         StatsProvider::Claude => "claude",
+        StatsProvider::Aider => "aider",
+        StatsProvider::AmazonQ => "amazonq",
+        StatsProvider::Cline => "cline",
         StatsProvider::Codebuddy => "codebuddy",
         StatsProvider::Codex => "codex",
+        StatsProvider::Continue => "continue",
         StatsProvider::ForgeCode => "forgecode",
         StatsProvider::OpenCode => "opencode",
+        StatsProvider::OpenHands => "openhands",
+        StatsProvider::OpenInterpreter => "openinterpreter",
+        StatsProvider::PearAI => "pearai",
+        StatsProvider::Qwen => "qwen",
+        StatsProvider::Trae => "trae",
+        StatsProvider::Vibe => "vibe",
+        StatsProvider::Zed => "zed",
+        StatsProvider::Crush => "crush",
+        StatsProvider::CursorAgent => "cursor-agent",
+        StatsProvider::Goose => "goose",
+        StatsProvider::Kiro => "kiro",
+        StatsProvider::Llm => "llm",
         StatsProvider::Grok => "grok",
         StatsProvider::Kimi => "kimi",
         StatsProvider::Antigravity => "antigravity",
@@ -104,21 +136,51 @@ fn token_usage_has_token_fields(usage: &TokenUsage) -> bool {
     usage.input_tokens.is_some()
         || usage.output_tokens.is_some()
         || usage.cache_creation_input_tokens.is_some()
+        || usage.cache_creation_input_tokens_5m.is_some()
+        || usage.cache_creation_input_tokens_1h.is_some()
+        || usage.cache_creation.is_some()
         || usage.cache_read_input_tokens.is_some()
+        || usage.reasoning_tokens.is_some()
+}
+
+/// Normalize nested cache-write usage into the flat fields used by the
+/// dashboard while retaining the provider's 5-minute/1-hour split.
+fn normalize_token_usage(mut usage: TokenUsage) -> TokenUsage {
+    if let Some(cache_creation) = usage.cache_creation.take() {
+        let five_minute = cache_creation.ephemeral_5m_input_tokens;
+        let one_hour = cache_creation.ephemeral_1h_input_tokens;
+        if usage.cache_creation_input_tokens_5m.is_none() {
+            usage.cache_creation_input_tokens_5m = five_minute;
+        }
+        if usage.cache_creation_input_tokens_1h.is_none() {
+            usage.cache_creation_input_tokens_1h = one_hour;
+        }
+        if usage.cache_creation_input_tokens.is_none() {
+            usage.cache_creation_input_tokens = Some(
+                five_minute
+                    .unwrap_or(0)
+                    .saturating_add(one_hour.unwrap_or(0)),
+            );
+        }
+    }
+    usage
 }
 
 /// Summarize token usage into input, output, cache, and total counts.
-fn token_usage_totals(usage: &TokenUsage) -> (u64, u64, u64, u64, u64) {
+fn token_usage_totals(usage: &TokenUsage) -> (u64, u64, u64, u64, u64, u64) {
     let input_tokens = u64::from(usage.input_tokens.unwrap_or(0));
     let output_tokens = u64::from(usage.output_tokens.unwrap_or(0));
     let cache_creation_tokens = u64::from(usage.cache_creation_input_tokens.unwrap_or(0));
     let cache_read_tokens = u64::from(usage.cache_read_input_tokens.unwrap_or(0));
-    let total_tokens = input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens;
+    let reasoning_tokens = u64::from(usage.reasoning_tokens.unwrap_or(0));
+    let total_tokens =
+        input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens + reasoning_tokens;
     (
         input_tokens,
         output_tokens,
         cache_creation_tokens,
         cache_read_tokens,
+        reasoning_tokens,
         total_tokens,
     )
 }
@@ -227,10 +289,26 @@ fn should_include_stats_message(message: &ClaudeMessage, mode: StatsMode) -> boo
 fn all_stats_providers() -> HashSet<StatsProvider> {
     [
         StatsProvider::Claude,
+        StatsProvider::Aider,
+        StatsProvider::AmazonQ,
+        StatsProvider::Cline,
         StatsProvider::Codebuddy,
         StatsProvider::Codex,
+        StatsProvider::Continue,
         StatsProvider::ForgeCode,
         StatsProvider::OpenCode,
+        StatsProvider::OpenHands,
+        StatsProvider::OpenInterpreter,
+        StatsProvider::PearAI,
+        StatsProvider::Qwen,
+        StatsProvider::Trae,
+        StatsProvider::Vibe,
+        StatsProvider::Zed,
+        StatsProvider::Crush,
+        StatsProvider::CursorAgent,
+        StatsProvider::Goose,
+        StatsProvider::Kiro,
+        StatsProvider::Llm,
         StatsProvider::Grok,
         StatsProvider::Kimi,
         StatsProvider::Antigravity,
@@ -255,10 +333,26 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
         .into_iter()
         .filter_map(|provider| match provider.as_str() {
             "claude" => Some(StatsProvider::Claude),
+            "aider" => Some(StatsProvider::Aider),
+            "amazonq" => Some(StatsProvider::AmazonQ),
+            "cline" => Some(StatsProvider::Cline),
             "codebuddy" => Some(StatsProvider::Codebuddy),
             "codex" => Some(StatsProvider::Codex),
+            "continue" => Some(StatsProvider::Continue),
             "forgecode" => Some(StatsProvider::ForgeCode),
             "opencode" => Some(StatsProvider::OpenCode),
+            "openhands" => Some(StatsProvider::OpenHands),
+            "openinterpreter" => Some(StatsProvider::OpenInterpreter),
+            "pearai" => Some(StatsProvider::PearAI),
+            "qwen" => Some(StatsProvider::Qwen),
+            "trae" => Some(StatsProvider::Trae),
+            "vibe" => Some(StatsProvider::Vibe),
+            "zed" => Some(StatsProvider::Zed),
+            "crush" => Some(StatsProvider::Crush),
+            "cursor-agent" => Some(StatsProvider::CursorAgent),
+            "goose" => Some(StatsProvider::Goose),
+            "kiro" => Some(StatsProvider::Kiro),
+            "llm" => Some(StatsProvider::Llm),
             "grok" => Some(StatsProvider::Grok),
             "kimi" => Some(StatsProvider::Kimi),
             "antigravity" => Some(StatsProvider::Antigravity),
@@ -286,7 +380,37 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
 
 /// Detect the provider encoded in a project path.
 fn detect_project_provider(project_path: &str) -> StatsProvider {
-    if project_path.starts_with("codex://") {
+    if project_path.starts_with("aider://") {
+        StatsProvider::Aider
+    } else if project_path.starts_with("amazonq://") {
+        StatsProvider::AmazonQ
+    } else if project_path.starts_with("cline://") {
+        StatsProvider::Cline
+    } else if project_path.starts_with("continue://") {
+        StatsProvider::Continue
+    } else if project_path.starts_with("crush://") {
+        StatsProvider::Crush
+    } else if project_path.starts_with("goose://") {
+        StatsProvider::Goose
+    } else if project_path.starts_with("kiro://") {
+        StatsProvider::Kiro
+    } else if project_path.starts_with("llm://") {
+        StatsProvider::Llm
+    } else if project_path.starts_with("openhands://") {
+        StatsProvider::OpenHands
+    } else if project_path.starts_with("openinterpreter://") {
+        StatsProvider::OpenInterpreter
+    } else if project_path.starts_with("pearai://") {
+        StatsProvider::PearAI
+    } else if project_path.starts_with("qwen://") {
+        StatsProvider::Qwen
+    } else if project_path.starts_with("trae://") {
+        StatsProvider::Trae
+    } else if project_path.starts_with("vibe://") {
+        StatsProvider::Vibe
+    } else if project_path.starts_with("zed://") {
+        StatsProvider::Zed
+    } else if project_path.starts_with("codex://") {
         StatsProvider::Codex
     } else if project_path.starts_with("forgecode://") {
         StatsProvider::ForgeCode
@@ -308,6 +432,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::Pi
     } else if is_codebuddy_path(project_path) {
         StatsProvider::Codebuddy
+    } else if path_under_root(project_path, providers::cursor_agent::get_base_path()) {
+        StatsProvider::CursorAgent
     } else if project_path.starts_with("copilot://")
         || project_path.starts_with("copilot-cli://")
         || project_path.starts_with("copilot-desktop://")
@@ -321,6 +447,69 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
 
 /// Detect the provider encoded in a session path.
 fn detect_session_provider(session_path: &str) -> StatsProvider {
+    if session_path.starts_with("aider://") || session_path.ends_with(".aider.chat.history.md") {
+        return StatsProvider::Aider;
+    }
+    if session_path.starts_with("amazonq://") {
+        return StatsProvider::AmazonQ;
+    }
+    if session_path.starts_with("cline://") {
+        return StatsProvider::Cline;
+    }
+    if session_path.starts_with("continue://") {
+        return StatsProvider::Continue;
+    }
+    if session_path.starts_with("crush://") {
+        return StatsProvider::Crush;
+    }
+    if session_path.starts_with("goose://") {
+        return StatsProvider::Goose;
+    }
+    if session_path.starts_with("kiro://") {
+        return StatsProvider::Kiro;
+    }
+    if session_path.starts_with("llm://") {
+        return StatsProvider::Llm;
+    }
+    if session_path.starts_with("openhands://") {
+        return StatsProvider::OpenHands;
+    }
+    if session_path.starts_with("openinterpreter://") {
+        return StatsProvider::OpenInterpreter;
+    }
+    if session_path.starts_with("pearai://") {
+        return StatsProvider::PearAI;
+    }
+    if session_path.starts_with("qwen://") {
+        return StatsProvider::Qwen;
+    }
+    if session_path.starts_with("trae://") {
+        return StatsProvider::Trae;
+    }
+    if session_path.starts_with("vibe://") {
+        return StatsProvider::Vibe;
+    }
+    if session_path.starts_with("zed://") {
+        return StatsProvider::Zed;
+    }
+    if path_under_root(session_path, providers::cursor_agent::get_base_path()) {
+        return StatsProvider::CursorAgent;
+    }
+    if path_under_root(session_path, providers::continue_dev::get_base_path()) {
+        return StatsProvider::Continue;
+    }
+    if path_under_root(session_path, providers::pearai::get_base_path()) {
+        return StatsProvider::PearAI;
+    }
+    if path_under_root(session_path, providers::qwen::get_base_path()) {
+        return StatsProvider::Qwen;
+    }
+    if path_under_root(session_path, providers::vibe::get_base_path()) {
+        return StatsProvider::Vibe;
+    }
+    if path_under_root(session_path, providers::openinterpreter::get_base_path()) {
+        return StatsProvider::OpenInterpreter;
+    }
     if session_path.starts_with("opencode://") {
         return StatsProvider::OpenCode;
     }
@@ -393,6 +582,10 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
     } else {
         StatsProvider::Claude
     }
+}
+
+fn path_under_root(path: &str, root: Option<String>) -> bool {
+    root.is_some_and(|root| Path::new(path).starts_with(Path::new(&root)))
 }
 
 fn is_copilot_cli_session_path(session_path: &str) -> bool {
@@ -560,6 +753,8 @@ struct GlobalStatsLogEntry {
     /// Row identifier — fallback dedup key when `message.id` is absent (#283).
     uuid: Option<String>,
     message: Option<GlobalStatsMessageContent>,
+    #[serde(rename = "costUSD")]
+    cost_usd: Option<f64>,
     #[serde(rename = "toolUse")]
     tool_use: Option<GlobalStatsToolUse>,
     #[serde(rename = "toolUseResult")]
@@ -576,6 +771,8 @@ struct GlobalStatsMessageContent {
     content: Option<serde_json::Value>,
     model: Option<String>,
     usage: Option<TokenUsage>,
+    #[serde(rename = "costUSD")]
+    cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -597,34 +794,71 @@ fn parse_global_stats_entry_simd(line: &mut [u8]) -> Option<GlobalStatsLogEntry>
     simd_json::serde::from_slice(line).ok()
 }
 
+/// Read the first numeric token field that a provider exposes under one of
+/// its known `snake_case`/`camelCase` aliases.
+fn usage_u32(value: &serde_json::Value, keys: &[&str]) -> Option<u32> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(serde_json::Value::as_u64))
+        .and_then(|value| u32::try_from(value).ok())
+}
+
 /// Apply token usage fields from a JSON value into a token-usage struct.
 fn apply_usage_fields_from_value(usage_obj: &serde_json::Value, usage: &mut TokenUsage) {
-    if let Some(input) = usage_obj
-        .get("input_tokens")
-        .and_then(serde_json::Value::as_u64)
-    {
-        usage.input_tokens = Some(input as u32);
+    usage.input_tokens =
+        usage_u32(usage_obj, &["input_tokens", "inputTokens"]).or(usage.input_tokens);
+    usage.output_tokens =
+        usage_u32(usage_obj, &["output_tokens", "outputTokens"]).or(usage.output_tokens);
+    usage.cache_creation_input_tokens = usage_u32(
+        usage_obj,
+        &[
+            "cache_creation_input_tokens",
+            "cacheCreationInputTokens",
+            "cacheWrite",
+        ],
+    )
+    .or(usage.cache_creation_input_tokens);
+    if let Some(cache_creation) = usage_obj.get("cache_creation") {
+        usage.cache_creation_input_tokens_5m = usage_u32(
+            cache_creation,
+            &["ephemeral_5m_input_tokens", "ephemeral5mInputTokens"],
+        )
+        .or(usage.cache_creation_input_tokens_5m);
+        usage.cache_creation_input_tokens_1h = usage_u32(
+            cache_creation,
+            &["ephemeral_1h_input_tokens", "ephemeral1hInputTokens"],
+        )
+        .or(usage.cache_creation_input_tokens_1h);
+        if usage.cache_creation_input_tokens.is_none() {
+            usage.cache_creation_input_tokens = Some(
+                usage
+                    .cache_creation_input_tokens_5m
+                    .unwrap_or(0)
+                    .saturating_add(usage.cache_creation_input_tokens_1h.unwrap_or(0)),
+            );
+        }
     }
-    if let Some(output) = usage_obj
-        .get("output_tokens")
-        .and_then(serde_json::Value::as_u64)
-    {
-        usage.output_tokens = Some(output as u32);
-    }
-    if let Some(cache_creation) = usage_obj
-        .get("cache_creation_input_tokens")
-        .and_then(serde_json::Value::as_u64)
-    {
-        usage.cache_creation_input_tokens = Some(cache_creation as u32);
-    }
-    if let Some(cache_read) = usage_obj
-        .get("cache_read_input_tokens")
-        .and_then(serde_json::Value::as_u64)
-    {
-        usage.cache_read_input_tokens = Some(cache_read as u32);
-    }
+    usage.cache_read_input_tokens = usage_u32(
+        usage_obj,
+        &[
+            "cache_read_input_tokens",
+            "cacheReadInputTokens",
+            "cacheRead",
+        ],
+    )
+    .or(usage.cache_read_input_tokens);
+    usage.reasoning_tokens = usage_u32(
+        usage_obj,
+        &[
+            "reasoning_tokens",
+            "reasoningTokens",
+            "reasoning",
+            "thoughtsTokenCount",
+        ],
+    )
+    .or(usage.reasoning_tokens);
     if let Some(tier) = usage_obj
         .get("service_tier")
+        .or_else(|| usage_obj.get("serviceTier"))
         .and_then(serde_json::Value::as_str)
     {
         usage.service_tier = Some(tier.to_string());
@@ -636,7 +870,7 @@ fn extract_token_usage_from_global_entry(entry: &GlobalStatsLogEntry) -> TokenUs
     // 1. From message.usage (most common for assistant messages)
     if let Some(msg) = &entry.message {
         if let Some(usage) = &msg.usage {
-            return usage.clone();
+            return normalize_token_usage(usage.clone());
         }
 
         if let Some(content) = &msg.content {
@@ -646,7 +880,9 @@ fn extract_token_usage_from_global_entry(entry: &GlobalStatsLogEntry) -> TokenUs
                     output_tokens: None,
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
+                    reasoning_tokens: None,
                     service_tier: None,
+                    ..Default::default()
                 };
                 if let Some(usage_obj) = content.get("usage") {
                     apply_usage_fields_from_value(usage_obj, &mut usage);
@@ -663,7 +899,9 @@ fn extract_token_usage_from_global_entry(entry: &GlobalStatsLogEntry) -> TokenUs
         output_tokens: None,
         cache_creation_input_tokens: None,
         cache_read_input_tokens: None,
+        reasoning_tokens: None,
         service_tier: None,
+        ..Default::default()
     };
 
     // 2. From tool_use_result.usage
@@ -684,7 +922,7 @@ fn extract_token_usage_from_global_entry(entry: &GlobalStatsLogEntry) -> TokenUs
         }
     }
 
-    usage
+    normalize_token_usage(usage)
 }
 
 /// Track tool usage from the lightweight global stats entry
@@ -734,6 +972,93 @@ fn track_tool_usage_from_global_entry(
 
 /// Intermediate stats collected from a single session file (for parallel processing)
 type ModelUsageAggregate = (u32, u64, u64, u64, u64, u64, u64);
+type ModelContextUsageMap = HashMap<String, HashMap<u64, ModelContextStats>>;
+const UNKNOWN_MODEL_NAME: &str = "unknown";
+const MODEL_USAGE_KEY_SEPARATOR: char = '\u{1f}';
+
+fn normalize_service_tier(service_tier: Option<&str>) -> Option<String> {
+    service_tier
+        .map(str::trim)
+        .filter(|tier| !tier.is_empty())
+        .map(|tier| match tier.to_ascii_lowercase().as_str() {
+            // OpenAI renamed Priority to Fast while keeping the old API value
+            // accepted for compatibility. Normalize both to one display row.
+            "priority" => "fast".to_string(),
+            normalized => normalized.to_string(),
+        })
+}
+
+fn model_usage_key(model_name: &str, service_tier: Option<&str>) -> String {
+    let model_name = model_name.to_string();
+    match normalize_service_tier(service_tier) {
+        Some(service_tier) => format!("{model_name}{MODEL_USAGE_KEY_SEPARATOR}{service_tier}"),
+        None => model_name,
+    }
+}
+
+fn split_model_usage_key(key: &str) -> (&str, Option<&str>) {
+    key.split_once(MODEL_USAGE_KEY_SEPARATOR)
+        .map_or((key, None), |(model_name, service_tier)| {
+            (model_name, Some(service_tier))
+        })
+}
+
+fn context_tier_min_tokens(model_name: &str, context_tokens: u64) -> u64 {
+    let normalized = model_name.trim().to_ascii_lowercase();
+    let model = normalized
+        .strip_prefix("models/")
+        .unwrap_or(&normalized)
+        .rsplit('/')
+        .next()
+        .unwrap_or(&normalized);
+    let matches_model = |key: &str| {
+        model == key
+            || model.starts_with(&format!("{key}-"))
+            || model.starts_with(&format!("{key}@"))
+            || model.starts_with(&format!("{key}:"))
+    };
+    let threshold = if [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+    ]
+    .into_iter()
+    .any(matches_model)
+    {
+        Some(272_001)
+    } else if matches_model("gemini-3.1-pro-preview") || matches_model("gemini-2.5-pro") {
+        Some(200_001)
+    } else if matches_model("minimax-m3") {
+        Some(512_001)
+    } else if [
+        "grok-4.6",
+        "grok-4.5",
+        "grok-4.5-build",
+        "grok-build-latest",
+        "grok-build-0.1",
+        "grok-code-fast-1-0825",
+        "grok-code-fast-1",
+        "grok-code-fast",
+        "grok-4.3",
+        "grok-4.20-multi-agent-0309",
+        "grok-4.20-0309-reasoning",
+        "grok-4.20-0309-non-reasoning",
+        "grok-build",
+    ]
+    .into_iter()
+    .any(matches_model)
+    {
+        Some(200_001)
+    } else {
+        None
+    };
+    threshold
+        .filter(|threshold| context_tokens >= *threshold)
+        .unwrap_or(0)
+}
 
 #[derive(Default)]
 struct SessionFileStats {
@@ -746,6 +1071,8 @@ struct SessionFileStats {
     daily_stats: HashMap<String, DailyStats>,
     activity_data: HashMap<(u8, u8), (u32, u64)>, // (hour, day) -> (count, tokens)
     model_usage: HashMap<String, ModelUsageAggregate>, // model -> (msg_count, total, input, output, cache_create, cache_read, reasoning)
+    model_context_usage: ModelContextUsageMap,
+    model_costs: HashMap<String, f64>, // model -> authoritative source cost when present
     session_duration_minutes: u64,
     first_message: Option<DateTime<Utc>>,
     last_message: Option<DateTime<Utc>>,
@@ -814,6 +1141,7 @@ fn scan_session_file_for_global_stats(
     // #283: stream entries one at a time with owned-key dedup so we never
     // buffer parsed log entries (which can carry MB-sized `content` payloads).
     let mut seen_usage_keys: HashSet<String> = HashSet::new();
+    let mut seen_cost_keys: HashSet<String> = HashSet::new();
 
     // Use SIMD-accelerated line detection
     let line_ranges = find_line_ranges(&mmap);
@@ -847,27 +1175,52 @@ fn scan_session_file_for_global_stats(
         stats.total_messages = stats.total_messages.saturating_add(1);
         let message_id = entry.message.as_ref().and_then(|m| m.id.as_deref());
         let uuid = entry.uuid.as_deref().unwrap_or("");
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, tokens) =
-            dedup_token_totals(&mut seen_usage_keys, "", message_id, uuid, &usage);
+        let (
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            reasoning_tokens,
+            tokens,
+        ) = dedup_token_totals(&mut seen_usage_keys, "", message_id, uuid, &usage);
+        let source_cost = entry
+            .cost_usd
+            .or_else(|| entry.message.as_ref().and_then(|message| message.cost_usd));
+        let deduped_source_cost =
+            dedup_source_cost(&mut seen_cost_keys, "", message_id, uuid, source_cost);
 
         stats.total_tokens += tokens;
         stats.token_distribution.input += input_tokens;
         stats.token_distribution.output += output_tokens;
         stats.token_distribution.cache_creation += cache_creation_tokens;
         stats.token_distribution.cache_read += cache_read_tokens;
-        if let Some(msg) = &entry.message {
-            if let Some(model_name) = &msg.model {
-                let model_entry = stats
-                    .model_usage
-                    .entry(model_name.clone())
-                    .or_insert((0, 0, 0, 0, 0, 0, 0));
-                model_entry.0 += 1;
-                model_entry.1 += tokens;
-                model_entry.2 += input_tokens;
-                model_entry.3 += output_tokens;
-                model_entry.4 += cache_creation_tokens;
-                model_entry.5 += cache_read_tokens;
-                model_entry.6 += 0;
+        stats.token_distribution.reasoning += reasoning_tokens;
+        let model_name = entry
+            .message
+            .as_ref()
+            .and_then(|message| message.model.as_deref())
+            .unwrap_or(UNKNOWN_MODEL_NAME);
+        let has_model = entry
+            .message
+            .as_ref()
+            .is_some_and(|message| message.model.is_some());
+        if has_model || tokens > 0 || deduped_source_cost.is_some() {
+            let model_entry = stats
+                .model_usage
+                .entry(model_name.to_string())
+                .or_insert((0, 0, 0, 0, 0, 0, 0));
+            model_entry.0 += 1;
+            model_entry.1 += tokens;
+            model_entry.2 += input_tokens;
+            model_entry.3 += output_tokens;
+            model_entry.4 += cache_creation_tokens;
+            model_entry.5 += cache_read_tokens;
+            model_entry.6 += reasoning_tokens;
+            if let Some(cost_usd) = deduped_source_cost {
+                *stats
+                    .model_costs
+                    .entry(model_name.to_string())
+                    .or_insert(0.0) += cost_usd;
             }
         }
 
@@ -990,6 +1343,7 @@ fn build_global_session_file_stats_from_messages(
     let mut session_timestamps: Vec<DateTime<Utc>> = Vec::new();
     // #283: counts rows but only adds usage once per (session_id, message.id).
     let mut seen_usage_keys: HashSet<String> = HashSet::with_capacity(messages.len());
+    let mut seen_cost_keys: HashSet<String> = HashSet::with_capacity(messages.len());
 
     let has_date_filter = s_limit.is_some() || e_limit.is_some();
 
@@ -1007,18 +1361,33 @@ fn build_global_session_file_stats_from_messages(
         }
 
         stats.total_messages = stats.total_messages.saturating_add(1);
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, tokens) =
-            dedup_token_totals_msg(&mut seen_usage_keys, message, &usage);
+        let (
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            reasoning_tokens,
+            tokens,
+        ) = dedup_token_totals_msg(&mut seen_usage_keys, message, &usage);
+        let deduped_source_cost = dedup_source_cost(
+            &mut seen_cost_keys,
+            &message.session_id,
+            message.message_id.as_deref(),
+            &message.uuid,
+            message.cost_usd,
+        );
 
         stats.total_tokens += tokens;
         stats.token_distribution.input += input_tokens;
         stats.token_distribution.output += output_tokens;
         stats.token_distribution.cache_creation += cache_creation_tokens;
         stats.token_distribution.cache_read += cache_read_tokens;
-        if let Some(model_name) = &message.model {
+        stats.token_distribution.reasoning += reasoning_tokens;
+        if message.model.is_some() || tokens > 0 || deduped_source_cost.is_some() {
+            let model_name = message.model.as_deref().unwrap_or(UNKNOWN_MODEL_NAME);
             let model_entry = stats
                 .model_usage
-                .entry(model_name.clone())
+                .entry(model_name.to_string())
                 .or_insert((0, 0, 0, 0, 0, 0, 0));
             model_entry.0 += 1;
             model_entry.1 += tokens;
@@ -1026,7 +1395,13 @@ fn build_global_session_file_stats_from_messages(
             model_entry.3 += output_tokens;
             model_entry.4 += cache_creation_tokens;
             model_entry.5 += cache_read_tokens;
-            model_entry.6 += 0;
+            model_entry.6 += reasoning_tokens;
+            if let Some(cost_usd) = deduped_source_cost {
+                *stats
+                    .model_costs
+                    .entry(model_name.to_string())
+                    .or_insert(0.0) += cost_usd;
+            }
         }
 
         if let Some(timestamp) = parsed_timestamp {
@@ -1098,6 +1473,121 @@ fn build_global_session_file_stats_from_messages(
     }
 
     Some(stats)
+}
+
+/// Dispatch the common project/session/message interface used by global and
+/// project stats. Keeping this table in one place prevents a provider from
+/// being visible in the project tree but silently disappearing from stats.
+fn scan_stats_projects(
+    provider: StatsProvider,
+) -> Result<Vec<crate::models::ClaudeProject>, String> {
+    match provider {
+        StatsProvider::Aider => providers::aider::scan_projects(),
+        StatsProvider::AmazonQ => providers::amazon_q::scan_projects(),
+        StatsProvider::Cline => providers::cline::scan_projects(),
+        StatsProvider::Codebuddy => providers::codebuddy::scan_projects(),
+        StatsProvider::Codex => providers::codex::scan_projects(),
+        StatsProvider::Continue => providers::continue_dev::scan_projects(),
+        StatsProvider::ForgeCode => providers::forgecode::scan_projects(),
+        StatsProvider::OpenCode => providers::opencode::scan_projects(),
+        StatsProvider::OpenHands => providers::openhands::scan_projects(),
+        StatsProvider::OpenInterpreter => providers::openinterpreter::scan_projects(),
+        StatsProvider::PearAI => providers::pearai::scan_projects(),
+        StatsProvider::Qwen => providers::qwen::scan_projects(),
+        StatsProvider::Trae => providers::trae::scan_projects(),
+        StatsProvider::Vibe => providers::vibe::scan_projects(),
+        StatsProvider::Zed => providers::zed::scan_projects(),
+        StatsProvider::Crush => providers::crush::scan_projects(),
+        StatsProvider::CursorAgent => providers::cursor_agent::scan_projects(),
+        StatsProvider::Goose => providers::goose::scan_projects(),
+        StatsProvider::Kiro => providers::kiro::scan_projects(),
+        StatsProvider::Llm => providers::llm::scan_projects(),
+        StatsProvider::Grok => providers::grok::scan_projects(),
+        StatsProvider::Kimi => providers::kimi::scan_projects(),
+        StatsProvider::Antigravity => providers::antigravity::scan_projects(),
+        StatsProvider::Copilot => providers::copilot::scan_projects(),
+        StatsProvider::Ompi => providers::ompi::scan_projects(),
+        StatsProvider::Pi => providers::pi::scan_projects(),
+        StatsProvider::Gemini => providers::gemini::scan_projects(),
+        StatsProvider::Cursor => providers::cursor::scan_projects(),
+        StatsProvider::Claude => Ok(Vec::new()),
+    }
+}
+
+fn load_stats_sessions(
+    provider: StatsProvider,
+    project_path: &str,
+) -> Result<Vec<crate::models::ClaudeSession>, String> {
+    match provider {
+        StatsProvider::Aider => providers::aider::load_sessions(project_path, false),
+        StatsProvider::AmazonQ => providers::amazon_q::load_sessions(project_path, false),
+        StatsProvider::Cline => providers::cline::load_sessions(project_path, false),
+        StatsProvider::Codebuddy => providers::codebuddy::load_sessions(project_path, false),
+        StatsProvider::Codex => providers::codex::load_sessions(project_path, false),
+        StatsProvider::Continue => providers::continue_dev::load_sessions(project_path, false),
+        StatsProvider::ForgeCode => providers::forgecode::load_sessions(project_path, false),
+        StatsProvider::OpenCode => providers::opencode::load_sessions(project_path, false),
+        StatsProvider::OpenHands => providers::openhands::load_sessions(project_path, false),
+        StatsProvider::OpenInterpreter => {
+            providers::openinterpreter::load_sessions(project_path, false)
+        }
+        StatsProvider::PearAI => providers::pearai::load_sessions(project_path, false),
+        StatsProvider::Qwen => providers::qwen::load_sessions(project_path, false),
+        StatsProvider::Trae => providers::trae::load_sessions(project_path, false),
+        StatsProvider::Vibe => providers::vibe::load_sessions(project_path, false),
+        StatsProvider::Zed => providers::zed::load_sessions(project_path, false),
+        StatsProvider::Crush => providers::crush::load_sessions(project_path, false),
+        StatsProvider::CursorAgent => providers::cursor_agent::load_sessions(project_path, false),
+        StatsProvider::Goose => providers::goose::load_sessions(project_path, false),
+        StatsProvider::Kiro => providers::kiro::load_sessions(project_path, false),
+        StatsProvider::Llm => providers::llm::load_sessions(project_path, false),
+        StatsProvider::Grok => providers::grok::load_sessions(project_path, false),
+        StatsProvider::Kimi => providers::kimi::load_sessions(project_path, false),
+        StatsProvider::Antigravity => providers::antigravity::load_sessions(project_path, false),
+        StatsProvider::Copilot => providers::copilot::load_sessions(project_path, false),
+        StatsProvider::Ompi => providers::ompi::load_sessions(project_path, false),
+        StatsProvider::Pi => providers::pi::load_sessions(project_path, false),
+        StatsProvider::Gemini => providers::gemini::load_sessions(project_path, false),
+        StatsProvider::Cursor => providers::cursor::load_sessions(project_path, false),
+        StatsProvider::Claude => Ok(Vec::new()),
+    }
+}
+
+fn load_stats_messages(
+    provider: StatsProvider,
+    session_path: &str,
+) -> Result<Vec<ClaudeMessage>, String> {
+    match provider {
+        StatsProvider::Aider => providers::aider::load_messages(session_path),
+        StatsProvider::AmazonQ => providers::amazon_q::load_messages(session_path),
+        StatsProvider::Cline => providers::cline::load_messages(session_path),
+        StatsProvider::Codebuddy => providers::codebuddy::load_messages(session_path),
+        StatsProvider::Codex => providers::codex::load_messages(session_path),
+        StatsProvider::Continue => providers::continue_dev::load_messages(session_path),
+        StatsProvider::ForgeCode => providers::forgecode::load_messages(session_path),
+        StatsProvider::OpenCode => providers::opencode::load_messages(session_path),
+        StatsProvider::OpenHands => providers::openhands::load_messages(session_path),
+        StatsProvider::OpenInterpreter => providers::openinterpreter::load_messages(session_path),
+        StatsProvider::PearAI => providers::pearai::load_messages(session_path),
+        StatsProvider::Qwen => providers::qwen::load_messages(session_path),
+        StatsProvider::Trae => providers::trae::load_messages(session_path),
+        StatsProvider::Vibe => providers::vibe::load_messages(session_path),
+        StatsProvider::Zed => providers::zed::load_messages(session_path),
+        StatsProvider::Crush => providers::crush::load_messages(session_path),
+        StatsProvider::CursorAgent => providers::cursor_agent::load_messages(session_path),
+        StatsProvider::Goose => providers::goose::load_messages(session_path),
+        StatsProvider::Kiro => providers::kiro::load_messages(session_path),
+        StatsProvider::Llm => providers::llm::load_messages(session_path),
+        StatsProvider::Grok => providers::grok::load_messages(session_path),
+        StatsProvider::Kimi => providers::kimi::load_messages(session_path),
+        StatsProvider::Antigravity => providers::antigravity::load_messages(session_path),
+        StatsProvider::Copilot => providers::copilot::load_messages(session_path),
+        StatsProvider::Ompi => providers::ompi::load_messages(session_path),
+        StatsProvider::Pi => providers::pi::load_messages(session_path),
+        StatsProvider::Gemini => providers::gemini::load_messages(session_path),
+        StatsProvider::Cursor => providers::cursor::load_stats_messages(session_path),
+        StatsProvider::Claude => Ok(Vec::new()),
+    }
 }
 
 /// Collect global stats rows for a non-Claude provider.
@@ -1267,21 +1757,7 @@ fn collect_provider_global_file_stats(
         return (all_stats, project_keys);
     }
 
-    let projects = match provider {
-        StatsProvider::Codebuddy => providers::codebuddy::scan_projects().unwrap_or_default(),
-        StatsProvider::Codex => providers::codex::scan_projects().unwrap_or_default(),
-        StatsProvider::ForgeCode => providers::forgecode::scan_projects().unwrap_or_default(),
-        StatsProvider::OpenCode => providers::opencode::scan_projects().unwrap_or_default(),
-        StatsProvider::Grok => providers::grok::scan_projects().unwrap_or_default(),
-        StatsProvider::Kimi => providers::kimi::scan_projects().unwrap_or_default(),
-        StatsProvider::Antigravity => providers::antigravity::scan_projects().unwrap_or_default(),
-        StatsProvider::Copilot => providers::copilot::scan_projects().unwrap_or_default(),
-        StatsProvider::Ompi => providers::ompi::scan_projects().unwrap_or_default(),
-        StatsProvider::Pi => providers::pi::scan_projects().unwrap_or_default(),
-        StatsProvider::Gemini => providers::gemini::scan_projects().unwrap_or_default(),
-        StatsProvider::Cursor => providers::cursor::scan_projects().unwrap_or_default(),
-        StatsProvider::Claude => Vec::new(),
-    };
+    let projects = scan_stats_projects(provider).unwrap_or_default();
 
     let provider_tag = stats_provider_id(provider);
 
@@ -1292,24 +1768,7 @@ fn collect_provider_global_file_stats(
         let project_display_name = format!("{} [{}]", project.name, provider_tag);
         project_keys.insert(format!("{provider_tag}:{}", project.path));
 
-        let sessions = match provider {
-            StatsProvider::Codebuddy => providers::codebuddy::load_sessions(&project.path, false),
-            StatsProvider::Codex => providers::codex::load_sessions(&project.path, false),
-            StatsProvider::ForgeCode => providers::forgecode::load_sessions(&project.path, false),
-            StatsProvider::OpenCode => providers::opencode::load_sessions(&project.path, false),
-            StatsProvider::Grok => providers::grok::load_sessions(&project.path, false),
-            StatsProvider::Kimi => providers::kimi::load_sessions(&project.path, false),
-            StatsProvider::Antigravity => {
-                providers::antigravity::load_sessions(&project.path, false)
-            }
-            StatsProvider::Copilot => providers::copilot::load_sessions(&project.path, false),
-            StatsProvider::Ompi => providers::ompi::load_sessions(&project.path, false),
-            StatsProvider::Pi => providers::pi::load_sessions(&project.path, false),
-            StatsProvider::Gemini => providers::gemini::load_sessions(&project.path, false),
-            StatsProvider::Cursor => providers::cursor::load_sessions(&project.path, false),
-            StatsProvider::Claude => Ok(Vec::new()),
-        }
-        .unwrap_or_default();
+        let sessions = load_stats_sessions(provider, &project.path).unwrap_or_default();
 
         for session in sessions {
             session_tasks.push((project_display_name.clone(), session.file_path));
@@ -1320,22 +1779,7 @@ fn collect_provider_global_file_stats(
     let all_stats: Vec<SessionFileStats> = session_tasks
         .par_iter()
         .filter_map(|(project_name, file_path)| {
-            let messages = match provider {
-                StatsProvider::Codebuddy => providers::codebuddy::load_messages(file_path),
-                StatsProvider::Codex => providers::codex::load_messages(file_path),
-                StatsProvider::ForgeCode => providers::forgecode::load_messages(file_path),
-                StatsProvider::OpenCode => providers::opencode::load_messages(file_path),
-                StatsProvider::Grok => providers::grok::load_messages(file_path),
-                StatsProvider::Kimi => providers::kimi::load_messages(file_path),
-                StatsProvider::Antigravity => providers::antigravity::load_messages(file_path),
-                StatsProvider::Copilot => providers::copilot::load_messages(file_path),
-                StatsProvider::Ompi => providers::ompi::load_messages(file_path),
-                StatsProvider::Pi => providers::pi::load_messages(file_path),
-                StatsProvider::Gemini => providers::gemini::load_messages(file_path),
-                StatsProvider::Cursor => providers::cursor::load_stats_messages(file_path),
-                StatsProvider::Claude => Ok(Vec::new()),
-            }
-            .unwrap_or_default();
+            let messages = load_stats_messages(provider, file_path).unwrap_or_default();
 
             build_global_session_file_stats_from_messages(
                 provider,
@@ -1356,6 +1800,9 @@ fn collect_provider_global_file_stats(
 struct ProjectSessionFileStats {
     total_messages: u32,
     token_distribution: TokenDistribution,
+    model_usage: HashMap<String, ModelUsageAggregate>,
+    model_context_usage: ModelContextUsageMap,
+    model_costs: HashMap<String, f64>,
     tool_usage: HashMap<String, (u32, u32)>,
     skill_usage: HashMap<String, (u32, u32)>, // Skill tool, keyed by input.skill (#321)
     subagent_usage: HashMap<String, (u32, u32)>, // Agent tool, keyed by input.subagent_type (#321)
@@ -1410,6 +1857,7 @@ fn scan_session_file_for_project_stats(
     // #283: stream entries with owned-key dedup so we never buffer parsed
     // messages (which can carry MB-sized `content` payloads).
     let mut seen_usage_keys: HashSet<String> = HashSet::new();
+    let mut seen_cost_keys: HashSet<String> = HashSet::new();
 
     for (start, end) in line_ranges {
         let mut line_bytes = mmap[start..end].to_vec();
@@ -1434,13 +1882,52 @@ fn scan_session_file_for_project_stats(
         }
 
         stats.total_messages += 1;
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, tokens) =
-            dedup_token_totals_msg(&mut seen_usage_keys, &message, &usage);
+        let (
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            reasoning_tokens,
+            tokens,
+        ) = dedup_token_totals_msg(&mut seen_usage_keys, &message, &usage);
+        let deduped_source_cost = dedup_source_cost(
+            &mut seen_cost_keys,
+            &message.session_id,
+            message.message_id.as_deref(),
+            &message.uuid,
+            message.cost_usd,
+        );
+
+        let model_name = message.model.as_deref().unwrap_or(UNKNOWN_MODEL_NAME);
+        if message.model.is_some() || tokens > 0 || deduped_source_cost.is_some() {
+            accumulate_model_usage(
+                &mut stats.model_usage,
+                &mut stats.model_context_usage,
+                &mut stats.model_costs,
+                ModelUsageUpdate {
+                    model_name,
+                    service_tier: usage.service_tier.as_deref(),
+                    totals: (
+                        input_tokens,
+                        output_tokens,
+                        cache_creation_tokens,
+                        cache_read_tokens,
+                        reasoning_tokens,
+                        tokens,
+                    ),
+                    cache_creation_tokens_1h: u64::from(
+                        usage.cache_creation_input_tokens_1h.unwrap_or(0),
+                    ),
+                    source_cost: deduped_source_cost,
+                },
+            );
+        }
 
         stats.token_distribution.input += input_tokens;
         stats.token_distribution.output += output_tokens;
         stats.token_distribution.cache_creation += cache_creation_tokens;
         stats.token_distribution.cache_read += cache_read_tokens;
+        stats.token_distribution.reasoning += reasoning_tokens;
 
         if let Some(timestamp) = parsed_ts {
             session_timestamps.push(timestamp);
@@ -1659,7 +2146,7 @@ fn track_antigravity_tool_usage(
 /// Extract token usage from a normalized message.
 fn extract_token_usage(message: &ClaudeMessage) -> TokenUsage {
     if let Some(usage) = &message.usage {
-        return usage.clone();
+        return normalize_token_usage(usage.clone());
     }
 
     let mut usage = TokenUsage {
@@ -1667,7 +2154,9 @@ fn extract_token_usage(message: &ClaudeMessage) -> TokenUsage {
         output_tokens: None,
         cache_creation_input_tokens: None,
         cache_read_input_tokens: None,
+        reasoning_tokens: None,
         service_tier: None,
+        ..Default::default()
     };
 
     if let Some(content) = &message.content {
@@ -1701,7 +2190,7 @@ fn extract_token_usage(message: &ClaudeMessage) -> TokenUsage {
         }
     }
 
-    usage
+    normalize_token_usage(usage)
 }
 
 /// Dedup-aware token totals for usage accounting (#283).
@@ -1728,14 +2217,36 @@ fn dedup_token_totals(
     message_id: Option<&str>,
     uuid: &str,
     usage: &TokenUsage,
-) -> (u64, u64, u64, u64, u64) {
+) -> (u64, u64, u64, u64, u64, u64) {
     let Some(key) = dedup_usage_key(session_id, message_id, uuid) else {
         return token_usage_totals(usage);
     };
     if seen.insert(key) {
         token_usage_totals(usage)
     } else {
-        (0, 0, 0, 0, 0)
+        (0, 0, 0, 0, 0, 0)
+    }
+}
+
+/// Dedup an authoritative source cost using the same identity as token usage.
+/// Claude JSONL can repeat a complete `costUSD` value on every row belonging
+/// to one assistant turn, so summing every row would overstate billing.
+#[inline]
+fn dedup_source_cost(
+    seen: &mut HashSet<String>,
+    session_id: &str,
+    message_id: Option<&str>,
+    uuid: &str,
+    cost_usd: Option<f64>,
+) -> Option<f64> {
+    let cost_usd = cost_usd?;
+    let Some(key) = dedup_usage_key(session_id, message_id, uuid) else {
+        return Some(cost_usd);
+    };
+    if seen.insert(key) {
+        Some(cost_usd)
+    } else {
+        None
     }
 }
 
@@ -1756,7 +2267,7 @@ fn dedup_token_totals_msg(
     seen: &mut HashSet<String>,
     message: &ClaudeMessage,
     usage: &TokenUsage,
-) -> (u64, u64, u64, u64, u64) {
+) -> (u64, u64, u64, u64, u64, u64) {
     dedup_token_totals(
         seen,
         &message.session_id,
@@ -1933,6 +2444,49 @@ fn build_antigravity_session_token_stats(
         .map(|ts| ts.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
         .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
 
+    let mut model_usage: HashMap<String, ModelUsageAggregate> = HashMap::new();
+    let mut model_context_usage: ModelContextUsageMap = HashMap::new();
+    let mut model_costs: HashMap<String, f64> = HashMap::new();
+    for record in &records {
+        let (input_tokens, cache_creation_tokens, cache_read_tokens, token_count) = match mode {
+            StatsMode::BillingTotal => (
+                record.input_tokens,
+                record.cache_creation_tokens,
+                record.cache_read_tokens,
+                record.total_tokens,
+            ),
+            StatsMode::ConversationOnly => (
+                record.conversation_input_tokens,
+                record.conversation_cache_creation_tokens,
+                record.conversation_cache_read_tokens,
+                record.conversation_input_tokens
+                    + record.output_tokens
+                    + record.conversation_cache_creation_tokens
+                    + record.conversation_cache_read_tokens
+                    + record.reasoning_tokens,
+            ),
+        };
+        accumulate_model_usage(
+            &mut model_usage,
+            &mut model_context_usage,
+            &mut model_costs,
+            ModelUsageUpdate {
+                model_name: &record.model,
+                service_tier: None,
+                totals: (
+                    input_tokens,
+                    record.output_tokens,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    record.reasoning_tokens,
+                    token_count,
+                ),
+                cache_creation_tokens_1h: 0,
+                source_cost: None,
+            },
+        );
+    }
+
     let stats = SessionTokenStats {
         session_id: session.actual_session_id.clone(),
         project_name: session.project_name.clone(),
@@ -1977,6 +2531,12 @@ fn build_antigravity_session_token_stats(
         last_message_time,
         summary: session.summary.clone(),
         most_used_tools: Vec::new(),
+        model_distribution: build_model_stats(
+            StatsProvider::Antigravity,
+            model_usage,
+            model_context_usage,
+            model_costs,
+        ),
     };
 
     Ok(Some((stats, records)))
@@ -2000,6 +2560,232 @@ fn build_tool_usage_stats(tool_usage: HashMap<String, (u32, u32)>) -> Vec<ToolUs
 
     tools.sort_by_key(|tool| Reverse(tool.usage_count));
     tools
+}
+
+/// Add one row to a model aggregate. Token totals are already deduplicated by
+/// the caller, while `msg_count` intentionally remains row-based so the
+/// model breakdown agrees with the message count shown by the dashboard.
+struct ModelUsageUpdate<'a> {
+    model_name: &'a str,
+    service_tier: Option<&'a str>,
+    totals: (u64, u64, u64, u64, u64, u64),
+    cache_creation_tokens_1h: u64,
+    source_cost: Option<f64>,
+}
+
+fn accumulate_model_usage(
+    model_usage: &mut HashMap<String, ModelUsageAggregate>,
+    model_context_usage: &mut ModelContextUsageMap,
+    model_costs: &mut HashMap<String, f64>,
+    update: ModelUsageUpdate<'_>,
+) {
+    let ModelUsageUpdate {
+        model_name,
+        service_tier,
+        totals,
+        cache_creation_tokens_1h,
+        source_cost,
+    } = update;
+    let (
+        input_tokens,
+        output_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
+        reasoning_tokens,
+        tokens,
+    ) = totals;
+    let model_key = model_usage_key(model_name, service_tier);
+    let entry = model_usage
+        .entry(model_key.clone())
+        .or_insert((0, 0, 0, 0, 0, 0, 0));
+    entry.0 += 1;
+    entry.1 += tokens;
+    entry.2 += input_tokens;
+    entry.3 += output_tokens;
+    entry.4 += cache_creation_tokens;
+    entry.5 += cache_read_tokens;
+    entry.6 += reasoning_tokens;
+    let context_tier = context_tier_min_tokens(
+        model_name,
+        input_tokens + cache_creation_tokens + cache_read_tokens,
+    );
+    let context = model_context_usage
+        .entry(model_key.clone())
+        .or_default()
+        .entry(context_tier)
+        .or_insert_with(|| ModelContextStats {
+            min_context_tokens: context_tier,
+            ..Default::default()
+        });
+    let cache_creation_tokens_1h = cache_creation_tokens_1h.min(cache_creation_tokens);
+    context.token_count += tokens;
+    context.input_tokens += input_tokens;
+    context.output_tokens += output_tokens;
+    context.cache_creation_tokens += cache_creation_tokens;
+    context.cache_creation_tokens_1h += cache_creation_tokens_1h;
+    context.cache_creation_tokens_5m += cache_creation_tokens - cache_creation_tokens_1h;
+    context.cache_read_tokens += cache_read_tokens;
+    context.reasoning_tokens += reasoning_tokens;
+    if let Some(cost_usd) = source_cost {
+        *model_costs.entry(model_key).or_insert(0.0) += cost_usd;
+    }
+}
+
+fn merge_model_context_usage(target: &mut ModelContextUsageMap, source: &ModelContextUsageMap) {
+    for (model, buckets) in source {
+        for (min_context_tokens, values) in buckets {
+            let entry = target
+                .entry(model.clone())
+                .or_default()
+                .entry(*min_context_tokens)
+                .or_insert_with(|| ModelContextStats {
+                    min_context_tokens: *min_context_tokens,
+                    ..Default::default()
+                });
+            entry.token_count += values.token_count;
+            entry.input_tokens += values.input_tokens;
+            entry.output_tokens += values.output_tokens;
+            entry.cache_creation_tokens += values.cache_creation_tokens;
+            entry.cache_creation_tokens_5m += values.cache_creation_tokens_5m;
+            entry.cache_creation_tokens_1h += values.cache_creation_tokens_1h;
+            entry.cache_read_tokens += values.cache_read_tokens;
+            entry.reasoning_tokens += values.reasoning_tokens;
+        }
+    }
+}
+
+/// Convert an internal model aggregate into the serialized model breakdown
+/// consumed by all billing views.
+fn build_model_stats(
+    provider: StatsProvider,
+    model_usage: HashMap<String, ModelUsageAggregate>,
+    model_context_usage: ModelContextUsageMap,
+    model_costs: HashMap<String, f64>,
+) -> Vec<ModelStats> {
+    let provider_id = stats_provider_id(provider).to_string();
+    let mut models = model_usage
+        .into_iter()
+        .map(
+            |(
+                model_key,
+                (
+                    message_count,
+                    token_count,
+                    input_tokens,
+                    output_tokens,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    reasoning_tokens,
+                ),
+            )| {
+                let (model_name, service_tier) = split_model_usage_key(&model_key);
+                let mut context_breakdown = model_context_usage
+                    .get(&model_key)
+                    .map(|buckets| buckets.values().cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+                context_breakdown.sort_by_key(|bucket| bucket.min_context_tokens);
+                ModelStats {
+                    provider_id: provider_id.clone(),
+                    model_name: model_name.to_string(),
+                    service_tier: service_tier.map(str::to_string),
+                    message_count,
+                    token_count,
+                    input_tokens,
+                    output_tokens,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    reasoning_tokens,
+                    cost_usd: model_costs.get(&model_key).copied(),
+                    context_breakdown,
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+    models.sort_by_key(|model| Reverse(model.token_count));
+    models
+}
+
+fn merge_model_stats(
+    model_usage: &mut HashMap<String, ModelUsageAggregate>,
+    model_context_usage: &mut ModelContextUsageMap,
+    model_costs: &mut HashMap<String, f64>,
+    models: Vec<ModelStats>,
+) {
+    for model in models {
+        let model_key = model_usage_key(&model.model_name, model.service_tier.as_deref());
+        let entry = model_usage
+            .entry(model_key.clone())
+            .or_insert((0, 0, 0, 0, 0, 0, 0));
+        entry.0 += model.message_count;
+        entry.1 += model.token_count;
+        entry.2 += model.input_tokens;
+        entry.3 += model.output_tokens;
+        entry.4 += model.cache_creation_tokens;
+        entry.5 += model.cache_read_tokens;
+        entry.6 += model.reasoning_tokens;
+        if let Some(cost_usd) = model.cost_usd {
+            *model_costs.entry(model_key.clone()).or_insert(0.0) += cost_usd;
+        }
+        if model.context_breakdown.is_empty() {
+            let context_tier = context_tier_min_tokens(
+                &model.model_name,
+                model.input_tokens + model.cache_creation_tokens + model.cache_read_tokens,
+            );
+            let fallback = ModelContextStats {
+                min_context_tokens: context_tier,
+                token_count: model.token_count,
+                input_tokens: model.input_tokens,
+                output_tokens: model.output_tokens,
+                cache_creation_tokens: model.cache_creation_tokens,
+                cache_creation_tokens_5m: model.cache_creation_tokens,
+                cache_creation_tokens_1h: 0,
+                cache_read_tokens: model.cache_read_tokens,
+                reasoning_tokens: model.reasoning_tokens,
+            };
+            model_context_usage
+                .entry(model_key)
+                .or_default()
+                .entry(context_tier)
+                .and_modify(|entry| {
+                    entry.token_count += fallback.token_count;
+                    entry.input_tokens += fallback.input_tokens;
+                    entry.output_tokens += fallback.output_tokens;
+                    entry.cache_creation_tokens += fallback.cache_creation_tokens;
+                    entry.cache_creation_tokens_5m += fallback.cache_creation_tokens_5m;
+                    entry.cache_read_tokens += fallback.cache_read_tokens;
+                    entry.reasoning_tokens += fallback.reasoning_tokens;
+                })
+                .or_insert(fallback);
+        } else {
+            for context in model.context_breakdown {
+                model_context_usage
+                    .entry(model_key.clone())
+                    .or_default()
+                    .entry(context.min_context_tokens)
+                    .and_modify(|entry| {
+                        entry.token_count += context.token_count;
+                        entry.input_tokens += context.input_tokens;
+                        entry.output_tokens += context.output_tokens;
+                        entry.cache_creation_tokens += context.cache_creation_tokens;
+                        entry.cache_creation_tokens_5m += context.cache_creation_tokens_5m;
+                        entry.cache_creation_tokens_1h += context.cache_creation_tokens_1h;
+                        entry.cache_read_tokens += context.cache_read_tokens;
+                        entry.reasoning_tokens += context.reasoning_tokens;
+                    })
+                    .or_insert(context);
+            }
+        }
+    }
+}
+
+fn fallback_provider_name(provider: StatsProvider, path: &str) -> String {
+    let raw = path.split_once("://").map(|(_, rest)| rest).unwrap_or(path);
+    Path::new(raw)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| stats_provider_id(provider))
+        .to_string()
 }
 
 /// Resolve the display name for a provider project path.
@@ -2163,6 +2949,22 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                 })
                 .unwrap_or_else(|| "Cursor".to_string())
         }
+        StatsProvider::Aider
+        | StatsProvider::AmazonQ
+        | StatsProvider::Cline
+        | StatsProvider::Continue
+        | StatsProvider::OpenHands
+        | StatsProvider::OpenInterpreter
+        | StatsProvider::PearAI
+        | StatsProvider::Qwen
+        | StatsProvider::Trae
+        | StatsProvider::Vibe
+        | StatsProvider::Zed
+        | StatsProvider::Crush
+        | StatsProvider::CursorAgent
+        | StatsProvider::Goose
+        | StatsProvider::Kiro
+        | StatsProvider::Llm => fallback_provider_name(provider, project_path),
     }
 }
 
@@ -2289,6 +3091,22 @@ fn resolve_provider_project_name_from_session(
             }
             "Cursor".to_string()
         }
+        StatsProvider::Aider
+        | StatsProvider::AmazonQ
+        | StatsProvider::Cline
+        | StatsProvider::Continue
+        | StatsProvider::OpenHands
+        | StatsProvider::OpenInterpreter
+        | StatsProvider::PearAI
+        | StatsProvider::Qwen
+        | StatsProvider::Trae
+        | StatsProvider::Vibe
+        | StatsProvider::Zed
+        | StatsProvider::Crush
+        | StatsProvider::CursorAgent
+        | StatsProvider::Goose
+        | StatsProvider::Kiro
+        | StatsProvider::Llm => fallback_provider_name(provider, session_path),
         StatsProvider::Claude => "unknown".to_string(),
     }
 }
@@ -2298,23 +3116,7 @@ fn load_provider_sessions_for_stats(
     provider: StatsProvider,
     project_path: &str,
 ) -> Result<Vec<crate::models::ClaudeSession>, String> {
-    match provider {
-        StatsProvider::Codebuddy => providers::codebuddy::load_sessions(project_path, false),
-        StatsProvider::Codex => providers::codex::load_sessions(project_path, false),
-        StatsProvider::ForgeCode => providers::forgecode::load_sessions(project_path, false),
-        StatsProvider::OpenCode => providers::opencode::load_sessions(project_path, false),
-        StatsProvider::Grok => providers::grok::load_sessions(project_path, false),
-        StatsProvider::Kimi => providers::kimi::load_sessions(project_path, false),
-        StatsProvider::Antigravity => providers::antigravity::load_sessions(project_path, false),
-        StatsProvider::Copilot => providers::copilot::load_sessions(project_path, false),
-        StatsProvider::Ompi => providers::ompi::load_sessions(project_path, false),
-        StatsProvider::Pi => providers::pi::load_sessions(project_path, false),
-        StatsProvider::Gemini => providers::gemini::load_sessions(project_path, false),
-        StatsProvider::Cursor => providers::cursor::load_sessions(project_path, false),
-        StatsProvider::Claude => {
-            Err("Claude sessions are handled by legacy stats path".to_string())
-        }
-    }
+    load_stats_sessions(provider, project_path)
 }
 
 /// Load messages for a provider-specific stats request.
@@ -2322,35 +3124,35 @@ fn load_provider_messages_for_stats(
     provider: StatsProvider,
     session: &crate::models::ClaudeSession,
 ) -> Result<Vec<ClaudeMessage>, String> {
-    match provider {
-        StatsProvider::Codebuddy => providers::codebuddy::load_messages(&session.file_path),
-        StatsProvider::Codex => providers::codex::load_messages(&session.file_path),
-        StatsProvider::ForgeCode => providers::forgecode::load_messages(&session.file_path),
-        StatsProvider::OpenCode => providers::opencode::load_messages(&session.file_path),
-        StatsProvider::Grok => providers::grok::load_messages(&session.file_path),
-        StatsProvider::Kimi => providers::kimi::load_messages(&session.file_path),
-        StatsProvider::Antigravity => providers::antigravity::load_messages(&session.file_path),
-        StatsProvider::Copilot => providers::copilot::load_messages(&session.file_path),
-        StatsProvider::Ompi => providers::ompi::load_messages(&session.file_path),
-        StatsProvider::Pi => providers::pi::load_messages(&session.file_path),
-        StatsProvider::Gemini => providers::gemini::load_messages(&session.file_path),
-        StatsProvider::Cursor => providers::cursor::load_stats_messages(&session.file_path),
-        StatsProvider::Claude => {
-            Err("Claude messages are handled by legacy stats path".to_string())
-        }
-    }
+    load_stats_messages(provider, &session.file_path)
+}
+
+struct SessionTokenStatsOptions {
+    provider: StatsProvider,
+    session_id: String,
+    project_name: String,
+    summary: Option<String>,
+    mode: StatsMode,
+    start_date: Option<DateTime<Utc>>,
+    end_date: Option<DateTime<Utc>>,
 }
 
 /// Build session token stats from normalized provider messages.
 fn build_session_token_stats_from_messages(
-    session_id: String,
-    project_name: String,
-    summary: Option<String>,
+    options: SessionTokenStatsOptions,
     messages: &[ClaudeMessage],
-    mode: StatsMode,
-    s_limit: Option<&DateTime<Utc>>,
-    e_limit: Option<&DateTime<Utc>>,
 ) -> Option<SessionTokenStats> {
+    let SessionTokenStatsOptions {
+        provider,
+        session_id,
+        project_name,
+        summary,
+        mode,
+        start_date,
+        end_date,
+    } = options;
+    let s_limit = start_date.as_ref();
+    let e_limit = end_date.as_ref();
     if messages.is_empty() {
         return None;
     }
@@ -2359,9 +3161,14 @@ fn build_session_token_stats_from_messages(
     let mut total_output_tokens = 0u64;
     let mut total_cache_creation_tokens = 0u64;
     let mut total_cache_read_tokens = 0u64;
+    let mut total_reasoning_tokens = 0u64;
     let mut tool_usage: HashMap<String, (u32, u32)> = HashMap::new();
     // #283: only add usage once per (session_id, message.id).
     let mut seen_usage_keys: HashSet<String> = HashSet::with_capacity(messages.len());
+    let mut seen_cost_keys: HashSet<String> = HashSet::with_capacity(messages.len());
+    let mut model_usage: HashMap<String, ModelUsageAggregate> = HashMap::new();
+    let mut model_context_usage: ModelContextUsageMap = HashMap::new();
+    let mut model_costs: HashMap<String, f64> = HashMap::new();
 
     let mut first_time: Option<DateTime<Utc>> = None;
     let mut last_time: Option<DateTime<Utc>> = None;
@@ -2381,12 +3188,50 @@ fn build_session_token_stats_from_messages(
 
         let usage = extract_token_usage(message);
         included_message_count += 1;
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, _) =
-            dedup_token_totals_msg(&mut seen_usage_keys, message, &usage);
+        let (
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            reasoning_tokens,
+            tokens,
+        ) = dedup_token_totals_msg(&mut seen_usage_keys, message, &usage);
+        let deduped_source_cost = dedup_source_cost(
+            &mut seen_cost_keys,
+            &message.session_id,
+            message.message_id.as_deref(),
+            &message.uuid,
+            message.cost_usd,
+        );
+        let model_name = message.model.as_deref().unwrap_or(UNKNOWN_MODEL_NAME);
+        if message.model.is_some() || tokens > 0 || deduped_source_cost.is_some() {
+            accumulate_model_usage(
+                &mut model_usage,
+                &mut model_context_usage,
+                &mut model_costs,
+                ModelUsageUpdate {
+                    model_name,
+                    service_tier: usage.service_tier.as_deref(),
+                    totals: (
+                        input_tokens,
+                        output_tokens,
+                        cache_creation_tokens,
+                        cache_read_tokens,
+                        reasoning_tokens,
+                        tokens,
+                    ),
+                    cache_creation_tokens_1h: u64::from(
+                        usage.cache_creation_input_tokens_1h.unwrap_or(0),
+                    ),
+                    source_cost: deduped_source_cost,
+                },
+            );
+        }
         total_input_tokens += input_tokens;
         total_output_tokens += output_tokens;
         total_cache_creation_tokens += cache_creation_tokens;
         total_cache_read_tokens += cache_read_tokens;
+        total_reasoning_tokens += reasoning_tokens;
 
         if let Some(ts) = parsed_timestamp {
             if first_time.map_or(true, |current| ts < current) {
@@ -2405,7 +3250,8 @@ fn build_session_token_stats_from_messages(
     let total_tokens = total_input_tokens
         + total_output_tokens
         + total_cache_creation_tokens
-        + total_cache_read_tokens;
+        + total_cache_read_tokens
+        + total_reasoning_tokens;
     if included_message_count == 0 {
         return None;
     }
@@ -2417,13 +3263,19 @@ fn build_session_token_stats_from_messages(
         total_output_tokens,
         total_cache_creation_tokens,
         total_cache_read_tokens,
-        total_reasoning_tokens: 0,
+        total_reasoning_tokens,
         total_tokens,
         message_count: included_message_count,
         first_message_time: first_time_raw.unwrap_or_else(|| "unknown".to_string()),
         last_message_time: last_time_raw.unwrap_or_else(|| "unknown".to_string()),
         summary,
         most_used_tools: build_tool_usage_stats(tool_usage),
+        model_distribution: build_model_stats(
+            provider,
+            model_usage,
+            model_context_usage,
+            model_costs,
+        ),
     })
 }
 
@@ -2481,17 +3333,20 @@ fn get_provider_project_token_stats(
     for session in &sessions {
         let messages = load_provider_messages_for_stats(provider, session)?;
         if let Some(stats) = build_session_token_stats_from_messages(
-            session.actual_session_id.clone(),
-            if session.project_name.is_empty() {
-                project_name.clone()
-            } else {
-                session.project_name.clone()
+            SessionTokenStatsOptions {
+                provider,
+                session_id: session.actual_session_id.clone(),
+                project_name: if session.project_name.is_empty() {
+                    project_name.clone()
+                } else {
+                    session.project_name.clone()
+                },
+                summary: session.summary.clone(),
+                mode,
+                start_date: s_limit,
+                end_date: e_limit,
             },
-            session.summary.clone(),
             &messages,
-            mode,
-            s_limit.as_ref(),
-            e_limit.as_ref(),
         ) {
             all_stats.push(stats);
         }
@@ -2535,6 +3390,9 @@ fn get_provider_project_stats_summary(
         let mut tool_usage_map: HashMap<String, (u32, u32)> = HashMap::new();
         let mut daily_stats_map: HashMap<String, DailyStats> = HashMap::new();
         let mut activity_map: HashMap<(u8, u8), (u32, u64)> = HashMap::new();
+        let mut project_model_usage: HashMap<String, ModelUsageAggregate> = HashMap::new();
+        let mut project_model_context_usage: ModelContextUsageMap = HashMap::new();
+        let mut project_model_costs: HashMap<String, f64> = HashMap::new();
 
         for session in &sessions {
             let Some((session_stats, records)) = build_antigravity_session_token_stats(
@@ -2555,6 +3413,12 @@ fn get_provider_project_stats_summary(
             summary.token_distribution.cache_creation += session_stats.total_cache_creation_tokens;
             summary.token_distribution.cache_read += session_stats.total_cache_read_tokens;
             summary.token_distribution.reasoning += session_stats.total_reasoning_tokens;
+            merge_model_stats(
+                &mut project_model_usage,
+                &mut project_model_context_usage,
+                &mut project_model_costs,
+                session_stats.model_distribution,
+            );
 
             if let Ok(messages) = providers::antigravity::load_messages(&session.file_path) {
                 track_antigravity_tool_usage(
@@ -2637,6 +3501,12 @@ fn get_provider_project_stats_summary(
         summary.daily_stats = daily_stats_map.into_values().collect();
         summary.daily_stats.sort_by(|a, b| a.date.cmp(&b.date));
         summary.most_used_tools = build_tool_usage_stats(tool_usage_map);
+        summary.model_distribution = build_model_stats(
+            StatsProvider::Antigravity,
+            project_model_usage,
+            project_model_context_usage,
+            project_model_costs,
+        );
         summary.activity_heatmap = activity_map
             .into_iter()
             .map(|((hour, day), (count, tokens))| ActivityHeatmap {
@@ -2677,6 +3547,9 @@ fn get_provider_project_stats_summary(
 
     let mut session_durations: Vec<u32> = Vec::new();
     let mut tool_usage_map: HashMap<String, (u32, u32)> = HashMap::new();
+    let mut project_model_usage: HashMap<String, ModelUsageAggregate> = HashMap::new();
+    let mut project_model_context_usage: ModelContextUsageMap = HashMap::new();
+    let mut project_model_costs: HashMap<String, f64> = HashMap::new();
     let mut daily_stats_map: HashMap<String, DailyStats> = HashMap::new();
     let mut activity_map: HashMap<(u8, u8), (u32, u64)> = HashMap::new();
 
@@ -2691,6 +3564,7 @@ fn get_provider_project_stats_summary(
         let mut session_dates = HashSet::new();
         // #283: per-session dedup
         let mut seen_usage_keys: HashSet<String> = HashSet::with_capacity(messages.len());
+        let mut seen_cost_keys: HashSet<String> = HashSet::with_capacity(messages.len());
 
         for message in &messages {
             if !should_include_stats_message(message, mode) {
@@ -2712,13 +3586,46 @@ fn get_provider_project_stats_summary(
                 output_tokens,
                 cache_creation_tokens,
                 cache_read_tokens,
+                reasoning_tokens,
                 total_tokens,
             ) = dedup_token_totals_msg(&mut seen_usage_keys, message, &usage);
+            let deduped_source_cost = dedup_source_cost(
+                &mut seen_cost_keys,
+                &message.session_id,
+                message.message_id.as_deref(),
+                &message.uuid,
+                message.cost_usd,
+            );
+            let model_name = message.model.as_deref().unwrap_or(UNKNOWN_MODEL_NAME);
+            if message.model.is_some() || total_tokens > 0 || deduped_source_cost.is_some() {
+                accumulate_model_usage(
+                    &mut project_model_usage,
+                    &mut project_model_context_usage,
+                    &mut project_model_costs,
+                    ModelUsageUpdate {
+                        model_name,
+                        service_tier: usage.service_tier.as_deref(),
+                        totals: (
+                            input_tokens,
+                            output_tokens,
+                            cache_creation_tokens,
+                            cache_read_tokens,
+                            reasoning_tokens,
+                            total_tokens,
+                        ),
+                        cache_creation_tokens_1h: u64::from(
+                            usage.cache_creation_input_tokens_1h.unwrap_or(0),
+                        ),
+                        source_cost: deduped_source_cost,
+                    },
+                );
+            }
 
             summary.token_distribution.input += input_tokens;
             summary.token_distribution.output += output_tokens;
             summary.token_distribution.cache_creation += cache_creation_tokens;
             summary.token_distribution.cache_read += cache_read_tokens;
+            summary.token_distribution.reasoning += reasoning_tokens;
 
             if let Some(timestamp) = parsed_ts {
                 parsed_timestamps.push(timestamp);
@@ -2779,6 +3686,12 @@ fn get_provider_project_stats_summary(
     }
 
     summary.most_used_tools = build_tool_usage_stats(tool_usage_map);
+    summary.model_distribution = build_model_stats(
+        provider,
+        project_model_usage,
+        project_model_context_usage,
+        project_model_costs,
+    );
     summary.daily_stats = daily_stats_map.into_values().collect();
     summary.daily_stats.sort_by(|a, b| a.date.cmp(&b.date));
     summary.activity_heatmap = activity_map
@@ -2794,7 +3707,8 @@ fn get_provider_project_stats_summary(
     summary.total_tokens = summary.token_distribution.input
         + summary.token_distribution.output
         + summary.token_distribution.cache_creation
-        + summary.token_distribution.cache_read;
+        + summary.token_distribution.cache_read
+        + summary.token_distribution.reasoning;
     summary.avg_tokens_per_session = if summary.total_sessions > 0 {
         summary.total_tokens / summary.total_sessions as u64
     } else {
@@ -2949,7 +3863,7 @@ fn get_provider_session_comparison(
             }
 
             included_message_count += 1;
-            let (_, _, _, _, tokens) =
+            let (_, _, _, _, _, tokens) =
                 dedup_token_totals_msg(&mut seen_usage_keys, message, &usage);
             total_tokens += tokens;
 
@@ -3074,21 +3988,7 @@ pub async fn get_session_token_stats(
             .ok_or_else(|| "No valid messages found in session".to_string());
         }
 
-        let messages = match provider {
-            StatsProvider::Codebuddy => providers::codebuddy::load_messages(&session_path)?,
-            StatsProvider::Codex => providers::codex::load_messages(&session_path)?,
-            StatsProvider::ForgeCode => providers::forgecode::load_messages(&session_path)?,
-            StatsProvider::OpenCode => providers::opencode::load_messages(&session_path)?,
-            StatsProvider::Grok => providers::grok::load_messages(&session_path)?,
-            StatsProvider::Kimi => providers::kimi::load_messages(&session_path)?,
-            StatsProvider::Antigravity => providers::antigravity::load_messages(&session_path)?,
-            StatsProvider::Copilot => providers::copilot::load_messages(&session_path)?,
-            StatsProvider::Ompi => providers::ompi::load_messages(&session_path)?,
-            StatsProvider::Pi => providers::pi::load_messages(&session_path)?,
-            StatsProvider::Gemini => providers::gemini::load_messages(&session_path)?,
-            StatsProvider::Cursor => providers::cursor::load_stats_messages(&session_path)?,
-            StatsProvider::Claude => Vec::new(),
-        };
+        let messages = load_stats_messages(provider, &session_path)?;
 
         let session_id = messages
             .first()
@@ -3097,13 +3997,16 @@ pub async fn get_session_token_stats(
         let project_name = resolve_provider_project_name_from_session(provider, &session_path);
 
         return build_session_token_stats_from_messages(
-            session_id,
-            project_name,
-            None,
+            SessionTokenStatsOptions {
+                provider,
+                session_id,
+                project_name,
+                summary: None,
+                mode,
+                start_date: s_limit,
+                end_date: e_limit,
+            },
             &messages,
-            mode,
-            s_limit.as_ref(),
-            e_limit.as_ref(),
         )
         .filter(|stats| {
             is_within_date_limits(
@@ -3197,11 +4100,15 @@ fn scan_session_token_stats(
     let mut total_output_tokens = 0u64;
     let mut total_cache_creation_tokens = 0u64;
     let mut total_cache_read_tokens = 0u64;
+    let mut total_reasoning_tokens = 0u64;
     let mut message_count = 0usize;
     let mut first_time: Option<String> = None;
     let mut last_time: Option<String> = None;
     let mut summary: Option<String> = None;
     let mut tool_usage: HashMap<String, (u32, u32)> = HashMap::new();
+    let mut model_usage: HashMap<String, ModelUsageAggregate> = HashMap::new();
+    let mut model_context_usage: ModelContextUsageMap = HashMap::new();
+    let mut model_costs: HashMap<String, f64> = HashMap::new();
     let mut included_message_count = 0usize;
 
     // Use SIMD-accelerated line detection
@@ -3209,6 +4116,7 @@ fn scan_session_token_stats(
 
     // #283: stream entries with owned-key dedup (no per-file Vec buffering).
     let mut seen_usage_keys: HashSet<String> = HashSet::new();
+    let mut seen_cost_keys: HashSet<String> = HashSet::new();
 
     for (start, end) in line_ranges {
         let mut line_bytes = mmap[start..end].to_vec();
@@ -3244,12 +4152,50 @@ fn scan_session_token_stats(
         message_count += 1;
         included_message_count += 1;
 
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, _) =
-            dedup_token_totals_msg(&mut seen_usage_keys, &message, &usage);
+        let (
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            reasoning_tokens,
+            tokens,
+        ) = dedup_token_totals_msg(&mut seen_usage_keys, &message, &usage);
+        let deduped_source_cost = dedup_source_cost(
+            &mut seen_cost_keys,
+            &message.session_id,
+            message.message_id.as_deref(),
+            &message.uuid,
+            message.cost_usd,
+        );
+        let model_name = message.model.as_deref().unwrap_or(UNKNOWN_MODEL_NAME);
+        if message.model.is_some() || tokens > 0 || deduped_source_cost.is_some() {
+            accumulate_model_usage(
+                &mut model_usage,
+                &mut model_context_usage,
+                &mut model_costs,
+                ModelUsageUpdate {
+                    model_name,
+                    service_tier: usage.service_tier.as_deref(),
+                    totals: (
+                        input_tokens,
+                        output_tokens,
+                        cache_creation_tokens,
+                        cache_read_tokens,
+                        reasoning_tokens,
+                        tokens,
+                    ),
+                    cache_creation_tokens_1h: u64::from(
+                        usage.cache_creation_input_tokens_1h.unwrap_or(0),
+                    ),
+                    source_cost: deduped_source_cost,
+                },
+            );
+        }
         total_input_tokens += input_tokens;
         total_output_tokens += output_tokens;
         total_cache_creation_tokens += cache_creation_tokens;
         total_cache_read_tokens += cache_read_tokens;
+        total_reasoning_tokens += reasoning_tokens;
 
         if let Some(ts) = parsed_timestamp {
             let should_set_first = first_time
@@ -3281,7 +4227,8 @@ fn scan_session_token_stats(
     let total_tokens = total_input_tokens
         + total_output_tokens
         + total_cache_creation_tokens
-        + total_cache_read_tokens;
+        + total_cache_read_tokens
+        + total_reasoning_tokens;
 
     Some(SessionTokenStats {
         session_id,
@@ -3290,12 +4237,18 @@ fn scan_session_token_stats(
         total_output_tokens,
         total_cache_creation_tokens,
         total_cache_read_tokens,
-        total_reasoning_tokens: 0,
+        total_reasoning_tokens,
         total_tokens,
         message_count: included_message_count,
         first_message_time: first_time.unwrap_or_else(|| "unknown".to_string()),
         last_message_time: last_time.unwrap_or_else(|| "unknown".to_string()),
         summary,
+        model_distribution: build_model_stats(
+            StatsProvider::Claude,
+            model_usage,
+            model_context_usage,
+            model_costs,
+        ),
         most_used_tools: tool_usage
             .into_iter()
             .map(|(name, (usage, success))| ToolUsageStats {
@@ -3472,6 +4425,9 @@ pub async fn get_project_stats_summary(
     let mut tool_usage_map: HashMap<String, (u32, u32)> = HashMap::new();
     let mut skill_usage_map: HashMap<String, (u32, u32)> = HashMap::new();
     let mut subagent_usage_map: HashMap<String, (u32, u32)> = HashMap::new();
+    let mut project_model_usage: HashMap<String, ModelUsageAggregate> = HashMap::new();
+    let mut project_model_context_usage: ModelContextUsageMap = HashMap::new();
+    let mut project_model_costs: HashMap<String, f64> = HashMap::new();
     let mut daily_stats_map: HashMap<String, DailyStats> = HashMap::new();
     let mut activity_map: HashMap<(u8, u8), (u32, u64)> = HashMap::new();
     let mut session_count_by_date: HashMap<String, usize> = HashMap::new();
@@ -3485,6 +4441,17 @@ pub async fn get_project_stats_summary(
         summary.token_distribution.cache_creation += stats.token_distribution.cache_creation;
         summary.token_distribution.cache_read += stats.token_distribution.cache_read;
         summary.token_distribution.reasoning += stats.token_distribution.reasoning;
+        merge_model_stats(
+            &mut project_model_usage,
+            &mut project_model_context_usage,
+            &mut project_model_costs,
+            build_model_stats(
+                StatsProvider::Claude,
+                stats.model_usage,
+                stats.model_context_usage,
+                stats.model_costs,
+            ),
+        );
 
         // Aggregate tool usage
         for (name, (usage, success)) in stats.tool_usage {
@@ -3566,6 +4533,13 @@ pub async fn get_project_stats_summary(
         .sort_by_key(|tool| Reverse(tool.usage_count));
     summary.most_used_skills = build_tool_usage_stats(skill_usage_map);
     summary.most_used_subagents = build_tool_usage_stats(subagent_usage_map);
+    let project_model_distribution = build_model_stats(
+        StatsProvider::Claude,
+        project_model_usage,
+        project_model_context_usage,
+        project_model_costs,
+    );
+    summary.model_distribution = project_model_distribution;
 
     summary.daily_stats = daily_stats_map.into_values().collect();
     summary.daily_stats.sort_by(|a, b| a.date.cmp(&b.date));
@@ -3583,7 +4557,8 @@ pub async fn get_project_stats_summary(
     summary.total_tokens = summary.token_distribution.input
         + summary.token_distribution.output
         + summary.token_distribution.cache_creation
-        + summary.token_distribution.cache_read;
+        + summary.token_distribution.cache_read
+        + summary.token_distribution.reasoning;
     summary.avg_tokens_per_session = if summary.total_sessions > 0 {
         summary.total_tokens / summary.total_sessions as u64
     } else {
@@ -3699,7 +4674,8 @@ fn scan_session_file_for_comparison(
 
         message_count += 1;
 
-        let (_, _, _, _, tokens) = dedup_token_totals_msg(&mut seen_usage_keys, &message, &usage);
+        let (_, _, _, _, _, tokens) =
+            dedup_token_totals_msg(&mut seen_usage_keys, &message, &usage);
         total_tokens += tokens;
 
         if let Some(timestamp) = parsed_ts {
@@ -4092,6 +5068,35 @@ pub async fn get_global_stats_summary(
         file_stats.extend(gemini_stats);
     }
 
+    // Provider IDs that use the same normalized message pipeline as the
+    // original stats providers. Keep this list explicit so adding a provider
+    // to the enum cannot accidentally trigger an expensive scan twice.
+    for provider in [
+        StatsProvider::Aider,
+        StatsProvider::AmazonQ,
+        StatsProvider::Cline,
+        StatsProvider::Continue,
+        StatsProvider::Crush,
+        StatsProvider::CursorAgent,
+        StatsProvider::Goose,
+        StatsProvider::Kiro,
+        StatsProvider::Llm,
+        StatsProvider::OpenHands,
+        StatsProvider::OpenInterpreter,
+        StatsProvider::PearAI,
+        StatsProvider::Qwen,
+        StatsProvider::Trae,
+        StatsProvider::Vibe,
+        StatsProvider::Zed,
+    ] {
+        if providers_to_include.contains(&provider) {
+            let (provider_stats, provider_projects) =
+                collect_provider_global_file_stats(provider, mode, s_ref, e_ref);
+            project_names.extend(provider_projects);
+            file_stats.extend(provider_stats);
+        }
+    }
+
     // When date filtering is active, exclude sessions that ended up with zero messages
     if s_ref.is_some() || e_ref.is_some() {
         file_stats.retain(|s| s.total_messages > 0);
@@ -4118,7 +5123,10 @@ pub async fn get_global_stats_summary(
     let mut subagent_usage_map: HashMap<String, (u32, u32)> = HashMap::new();
     let mut daily_stats_map: HashMap<String, DailyStats> = HashMap::new();
     let mut activity_map: HashMap<(u8, u8), (u32, u64)> = HashMap::new();
-    let mut model_usage_map: HashMap<String, ModelUsageAggregate> = HashMap::new();
+    let mut model_usage_map: HashMap<(StatsProvider, String), ModelUsageAggregate> = HashMap::new();
+    let mut model_context_map: HashMap<(StatsProvider, String), HashMap<u64, ModelContextStats>> =
+        HashMap::new();
+    let mut model_cost_map: HashMap<(StatsProvider, String), f64> = HashMap::new();
     let mut project_stats_map: HashMap<String, (u32, u32, u64)> = HashMap::new();
     let mut provider_stats_map: HashMap<StatsProvider, (u32, u32, u64)> = HashMap::new();
     let mut provider_projects_map: HashMap<StatsProvider, HashSet<String>> = HashMap::new();
@@ -4183,8 +5191,13 @@ pub async fn get_global_stats_summary(
         for (model, (msg_count, total, input, output, cache_create, cache_read, reasoning)) in
             stats.model_usage
         {
+            if let Some(cost_usd) = stats.model_costs.get(&model) {
+                *model_cost_map
+                    .entry((provider, model.clone()))
+                    .or_insert(0.0) += cost_usd;
+            }
             let entry = model_usage_map
-                .entry(model)
+                .entry((provider, model))
                 .or_insert((0, 0, 0, 0, 0, 0, 0));
             entry.0 += msg_count;
             entry.1 += total;
@@ -4193,6 +5206,24 @@ pub async fn get_global_stats_summary(
             entry.4 += cache_create;
             entry.5 += cache_read;
             entry.6 += reasoning;
+        }
+        for (model, buckets) in stats.model_context_usage {
+            let target = model_context_map.entry((provider, model)).or_default();
+            for (min_context_tokens, values) in buckets {
+                target
+                    .entry(min_context_tokens)
+                    .and_modify(|entry| {
+                        entry.token_count += values.token_count;
+                        entry.input_tokens += values.input_tokens;
+                        entry.output_tokens += values.output_tokens;
+                        entry.cache_creation_tokens += values.cache_creation_tokens;
+                        entry.cache_creation_tokens_5m += values.cache_creation_tokens_5m;
+                        entry.cache_creation_tokens_1h += values.cache_creation_tokens_1h;
+                        entry.cache_read_tokens += values.cache_read_tokens;
+                        entry.reasoning_tokens += values.reasoning_tokens;
+                    })
+                    .or_insert(values);
+            }
         }
 
         // Aggregate provider stats
@@ -4267,7 +5298,7 @@ pub async fn get_global_stats_summary(
         .into_iter()
         .map(
             |(
-                model_name,
+                (provider, model_key),
                 (
                     message_count,
                     token_count,
@@ -4277,15 +5308,28 @@ pub async fn get_global_stats_summary(
                     cache_read_tokens,
                     reasoning_tokens,
                 ),
-            )| ModelStats {
-                model_name,
-                message_count,
-                token_count,
-                input_tokens,
-                output_tokens,
-                cache_creation_tokens,
-                cache_read_tokens,
-                reasoning_tokens,
+            )| {
+                let (model_name, service_tier) = split_model_usage_key(&model_key);
+                let mut context_breakdown = model_context_map
+                    .get(&(provider, model_key.clone()))
+                    .map(|buckets| buckets.values().cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+                context_breakdown.sort_by_key(|bucket| bucket.min_context_tokens);
+                let cost_usd = model_cost_map.get(&(provider, model_key.clone())).copied();
+                ModelStats {
+                    provider_id: stats_provider_id(provider).to_string(),
+                    model_name: model_name.to_string(),
+                    service_tier: service_tier.map(str::to_string),
+                    message_count,
+                    token_count,
+                    input_tokens,
+                    output_tokens,
+                    cache_creation_tokens,
+                    cache_read_tokens,
+                    reasoning_tokens,
+                    cost_usd,
+                    context_breakdown,
+                }
             },
         )
         .collect();
@@ -4530,7 +5574,9 @@ mod tests {
                     output_tokens: Some(50),
                     cache_creation_input_tokens: Some(20),
                     cache_read_input_tokens: Some(10),
+                    reasoning_tokens: None,
                     service_tier: Some("standard".to_string()),
+                    ..Default::default()
                 }),
             }),
             tool_use: None,
@@ -4739,7 +5785,9 @@ mod tests {
                 output_tokens: Some(50),
                 cache_creation_input_tokens: Some(20),
                 cache_read_input_tokens: Some(10),
+                reasoning_tokens: None,
                 service_tier: Some("standard".to_string()),
+                ..Default::default()
             }),
             role: Some("assistant".to_string()),
             model: None,
@@ -5128,6 +6176,19 @@ mod tests {
         assert!(providers.contains(&StatsProvider::Antigravity));
         assert!(providers.contains(&StatsProvider::Copilot));
         assert!(providers.contains(&StatsProvider::Cursor));
+    }
+
+    #[test]
+    fn test_parse_active_stats_providers_covers_every_supported_provider() {
+        let supported = all_stats_providers();
+        let ids = supported
+            .iter()
+            .map(|provider| stats_provider_id(*provider).to_string())
+            .collect::<Vec<_>>();
+        let parsed = parse_active_stats_providers(Some(ids));
+
+        assert_eq!(parsed, supported);
+        assert_eq!(supported.len(), 29);
     }
 
     #[test]
@@ -5640,7 +6701,9 @@ mod tests {
                 output_tokens: Some(5),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: None,
+                reasoning_tokens: None,
                 service_tier: None,
+                ..Default::default()
             }),
         );
         assert!(should_include_stats_message(
@@ -5738,6 +6801,54 @@ mod tests {
             2,
             "appended file must be re-parsed exactly once"
         );
+    }
+
+    #[tokio::test]
+    async fn test_global_model_distribution_preserves_source_cost() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let project_dir = temp_dir.path().join("projects").join("cost-project");
+        fs::create_dir_all(&project_dir).expect("project dir");
+        let session_path = project_dir.join("session-cost.jsonl");
+        let entry = json!({
+            "uuid": "cost-row",
+            "sessionId": "cost-session",
+            "timestamp": "2026-08-01T10:00:00Z",
+            "type": "assistant",
+            "costUSD": 0.005,
+            "isSidechain": false,
+            "message": {
+                "role": "assistant",
+                "id": "cost-message",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "priced"}],
+                "usage": {"input_tokens": 100, "output_tokens": 50}
+            }
+        });
+        // Claude may repeat the complete source cost on split rows for one
+        // assistant turn. The duplicate uuid must not make billing double.
+        let mut duplicate = entry.clone();
+        duplicate["uuid"] = json!("cost-row-duplicate");
+        fs::write(&session_path, format!("{entry}\n{duplicate}\n")).expect("session file");
+
+        let summary = get_global_stats_summary(
+            temp_dir.path().to_string_lossy().to_string(),
+            Some(vec!["claude".to_string()]),
+            Some("billing_total".to_string()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("global summary");
+
+        let model = summary
+            .model_distribution
+            .iter()
+            .find(|model| model.model_name == "claude-sonnet-4-6")
+            .expect("model distribution entry");
+        assert_eq!(model.provider_id, "claude");
+        assert_eq!(model.token_count, 150);
+        assert_eq!(model.cost_usd, Some(0.005));
     }
 
     #[tokio::test]
@@ -6696,7 +7807,9 @@ mod tests {
             output_tokens: Some(222),
             cache_creation_input_tokens: Some(28644),
             cache_read_input_tokens: Some(14732),
+            reasoning_tokens: None,
             service_tier: Some("standard".to_string()),
+            ..Default::default()
         }
     }
 
@@ -6824,11 +7937,47 @@ mod tests {
     }
 
     #[test]
+    fn test_global_model_distribution_keeps_token_usage_without_model_name() {
+        let message = make_test_message(
+            Some("qwen"),
+            "assistant",
+            Some(TokenUsage {
+                input_tokens: Some(10),
+                output_tokens: Some(5),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+                reasoning_tokens: Some(7),
+                service_tier: None,
+                ..Default::default()
+            }),
+        );
+
+        let stats = build_global_session_file_stats_from_messages(
+            StatsProvider::Qwen,
+            "qwen-project".to_string(),
+            &[message],
+            StatsMode::BillingTotal,
+            None,
+            None,
+        )
+        .expect("stats");
+
+        let model_entry = stats
+            .model_usage
+            .get(UNKNOWN_MODEL_NAME)
+            .expect("unknown model");
+        assert_eq!(model_entry.0, 1);
+        assert_eq!(model_entry.1, 22);
+        assert_eq!(model_entry.6, 7);
+        assert_eq!(stats.total_tokens, 22);
+    }
+
+    #[test]
     fn test_dedup_token_totals_returns_full_when_first_seen() {
         let mut seen: HashSet<String> = HashSet::new();
         let usage = sample_usage();
         let result = dedup_token_totals(&mut seen, "sess-1", Some("msg_a"), "uuid-1", &usage);
-        assert_eq!(result, (6, 222, 28644, 14732, 6 + 222 + 28644 + 14732));
+        assert_eq!(result, (6, 222, 28644, 14732, 0, 6 + 222 + 28644 + 14732));
     }
 
     #[test]
@@ -6837,7 +7986,7 @@ mod tests {
         let usage = sample_usage();
         let _ = dedup_token_totals(&mut seen, "sess-1", Some("msg_a"), "uuid-1", &usage);
         let result = dedup_token_totals(&mut seen, "sess-1", Some("msg_a"), "uuid-2", &usage);
-        assert_eq!(result, (0, 0, 0, 0, 0), "duplicate by message_id");
+        assert_eq!(result, (0, 0, 0, 0, 0, 0), "duplicate by message_id");
     }
 
     #[test]
@@ -6847,7 +7996,7 @@ mod tests {
         let r1 = dedup_token_totals(&mut seen, "sess-1", Some("msg_a"), "uuid-1", &usage);
         let r2 = dedup_token_totals(&mut seen, "sess-1", Some("msg_b"), "uuid-2", &usage);
         assert_eq!(r1, r2, "both should return full totals");
-        assert_ne!(r1, (0, 0, 0, 0, 0));
+        assert_ne!(r1, (0, 0, 0, 0, 0, 0));
     }
 
     #[test]
@@ -6861,7 +8010,7 @@ mod tests {
         assert_eq!(r2.0, 6);
         // Same uuid repeated → second is deduped.
         let r3 = dedup_token_totals(&mut seen, "sess-1", None, "uuid-1", &usage);
-        assert_eq!(r3, (0, 0, 0, 0, 0));
+        assert_eq!(r3, (0, 0, 0, 0, 0, 0));
     }
 
     #[test]
@@ -6870,8 +8019,8 @@ mod tests {
         let usage = sample_usage();
         let r1 = dedup_token_totals(&mut seen, "sess-1", Some(""), "uuid-1", &usage);
         let r2 = dedup_token_totals(&mut seen, "sess-1", Some(""), "uuid-1", &usage);
-        assert_ne!(r1, (0, 0, 0, 0, 0));
-        assert_eq!(r2, (0, 0, 0, 0, 0));
+        assert_ne!(r1, (0, 0, 0, 0, 0, 0));
+        assert_eq!(r2, (0, 0, 0, 0, 0, 0));
     }
 
     #[test]
@@ -6880,8 +8029,8 @@ mod tests {
         let usage = sample_usage();
         let r1 = dedup_token_totals(&mut seen, "sess-1", Some("msg_a"), "uuid-1", &usage);
         let r2 = dedup_token_totals(&mut seen, "sess-2", Some("msg_a"), "uuid-2", &usage);
-        assert_ne!(r1, (0, 0, 0, 0, 0));
-        assert_ne!(r2, (0, 0, 0, 0, 0));
+        assert_ne!(r1, (0, 0, 0, 0, 0, 0));
+        assert_ne!(r2, (0, 0, 0, 0, 0, 0));
     }
 
     #[test]
@@ -6893,8 +8042,8 @@ mod tests {
         let usage = sample_usage();
         let r1 = dedup_token_totals(&mut seen, "", None, "", &usage);
         let r2 = dedup_token_totals(&mut seen, "", None, "", &usage);
-        assert_ne!(r1, (0, 0, 0, 0, 0), "first unkeyable row counts");
-        assert_ne!(r2, (0, 0, 0, 0, 0), "second unkeyable row also counts");
+        assert_ne!(r1, (0, 0, 0, 0, 0, 0), "first unkeyable row counts");
+        assert_ne!(r2, (0, 0, 0, 0, 0, 0), "second unkeyable row also counts");
         assert_eq!(r1, r2, "both contribute full totals");
     }
 
@@ -6918,13 +8067,16 @@ mod tests {
         ];
 
         let stats = build_session_token_stats_from_messages(
-            "sess-1".to_string(),
-            "test-project".to_string(),
-            None,
+            SessionTokenStatsOptions {
+                provider: StatsProvider::Claude,
+                session_id: "sess-1".to_string(),
+                project_name: "test-project".to_string(),
+                summary: None,
+                mode: StatsMode::BillingTotal,
+                start_date: None,
+                end_date: None,
+            },
             &messages,
-            StatsMode::BillingTotal,
-            None,
-            None,
         )
         .expect("stats");
 
@@ -7126,5 +8278,61 @@ mod tests {
         assert_eq!(stats_provider_id(StatsProvider::Pi), "pi");
         assert_eq!(stats_provider_id(StatsProvider::Gemini), "gemini");
         assert_eq!(stats_provider_id(StatsProvider::Claude), "claude");
+    }
+
+    #[test]
+    fn model_stats_preserve_context_buckets_and_normalize_fast_tier() {
+        assert_eq!(
+            context_tier_min_tokens("openai/gpt-5.6-terra-2026-01-01", 272_001),
+            272_001
+        );
+        assert_eq!(context_tier_min_tokens("gpt-5.6-terra", 272_000), 0);
+
+        let model_key = model_usage_key("gpt-5.6-terra", Some("priority"));
+        let mut model_usage = HashMap::new();
+        model_usage.insert(model_key.clone(), (1, 300, 200, 100, 0, 0, 0));
+        let mut context_usage = HashMap::new();
+        context_usage.insert(
+            model_key,
+            HashMap::from([(
+                272_001,
+                ModelContextStats {
+                    min_context_tokens: 272_001,
+                    token_count: 300,
+                    input_tokens: 200,
+                    output_tokens: 100,
+                    ..Default::default()
+                },
+            )]),
+        );
+
+        let models = build_model_stats(
+            StatsProvider::Codex,
+            model_usage,
+            context_usage,
+            HashMap::new(),
+        );
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].service_tier.as_deref(), Some("fast"));
+        assert_eq!(models[0].context_breakdown[0].min_context_tokens, 272_001);
+    }
+
+    #[test]
+    fn nested_anthropic_cache_usage_is_flattened_with_ttl_split() {
+        let usage: TokenUsage = serde_json::from_value(json!({
+            "input_tokens": 100,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 10,
+                "ephemeral_1h_input_tokens": 5
+            },
+            "serviceTier": "standard"
+        }))
+        .expect("nested usage should deserialize");
+        let usage = normalize_token_usage(usage);
+
+        assert_eq!(usage.cache_creation_input_tokens, Some(15));
+        assert_eq!(usage.cache_creation_input_tokens_5m, Some(10));
+        assert_eq!(usage.cache_creation_input_tokens_1h, Some(5));
+        assert_eq!(usage.service_tier.as_deref(), Some("standard"));
     }
 }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -2685,7 +2685,7 @@ fn build_model_stats(
                     .unwrap_or_default();
                 context_breakdown.sort_by_key(|bucket| bucket.min_context_tokens);
                 ModelStats {
-                    provider_id: provider_id.clone(),
+                    provider_id: Some(provider_id.clone()),
                     model_name: model_name.to_string(),
                     service_tier: service_tier.map(str::to_string),
                     message_count,
@@ -5317,7 +5317,7 @@ pub async fn get_global_stats_summary(
                 context_breakdown.sort_by_key(|bucket| bucket.min_context_tokens);
                 let cost_usd = model_cost_map.get(&(provider, model_key.clone())).copied();
                 ModelStats {
-                    provider_id: stats_provider_id(provider).to_string(),
+                    provider_id: Some(stats_provider_id(provider).to_string()),
                     model_name: model_name.to_string(),
                     service_tier: service_tier.map(str::to_string),
                     message_count,
@@ -6846,7 +6846,7 @@ mod tests {
             .iter()
             .find(|model| model.model_name == "claude-sonnet-4-6")
             .expect("model distribution entry");
-        assert_eq!(model.provider_id, "claude");
+        assert_eq!(model.provider_id.as_deref(), Some("claude"));
         assert_eq!(model.token_count, 150);
         assert_eq!(model.cost_usd, Some(0.005));
     }

--- a/src-tauri/src/commands/stats/cache.rs
+++ b/src-tauri/src/commands/stats/cache.rs
@@ -54,12 +54,14 @@
 //! (`opencode://` …) and carry no `(size, mtime)` identity.
 
 use super::{
-    dedup_usage_key, extract_token_usage, extract_token_usage_from_global_entry,
-    parse_global_stats_entry_simd, parse_raw_log_entry_simd, parse_timestamp_utc,
-    should_include_stats_entry, token_usage_has_token_fields, token_usage_totals,
-    track_skill_and_subagent_usage, track_skill_and_subagent_usage_from_global_entry,
-    track_tool_usage, track_tool_usage_from_global_entry, ModelUsageAggregate,
+    build_model_stats, dedup_usage_key, extract_token_usage, extract_token_usage_from_global_entry,
+    merge_model_context_usage, parse_global_stats_entry_simd, parse_raw_log_entry_simd,
+    parse_timestamp_utc, should_include_stats_entry, token_usage_has_token_fields,
+    token_usage_totals, track_skill_and_subagent_usage,
+    track_skill_and_subagent_usage_from_global_entry, track_tool_usage,
+    track_tool_usage_from_global_entry, ModelContextUsageMap, ModelUsageAggregate,
     ProjectSessionFileStats, SessionComparisonStats, SessionFileStats, StatsMode, StatsProvider,
+    UNKNOWN_MODEL_NAME,
 };
 use crate::models::{ClaudeMessage, DailyStats, SessionTokenStats, TokenUsage, ToolUsageStats};
 use crate::utils::find_line_ranges;
@@ -87,12 +89,15 @@ pub(super) struct DayBucket {
     output_tokens: u64,
     cache_creation_tokens: u64,
     cache_read_tokens: u64,
+    reasoning_tokens: u64,
     tool_usage: HashMap<String, (u32, u32)>,
     skill_usage: HashMap<String, (u32, u32)>,
     subagent_usage: HashMap<String, (u32, u32)>,
-    /// Populated by the global builder only; message-pipeline composers do
-    /// not read model breakdowns.
+    /// Populated by both global and message-pipeline builders for billing
+    /// breakdowns. Project/session composers may consume this map directly.
     model_usage: HashMap<String, ModelUsageAggregate>,
+    model_context_usage: ModelContextUsageMap,
+    model_costs: HashMap<String, f64>,
     /// hour-of-day → (message count, deduped tokens).
     hourly_activity: HashMap<u8, (u32, u64)>,
     first_ts: Option<DateTime<Utc>>,
@@ -114,7 +119,11 @@ pub(super) struct DayBucket {
 
 impl DayBucket {
     fn token_total(&self) -> u64 {
-        self.input_tokens + self.output_tokens + self.cache_creation_tokens + self.cache_read_tokens
+        self.input_tokens
+            + self.output_tokens
+            + self.cache_creation_tokens
+            + self.cache_read_tokens
+            + self.reasoning_tokens
     }
 }
 
@@ -281,7 +290,7 @@ fn bucketed_dedup_totals(
     bucket: Option<&str>,
     usage: &TokenUsage,
     spans_buckets: &mut bool,
-) -> (u64, u64, u64, u64, u64) {
+) -> (u64, u64, u64, u64, u64, u64) {
     let Some(key) = dedup_key else {
         return token_usage_totals(usage);
     };
@@ -294,7 +303,36 @@ fn bucketed_dedup_totals(
             if occupied.get().as_deref() != bucket {
                 *spans_buckets = true;
             }
-            (0, 0, 0, 0, 0)
+            (0, 0, 0, 0, 0, 0)
+        }
+    }
+}
+
+/// Dedup an authoritative source cost while recording whether the same
+/// message identity appears in more than one day bucket. This mirrors
+/// [`bucketed_dedup_totals`] so date-filtered composition can fall back to a
+/// row-level scan instead of assigning a repeated cost to the wrong day.
+fn bucketed_dedup_source_cost(
+    first_bucket_by_key: &mut HashMap<String, Option<String>>,
+    dedup_key: Option<String>,
+    bucket: Option<&str>,
+    cost_usd: Option<f64>,
+    spans_buckets: &mut bool,
+) -> Option<f64> {
+    let cost_usd = cost_usd?;
+    let Some(key) = dedup_key else {
+        return Some(cost_usd);
+    };
+    match first_bucket_by_key.entry(key) {
+        Entry::Vacant(vacant) => {
+            vacant.insert(bucket.map(str::to_string));
+            Some(cost_usd)
+        }
+        Entry::Occupied(occupied) => {
+            if occupied.get().as_deref() != bucket {
+                *spans_buckets = true;
+            }
+            None
         }
     }
 }
@@ -303,18 +341,25 @@ impl DayBucket {
     /// Token, timestamp, and session-id bookkeeping shared by both builders.
     fn record_row(
         &mut self,
-        totals: (u64, u64, u64, u64, u64),
+        totals: (u64, u64, u64, u64, u64, u64),
         timestamp: Option<(DateTime<Utc>, &str)>,
         session_id: Option<&str>,
         row_seq: u64,
     ) {
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, tokens) =
-            totals;
+        let (
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            reasoning_tokens,
+            tokens,
+        ) = totals;
         self.message_count = self.message_count.saturating_add(1);
         self.input_tokens += input_tokens;
         self.output_tokens += output_tokens;
         self.cache_creation_tokens += cache_creation_tokens;
         self.cache_read_tokens += cache_read_tokens;
+        self.reasoning_tokens += reasoning_tokens;
 
         if self.first_session_id.is_none() {
             if let Some(session_id) = session_id {
@@ -343,20 +388,26 @@ impl DayBucket {
         }
     }
 
-    fn record_model_usage(&mut self, model_name: &str, totals: (u64, u64, u64, u64, u64)) {
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, tokens) =
-            totals;
-        let entry = self
-            .model_usage
-            .entry(model_name.to_string())
-            .or_insert((0, 0, 0, 0, 0, 0, 0));
-        entry.0 += 1;
-        entry.1 += tokens;
-        entry.2 += input_tokens;
-        entry.3 += output_tokens;
-        entry.4 += cache_creation_tokens;
-        entry.5 += cache_read_tokens;
-        entry.6 += 0;
+    fn record_model_usage(
+        &mut self,
+        model_name: &str,
+        totals: (u64, u64, u64, u64, u64, u64),
+        service_tier: Option<&str>,
+        cache_creation_tokens_1h: u64,
+        cost_usd: Option<f64>,
+    ) {
+        super::accumulate_model_usage(
+            &mut self.model_usage,
+            &mut self.model_context_usage,
+            &mut self.model_costs,
+            super::ModelUsageUpdate {
+                model_name,
+                service_tier,
+                totals,
+                cache_creation_tokens_1h,
+                source_cost: cost_usd,
+            },
+        );
     }
 }
 
@@ -409,6 +460,7 @@ pub(super) fn build_global_file_aggregate(
 
     let mut aggregate = FileAggregate::default();
     let mut first_bucket_by_key: HashMap<String, Option<String>> = HashMap::new();
+    let mut first_cost_bucket_by_key: HashMap<String, Option<String>> = HashMap::new();
     let mut day_timestamps: HashMap<String, Vec<DateTime<Utc>>> = HashMap::new();
     let mut row_seq = 0u64;
 
@@ -440,6 +492,16 @@ pub(super) fn build_global_file_aggregate(
             &usage,
             &mut aggregate.dedup_spans_buckets,
         );
+        let source_cost = entry
+            .cost_usd
+            .or_else(|| entry.message.as_ref().and_then(|message| message.cost_usd));
+        let deduped_source_cost = bucketed_dedup_source_cost(
+            &mut first_cost_bucket_by_key,
+            dedup_usage_key("", message_id, uuid),
+            date.as_deref(),
+            source_cost,
+            &mut aggregate.dedup_spans_buckets,
+        );
 
         if let Some(ts) = parsed_ts {
             day_timestamps
@@ -455,8 +517,22 @@ pub(super) fn build_global_file_aggregate(
             None,
             row_seq,
         );
-        if let Some(model_name) = entry.message.as_ref().and_then(|m| m.model.as_deref()) {
-            bucket.record_model_usage(model_name, totals);
+        let model_name = entry
+            .message
+            .as_ref()
+            .and_then(|m| m.model.as_deref())
+            .unwrap_or(UNKNOWN_MODEL_NAME);
+        if entry.message.as_ref().is_some_and(|m| m.model.is_some())
+            || totals.5 > 0
+            || deduped_source_cost.is_some()
+        {
+            bucket.record_model_usage(
+                model_name,
+                totals,
+                usage.service_tier.as_deref(),
+                u64::from(usage.cache_creation_input_tokens_1h.unwrap_or(0)),
+                deduped_source_cost,
+            );
         }
         track_tool_usage_from_global_entry(&entry, &mut bucket.tool_usage);
         track_skill_and_subagent_usage_from_global_entry(
@@ -487,6 +563,7 @@ pub(super) fn build_message_file_aggregate(
 
     let mut aggregate = FileAggregate::default();
     let mut first_bucket_by_key: HashMap<String, Option<String>> = HashMap::new();
+    let mut first_cost_bucket_by_key: HashMap<String, Option<String>> = HashMap::new();
     let mut day_timestamps: HashMap<String, Vec<DateTime<Utc>>> = HashMap::new();
     let mut row_seq = 0u64;
 
@@ -529,6 +606,17 @@ pub(super) fn build_message_file_aggregate(
             &usage,
             &mut aggregate.dedup_spans_buckets,
         );
+        let deduped_source_cost = bucketed_dedup_source_cost(
+            &mut first_cost_bucket_by_key,
+            dedup_usage_key(
+                &message.session_id,
+                message.message_id.as_deref(),
+                &message.uuid,
+            ),
+            date.as_deref(),
+            message.cost_usd,
+            &mut aggregate.dedup_spans_buckets,
+        );
 
         if let Some(ts) = parsed_ts {
             day_timestamps
@@ -544,6 +632,16 @@ pub(super) fn build_message_file_aggregate(
             Some(&message.session_id),
             row_seq,
         );
+        let model_name = message.model.as_deref().unwrap_or(UNKNOWN_MODEL_NAME);
+        if message.model.is_some() || totals.5 > 0 || deduped_source_cost.is_some() {
+            bucket.record_model_usage(
+                model_name,
+                totals,
+                usage.service_tier.as_deref(),
+                u64::from(usage.cache_creation_input_tokens_1h.unwrap_or(0)),
+                deduped_source_cost,
+            );
+        }
         track_tool_usage(&message, &mut bucket.tool_usage);
         track_skill_and_subagent_usage(
             &message,
@@ -681,10 +779,15 @@ pub(super) fn compose_global(
         stats.token_distribution.output += bucket.output_tokens;
         stats.token_distribution.cache_creation += bucket.cache_creation_tokens;
         stats.token_distribution.cache_read += bucket.cache_read_tokens;
+        stats.token_distribution.reasoning += bucket.reasoning_tokens;
         merge_counter_map(&mut stats.tool_usage, &bucket.tool_usage);
         merge_counter_map(&mut stats.skill_usage, &bucket.skill_usage);
         merge_counter_map(&mut stats.subagent_usage, &bucket.subagent_usage);
         merge_model_map(&mut stats.model_usage, &bucket.model_usage);
+        merge_model_context_usage(&mut stats.model_context_usage, &bucket.model_context_usage);
+        for (model, cost) in &bucket.model_costs {
+            *stats.model_costs.entry(model.clone()).or_insert(0.0) += cost;
+        }
 
         stats.daily_stats.insert(
             (*date).clone(),
@@ -734,10 +837,15 @@ pub(super) fn compose_global(
         stats.token_distribution.output += undated.output_tokens;
         stats.token_distribution.cache_creation += undated.cache_creation_tokens;
         stats.token_distribution.cache_read += undated.cache_read_tokens;
+        stats.token_distribution.reasoning += undated.reasoning_tokens;
         merge_counter_map(&mut stats.tool_usage, &undated.tool_usage);
         merge_counter_map(&mut stats.skill_usage, &undated.skill_usage);
         merge_counter_map(&mut stats.subagent_usage, &undated.subagent_usage);
         merge_model_map(&mut stats.model_usage, &undated.model_usage);
+        merge_model_context_usage(&mut stats.model_context_usage, &undated.model_context_usage);
+        for (model, cost) in &undated.model_costs {
+            *stats.model_costs.entry(model.clone()).or_insert(0.0) += cost;
+        }
     }
 
     stats.session_duration_minutes = merged_active_minutes(&runs);
@@ -763,9 +871,15 @@ pub(super) fn compose_project(
         stats.token_distribution.output += bucket.output_tokens;
         stats.token_distribution.cache_creation += bucket.cache_creation_tokens;
         stats.token_distribution.cache_read += bucket.cache_read_tokens;
+        stats.token_distribution.reasoning += bucket.reasoning_tokens;
         merge_counter_map(&mut stats.tool_usage, &bucket.tool_usage);
         merge_counter_map(&mut stats.skill_usage, &bucket.skill_usage);
         merge_counter_map(&mut stats.subagent_usage, &bucket.subagent_usage);
+        merge_model_map(&mut stats.model_usage, &bucket.model_usage);
+        merge_model_context_usage(&mut stats.model_context_usage, &bucket.model_context_usage);
+        for (model, cost) in &bucket.model_costs {
+            *stats.model_costs.entry(model.clone()).or_insert(0.0) += cost;
+        }
 
         stats.session_dates.insert((*date).clone());
         stats.daily_stats.insert(
@@ -803,9 +917,15 @@ pub(super) fn compose_project(
         stats.token_distribution.output += undated.output_tokens;
         stats.token_distribution.cache_creation += undated.cache_creation_tokens;
         stats.token_distribution.cache_read += undated.cache_read_tokens;
+        stats.token_distribution.reasoning += undated.reasoning_tokens;
         merge_counter_map(&mut stats.tool_usage, &undated.tool_usage);
         merge_counter_map(&mut stats.skill_usage, &undated.skill_usage);
         merge_counter_map(&mut stats.subagent_usage, &undated.subagent_usage);
+        merge_model_map(&mut stats.model_usage, &undated.model_usage);
+        merge_model_context_usage(&mut stats.model_context_usage, &undated.model_context_usage);
+        for (model, cost) in &undated.model_costs {
+            *stats.model_costs.entry(model.clone()).or_insert(0.0) += cost;
+        }
     }
 
     if stats.total_messages == 0 {
@@ -836,8 +956,12 @@ pub(super) fn compose_session_token(
     let mut total_output_tokens = 0u64;
     let mut total_cache_creation_tokens = 0u64;
     let mut total_cache_read_tokens = 0u64;
+    let mut total_reasoning_tokens = 0u64;
     let mut message_count = 0usize;
     let mut tool_usage: HashMap<String, (u32, u32)> = HashMap::new();
+    let mut model_usage: HashMap<String, ModelUsageAggregate> = HashMap::new();
+    let mut model_context_usage: ModelContextUsageMap = HashMap::new();
+    let mut model_costs: HashMap<String, f64> = HashMap::new();
     let mut first: Option<(DateTime<Utc>, &String)> = None;
     let mut last: Option<(DateTime<Utc>, &String)> = None;
 
@@ -856,7 +980,13 @@ pub(super) fn compose_session_token(
         total_output_tokens += bucket.output_tokens;
         total_cache_creation_tokens += bucket.cache_creation_tokens;
         total_cache_read_tokens += bucket.cache_read_tokens;
+        total_reasoning_tokens += bucket.reasoning_tokens;
         merge_counter_map(&mut tool_usage, &bucket.tool_usage);
+        merge_model_map(&mut model_usage, &bucket.model_usage);
+        merge_model_context_usage(&mut model_context_usage, &bucket.model_context_usage);
+        for (model, cost) in &bucket.model_costs {
+            *model_costs.entry(model.clone()).or_insert(0.0) += cost;
+        }
 
         if let (Some(ts), Some(raw)) = (bucket.first_ts, bucket.first_ts_raw.as_ref()) {
             if first.map_or(true, |(current, _)| ts < current) {
@@ -877,7 +1007,8 @@ pub(super) fn compose_session_token(
     let total_tokens = total_input_tokens
         + total_output_tokens
         + total_cache_creation_tokens
-        + total_cache_read_tokens;
+        + total_cache_read_tokens
+        + total_reasoning_tokens;
 
     Composed::Ready(Some(SessionTokenStats {
         session_id: session_id.to_string(),
@@ -886,7 +1017,7 @@ pub(super) fn compose_session_token(
         total_output_tokens,
         total_cache_creation_tokens,
         total_cache_read_tokens,
-        total_reasoning_tokens: 0,
+        total_reasoning_tokens,
         total_tokens,
         message_count,
         first_message_time: first
@@ -896,6 +1027,12 @@ pub(super) fn compose_session_token(
             .map(|(_, raw)| raw.clone())
             .unwrap_or_else(|| "unknown".to_string()),
         summary: aggregate.summary.clone(),
+        model_distribution: build_model_stats(
+            StatsProvider::Claude,
+            model_usage,
+            model_context_usage,
+            model_costs,
+        ),
         // The scan path emits the map unsorted; keep that shape.
         most_used_tools: tool_usage
             .into_iter()

--- a/src-tauri/src/models/message.rs
+++ b/src-tauri/src/models/message.rs
@@ -249,6 +249,50 @@ mod tests {
     }
 
     #[test]
+    fn test_token_usage_provider_aliases() {
+        let usage: TokenUsage = serde_json::from_value(json!({
+            "inputTokens": 100,
+            "output": 200,
+            "cacheWrite": 50,
+            "cacheReadInputTokens": 25,
+            "cacheCreationInputTokens5m": 40,
+            "cacheCreationInputTokens1h": 10,
+            "cache_creation": {
+                "ephemeral5mInputTokens": 40,
+                "ephemeral1hInputTokens": 10
+            },
+            "reasoning": 7,
+            "serviceTier": "fast"
+        }))
+        .unwrap();
+
+        assert_eq!(usage.input_tokens, Some(100));
+        assert_eq!(usage.output_tokens, Some(200));
+        assert_eq!(usage.cache_creation_input_tokens, Some(50));
+        assert_eq!(usage.cache_read_input_tokens, Some(25));
+        assert_eq!(usage.cache_creation_input_tokens_5m, Some(40));
+        assert_eq!(usage.cache_creation_input_tokens_1h, Some(10));
+        assert_eq!(
+            usage
+                .cache_creation
+                .as_ref()
+                .unwrap()
+                .ephemeral_5m_input_tokens,
+            Some(40)
+        );
+        assert_eq!(
+            usage
+                .cache_creation
+                .as_ref()
+                .unwrap()
+                .ephemeral_1h_input_tokens,
+            Some(10)
+        );
+        assert_eq!(usage.reasoning_tokens, Some(7));
+        assert_eq!(usage.service_tier.as_deref(), Some("fast"));
+    }
+
+    #[test]
     fn test_token_usage_with_none_values() {
         let json_str = r#"{"input_tokens": 100}"#;
         let usage: TokenUsage = serde_json::from_str(json_str).unwrap();

--- a/src-tauri/src/models/message.rs
+++ b/src-tauri/src/models/message.rs
@@ -1,12 +1,49 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TokenUsage {
+    #[serde(alias = "inputTokens", alias = "input")]
     pub input_tokens: Option<u32>,
+    #[serde(alias = "outputTokens", alias = "output")]
     pub output_tokens: Option<u32>,
+    #[serde(alias = "cacheCreationInputTokens", alias = "cacheWrite")]
     pub cache_creation_input_tokens: Option<u32>,
+    #[serde(alias = "cacheReadInputTokens", alias = "cacheRead")]
     pub cache_read_input_tokens: Option<u32>,
+    /// Anthropic's nested cache-write breakdown. The aggregate field above is
+    /// retained for providers that only expose one cache-write number.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation: Option<CacheCreationUsage>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "cacheCreationInputTokens5m"
+    )]
+    pub cache_creation_input_tokens_5m: Option<u32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "cacheCreationInputTokens1h"
+    )]
+    pub cache_creation_input_tokens_1h: Option<u32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "reasoningTokens",
+        alias = "reasoning",
+        alias = "thoughtsTokenCount"
+    )]
+    pub reasoning_tokens: Option<u32>,
+    #[serde(default, alias = "serviceTier")]
     pub service_tier: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CacheCreationUsage {
+    #[serde(default, alias = "ephemeral5mInputTokens")]
+    pub ephemeral_5m_input_tokens: Option<u32>,
+    #[serde(default, alias = "ephemeral1hInputTokens")]
+    pub ephemeral_1h_input_tokens: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -196,7 +233,9 @@ mod tests {
             output_tokens: Some(200),
             cache_creation_input_tokens: Some(50),
             cache_read_input_tokens: Some(25),
+            reasoning_tokens: None,
             service_tier: Some("standard".to_string()),
+            ..Default::default()
         };
 
         let serialized = serde_json::to_string(&usage).unwrap();

--- a/src-tauri/src/models/message.rs
+++ b/src-tauri/src/models/message.rs
@@ -239,8 +239,10 @@ mod tests {
         };
 
         let serialized = serde_json::to_string(&usage).unwrap();
+        let serialized_value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
         let deserialized: TokenUsage = serde_json::from_str(&serialized).unwrap();
 
+        assert!(serialized_value.get("reasoning_tokens").is_none());
         assert_eq!(deserialized.input_tokens, Some(100));
         assert_eq!(deserialized.output_tokens, Some(200));
         assert_eq!(deserialized.cache_creation_input_tokens, Some(50));

--- a/src-tauri/src/models/snapshot_tests.rs
+++ b/src-tauri/src/models/snapshot_tests.rs
@@ -73,7 +73,9 @@ mod claude_message_snapshots {
                 output_tokens: Some(50),
                 cache_creation_input_tokens: Some(20),
                 cache_read_input_tokens: Some(10),
+                reasoning_tokens: None,
                 service_tier: Some("standard".to_string()),
+                ..Default::default()
             }),
             role: Some("assistant".to_string()),
             model: Some("claude-opus-4-20250514".to_string()),
@@ -132,7 +134,9 @@ mod claude_message_snapshots {
                 output_tokens: Some(45),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: Some(30),
+                reasoning_tokens: None,
                 service_tier: None,
+                ..Default::default()
             }),
             role: Some("assistant".to_string()),
             model: Some("forge-model-v1".to_string()),
@@ -196,7 +200,9 @@ mod claude_message_snapshots {
                 output_tokens: Some(34),
                 cache_creation_input_tokens: Some(0),
                 cache_read_input_tokens: Some(5),
+                reasoning_tokens: None,
                 service_tier: None,
+                ..Default::default()
             }),
             role: Some("assistant".to_string()),
             model: Some("claude-opus-4-8".to_string()),
@@ -254,7 +260,9 @@ mod claude_message_snapshots {
                 output_tokens: Some(100),
                 cache_creation_input_tokens: None,
                 cache_read_input_tokens: None,
+                reasoning_tokens: None,
                 service_tier: None,
+                ..Default::default()
             }),
             role: Some("assistant".to_string()),
             model: Some("claude-opus-4-20250514".to_string()),
@@ -294,7 +302,9 @@ mod token_usage_snapshots {
             output_tokens: Some(500),
             cache_creation_input_tokens: Some(200),
             cache_read_input_tokens: Some(100),
+            reasoning_tokens: None,
             service_tier: Some("premium".to_string()),
+            ..Default::default()
         };
 
         assert_json_snapshot!("full_token_usage", usage);
@@ -307,7 +317,9 @@ mod token_usage_snapshots {
             output_tokens: Some(25),
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: None,
             service_tier: None,
+            ..Default::default()
         };
 
         assert_json_snapshot!("minimal_token_usage", usage);
@@ -471,6 +483,7 @@ mod stats_snapshots {
             last_message_time: "2025-01-01T17:00:00Z".to_string(),
             summary: None,
             most_used_tools: Vec::new(),
+            model_distribution: Vec::new(),
         };
 
         assert_json_snapshot!("session_token_stats", stats);

--- a/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__stats_snapshots__session_token_stats.snap
+++ b/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__stats_snapshots__session_token_stats.snap
@@ -14,5 +14,6 @@ expression: stats
   "message_count": 50,
   "first_message_time": "2025-01-01T08:00:00Z",
   "last_message_time": "2025-01-01T17:00:00Z",
-  "most_used_tools": []
+  "most_used_tools": [],
+  "model_distribution": []
 }

--- a/src-tauri/src/models/stats.rs
+++ b/src-tauri/src/models/stats.rs
@@ -17,6 +17,9 @@ pub struct SessionTokenStats {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
     pub most_used_tools: Vec<ToolUsageStats>,
+    /// Per-model token/cost breakdown used by project and session billing UI.
+    #[serde(default)]
+    pub model_distribution: Vec<ModelStats>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -68,6 +71,9 @@ pub struct ProjectStatsSummary {
     pub daily_stats: Vec<DailyStats>,
     pub activity_heatmap: Vec<ActivityHeatmap>,
     pub token_distribution: TokenDistribution,
+    /// Per-model token/cost breakdown used by project billing UI.
+    #[serde(default)]
+    pub model_distribution: Vec<ModelStats>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -99,12 +105,40 @@ pub struct DateRange {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelStats {
+    #[serde(default)]
+    pub provider_id: String,
     pub model_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
     pub message_count: u32,
     pub token_count: u64,
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub reasoning_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    /// Per-request context buckets. Keeping this at the model row preserves
+    /// exact context-tier billing after rows are aggregated by model.
+    #[serde(default)]
+    pub context_breakdown: Vec<ModelContextStats>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ModelContextStats {
+    /// Zero means the default/short context tier; otherwise this is the
+    /// provider's minimum token threshold for the long tier.
+    pub min_context_tokens: u64,
+    pub token_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_tokens_5m: u64,
+    #[serde(default)]
+    pub cache_creation_tokens_1h: u64,
     pub cache_read_tokens: u64,
     #[serde(default)]
     pub reasoning_tokens: u64,
@@ -170,6 +204,7 @@ mod tests {
             last_message_time: "2025-06-01T12:00:00Z".to_string(),
             summary: Some("Test session summary".to_string()),
             most_used_tools: Vec::new(),
+            model_distribution: Vec::new(),
         };
 
         let serialized = serde_json::to_string(&stats).unwrap();

--- a/src-tauri/src/models/stats.rs
+++ b/src-tauri/src/models/stats.rs
@@ -105,8 +105,8 @@ pub struct DateRange {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelStats {
-    #[serde(default)]
-    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
     pub model_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
@@ -187,6 +187,7 @@ pub struct GlobalStatsSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_session_token_stats_serialization() {
@@ -238,5 +239,27 @@ mod tests {
         assert_eq!(dist.cache_creation, 0);
         assert_eq!(dist.cache_read, 0);
         assert_eq!(dist.reasoning, 0);
+    }
+
+    #[test]
+    fn test_model_stats_legacy_payload_without_provider_id() {
+        let stats: ModelStats = serde_json::from_value(json!({
+            "model_name": "legacy-model",
+            "message_count": 1,
+            "token_count": 10,
+            "input_tokens": 5,
+            "output_tokens": 5,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+            "context_breakdown": []
+        }))
+        .unwrap();
+
+        assert_eq!(stats.provider_id, None);
+        assert!(!serde_json::to_value(stats)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .contains_key("provider_id"));
     }
 }

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -614,7 +614,9 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
                 output_tokens: Some(output_tokens),
                 cache_creation_input_tokens: Some(cache_write),
                 cache_read_input_tokens: Some(cache_read),
+                reasoning_tokens: None,
                 service_tier: None,
+                ..Default::default()
             }),
             provider: Some("antigravity".to_string()),
             message_id: None,

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -485,12 +485,24 @@ pub(crate) fn parse_rollout_file(canonical_path: &Path) -> Result<Vec<ClaudeMess
                         // Apply to last assistant message without usage
                         if let Some(last_msg) = messages.last_mut() {
                             if last_msg.message_type == "assistant" && last_msg.usage.is_none() {
+                                let service_tier = payload
+                                    .get("service_tier")
+                                    .or_else(|| payload.get("serviceTier"))
+                                    .or_else(|| {
+                                        payload
+                                            .get("usage")
+                                            .and_then(|usage| usage.get("service_tier"))
+                                    })
+                                    .and_then(|value| value.as_str())
+                                    .map(str::to_string);
                                 last_msg.usage = Some(TokenUsage {
                                     input_tokens: Some(non_cached_input),
                                     output_tokens: Some(delta_output),
                                     cache_creation_input_tokens: None,
                                     cache_read_input_tokens: Some(delta_cached),
-                                    service_tier: None,
+                                    reasoning_tokens: None,
+                                    service_tier,
+                                    ..Default::default()
                                 });
                             }
                         }

--- a/src-tauri/src/providers/copilot_cli.rs
+++ b/src-tauri/src/providers/copilot_cli.rs
@@ -1006,7 +1006,9 @@ fn convert_assistant_message(
         output_tokens: Some(out),
         cache_creation_input_tokens: None,
         cache_read_input_tokens: None,
+        reasoning_tokens: None,
         service_tier: None,
+        ..Default::default()
     });
 
     let message_id = data

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -632,7 +632,9 @@ fn attach_composer_token_usage(composer: &Value, messages: &mut [ClaudeMessage])
             output_tokens: None,
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: None,
             service_tier: None,
+            ..Default::default()
         });
         if !stamp.is_empty() {
             message.timestamp = stamp;

--- a/src-tauri/src/providers/forgecode.rs
+++ b/src-tauri/src/providers/forgecode.rs
@@ -1125,12 +1125,14 @@ fn extract_usage(payload: &Value) -> Option<TokenUsage> {
     let input_tokens = direct_input_tokens.or_else(|| {
         prompt_tokens.map(|prompt| prompt.saturating_sub(cache_read_input_tokens.unwrap_or(0)))
     });
+    let reasoning_tokens = extract_u32(usage, &["reasoning_tokens", "reasoningTokens"]);
     let service_tier = extract_string(usage, &["service_tier", "serviceTier"]);
 
     if input_tokens.is_none()
         && output_tokens.is_none()
         && cache_creation_input_tokens.is_none()
         && cache_read_input_tokens.is_none()
+        && reasoning_tokens.is_none()
         && service_tier.is_none()
     {
         None
@@ -1140,7 +1142,9 @@ fn extract_usage(payload: &Value) -> Option<TokenUsage> {
             output_tokens,
             cache_creation_input_tokens,
             cache_read_input_tokens,
+            reasoning_tokens,
             service_tier,
+            ..Default::default()
         })
     }
 }

--- a/src-tauri/src/providers/gemini.rs
+++ b/src-tauri/src/providers/gemini.rs
@@ -678,7 +678,11 @@ fn convert_gemini_response(
         output_tokens: t.get("output").and_then(Value::as_u64).map(|v| v as u32),
         cache_creation_input_tokens: None,
         cache_read_input_tokens: t.get("cached").and_then(Value::as_u64).map(|v| v as u32),
-        reasoning_tokens: t.get("reasoning").and_then(Value::as_u64).map(|v| v as u32),
+        reasoning_tokens: t
+            .get("thoughts")
+            .or_else(|| t.get("reasoning"))
+            .and_then(Value::as_u64)
+            .map(|v| v as u32),
         service_tier: None,
         ..Default::default()
     });
@@ -1187,6 +1191,7 @@ mod tests {
         assert_eq!(usage.input_tokens, Some(100));
         assert_eq!(usage.output_tokens, Some(50));
         assert_eq!(usage.cache_read_input_tokens, Some(0));
+        assert_eq!(usage.reasoning_tokens, Some(10));
 
         let content = result.content.unwrap();
         let arr = content.as_array().unwrap();

--- a/src-tauri/src/providers/gemini.rs
+++ b/src-tauri/src/providers/gemini.rs
@@ -678,7 +678,9 @@ fn convert_gemini_response(
         output_tokens: t.get("output").and_then(Value::as_u64).map(|v| v as u32),
         cache_creation_input_tokens: None,
         cache_read_input_tokens: t.get("cached").and_then(Value::as_u64).map(|v| v as u32),
+        reasoning_tokens: t.get("reasoning").and_then(Value::as_u64).map(|v| v as u32),
         service_tier: None,
+        ..Default::default()
     });
 
     let content = if content_blocks.is_empty() {

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -716,7 +716,9 @@ fn attach_session_token_usage(session_dir: &Path, messages: &mut [ClaudeMessage]
             output_tokens: None,
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: None,
             service_tier: None,
+            ..Default::default()
         });
         if message.model.is_none() {
             message.model = fallback_model;

--- a/src-tauri/src/providers/llm.rs
+++ b/src-tauri/src/providers/llm.rs
@@ -272,7 +272,9 @@ fn load_messages_conn(conn: &Connection, conv_id: &str) -> Result<Vec<ClaudeMess
                     output_tokens: output_tokens.map(|t| t.max(0) as u32),
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
+                    reasoning_tokens: None,
                     service_tier: None,
+                    ..Default::default()
                 });
             }
             messages.push(msg);

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -533,16 +533,10 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        // Extract usage from val["tokens"] with fields "input" and "output"
-        let usage = val.get("tokens").map(|t| TokenUsage {
-            input_tokens: t.get("input").and_then(Value::as_u64).map(|v| v as u32),
-            output_tokens: t.get("output").and_then(Value::as_u64).map(|v| v as u32),
-            cache_creation_input_tokens: None,
-            cache_read_input_tokens: None,
-            reasoning_tokens: t.get("reasoning").and_then(Value::as_u64).map(|v| v as u32),
-            service_tier: None,
-            ..Default::default()
-        });
+        // Extract usage from val["tokens"]. Parts can contain additional
+        // cache/reasoning fields, so the message-level value is merged below
+        // instead of unconditionally winning.
+        let usage = val.get("tokens").map(parse_opencode_token_usage);
 
         // Extract cost from val["cost"]
         let cost_usd = val.get("cost").and_then(Value::as_f64);
@@ -564,8 +558,10 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
 
         let (content_value, parts_usage, parts_cost) = process_parts(&part_values);
 
-        // Use message-level usage/cost if present, otherwise fall back to parts-derived
-        let final_usage = usage.or(parts_usage);
+        // Message-level input/output are aggregate values. Fill only missing
+        // fields from parts so cache/reasoning usage is retained without
+        // double-counting input/output.
+        let final_usage = merge_token_usage(usage, parts_usage);
         let final_cost = cost_usd.or(parts_cost);
 
         let message_type = match role {
@@ -1030,15 +1026,7 @@ fn load_messages_with_conn(conn: &Connection, session_id: &str) -> Option<Vec<Cl
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let usage = val.get("tokens").map(|t| TokenUsage {
-            input_tokens: t.get("input").and_then(Value::as_u64).map(|v| v as u32),
-            output_tokens: t.get("output").and_then(Value::as_u64).map(|v| v as u32),
-            cache_creation_input_tokens: None,
-            cache_read_input_tokens: None,
-            reasoning_tokens: t.get("reasoning").and_then(Value::as_u64).map(|v| v as u32),
-            service_tier: None,
-            ..Default::default()
-        });
+        let usage = val.get("tokens").map(parse_opencode_token_usage);
 
         let cost_usd = val.get("cost").and_then(Value::as_f64);
 
@@ -1057,7 +1045,7 @@ fn load_messages_with_conn(conn: &Connection, session_id: &str) -> Option<Vec<Cl
 
         let (content_value, parts_usage, parts_cost) = process_parts(&part_values);
 
-        let final_usage = usage.or(parts_usage);
+        let final_usage = merge_token_usage(usage, parts_usage);
         let final_cost = cost_usd.or(parts_cost);
 
         let message_type = match role {
@@ -1247,6 +1235,58 @@ fn sum_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
     }
 }
 
+fn parse_opencode_token_usage(tokens: &Value) -> TokenUsage {
+    let cache = tokens.get("cache");
+    let token = |key: &str| tokens.get(key).and_then(Value::as_u64).map(|v| v as u32);
+    let cache_token = |key: &str| {
+        cache
+            .and_then(|value| value.get(key))
+            .and_then(Value::as_u64)
+            .map(|v| v as u32)
+    };
+
+    TokenUsage {
+        input_tokens: token("input"),
+        output_tokens: token("output"),
+        cache_creation_input_tokens: cache_token("write"),
+        cache_read_input_tokens: cache_token("read"),
+        reasoning_tokens: token("reasoning"),
+        service_tier: None,
+        ..Default::default()
+    }
+}
+
+/// Preserve message-level aggregate input/output while filling fields that
+/// are only present on step-finish parts.
+fn merge_token_usage(
+    primary: Option<TokenUsage>,
+    fallback: Option<TokenUsage>,
+) -> Option<TokenUsage> {
+    match (primary, fallback) {
+        (Some(primary), Some(fallback)) => Some(TokenUsage {
+            input_tokens: primary.input_tokens.or(fallback.input_tokens),
+            output_tokens: primary.output_tokens.or(fallback.output_tokens),
+            cache_creation_input_tokens: primary
+                .cache_creation_input_tokens
+                .or(fallback.cache_creation_input_tokens),
+            cache_creation_input_tokens_5m: primary
+                .cache_creation_input_tokens_5m
+                .or(fallback.cache_creation_input_tokens_5m),
+            cache_creation_input_tokens_1h: primary
+                .cache_creation_input_tokens_1h
+                .or(fallback.cache_creation_input_tokens_1h),
+            cache_read_input_tokens: primary
+                .cache_read_input_tokens
+                .or(fallback.cache_read_input_tokens),
+            reasoning_tokens: primary.reasoning_tokens.or(fallback.reasoning_tokens),
+            service_tier: primary.service_tier.or(fallback.service_tier),
+            cache_creation: primary.cache_creation.or(fallback.cache_creation),
+        }),
+        (Some(usage), None) | (None, Some(usage)) => Some(usage),
+        (None, None) => None,
+    }
+}
+
 // is_safe_storage_id is imported from crate::utils
 
 fn process_parts(parts: &[Value]) -> (Option<Value>, Option<TokenUsage>, Option<f64>) {
@@ -1342,28 +1382,12 @@ fn process_parts(parts: &[Value]) -> (Option<Value>, Option<TokenUsage>, Option<
                 // Extract token usage if available
                 let (input, output, reasoning, cache_read, cache_write) =
                     if let Some(t) = part.get("tokens") {
-                        let cache_obj = t.get("cache");
-                        let i = t.get("input").and_then(Value::as_u64).map(|v| v as u32);
-                        let o = t.get("output").and_then(Value::as_u64).map(|v| v as u32);
-                        let r = t.get("reasoning").and_then(Value::as_u64).map(|v| v as u32);
-                        let cw = cache_obj
-                            .and_then(|c| c.get("write"))
-                            .and_then(Value::as_u64)
-                            .map(|v| v as u32);
-                        let cr = cache_obj
-                            .and_then(|c| c.get("read"))
-                            .and_then(Value::as_u64)
-                            .map(|v| v as u32);
-
-                        let new_usage = TokenUsage {
-                            input_tokens: i,
-                            output_tokens: o,
-                            cache_creation_input_tokens: cw,
-                            cache_read_input_tokens: cr,
-                            reasoning_tokens: r,
-                            service_tier: None,
-                            ..Default::default()
-                        };
+                        let new_usage = parse_opencode_token_usage(t);
+                        let i = new_usage.input_tokens;
+                        let o = new_usage.output_tokens;
+                        let r = new_usage.reasoning_tokens;
+                        let cw = new_usage.cache_creation_input_tokens;
+                        let cr = new_usage.cache_read_input_tokens;
                         usage = match usage {
                             Some(prev) => Some(TokenUsage {
                                 input_tokens: sum_opt(prev.input_tokens, new_usage.input_tokens),
@@ -1637,6 +1661,29 @@ mod tests {
         assert_eq!(blocks[2]["name"], "Task");
         assert_eq!(blocks[2]["id"], "task-2");
         assert_eq!(blocks[3]["tool_use_id"], "task-2");
+    }
+
+    #[test]
+    fn merges_message_usage_with_part_usage_without_double_counting() {
+        let message_usage = parse_opencode_token_usage(&json!({
+            "input": 100,
+            "output": 50
+        }));
+        let part_usage = parse_opencode_token_usage(&json!({
+            "input": 10,
+            "output": 5,
+            "reasoning": 7,
+            "cache": { "read": 30, "write": 20 }
+        }));
+
+        let merged = merge_token_usage(Some(message_usage), Some(part_usage))
+            .expect("partial usage should merge");
+
+        assert_eq!(merged.input_tokens, Some(100));
+        assert_eq!(merged.output_tokens, Some(50));
+        assert_eq!(merged.reasoning_tokens, Some(7));
+        assert_eq!(merged.cache_read_input_tokens, Some(30));
+        assert_eq!(merged.cache_creation_input_tokens, Some(20));
     }
 
     #[test]

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -539,7 +539,9 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
             output_tokens: t.get("output").and_then(Value::as_u64).map(|v| v as u32),
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: t.get("reasoning").and_then(Value::as_u64).map(|v| v as u32),
             service_tier: None,
+            ..Default::default()
         });
 
         // Extract cost from val["cost"]
@@ -1033,7 +1035,9 @@ fn load_messages_with_conn(conn: &Connection, session_id: &str) -> Option<Vec<Cl
             output_tokens: t.get("output").and_then(Value::as_u64).map(|v| v as u32),
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: t.get("reasoning").and_then(Value::as_u64).map(|v| v as u32),
             service_tier: None,
+            ..Default::default()
         });
 
         let cost_usd = val.get("cost").and_then(Value::as_f64);
@@ -1356,7 +1360,9 @@ fn process_parts(parts: &[Value]) -> (Option<Value>, Option<TokenUsage>, Option<
                             output_tokens: o,
                             cache_creation_input_tokens: cw,
                             cache_read_input_tokens: cr,
+                            reasoning_tokens: r,
                             service_tier: None,
+                            ..Default::default()
                         };
                         usage = match usage {
                             Some(prev) => Some(TokenUsage {
@@ -1370,7 +1376,12 @@ fn process_parts(parts: &[Value]) -> (Option<Value>, Option<TokenUsage>, Option<
                                     prev.cache_read_input_tokens,
                                     new_usage.cache_read_input_tokens,
                                 ),
+                                reasoning_tokens: sum_opt(
+                                    prev.reasoning_tokens,
+                                    new_usage.reasoning_tokens,
+                                ),
                                 service_tier: None,
+                                ..Default::default()
                             }),
                             None => Some(new_usage),
                         };

--- a/src-tauri/src/providers/pi.rs
+++ b/src-tauri/src/providers/pi.rs
@@ -522,6 +522,14 @@ fn convert_record(rec: &Value, session_id: &str, provider: &'static str) -> Opti
     } else {
         None
     };
+    let cost_usd = msg
+        .get("usage")
+        .and_then(|usage| usage.get("cost"))
+        .and_then(|cost| {
+            cost.get("total")
+                .and_then(Value::as_f64)
+                .or_else(|| cost.as_f64())
+        });
 
     let mut out = build_provider_message(
         provider,
@@ -543,6 +551,7 @@ fn convert_record(rec: &Value, session_id: &str, provider: &'static str) -> Opti
             out.usage = Some(convert_usage(usage));
         }
     }
+    out.cost_usd = cost_usd;
     Some(out)
 }
 
@@ -633,7 +642,9 @@ fn convert_usage(usage: &Value) -> TokenUsage {
         output_tokens: g("output"),
         cache_creation_input_tokens: g("cacheWrite"),
         cache_read_input_tokens: g("cacheRead"),
+        reasoning_tokens: g("reasoning"),
         service_tier: None,
+        ..Default::default()
     }
 }
 
@@ -769,6 +780,7 @@ mod tests {
         assert_eq!(a.role.as_deref(), Some("assistant"));
         assert_eq!(a.parent_uuid.as_deref(), Some("u1"));
         assert_eq!(a.model.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(a.cost_usd, Some(0.001));
         assert_eq!(a.timestamp, ms_to_iso(1_749_412_330_000));
         assert_eq!(a.usage.as_ref().unwrap().input_tokens, Some(12));
         assert_eq!(a.usage.as_ref().unwrap().output_tokens, Some(34));

--- a/src-tauri/src/providers/qwen.rs
+++ b/src-tauri/src/providers/qwen.rs
@@ -457,12 +457,19 @@ fn convert_part(part: &Value) -> Option<Value> {
 
 fn convert_usage(usage: &Value) -> TokenUsage {
     let g = |k: &str| usage.get(k).and_then(Value::as_u64).map(|n| n as u32);
+    let prompt_tokens = g("promptTokenCount");
+    let cached_tokens = g("cachedContentTokenCount");
     TokenUsage {
-        input_tokens: g("promptTokenCount"),
+        // Gemini-compatible usage reports promptTokenCount inclusive of the
+        // cached subset. Keep only non-cached prompt tokens in input_tokens so
+        // totals and billing do not count the same cached tokens twice.
+        input_tokens: prompt_tokens.map(|prompt| prompt.saturating_sub(cached_tokens.unwrap_or(0))),
         output_tokens: g("candidatesTokenCount"),
         cache_creation_input_tokens: None,
-        cache_read_input_tokens: g("cachedContentTokenCount"),
+        cache_read_input_tokens: cached_tokens,
+        reasoning_tokens: g("thoughtsTokenCount"),
         service_tier: None,
+        ..Default::default()
     }
 }
 
@@ -591,7 +598,8 @@ mod tests {
         assert_eq!(a.role.as_deref(), Some("assistant"));
         assert_eq!(a.parent_uuid.as_deref(), Some("u1"));
         assert_eq!(a.model.as_deref(), Some("qwen3-coder-plus"));
-        assert_eq!(a.usage.as_ref().unwrap().input_tokens, Some(12));
+        // promptTokenCount includes the cached subset (12 total - 5 cached).
+        assert_eq!(a.usage.as_ref().unwrap().input_tokens, Some(7));
         assert_eq!(a.usage.as_ref().unwrap().output_tokens, Some(34));
         assert_eq!(a.usage.as_ref().unwrap().cache_read_input_tokens, Some(5));
         let ab = a.content.as_ref().unwrap().as_array().unwrap();

--- a/src-tauri/src/providers/vscode.rs
+++ b/src-tauri/src/providers/vscode.rs
@@ -916,7 +916,9 @@ fn build_assistant_message(
             output_tokens: Some(out as u32),
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: None,
             service_tier: None,
+            ..Default::default()
         });
     let duration_ms = req.get("elapsedMs").and_then(Value::as_u64);
 

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -157,7 +157,9 @@ impl MessageBuilder {
             output_tokens: Some(output),
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            reasoning_tokens: None,
             service_tier: None,
+            ..Default::default()
         });
         self
     }

--- a/src/components/AnalyticsDashboard/AnalyticsDashboard.tsx
+++ b/src/components/AnalyticsDashboard/AnalyticsDashboard.tsx
@@ -15,6 +15,7 @@ import { useAppStore } from "../../store/useAppStore";
 import type { AnalyticsDashboardProps } from "./types";
 import { ProjectStatsView, SessionStatsView, GlobalStatsView } from "./views";
 import { DatePickerHeader } from "../ui/DatePickerHeader";
+import { MetricModeToggle } from "../ui/MetricModeToggle";
 
 export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
   isViewingGlobalStats = false,
@@ -30,6 +31,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
     isLoadingGlobalStats,
     dateFilter,
     setDateFilter,
+    setAnalyticsMetricMode,
     analytics: analyticsState,
   } = useAppStore();
   const [activeTab, setActiveTab] = useState<"project" | "session">("project");
@@ -65,6 +67,11 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
       return (
         <div className="flex-1 flex flex-col overflow-auto bg-background">
           <div className="p-3 md:p-6 pb-0">
+            <MetricModeToggle
+              value={analyticsState.metricMode}
+              onChange={setAnalyticsMetricMode}
+              className="mb-2"
+            />
             <DatePickerHeader
               dateFilter={dateFilter}
               setDateFilter={setDateFilter}
@@ -74,6 +81,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
           <GlobalStatsView
             globalSummary={globalSummary}
             globalConversationSummary={globalConversationSummary}
+            metricMode={analyticsState.metricMode}
           />
         </div>
       );

--- a/src/components/AnalyticsDashboard/components/TokenDistributionChart.tsx
+++ b/src/components/AnalyticsDashboard/components/TokenDistributionChart.tsx
@@ -93,7 +93,10 @@ export const TokenDistributionChart: React.FC<TokenDistributionChartProps> = ({
                   stroke={arc.color}
                   strokeWidth="20"
                   strokeLinecap="butt"
-                  className="cursor-pointer transition-opacity duration-200 hover:opacity-70"
+                  tabIndex={0}
+                  role="img"
+                  aria-label={`${arc.label}: ${formatNumber(arc.value)} (${(arc.percentage * 100).toFixed(1)}%)`}
+                  className="cursor-pointer transition-opacity duration-200 hover:opacity-70 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:opacity-70"
                 />
               </TooltipTrigger>
               <ChartTooltip

--- a/src/components/AnalyticsDashboard/components/TokenDistributionChart.tsx
+++ b/src/components/AnalyticsDashboard/components/TokenDistributionChart.tsx
@@ -6,7 +6,7 @@
 
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { TrendingUp, Zap, Database, Eye } from "lucide-react";
+import { TrendingUp, Zap, Database, Eye, Brain } from "lucide-react";
 import { Tooltip, TooltipTrigger } from "../../ui/tooltip";
 import { ChartTooltip } from "../../ui/chart-tooltip";
 import type { TokenDistribution } from "../types";
@@ -30,6 +30,7 @@ export const TokenDistributionChart: React.FC<TokenDistributionChartProps> = ({
       { label: t("analytics.output"), value: distribution.output, color: "var(--metric-purple)", icon: Zap },
       { label: t("analytics.cacheCreation"), value: distribution.cache_creation, color: "var(--metric-blue)", icon: Database },
       { label: t("analytics.cacheRead"), value: distribution.cache_read, color: "var(--metric-amber)", icon: Eye },
+      { label: t("analytics.reasoning", "Reasoning"), value: distribution.reasoning, color: "var(--metric-pink)", icon: Brain },
     ],
     [t, distribution]
   );

--- a/src/components/AnalyticsDashboard/types.ts
+++ b/src/components/AnalyticsDashboard/types.ts
@@ -61,4 +61,5 @@ export interface TokenDistribution {
   output: number;
   cache_creation: number;
   cache_read: number;
+  reasoning: number;
 }

--- a/src/components/AnalyticsDashboard/utils/calculations.test.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.test.ts
@@ -39,4 +39,354 @@ describe("Grok model pricing", () => {
       )
     ).toBeCloseTo(8.3);
   });
+
+  it("applies the long-context tier to Grok 4.3 and its 4.20 variants", () => {
+    expect(
+      calculateModelPrice(
+        "grok-4.3",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 200_001 },
+      ),
+    ).toBeCloseTo(7.9);
+    expect(
+      calculateModelPrice(
+        "grok-4.20-0309-reasoning",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 200_001 },
+      ),
+    ).toBeCloseTo(7.9);
+  });
+
+  it("applies the long-context tier to Grok Build 0.1", () => {
+    expect(
+      calculateModelPrice(
+        "grok-build-0.1",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 200_001 },
+      ),
+    ).toBeCloseTo(6.4);
+  });
+});
+
+describe("provider pricing boundaries", () => {
+  it("does not apply a default price to an unknown model", () => {
+    expect(
+      calculateModelPrice(
+        "provider/private-model",
+        oneMillionTokens,
+        oneMillionTokens,
+        oneMillionTokens,
+        oneMillionTokens,
+      ),
+    ).toBeNull();
+  });
+
+  it("recognizes canonical provider/model identifiers", () => {
+    expect(
+      calculateModelPrice(
+        "openai/gpt-5.6-terra-2026-01-01",
+        oneMillionTokens,
+        oneMillionTokens,
+        oneMillionTokens,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(16.7);
+  });
+
+  it("uses the model-specific GPT-4.1 cached-input rate", () => {
+    expect(
+      calculateModelPrice(
+        "gpt-4.1",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(10.5);
+  });
+
+  it("recognizes GPT-5 and GPT-5-Codex aliases with cached input pricing", () => {
+    expect(
+      calculateModelPrice(
+        "gpt-5-codex",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(11.375);
+    expect(
+      calculateModelPrice(
+        "copilot/gpt-5-2025-08-07",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(11.375);
+  });
+
+  it("supports the OpenAI fast-mode Codex price when encoded in the model id", () => {
+    expect(
+      calculateModelPrice(
+        "gpt-5.3-codex-fast",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(31.85);
+  });
+
+  it("uses the reported OpenAI fast/priority service tier for the canonical model id", () => {
+    const fast = calculateModelPrice(
+      "gpt-5.3-codex",
+      oneMillionTokens,
+      oneMillionTokens,
+      0,
+      oneMillionTokens,
+      { serviceTier: "fast" },
+    );
+    const priority = calculateModelPrice(
+      "gpt-5.3-codex",
+      oneMillionTokens,
+      oneMillionTokens,
+      0,
+      oneMillionTokens,
+      { serviceTier: "priority" },
+    );
+
+    expect(fast).toBeCloseTo(31.85);
+    expect(priority).toBeCloseTo(31.85);
+  });
+
+  it("does not turn Cursor subscription usage into a zero-dollar API estimate", () => {
+    expect(
+      calculateModelPrice(
+        "cursor",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        0,
+        { providerId: "cursor" },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not infer proxy or subscription provider pricing without source cost", () => {
+    expect(
+      calculateModelPrice(
+        "gpt-5.3-codex",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        0,
+        { providerId: "opencode" },
+      ),
+    ).toBeNull();
+    expect(
+      calculateModelPrice(
+        "gpt-5.3-codex",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        0,
+        { providerId: "copilot" },
+      ),
+    ).toBeNull();
+  });
+
+  it("applies GPT-5.6 and GPT-5.4 long-context pricing", () => {
+    expect(
+      calculateModelPrice(
+        "gpt-5.6-terra",
+        oneMillionTokens,
+        oneMillionTokens,
+        oneMillionTokens,
+        oneMillionTokens,
+        { contextTokens: 272_001 },
+      ),
+    ).toBeCloseTo(27.4);
+    expect(
+      calculateModelPrice(
+        "gpt-5.4",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 272_001 },
+      ),
+    ).toBeCloseTo(28);
+  });
+
+  it("selects Gemini's long-context tier only above its threshold", () => {
+    expect(
+      calculateModelPrice(
+        "gemini-2.5-pro",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 200_000 },
+      ),
+    ).toBeCloseTo(11.375);
+    expect(
+      calculateModelPrice(
+        "gemini-2.5-pro",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 200_001 },
+      ),
+    ).toBeCloseTo(17.75);
+  });
+
+  it("prices Gemini 3.1 Pro Preview, including custom tools and long context", () => {
+    expect(
+      calculateModelPrice(
+        "gemini-3.1-pro-preview-customtools",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 200_000 },
+      ),
+    ).toBeCloseTo(14.2);
+    expect(
+      calculateModelPrice(
+        "gemini-3.1-pro-preview",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+        { contextTokens: 200_001 },
+      ),
+    ).toBeCloseTo(22.4);
+  });
+
+  it("prices Gemini 3.1 Flash Lite text/image/video tokens", () => {
+    expect(
+      calculateModelPrice(
+        "gemini-3.1-flash-lite",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(1.775);
+  });
+
+  it("charges separately reported reasoning at the output rate", () => {
+    expect(
+      calculateModelPrice(
+        "gemini-3.1-flash-lite",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        0,
+        { reasoningTokens: oneMillionTokens },
+      ),
+    ).toBeCloseTo(3.25);
+  });
+
+  it("prices the current Gemini 3.5 Flash generations", () => {
+    expect(
+      calculateModelPrice(
+        "gemini-3.5-flash-preview",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(10.65);
+    expect(
+      calculateModelPrice(
+        "gemini-3.5-flash-lite",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(2.83);
+  });
+
+  it("prices the current Gemini 3.6 and 3.7 Flash generations", () => {
+    expect(
+      calculateModelPrice(
+        "gemini-3.7-flash",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(4.575);
+    expect(
+      calculateModelPrice(
+        "gemini-3.6-flash-preview",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        oneMillionTokens,
+      ),
+    ).toBeCloseTo(4.575);
+  });
+
+  it("does not apply text pricing to modality-specific models", () => {
+    for (const model of [
+      "gemini-2.5-flash-preview-tts",
+      "gemini-2.5-flash-native-audio-preview",
+      "gemini-2.5-flash-image",
+      "gemini-3.1-pro-preview-image-generation",
+      "gemini-omni-flash-preview",
+      "gpt-4o-audio-preview",
+      "gpt-4o-mini-transcribe",
+      "gpt-4o-mini-search-preview",
+      "gpt-image-1",
+      "sora-2",
+      "grok-imagine-video",
+    ]) {
+      expect(
+        calculateModelPrice(
+          model,
+          oneMillionTokens,
+          oneMillionTokens,
+          oneMillionTokens,
+          oneMillionTokens,
+        ),
+        model,
+      ).toBeNull();
+    }
+  });
+
+  it("supports both five-minute and one-hour Claude cache writes", () => {
+    const fiveMinute = calculateModelPrice(
+      "claude-sonnet-5",
+      oneMillionTokens,
+      oneMillionTokens,
+      oneMillionTokens,
+      oneMillionTokens,
+      { cacheWriteTtl: "5m" },
+    );
+    const oneHour = calculateModelPrice(
+      "claude-sonnet-5",
+      oneMillionTokens,
+      oneMillionTokens,
+      oneMillionTokens,
+      oneMillionTokens,
+      { cacheWriteTtl: "1h" },
+    );
+
+    expect(fiveMinute).toBeCloseTo(14.7);
+    expect(oneHour).toBeCloseTo(16.2);
+  });
 });

--- a/src/components/AnalyticsDashboard/utils/calculations.test.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.test.ts
@@ -77,6 +77,34 @@ describe("Grok model pricing", () => {
   });
 });
 
+describe("service tier normalization", () => {
+  it("maps only the exact priority tier to fast", () => {
+    expect(
+      calculateModelPrice(
+        "gpt-5.3-codex",
+        oneMillionTokens,
+        oneMillionTokens,
+        0,
+        0,
+        { serviceTier: "priority" },
+      ),
+    ).toBeCloseTo(31.5);
+  });
+
+  it("falls back to the 5-minute cache-write rate when no 1-hour rate exists", () => {
+    expect(
+      calculateModelPrice(
+        "minimax-m2.7",
+        0,
+        0,
+        oneMillionTokens,
+        0,
+        { cacheWriteTtl: "1h" },
+      ),
+    ).toBeCloseTo(0.375);
+  });
+});
+
 describe("provider pricing boundaries", () => {
   it("does not apply a default price to an unknown model", () => {
     expect(

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -278,7 +278,8 @@ const findModelPricing = (
   if (TOKEN_UNSUPPORTED_MODEL_PATTERNS.some((pattern) => pattern.test(modelSegment))) {
     return null;
   }
-  const normalizedServiceTier = serviceTier?.trim().toLowerCase().replace("priority", "fast");
+  const rawServiceTier = serviceTier?.trim().toLowerCase();
+  const normalizedServiceTier = rawServiceTier === "priority" ? "fast" : rawServiceTier;
   const candidates = SORTED_MODEL_PRICING_ENTRIES
     .filter(([key]) => matchesModelKey(normalizedModelName, key))
     .flatMap(([key, basePricing]) => {

--- a/src/components/AnalyticsDashboard/utils/calculations.ts
+++ b/src/components/AnalyticsDashboard/utils/calculations.ts
@@ -22,85 +22,292 @@ export const formatNumber = (num: number): string => {
 };
 
 /**
- * Model API pricing configuration
+ * Model API pricing configuration.
+ *
+ * Prices are USD per 1M tokens. A pricing entry can contain multiple context
+ * tiers because several providers change every token rate once a request is
+ * above a context threshold. `cacheWrite` is the 5-minute/default write rate;
+ * `cacheWriteOneHour` is optional because not every provider publishes a
+ * separate one-hour cache rate.
  */
-interface ModelPricing {
+export interface ModelPricing {
   input: number;
   output: number;
   cacheWrite: number | null;
   cacheRead: number;
+  minContextTokens?: number;
+  cacheWriteOneHour?: number | null;
+  contextTiers?: ModelPricing[];
+  serviceTiers?: Record<string, ModelPricing>;
 }
 
-const MODEL_PRICING: Record<string, ModelPricing> = {
-  // Claude models
-  'claude-fable-5': { input: 10, output: 50, cacheWrite: 12.50, cacheRead: 1.00 },
-  'claude-opus-4-8': { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.50 },
-  'claude-opus-4-7': { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.50 },
-  'claude-opus-4-6': { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.50 },
-  'claude-opus-4-5': { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.50 },
-  'claude-opus-4': { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.50 },
-  'claude-sonnet-5': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
-  'claude-sonnet-4-6': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
-  'claude-sonnet-4-5': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
-  'claude-sonnet-4': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
-  'claude-haiku-4-5': { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.10 },
-  'claude-3-5-sonnet': { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 },
-  'claude-3-5-haiku': { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.10 },
-  'claude-3-haiku': { input: 0.25, output: 1.25, cacheWrite: 0.30, cacheRead: 0.03 },
-  // MiniMax models. M3 uses the Standard <=512K context tier; this calculator
-  // has no context-length input, and the current tier publishes no separate
-  // cache-write charge, so cache creation is intentionally treated as free.
-  'minimax-m3': { input: 0.6, output: 2.4, cacheWrite: null, cacheRead: 0.12 },
-  'minimax-m2.7': { input: 0.3, output: 1.2, cacheWrite: 0.375, cacheRead: 0.06 },
-  // OpenAI models (Codex CLI) - specific keys must precede prefix matches
-  // cacheWrite is 0 (OpenAI does not charge for cache writes)
-  // cacheRead is input_rate * 0.1 (90% discount on cached input)
-  'gpt-5.6-sol': { input: 5, output: 30, cacheWrite: 0, cacheRead: 0.50 },
-  'gpt-5.6-terra': { input: 2.5, output: 15, cacheWrite: 0, cacheRead: 0.25 },
-  'gpt-5.6-luna': { input: 1, output: 6, cacheWrite: 0, cacheRead: 0.10 },
-  'gpt-5.5': { input: 5, output: 30, cacheWrite: 0, cacheRead: 0.50 },
-  'gpt-5.4': { input: 2.5, output: 15, cacheWrite: 0, cacheRead: 0.25 },
-  'gpt-4.1-mini': { input: 0.4, output: 1.6, cacheWrite: 0, cacheRead: 0.04 },
-  'gpt-4.1-nano': { input: 0.1, output: 0.4, cacheWrite: 0, cacheRead: 0.01 },
-  'gpt-4.1': { input: 2, output: 8, cacheWrite: 0, cacheRead: 0.20 },
-  'o4-mini': { input: 1.1, output: 4.4, cacheWrite: 0, cacheRead: 0.11 },
-  'codex-mini': { input: 1.5, output: 6, cacheWrite: 0, cacheRead: 0.15 },
-  // Google models (OpenCode)
-  'gemini-2.5-pro': { input: 1.25, output: 10, cacheWrite: 0, cacheRead: 0 },
-  'gemini-2.5-flash': { input: 0.15, output: 0.60, cacheWrite: 0, cacheRead: 0 },
-  // xAI's Grok Build aliases: grok-build-latest resolves to Grok 4.5,
-  // while grok-build-0.1 / grok-code-fast are the lower-priced Build model.
-  'grok-build-latest': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
-  'grok-build-0.1': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
-  'grok-code-fast-1-0825': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
-  'grok-code-fast-1': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
-  'grok-code-fast': { input: 1, output: 2, cacheWrite: 0, cacheRead: 0.20 },
-  'grok-4.5-build': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
-  'grok-4.5': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
-  'grok-4.3': { input: 1.25, output: 2.5, cacheWrite: 0, cacheRead: 0.20 },
-  'grok-build': { input: 2, output: 6, cacheWrite: 0, cacheRead: 0.30 },
-  'grok-4': { input: 3, output: 15, cacheWrite: 0, cacheRead: 0.75 },
-  // Cursor product-level label (not underlying Claude/GPT)
-  'cursor': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
-};
+export type CacheWriteTtl = "5m" | "1h";
 
-const DEFAULT_PRICING: ModelPricing = { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.30 };
+export interface ModelPriceOptions {
+  providerId?: string;
+  contextTokens?: number;
+  cacheWriteTtl?: CacheWriteTtl;
+  /** Provider billing tier, e.g. OpenAI's `standard` or `fast`. */
+  serviceTier?: string;
+  /** Providers such as Gemini and OpenCode may expose reasoning separately from output. */
+  reasoningTokens?: number;
+}
+
+type ModelPricingTierOptions = Omit<
+  ModelPricing,
+  "input" | "output" | "cacheRead" | "cacheWrite"
+> & { cacheWrite?: number | null };
+
+const tier = (
+  input: number,
+  output: number,
+  cacheRead: number,
+  options: ModelPricingTierOptions = {},
+): ModelPricing => ({ input, output, cacheRead, cacheWrite: null, ...options });
+
+const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Anthropic. Current standard prices; cacheWrite is the 5-minute rate.
+  "claude-fable-5": tier(10, 50, 1, { cacheWrite: 12.5, cacheWriteOneHour: 20 }),
+  "claude-mythos-5": tier(10, 50, 1, { cacheWrite: 12.5, cacheWriteOneHour: 20 }),
+  "claude-mythos-preview": tier(10, 50, 1, { cacheWrite: 12.5, cacheWriteOneHour: 20 }),
+  "claude-opus-5": tier(5, 25, 0.5, { cacheWrite: 6.25, cacheWriteOneHour: 10 }),
+  "claude-opus-4-8": tier(5, 25, 0.5, { cacheWrite: 6.25, cacheWriteOneHour: 10 }),
+  "claude-opus-4-7": tier(5, 25, 0.5, { cacheWrite: 6.25, cacheWriteOneHour: 10 }),
+  "claude-opus-4-6": tier(5, 25, 0.5, { cacheWrite: 6.25, cacheWriteOneHour: 10 }),
+  "claude-opus-4-5": tier(5, 25, 0.5, { cacheWrite: 6.25, cacheWriteOneHour: 10 }),
+  "claude-opus-4-1": tier(15, 75, 1.5, { cacheWrite: 18.75, cacheWriteOneHour: 30 }),
+  "claude-opus-4": tier(15, 75, 1.5, { cacheWrite: 18.75, cacheWriteOneHour: 30 }),
+  "claude-sonnet-5": tier(2, 10, 0.2, { cacheWrite: 2.5, cacheWriteOneHour: 4 }),
+  "claude-sonnet-4-6": tier(3, 15, 0.3, { cacheWrite: 3.75, cacheWriteOneHour: 6 }),
+  "claude-sonnet-4-5": tier(3, 15, 0.3, { cacheWrite: 3.75, cacheWriteOneHour: 6 }),
+  "claude-sonnet-4": tier(3, 15, 0.3, { cacheWrite: 3.75, cacheWriteOneHour: 6 }),
+  "claude-haiku-4-5": tier(1, 5, 0.1, { cacheWrite: 1.25, cacheWriteOneHour: 2 }),
+  "claude-3-5-sonnet": tier(3, 15, 0.3, { cacheWrite: 3.75, cacheWriteOneHour: 6 }),
+  "claude-3-5-haiku": tier(0.8, 4, 0.08, { cacheWrite: 1, cacheWriteOneHour: 1.6 }),
+  "claude-haiku-3": tier(0.25, 1.25, 0.03, { cacheWrite: 0.3, cacheWriteOneHour: 0.5 }),
+  "claude-3-haiku": tier(0.25, 1.25, 0.03, { cacheWrite: 0.3, cacheWriteOneHour: 0.5 }),
+
+  // MiniMax. M3 has a second price tier above 512K context.
+  "minimax-m3": tier(0.6, 2.4, 0.12, {
+    cacheWrite: null,
+    contextTiers: [tier(1.2, 4.8, 0.24, { minContextTokens: 512_001, cacheWrite: null })],
+  }),
+  "minimax-m2.7": tier(0.3, 1.2, 0.06, { cacheWrite: 0.375 }),
+  "minimax-m2.5": tier(0.3, 1.2, 0.06, { cacheWrite: 0.375 }),
+  "minimax-m2.1": tier(0.3, 1.2, 0.06, { cacheWrite: 0.375 }),
+
+  // OpenAI. Cached input is a separate input rate. Cache writes are only
+  // charged for the GPT-5.6 family; older GPT-5 generations do not publish a
+  // separate cache-write charge. Long-context GPT-5.4/5.5/5.6 rates apply to
+  // the whole request after the 272K prompt threshold is crossed.
+  "gpt-5.6": tier(5, 30, 0.5, {
+    cacheWrite: 6.25,
+    contextTiers: [tier(10, 45, 1, { minContextTokens: 272_001, cacheWrite: 12.5 })],
+  }),
+  "gpt-5.6-sol": tier(5, 30, 0.5, {
+    cacheWrite: 6.25,
+    contextTiers: [tier(10, 45, 1, { minContextTokens: 272_001, cacheWrite: 12.5 })],
+  }),
+  "gpt-5.6-terra": tier(2, 12, 0.2, {
+    cacheWrite: 2.5,
+    contextTiers: [tier(4, 18, 0.4, { minContextTokens: 272_001, cacheWrite: 5 })],
+  }),
+  "gpt-5.6-luna": tier(0.2, 1.2, 0.02, {
+    cacheWrite: 0.25,
+    contextTiers: [tier(0.4, 1.8, 0.04, { minContextTokens: 272_001, cacheWrite: 0.5 })],
+  }),
+  "gpt-5.6-cyber": tier(12.5, 75, 1.25, { cacheWrite: 15.625 }),
+  "daybreak-blue-latest": tier(5, 30, 0.5, { cacheWrite: 6.25 }),
+  "daybreak-red-latest": tier(12.5, 75, 1.25, { cacheWrite: 15.625 }),
+  "gpt-5.5": tier(5, 30, 0.5, {
+    contextTiers: [tier(10, 45, 1, { minContextTokens: 272_001 })],
+  }),
+  "gpt-5.4": tier(2.5, 15, 0.25, {
+    contextTiers: [tier(5, 22.5, 0.5, { minContextTokens: 272_001 })],
+  }),
+  "gpt-5.4-mini": tier(0.75, 4.5, 0.075),
+  "gpt-5.4-nano": tier(0.2, 1.25, 0.02),
+  "gpt-5.2": tier(1.75, 14, 0.175),
+  "chat-latest": tier(5, 30, 0.5),
+  "gpt-5.3-chat-latest": tier(1.75, 14, 0.175),
+  "gpt-5.3-codex-fast": tier(3.5, 28, 0.35),
+  "gpt-5.3-codex": tier(1.75, 14, 0.175, {
+    serviceTiers: {
+      fast: tier(3.5, 28, 0.35),
+    },
+  }),
+  "gpt-5.2-codex": tier(1.75, 14, 0.175),
+  "gpt-5.1": tier(1.25, 10, 0.125),
+  "gpt-5.1-chat-latest": tier(1.25, 10, 0.125),
+  "gpt-5.1-codex": tier(1.25, 10, 0.125),
+  "gpt-5.1-codex-max": tier(1.25, 10, 0.125),
+  "gpt-5": tier(1.25, 10, 0.125),
+  "gpt-5-chat-latest": tier(1.25, 10, 0.125),
+  "gpt-5-codex": tier(1.25, 10, 0.125),
+  "gpt-5-mini": tier(0.25, 2, 0.025),
+  "gpt-5-nano": tier(0.05, 0.4, 0.005),
+  "gpt-4.1-mini": tier(0.4, 1.6, 0.1, { cacheWrite: null }),
+  "gpt-4.1-nano": tier(0.1, 0.4, 0.025, { cacheWrite: null }),
+  "gpt-4.1": tier(2, 8, 0.5, { cacheWrite: null }),
+  "gpt-4o-mini": tier(0.15, 0.6, 0.075, { cacheWrite: null }),
+  "gpt-4o": tier(2.5, 10, 1.25, { cacheWrite: null }),
+  "gpt-4": tier(30, 60, 0, { cacheWrite: null }),
+  "o4-mini": tier(1.1, 4.4, 0.275, { cacheWrite: null }),
+  "codex-mini": tier(1.5, 6, 0.375, { cacheWrite: null }),
+
+  // Google. Gemini output rates include thinking tokens where the API does so.
+  // Current promotional paid-tier rates are valid through 2026-12-31.
+  "gemini-3.7-flash": tier(0.75, 3.75, 0.075),
+  "gemini-3.6-flash": tier(0.75, 3.75, 0.075),
+  "gemini-3.5-flash": tier(1.5, 9, 0.15),
+  "gemini-3.5-flash-lite": tier(0.3, 2.5, 0.03),
+  "gemini-3.1-pro-preview": tier(2, 12, 0.2, {
+    contextTiers: [tier(4, 18, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "gemini-3-flash-preview": tier(0.5, 3, 0.05),
+  "gemini-3.1-flash-lite": tier(0.25, 1.5, 0.025),
+  "gemini-2.5-pro": tier(1.25, 10, 0.125, {
+    contextTiers: [tier(2.5, 15, 0.25, { minContextTokens: 200_001 })],
+  }),
+  "gemini-2.5-flash": tier(0.3, 2.5, 0.03),
+  "gemini-2.5-flash-lite": tier(0.1, 0.4, 0.01),
+
+  // xAI. Long-context rates apply from 200K prompt tokens.
+  "grok-4.6": tier(2, 6, 0.5, {
+    contextTiers: [tier(4, 12, 1, { minContextTokens: 200_001 })],
+  }),
+  "grok-4.5": tier(2, 6, 0.3, {
+    contextTiers: [tier(4, 12, 0.6, { minContextTokens: 200_001 })],
+  }),
+  "grok-4.5-build": tier(2, 6, 0.3, {
+    contextTiers: [tier(4, 12, 0.6, { minContextTokens: 200_001 })],
+  }),
+  "grok-build-latest": tier(2, 6, 0.3, {
+    contextTiers: [tier(4, 12, 0.6, { minContextTokens: 200_001 })],
+  }),
+  "grok-build-0.1": tier(1, 2, 0.2, {
+    contextTiers: [tier(2, 4, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-code-fast-1-0825": tier(1.25, 2.5, 0.2, {
+    contextTiers: [tier(2.5, 5, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-code-fast-1": tier(1.25, 2.5, 0.2, {
+    contextTiers: [tier(2.5, 5, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-code-fast": tier(1.25, 2.5, 0.2, {
+    contextTiers: [tier(2.5, 5, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-4.3": tier(1.25, 2.5, 0.2, {
+    contextTiers: [tier(2.5, 5, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-4.20-multi-agent-0309": tier(1.25, 2.5, 0.2, {
+    contextTiers: [tier(2.5, 5, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-4.20-0309-reasoning": tier(1.25, 2.5, 0.2, {
+    contextTiers: [tier(2.5, 5, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-4.20-0309-non-reasoning": tier(1.25, 2.5, 0.2, {
+    contextTiers: [tier(2.5, 5, 0.4, { minContextTokens: 200_001 })],
+  }),
+  "grok-4": tier(3, 15, 0.75),
+  "grok-build": tier(2, 6, 0.3, {
+    contextTiers: [tier(4, 12, 0.6, { minContextTokens: 200_001 })],
+  }),
+
+};
 
 const SORTED_MODEL_PRICING_ENTRIES = Object.entries(MODEL_PRICING).sort(
-  (a, b) => b[0].length - a[0].length
+  (a, b) => b[0].length - a[0].length,
 );
 
-const findModelPricing = (modelName: string): ModelPricing | null => {
-  for (const [key, value] of SORTED_MODEL_PRICING_ENTRIES) {
-    if (modelName.toLowerCase().includes(key)) {
-      return value;
-    }
-  }
-  return null;
+// These models expose audio/image/video or flat-unit billing that cannot be
+// represented by the token-only fields in this dashboard. Keep them out of
+// prefix matching so e.g. `gemini-2.5-flash-preview-tts` is not accidentally
+// priced as ordinary Gemini 2.5 Flash text traffic.
+const TOKEN_UNSUPPORTED_MODEL_PATTERNS = [
+  /^(?:gemini-2\.5-(?:flash|pro)-preview-tts)(?:-|$)/,
+  /^gemini-2\.5-flash-(?:native-audio|image)(?:-|$)/,
+  /^gemini-.*-(?:tts|native-audio|audio|live|image|image-generation|video-generation)(?:-|$)/,
+  /^gemini-omni-flash(?:-|$)/,
+  /^gemini-(?:3\.5-live-translate|3\.1-flash-live)(?:-|$)/,
+  /^gpt-(?:4o(?:-mini)?|4\.1(?:-mini)?)-(?:audio|realtime|tts|transcribe|search-preview)(?:-|$)/,
+  /^gpt-(?:realtime|image)(?:-|$)/,
+  /^sora(?:-|$)/,
+  /^grok-imagine(?:-|$)/,
+];
+
+const SOURCE_COST_ONLY_PROVIDER_IDS = new Set([
+  "antigravity",
+  "copilot",
+  "cursor",
+  "cursor-agent",
+  "opencode",
+]);
+
+const normalizeModelName = (modelName: string): string =>
+  modelName.trim().toLowerCase().replace(/^models\//, "");
+
+const matchesModelKey = (normalizedModelName: string, key: string): boolean => {
+  // Gate on the final provider/model path segment so `openai/gpt-4.1-*` and
+  // `anthropic/claude-*` resolve, while `not-gpt-4.1` remains unknown.
+  const modelSegment = normalizedModelName.split("/").at(-1) ?? normalizedModelName;
+  return modelSegment === key ||
+    modelSegment.startsWith(`${key}-`) ||
+    modelSegment.startsWith(`${key}@`) ||
+    modelSegment.startsWith(`${key}:`);
 };
 
-export const hasExplicitModelPricing = (modelName: string): boolean =>
-  findModelPricing(modelName) != null;
+const findModelPricing = (
+  modelName: string,
+  providerId?: string,
+  contextTokens = 0,
+  serviceTier?: string,
+): ModelPricing | null => {
+  // A provider id is part of the billing identity. These products can route
+  // the same model through a subscription, proxy, or markup that cannot be
+  // reconstructed from token counts. Only an authoritative source cost is
+  // safe for them; `calculateGlobalCostSummary` checks that before calling
+  // this function.
+  const normalizedProviderId = providerId?.trim().toLowerCase();
+  if (normalizedProviderId && SOURCE_COST_ONLY_PROVIDER_IDS.has(normalizedProviderId)) {
+    return null;
+  }
+
+  const normalizedModelName = normalizeModelName(modelName);
+  const modelSegment = normalizedModelName.split("/").at(-1) ?? normalizedModelName;
+  if (TOKEN_UNSUPPORTED_MODEL_PATTERNS.some((pattern) => pattern.test(modelSegment))) {
+    return null;
+  }
+  const normalizedServiceTier = serviceTier?.trim().toLowerCase().replace("priority", "fast");
+  const candidates = SORTED_MODEL_PRICING_ENTRIES
+    .filter(([key]) => matchesModelKey(normalizedModelName, key))
+    .flatMap(([key, basePricing]) => {
+      const pricing = normalizedServiceTier
+        ? basePricing.serviceTiers?.[normalizedServiceTier] ?? basePricing
+        : basePricing;
+      return [
+        { key, pricing },
+        ...(pricing.contextTiers ?? []).map((contextPricing) => ({
+          key,
+          pricing: contextPricing,
+        })),
+      ];
+    })
+    .filter(({ pricing }) =>
+      pricing.minContextTokens == null || contextTokens >= pricing.minContextTokens,
+    )
+    .sort((a, b) =>
+      b.key.length - a.key.length ||
+      (b.pricing.minContextTokens ?? 0) - (a.pricing.minContextTokens ?? 0),
+    );
+
+  if (candidates.length === 0) return null;
+
+  return candidates.at(0)?.pricing ?? null;
+};
+
+export const hasExplicitModelPricing = (modelName: string, providerId?: string): boolean =>
+  findModelPricing(modelName, providerId) != null;
 
 /**
  * Calculate API pricing for a model
@@ -110,15 +317,30 @@ export const calculateModelPrice = (
   inputTokens: number,
   outputTokens: number,
   cacheCreationTokens: number,
-  cacheReadTokens: number
-): number => {
-  const modelPricing = findModelPricing(modelName) ?? DEFAULT_PRICING;
+  cacheReadTokens: number,
+  options: ModelPriceOptions = {},
+): number | null => {
+  const modelPricing = findModelPricing(
+    modelName,
+    options.providerId,
+    options.contextTokens ?? 0,
+    options.serviceTier,
+  );
+
+  if (!modelPricing) return null;
 
   const inputCost = (inputTokens / 1000000) * modelPricing.input;
-  const outputCost = (outputTokens / 1000000) * modelPricing.output;
-  const cacheWriteCost = modelPricing.cacheWrite == null
+  // The provider adapters keep reasoning separate so it remains visible in
+  // token distributions. It is nevertheless billed at the output rate by
+  // the token-priced APIs represented here.
+  const billableOutputTokens = outputTokens + (options.reasoningTokens ?? 0);
+  const outputCost = (billableOutputTokens / 1000000) * modelPricing.output;
+  const cacheWriteRate = options.cacheWriteTtl === "1h"
+    ? modelPricing.cacheWriteOneHour ?? modelPricing.cacheWrite
+    : modelPricing.cacheWrite;
+  const cacheWriteCost = cacheWriteRate == null
     ? 0
-    : (cacheCreationTokens / 1000000) * modelPricing.cacheWrite;
+    : (cacheCreationTokens / 1000000) * cacheWriteRate;
   const cacheReadCost = (cacheReadTokens / 1000000) * modelPricing.cacheRead;
 
   return inputCost + outputCost + cacheWriteCost + cacheReadCost;

--- a/src/components/AnalyticsDashboard/utils/globalCalculations.test.ts
+++ b/src/components/AnalyticsDashboard/utils/globalCalculations.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateGlobalCostSummary,
+  calculateModelMetrics,
+  type ModelUsageLike,
+} from "./globalCalculations";
+
+const usage = (overrides: Partial<ModelUsageLike>): ModelUsageLike => ({
+  model_name: "gpt-5.6-terra",
+  provider_id: "codex",
+  token_count: 2_000_000,
+  input_tokens: 1_000_000,
+  output_tokens: 1_000_000,
+  cache_creation_tokens: 0,
+  cache_read_tokens: 0,
+  ...overrides,
+});
+
+describe("global cost calculations", () => {
+  it("keeps unknown model usage visible without inventing a price", () => {
+    const summary = calculateGlobalCostSummary(
+      [usage({ model_name: "provider/private-model", token_count: 100 })],
+      100,
+    );
+
+    expect(summary.totalEstimatedCost).toBe(0);
+    expect(summary.estimatedCost).toBe(0);
+    expect(summary.exactCost).toBe(0);
+    expect(summary.coveredTokens).toBe(0);
+    expect(summary.unpricedTokens).toBe(100);
+    expect(summary.unpricedModels).toBe(1);
+  });
+
+  it("prefers a provider-reported zero cost over an estimate", () => {
+    const summary = calculateGlobalCostSummary(
+      [usage({ cost_usd: 0 })],
+      2_000_000,
+    );
+    const metrics = calculateModelMetrics(
+      "provider/private-model",
+      2_000_000,
+      1_000_000,
+      1_000_000,
+      0,
+      0,
+      2_000_000,
+      { sourceCostUSD: 0, providerId: "opencode" },
+    );
+
+    expect(summary.totalEstimatedCost).toBe(0);
+    expect(summary.exactCost).toBe(0);
+    expect(summary.coveredTokens).toBe(2_000_000);
+    expect(summary.unpricedTokens).toBe(0);
+    expect(metrics.price).toBe(0);
+    expect(metrics.formattedPrice).toBe("$0.00");
+    expect(metrics.pricingStatus).toBe("exact");
+  });
+
+  it("keeps estimated and source-reported costs separate", () => {
+    const summary = calculateGlobalCostSummary(
+      [
+        usage({ cost_usd: 0.42 }),
+        usage({
+          model_name: "gemini-3-flash-preview",
+          provider_id: "gemini",
+          token_count: 2_000_000,
+          input_tokens: 1_000_000,
+          output_tokens: 1_000_000,
+        }),
+      ],
+      4_000_000,
+    );
+
+    expect(summary.exactCost).toBeCloseTo(0.42);
+    expect(summary.estimatedCost).toBeCloseTo(3.5);
+    expect(summary.totalEstimatedCost).toBeCloseTo(3.92);
+    expect(summary.coveragePercent).toBe(100);
+  });
+
+  it("includes separately reported reasoning in estimated cost", () => {
+    const summary = calculateGlobalCostSummary(
+      [
+        usage({
+          model_name: "gemini-3.1-flash-lite",
+          provider_id: "gemini",
+          token_count: 3_000_000,
+          input_tokens: 1_000_000,
+          output_tokens: 1_000_000,
+          reasoning_tokens: 1_000_000,
+        }),
+      ],
+      3_000_000,
+    );
+
+    expect(summary.estimatedCost).toBeCloseTo(3.25);
+  });
+
+  it("marks a model row unavailable instead of showing a fallback estimate", () => {
+    const metrics = calculateModelMetrics(
+      "provider/private-model",
+      1_000,
+      1_000,
+      0,
+      0,
+      0,
+      1_000,
+    );
+
+    expect(metrics.formattedPrice).toBe("—");
+    expect(metrics.pricingStatus).toBe("unavailable");
+  });
+
+  it("prices context buckets independently instead of applying a long tier to the aggregate", () => {
+    const summary = calculateGlobalCostSummary(
+      [usage({
+        token_count: 800_000,
+        input_tokens: 400_000,
+        output_tokens: 400_000,
+        context_breakdown: [
+          {
+            min_context_tokens: 0,
+            token_count: 800_000,
+            input_tokens: 400_000,
+            output_tokens: 400_000,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            reasoning_tokens: 0,
+          },
+        ],
+      })],
+      800_000,
+    );
+
+    // 0.4M input at $2/M + 0.4M output at $12/M, all in the short tier.
+    expect(summary.estimatedCost).toBeCloseTo(5.6);
+  });
+
+  it("keeps fast-tier rows separate from standard-tier rows", () => {
+    const summary = calculateGlobalCostSummary(
+      [usage({
+        model_name: "gpt-5.3-codex",
+        service_tier: "fast",
+        token_count: 2_000_000,
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_read_tokens: 0,
+      })],
+      2_000_000,
+    );
+
+    expect(summary.estimatedCost).toBeCloseTo(31.5);
+  });
+
+  it("returns unavailable for Cursor even when the model label is present", () => {
+    const summary = calculateGlobalCostSummary(
+      [usage({ model_name: "cursor", provider_id: "cursor", token_count: 1_000 })],
+      1_000,
+    );
+
+    expect(summary.totalEstimatedCost).toBe(0);
+    expect(summary.coveredTokens).toBe(0);
+    expect(summary.unpricedTokens).toBe(1_000);
+  });
+});

--- a/src/components/AnalyticsDashboard/utils/globalCalculations.test.ts
+++ b/src/components/AnalyticsDashboard/utils/globalCalculations.test.ts
@@ -135,6 +135,35 @@ describe("global cost calculations", () => {
     expect(summary.estimatedCost).toBeCloseTo(5.6);
   });
 
+  it("subtracts one-hour cache tokens from the aggregate fallback", () => {
+    const summary = calculateGlobalCostSummary(
+      [usage({
+        model_name: "claude-sonnet-5",
+        provider_id: "claude",
+        token_count: 1_000_000,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_tokens: 1_000_000,
+        context_breakdown: [
+          {
+            min_context_tokens: 0,
+            token_count: 1_000_000,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_tokens: 1_000_000,
+            cache_creation_tokens_1h: 300_000,
+            cache_read_tokens: 0,
+            reasoning_tokens: 0,
+          },
+        ],
+      })],
+      1_000_000,
+    );
+
+    // 0.7M at $2.5/M (5m) + 0.3M at $4/M (1h).
+    expect(summary.estimatedCost).toBeCloseTo(2.95);
+  });
+
   it("keeps fast-tier rows separate from standard-tier rows", () => {
     const summary = calculateGlobalCostSummary(
       [usage({

--- a/src/components/AnalyticsDashboard/utils/globalCalculations.ts
+++ b/src/components/AnalyticsDashboard/utils/globalCalculations.ts
@@ -86,8 +86,9 @@ const calculateContextBreakdownPrice = (
 
   let total = 0;
   for (const bucket of breakdown) {
-    const cacheCreation5m = bucket.cache_creation_tokens_5m ?? bucket.cache_creation_tokens;
     const cacheCreation1h = bucket.cache_creation_tokens_1h ?? 0;
+    const cacheCreation5m = bucket.cache_creation_tokens_5m
+      ?? Math.max(bucket.cache_creation_tokens - cacheCreation1h, 0);
     const options = {
       providerId: usage.provider_id,
       serviceTier: usage.service_tier,

--- a/src/components/AnalyticsDashboard/utils/globalCalculations.ts
+++ b/src/components/AnalyticsDashboard/utils/globalCalculations.ts
@@ -9,6 +9,7 @@ import {
   formatNumber,
   hasExplicitModelPricing,
 } from "./calculations";
+import type { ModelContextStats } from "../../../types";
 
 // ============================================================================
 // Model Distribution Metrics
@@ -16,25 +17,106 @@ import {
 
 export interface ModelDisplayMetrics {
   percentage: number;
-  price: number;
+  price: number | null;
   formattedPrice: string;
   formattedTokens: string;
+  pricingStatus: "exact" | "estimated" | "unavailable";
 }
 
-interface ModelUsageLike {
+export interface ModelUsageLike {
   model_name: string;
+  provider_id?: string;
+  service_tier?: string;
   token_count: number;
   input_tokens: number;
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  reasoning_tokens?: number;
+  cost_usd?: number | null;
+  context_breakdown?: ModelContextStats[];
 }
 
 export interface GlobalCostSummary {
   totalEstimatedCost: number;
+  exactCost: number;
+  estimatedCost: number;
   coveragePercent: number;
   coveredTokens: number;
+  unpricedTokens: number;
+  unpricedModels: number;
+  pricedModels: number;
+  exactModels: number;
+  estimatedModels: number;
 }
+
+const calculateContextBreakdownPrice = (
+  modelName: string,
+  usage: Pick<
+    ModelUsageLike,
+    | "input_tokens"
+    | "output_tokens"
+    | "cache_creation_tokens"
+    | "cache_read_tokens"
+    | "reasoning_tokens"
+    | "context_breakdown"
+    | "provider_id"
+    | "service_tier"
+  >,
+): number | null => {
+  const breakdown = usage.context_breakdown;
+  if (!breakdown || breakdown.length === 0) {
+    return calculateModelPrice(
+      modelName,
+      usage.input_tokens,
+      usage.output_tokens,
+      usage.cache_creation_tokens,
+      usage.cache_read_tokens,
+      {
+        providerId: usage.provider_id,
+        serviceTier: usage.service_tier,
+        // Legacy payloads do not have per-request buckets. Keep them in the
+        // default tier rather than incorrectly treating aggregate tokens as a
+        // single long-context request.
+        contextTokens: 0,
+        reasoningTokens: usage.reasoning_tokens,
+      },
+    );
+  }
+
+  let total = 0;
+  for (const bucket of breakdown) {
+    const cacheCreation5m = bucket.cache_creation_tokens_5m ?? bucket.cache_creation_tokens;
+    const cacheCreation1h = bucket.cache_creation_tokens_1h ?? 0;
+    const options = {
+      providerId: usage.provider_id,
+      serviceTier: usage.service_tier,
+      contextTokens: bucket.min_context_tokens,
+      reasoningTokens: bucket.reasoning_tokens,
+    };
+    const basePrice = calculateModelPrice(
+      modelName,
+      bucket.input_tokens,
+      bucket.output_tokens,
+      cacheCreation5m,
+      bucket.cache_read_tokens,
+      { ...options, cacheWriteTtl: "5m" },
+    );
+    const oneHourPrice = cacheCreation1h > 0
+      ? calculateModelPrice(
+          modelName,
+          0,
+          0,
+          cacheCreation1h,
+          0,
+          { ...options, cacheWriteTtl: "1h", reasoningTokens: 0 },
+        )
+      : 0;
+    if (basePrice == null || oneHourPrice == null) return null;
+    total += basePrice + oneHourPrice;
+  }
+  return total;
+};
 
 /**
  * Calculate display metrics for a single model
@@ -46,19 +128,49 @@ export const calculateModelMetrics = (
   outputTokens: number,
   cacheCreationTokens: number,
   cacheReadTokens: number,
-  totalTokens: number
+  totalTokens: number,
+  options: {
+    providerId?: string;
+    serviceTier?: string;
+    reasoningTokens?: number;
+    sourceCostUSD?: number | null;
+    contextTokens?: number;
+    contextBreakdown?: ModelContextStats[];
+  } = {},
 ): ModelDisplayMetrics => {
-  const price = calculateModelPrice(
-    modelName,
-    inputTokens,
-    outputTokens,
-    cacheCreationTokens,
-    cacheReadTokens
-  );
+  const hasSourceCost = options.sourceCostUSD !== undefined && options.sourceCostUSD !== null;
+  const price = hasSourceCost
+    ? options.sourceCostUSD ?? null
+    : options.contextBreakdown
+      ? calculateContextBreakdownPrice(modelName, {
+          provider_id: options.providerId,
+          service_tier: options.serviceTier,
+          input_tokens: inputTokens,
+          output_tokens: outputTokens,
+          cache_creation_tokens: cacheCreationTokens,
+          cache_read_tokens: cacheReadTokens,
+          reasoning_tokens: options.reasoningTokens,
+          context_breakdown: options.contextBreakdown,
+        })
+      : calculateModelPrice(
+          modelName,
+          inputTokens,
+          outputTokens,
+          cacheCreationTokens,
+          cacheReadTokens,
+          {
+            providerId: options.providerId,
+            serviceTier: options.serviceTier,
+            contextTokens: options.contextTokens ?? 0,
+            reasoningTokens: options.reasoningTokens,
+          },
+        );
 
   const percentage = (tokenCount / Math.max(totalTokens, 1)) * 100;
 
-  const formattedPrice = `$${price.toFixed(price >= 100 ? 0 : price >= 10 ? 1 : 2)}`;
+  const formattedPrice = price == null
+    ? "—"
+    : `$${price.toFixed(price >= 100 ? 0 : price >= 10 ? 1 : 2)}`;
   const formattedTokens = formatNumber(tokenCount);
 
   return {
@@ -66,6 +178,11 @@ export const calculateModelMetrics = (
     price,
     formattedPrice,
     formattedTokens,
+    pricingStatus: hasSourceCost
+      ? "exact"
+      : price == null
+        ? "unavailable"
+        : "estimated",
   };
 };
 
@@ -74,18 +191,37 @@ export const calculateGlobalCostSummary = (
   totalTokens: number
 ): GlobalCostSummary => {
   let totalEstimatedCost = 0;
+  let exactCost = 0;
+  let estimatedCost = 0;
   let coveredTokens = 0;
+  let unpricedTokens = 0;
+  let unpricedModels = 0;
+  let pricedModels = 0;
+  let exactModels = 0;
+  let estimatedModels = 0;
 
   for (const model of models) {
-    totalEstimatedCost += calculateModelPrice(
-      model.model_name,
-      model.input_tokens,
-      model.output_tokens,
-      model.cache_creation_tokens,
-      model.cache_read_tokens
-    );
+    const hasSourceCost = model.cost_usd !== undefined && model.cost_usd !== null;
+    const price = hasSourceCost
+      ? model.cost_usd ?? 0
+      : calculateContextBreakdownPrice(model.model_name, model);
 
-    if (hasExplicitModelPricing(model.model_name)) {
+    if (price == null) {
+      unpricedTokens += model.token_count;
+      unpricedModels += 1;
+    } else {
+      totalEstimatedCost += price;
+      if (hasSourceCost) {
+        exactCost += price;
+        exactModels += 1;
+      } else {
+        estimatedCost += price;
+        estimatedModels += 1;
+      }
+      pricedModels += 1;
+    }
+
+    if (hasSourceCost || hasExplicitModelPricing(model.model_name, model.provider_id)) {
       coveredTokens += model.token_count;
     }
   }
@@ -95,8 +231,15 @@ export const calculateGlobalCostSummary = (
 
   return {
     totalEstimatedCost,
+    exactCost,
+    estimatedCost,
     coveragePercent,
     coveredTokens,
+    unpricedTokens,
+    unpricedModels,
+    pricedModels,
+    exactModels,
+    estimatedModels,
   };
 };
 

--- a/src/components/AnalyticsDashboard/utils/sessionCalculations.ts
+++ b/src/components/AnalyticsDashboard/utils/sessionCalculations.ts
@@ -38,6 +38,7 @@ export const calculateSessionMetrics = (stats: SessionTokenStats): SessionMetric
     output: stats.total_output_tokens,
     cache_creation: stats.total_cache_creation_tokens,
     cache_read: stats.total_cache_read_tokens,
+    reasoning: stats.total_reasoning_tokens,
   };
 
   return {

--- a/src/components/AnalyticsDashboard/views/GlobalStatsView.tsx
+++ b/src/components/AnalyticsDashboard/views/GlobalStatsView.tsx
@@ -46,6 +46,8 @@ interface GlobalStatsViewProps {
   metricMode?: MetricMode;
 }
 
+const EMPTY_MODEL_DISTRIBUTION: NonNullable<GlobalStatsSummary["model_distribution"]> = [];
+
 export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
   globalSummary,
   globalConversationSummary,
@@ -53,13 +55,16 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const totalSessionTime = globalSummary.total_session_duration_minutes;
+  const modelDistribution = globalSummary.model_distribution ?? EMPTY_MODEL_DISTRIBUTION;
+  const conversationModelDistribution =
+    globalConversationSummary?.model_distribution ?? EMPTY_MODEL_DISTRIBUTION;
   const costSummary = useMemo(
     () =>
       calculateGlobalCostSummary(
-        globalSummary.model_distribution,
+        modelDistribution,
         globalSummary.total_tokens
       ),
-    [globalSummary.model_distribution, globalSummary.total_tokens]
+    [modelDistribution, globalSummary.total_tokens]
   );
   const totalEstimatedCost = costSummary.totalEstimatedCost;
   const conversationCostSummary = useMemo(() => {
@@ -67,10 +72,10 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
       return null;
     }
     return calculateGlobalCostSummary(
-      globalConversationSummary.model_distribution,
+      conversationModelDistribution,
       globalConversationSummary.total_tokens
     );
-  }, [globalConversationSummary]);
+  }, [conversationModelDistribution, globalConversationSummary]);
 
   const billingTokens = globalSummary.total_tokens;
   const billingCost = costSummary.pricedModels > 0 ? totalEstimatedCost : null;
@@ -157,11 +162,13 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
 
       <div className="flex flex-wrap items-center gap-2">
         <span className="px-2 py-1 rounded-md bg-amber-500/10 text-amber-700 dark:text-amber-300 text-px11">
-          {costSummary.exactModels > 0 && costSummary.estimatedModels > 0
-            ? t("analytics.mixedCostLabel", "Exact + estimated")
-            : costSummary.exactModels > 0
-              ? t("analytics.exactCostLabel", "Exact source cost")
-              : t("analytics.estimatedLabel", "Estimated")}
+          {costSummary.exactModels === 0 && costSummary.estimatedModels === 0
+            ? t("analytics.noDataAvailable")
+            : costSummary.exactModels > 0 && costSummary.estimatedModels > 0
+              ? t("analytics.mixedCostLabel", "Exact + estimated")
+              : costSummary.exactModels > 0
+                ? t("analytics.exactCostLabel", "Exact source cost")
+                : t("analytics.estimatedLabel", "Estimated")}
         </span>
         <span className="px-2 py-1 rounded-md bg-muted/40 text-muted-foreground text-px11">
           {t("analytics.pricingCoverage", "Pricing coverage")}: {costSummary.coveragePercent.toFixed(1)}%
@@ -188,10 +195,10 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
           </SectionCard>
         )}
 
-        {globalSummary.model_distribution.length > 0 && (
+        {modelDistribution.length > 0 && (
           <SectionCard title={t("analytics.modelDistribution")} icon={Cpu} colorVariant="blue">
             <div className="space-y-3">
-              {globalSummary.model_distribution.map((model) => {
+              {modelDistribution.map((model) => {
                 const { percentage, formattedPrice, formattedTokens, pricingStatus } = calculateModelMetrics(
                   model.model_name,
                   model.token_count,
@@ -239,12 +246,12 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
                       </Tooltip>
                       <div className="flex items-center gap-2">
                         <span className="font-mono text-px12 text-muted-foreground">
-                          {metricMode === "cost_estimated" ? formattedPrice : formattedTokens}
+                          {metricMode === "cost_estimated" ? formattedTokens : formattedPrice}
                         </span>
                         <span className="font-mono text-px12 font-semibold text-foreground">
                           {metricMode === "cost_estimated"
-                            ? formattedTokens
-                            : formattedPrice}
+                            ? formattedPrice
+                            : formattedTokens}
                         </span>
                         <span
                           className={cn(

--- a/src/components/AnalyticsDashboard/views/GlobalStatsView.tsx
+++ b/src/components/AnalyticsDashboard/views/GlobalStatsView.tsx
@@ -18,7 +18,7 @@ import {
   Sparkles,
   Bot,
 } from "lucide-react";
-import type { GlobalStatsSummary } from "../../../types";
+import type { GlobalStatsSummary, MetricMode } from "../../../types";
 import { formatDuration } from "../../../utils/time";
 import { cn } from "@/lib/utils";
 import {
@@ -43,11 +43,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 interface GlobalStatsViewProps {
   globalSummary: GlobalStatsSummary;
   globalConversationSummary: GlobalStatsSummary | null;
+  metricMode?: MetricMode;
 }
 
 export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
   globalSummary,
   globalConversationSummary,
+  metricMode = "tokens",
 }) => {
   const { t } = useTranslation();
   const totalSessionTime = globalSummary.total_session_duration_minutes;
@@ -71,7 +73,7 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
   }, [globalConversationSummary]);
 
   const billingTokens = globalSummary.total_tokens;
-  const billingCost = totalEstimatedCost;
+  const billingCost = costSummary.pricedModels > 0 ? totalEstimatedCost : null;
   const conversationBreakdownCoverage = useMemo(
     () =>
       calculateConversationBreakdownCoverage(globalSummary.provider_distribution),
@@ -113,7 +115,9 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
           value={formatNumber(globalSummary.total_tokens)}
           subValue={
             t("analytics.estimatedCostValue", "Estimated Cost: {{cost}}", {
-              cost: formatCurrency(totalEstimatedCost),
+              cost: billingCost == null
+                ? t("common.dash", "—")
+                : formatCurrency(totalEstimatedCost),
             })
           }
           colorVariant="blue"
@@ -143,17 +147,30 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
         billingTokens={billingTokens}
         conversationTokens={globalConversationSummary?.total_tokens ?? null}
         billingCost={billingCost}
-        conversationCost={conversationCostSummary?.totalEstimatedCost ?? null}
+        conversationCost={
+          conversationCostSummary && conversationCostSummary.pricedModels > 0
+            ? conversationCostSummary.totalEstimatedCost
+            : null
+        }
         showProviderLimitHelp={conversationBreakdownCoverage.hasLimitedProviders}
       />
 
       <div className="flex flex-wrap items-center gap-2">
         <span className="px-2 py-1 rounded-md bg-amber-500/10 text-amber-700 dark:text-amber-300 text-px11">
-          {t("analytics.estimatedLabel", "Estimated")}
+          {costSummary.exactModels > 0 && costSummary.estimatedModels > 0
+            ? t("analytics.mixedCostLabel", "Exact + estimated")
+            : costSummary.exactModels > 0
+              ? t("analytics.exactCostLabel", "Exact source cost")
+              : t("analytics.estimatedLabel", "Estimated")}
         </span>
         <span className="px-2 py-1 rounded-md bg-muted/40 text-muted-foreground text-px11">
           {t("analytics.pricingCoverage", "Pricing coverage")}: {costSummary.coveragePercent.toFixed(1)}%
         </span>
+        {costSummary.unpricedModels > 0 && (
+          <span className="px-2 py-1 rounded-md bg-red-500/10 text-red-700 dark:text-red-300 text-px11">
+            {t("analytics.unpricedModels", "Unpriced models")}: {costSummary.unpricedModels}
+          </span>
+        )}
         <span className="px-2 py-1 rounded-md bg-muted/40 text-muted-foreground text-px11">
           {t("analytics.lastUpdated", "Last updated")}: {lastUpdated}
         </span>
@@ -175,18 +192,26 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
           <SectionCard title={t("analytics.modelDistribution")} icon={Cpu} colorVariant="blue">
             <div className="space-y-3">
               {globalSummary.model_distribution.map((model) => {
-                const { percentage, formattedPrice, formattedTokens } = calculateModelMetrics(
+                const { percentage, formattedPrice, formattedTokens, pricingStatus } = calculateModelMetrics(
                   model.model_name,
                   model.token_count,
                   model.input_tokens,
                   model.output_tokens,
                   model.cache_creation_tokens,
                   model.cache_read_tokens,
-                  globalSummary.total_tokens
+                  globalSummary.total_tokens,
+                  {
+                    providerId: model.provider_id,
+                    serviceTier: model.service_tier,
+                    sourceCostUSD: model.cost_usd,
+                    reasoningTokens: model.reasoning_tokens,
+                    contextBreakdown: model.context_breakdown,
+                  },
                 );
+                const modelKey = `${model.provider_id ?? "unknown"}:${model.model_name}:${model.service_tier ?? "standard"}`;
 
                 return (
-                  <div key={model.model_name}>
+                  <div key={modelKey}>
                     <div className="flex items-center justify-between mb-1.5">
                       <Tooltip>
                         <TooltipTrigger asChild>
@@ -194,19 +219,48 @@ export const GlobalStatsView: React.FC<GlobalStatsViewProps> = ({
                             type="button"
                             className="block max-w-[60%] text-px12 font-medium text-foreground truncate text-left cursor-default"
                           >
-                            {model.model_name}
+                            <span className="flex items-center gap-1.5">
+                              <span>{model.model_name}</span>
+                              <span className="text-px10 text-muted-foreground/70">
+                                [{model.provider_id ?? t("analytics.unknownProvider", "unknown provider")}]
+                              </span>
+                              {model.service_tier && model.service_tier !== "standard" && (
+                                <span className="text-px10 text-muted-foreground/70">
+                                  [{model.service_tier}]
+                                </span>
+                              )}
+                            </span>
                           </button>
                         </TooltipTrigger>
                         <TooltipContent>
-                          {model.model_name}
+                          {model.provider_id ? `${model.provider_id} / ` : ""}{model.model_name}
+                          {model.service_tier ? ` (${model.service_tier})` : ""}
                         </TooltipContent>
                       </Tooltip>
                       <div className="flex items-center gap-2">
                         <span className="font-mono text-px12 text-muted-foreground">
-                          {formattedPrice}
+                          {metricMode === "cost_estimated" ? formattedPrice : formattedTokens}
                         </span>
                         <span className="font-mono text-px12 font-semibold text-foreground">
-                          {formattedTokens}
+                          {metricMode === "cost_estimated"
+                            ? formattedTokens
+                            : formattedPrice}
+                        </span>
+                        <span
+                          className={cn(
+                            "text-px10 uppercase tracking-wide",
+                            pricingStatus === "exact"
+                              ? "text-emerald-600 dark:text-emerald-400"
+                              : pricingStatus === "estimated"
+                                ? "text-amber-600 dark:text-amber-400"
+                                : "text-red-600 dark:text-red-400",
+                          )}
+                        >
+                          {pricingStatus === "exact"
+                            ? t("analytics.costExact", "exact")
+                            : pricingStatus === "estimated"
+                              ? t("analytics.costEstimatedShort", "est.")
+                              : t("analytics.costUnavailable", "n/a")}
                         </span>
                       </div>
                     </div>

--- a/src/components/AnalyticsDashboard/views/ProjectStatsView.tsx
+++ b/src/components/AnalyticsDashboard/views/ProjectStatsView.tsx
@@ -19,7 +19,12 @@ import {
   DailyTrendChart,
   TokenDistributionChart,
 } from "../components";
-import { formatNumber, generateTrendData, extractProjectGrowth } from "../utils";
+import {
+  calculateGlobalCostSummary,
+  formatNumber,
+  generateTrendData,
+  extractProjectGrowth,
+} from "../utils";
 import { supportsConversationBreakdown } from "../../../utils/providers";
 
 interface ProjectStatsViewProps {
@@ -40,6 +45,22 @@ export const ProjectStatsView: React.FC<ProjectStatsViewProps> = ({
     () => generateTrendData(projectSummary?.daily_stats),
     [projectSummary?.daily_stats]
   );
+
+  const billingCostSummary = useMemo(
+    () =>
+      calculateGlobalCostSummary(
+        projectSummary?.model_distribution ?? [],
+        projectSummary?.total_tokens ?? 0,
+      ),
+    [projectSummary?.model_distribution, projectSummary?.total_tokens],
+  );
+  const conversationCostSummary = useMemo(() => {
+    if (!conversationSummary) return null;
+    return calculateGlobalCostSummary(
+      conversationSummary.model_distribution ?? [],
+      conversationSummary.total_tokens,
+    );
+  }, [conversationSummary]);
 
   // 데이터가 없으면 항상 로딩 상태 표시 (뷰 전환 직후 isLoading이 false일 수 있음)
   if (!projectSummary) {
@@ -100,6 +121,16 @@ export const ProjectStatsView: React.FC<ProjectStatsViewProps> = ({
       <BillingBreakdownCard
         billingTokens={billingTokens}
         conversationTokens={conversationSummary != null ? conversationSummary.total_tokens : null}
+        billingCost={
+          billingCostSummary.pricedModels > 0
+            ? billingCostSummary.totalEstimatedCost
+            : null
+        }
+        conversationCost={
+          conversationCostSummary && conversationCostSummary.pricedModels > 0
+            ? conversationCostSummary.totalEstimatedCost
+            : null
+        }
         showProviderLimitHelp={!supportsConversationBreakdown(providerId)}
       />
 

--- a/src/components/AnalyticsDashboard/views/SessionStatsView.tsx
+++ b/src/components/AnalyticsDashboard/views/SessionStatsView.tsx
@@ -11,6 +11,7 @@ import type { SessionTokenStats, SessionComparison, ProviderId } from "../../../
 import { formatTime } from "../../../utils/time";
 import { SectionCard, TokenDistributionChart, BillingBreakdownCard } from "../components";
 import {
+  calculateGlobalCostSummary,
   formatNumber,
   calculateSessionMetrics,
   calculateSessionComparisonMetrics,
@@ -46,6 +47,21 @@ export const SessionStatsView: React.FC<SessionStatsViewProps> = ({
     [sessionComparison, totalProjectSessions]
   );
   const billingTokens = sessionStats.total_tokens;
+  const billingCostSummary = useMemo(
+    () =>
+      calculateGlobalCostSummary(
+        sessionStats.model_distribution ?? [],
+        sessionStats.total_tokens,
+      ),
+    [sessionStats.model_distribution, sessionStats.total_tokens],
+  );
+  const conversationCostSummary = useMemo(() => {
+    if (!conversationStats) return null;
+    return calculateGlobalCostSummary(
+      conversationStats.model_distribution ?? [],
+      conversationStats.total_tokens,
+    );
+  }, [conversationStats]);
 
   return (
     <div className="space-y-6">
@@ -161,6 +177,16 @@ export const SessionStatsView: React.FC<SessionStatsViewProps> = ({
       <BillingBreakdownCard
         billingTokens={billingTokens}
         conversationTokens={conversationStats != null ? conversationStats.total_tokens : null}
+        billingCost={
+          billingCostSummary.pricedModels > 0
+            ? billingCostSummary.totalEstimatedCost
+            : null
+        }
+        conversationCost={
+          conversationCostSummary && conversationCostSummary.pricedModels > 0
+            ? conversationCostSummary.totalEstimatedCost
+            : null
+        }
         showProviderLimitHelp={!supportsConversationBreakdown(providerId)}
       />
 

--- a/src/components/MessageViewer/components/MessageHeader.tsx
+++ b/src/components/MessageViewer/components/MessageHeader.tsx
@@ -110,6 +110,7 @@ export const MessageHeader: React.FC<MessageHeaderProps> = ({ message }) => {
                 {message.usage.output_tokens && <p>{t("assistantMessageDetails.output")}: {message.usage.output_tokens.toLocaleString()}</p>}
                 {message.usage.cache_creation_input_tokens ? <p>{t("assistantMessageDetails.cacheCreation")}: {message.usage.cache_creation_input_tokens.toLocaleString()}</p> : null}
                 {message.usage.cache_read_input_tokens ? <p>{t("assistantMessageDetails.cacheRead")}: {message.usage.cache_read_input_tokens.toLocaleString()}</p> : null}
+                {typeof message.usage.reasoning_tokens === "number" ? <p>{t("analytics.reasoning", "Reasoning")}: {message.usage.reasoning_tokens.toLocaleString()}</p> : null}
                 <div className="absolute right-4 top-full w-0 h-0 border-x-4 border-x-transparent border-t-4 border-t-popover"></div>
               </div>
             </>

--- a/src/components/SessionBoard/ExpandedCard.tsx
+++ b/src/components/SessionBoard/ExpandedCard.tsx
@@ -295,6 +295,9 @@ export const ExpandedCard = memo(({
                         <>
                             <span>{t("session.board.input")} {message.usage.input_tokens || 0}</span>
                             <span>{t("session.board.output")} {message.usage.output_tokens || 0}</span>
+                            {message.usage.reasoning_tokens ? (
+                                <span>{t("analytics.reasoning", "Reasoning")} {message.usage.reasoning_tokens}</span>
+                            ) : null}
                         </>
                     )}
                 </div>

--- a/src/components/SessionBoard/InteractionCard.tsx
+++ b/src/components/SessionBoard/InteractionCard.tsx
@@ -218,7 +218,12 @@ export const InteractionCard = memo(({
         const totalMessagesCount = (siblings?.length || 0) + 1;
         const totalTokens = [message, ...(siblings || [])].reduce((sum, m) => {
             const usage = isClaudeAssistantMessage(m) ? m.usage : null;
-            return sum + (usage?.input_tokens || 0) + (usage?.output_tokens || 0);
+            return sum +
+                (usage?.input_tokens || 0) +
+                (usage?.output_tokens || 0) +
+                (usage?.cache_creation_input_tokens || 0) +
+                (usage?.cache_read_input_tokens || 0) +
+                (usage?.reasoning_tokens || 0);
         }, 0);
 
         // Normalize height: min 4px, max 24px, typical range handled logarithmically or linearly capped
@@ -555,6 +560,9 @@ export const InteractionCard = memo(({
                     <div className="mt-auto pt-1 flex gap-2 text-px9 text-muted-foreground opacity-60 font-mono items-center">
                         <span>{t("session.interaction.inputTokens")} {message.usage.input_tokens}</span>
                         <span>{t("session.interaction.outputTokens")} {message.usage.output_tokens}</span>
+                        {message.usage.reasoning_tokens ? (
+                            <span>{t("analytics.reasoning", "Reasoning")} {message.usage.reasoning_tokens}</span>
+                        ) : null}
 
                         {/* Cache Hit Indicator */}
                         {message.usage.cache_read_input_tokens && message.usage.cache_read_input_tokens > 0 && (

--- a/src/components/SessionBoard/SessionLane.tsx
+++ b/src/components/SessionBoard/SessionLane.tsx
@@ -157,7 +157,12 @@ export const SessionLane = ({
                 let hasUsageParams = false;
                 for (const m of allMsgs) {
                     if (isClaudeAssistantMessage(m) && m.usage) {
-                        totalTokens += (m.usage.input_tokens || 0) + (m.usage.output_tokens || 0);
+                        totalTokens +=
+                            (m.usage.input_tokens || 0) +
+                            (m.usage.output_tokens || 0) +
+                            (m.usage.cache_creation_input_tokens || 0) +
+                            (m.usage.cache_read_input_tokens || 0) +
+                            (m.usage.reasoning_tokens || 0);
                         hasUsageParams = true;
                     }
                 }

--- a/src/components/SessionStatsCard.tsx
+++ b/src/components/SessionStatsCard.tsx
@@ -2,7 +2,7 @@
 
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
-import { TrendingUp, Zap, Database, Eye } from "lucide-react";
+import { TrendingUp, Zap, Database, Eye, Brain } from "lucide-react";
 import type { SessionTokenStats } from "../types";
 import { formatDateCompact } from "../utils/time";
 import { cn } from "@/lib/utils";
@@ -53,6 +53,7 @@ export const SessionStatsCard = memo(({
     { key: "output", label: t("analytics.outputTokens"), value: stats.total_output_tokens, color: "#a855f7", icon: Zap },
     { key: "cache_create", label: t("analytics.cacheCreation"), value: stats.total_cache_creation_tokens, color: "#3b82f6", icon: Database },
     { key: "cache_read", label: t("analytics.cacheRead"), value: stats.total_cache_read_tokens, color: "#f59e0b", icon: Eye },
+    { key: "reasoning", label: t("analytics.reasoning", "Reasoning"), value: stats.total_reasoning_tokens, color: "#ec4899", icon: Brain },
   ];
 
   const activeTokens = tokenData.filter(t => t.value > 0);

--- a/src/components/TokenStatsViewer.tsx
+++ b/src/components/TokenStatsViewer.tsx
@@ -22,6 +22,7 @@ import { LoadingState } from "./ui/loading";
 import { SessionStatsCard } from "./SessionStatsCard";
 import { DatePickerHeader } from "./ui/DatePickerHeader";
 import { BillingBreakdownCard } from "./AnalyticsDashboard/components/BillingBreakdownCard";
+import { calculateGlobalCostSummary } from "./AnalyticsDashboard/utils";
 import { supportsConversationBreakdown } from "../utils/providers";
 import { useAppStore } from "../store/useAppStore";
 
@@ -55,6 +56,11 @@ const TOKEN_COLORS = {
     base: "var(--metric-amber)",
     glow: "var(--glow-amber)",
     bg: "color-mix(in oklch, var(--metric-amber) 10%, transparent)"
+  },
+  reasoning: {
+    base: "var(--metric-pink)",
+    glow: "var(--glow-pink)",
+    bg: "color-mix(in oklch, var(--metric-pink) 10%, transparent)"
   },
 } as const;
 
@@ -96,6 +102,26 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
   const sessionMetadata = useAppStore((state) => state.userMetadata.sessions);
   const showProviderLimitHelp = !supportsConversationBreakdown(providerId);
   const hasSessionConversationData = sessionConversationStats != null;
+  const sessionCostSummary = useMemo(
+    () =>
+      sessionStats
+        ? calculateGlobalCostSummary(
+            sessionStats.model_distribution ?? [],
+            sessionStats.total_tokens,
+          )
+        : null,
+    [sessionStats],
+  );
+  const sessionConversationCostSummary = useMemo(
+    () =>
+      sessionConversationStats
+        ? calculateGlobalCostSummary(
+            sessionConversationStats.model_distribution ?? [],
+            sessionConversationStats.total_tokens,
+          )
+        : null,
+    [sessionConversationStats],
+  );
   const sessionDisplayById = useMemo(() => {
     const byId = new Map<string, string | undefined>();
     for (const session of sessions) {
@@ -159,6 +185,7 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
           total_cache_creation_tokens:
             projectStatsSummary.token_distribution.cache_creation,
           total_cache_read_tokens: projectStatsSummary.token_distribution.cache_read,
+          total_reasoning_tokens: projectStatsSummary.token_distribution.reasoning,
           total_tokens: projectStatsSummary.total_tokens,
           message_count: projectStatsSummary.total_messages,
         }
@@ -171,6 +198,8 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
               acc.total_cache_creation_tokens + stats.total_cache_creation_tokens,
             total_cache_read_tokens:
               acc.total_cache_read_tokens + stats.total_cache_read_tokens,
+            total_reasoning_tokens:
+              acc.total_reasoning_tokens + stats.total_reasoning_tokens,
             total_tokens: acc.total_tokens + stats.total_tokens,
             message_count: acc.message_count + stats.message_count,
           }),
@@ -179,6 +208,7 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
             total_output_tokens: 0,
             total_cache_creation_tokens: 0,
             total_cache_read_tokens: 0,
+            total_reasoning_tokens: 0,
             total_tokens: 0,
             message_count: 0,
           }
@@ -193,12 +223,29 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
           const conversationStats = projectConversationById.get(stats.session_id);
           return acc + (conversationStats?.total_tokens ?? 0);
         }, 0);
+    const projectModelDistribution =
+      projectStatsSummary?.model_distribution ??
+      projectStats.flatMap((stats) => stats.model_distribution ?? []);
+    const projectCostSummary = calculateGlobalCostSummary(
+      projectModelDistribution,
+      totalStats.total_tokens,
+    );
+    const projectConversationModelDistribution =
+      projectConversationStatsSummary?.model_distribution ??
+      projectConversationStats.flatMap((stats) => stats.model_distribution ?? []);
+    const projectConversationCostSummary = hasProjectConversationData
+      ? calculateGlobalCostSummary(
+          projectConversationModelDistribution,
+          conversationTotalTokens,
+        )
+      : null;
 
     const metrics = [
       { label: t("analytics.totalTokens"), value: totalStats.total_tokens, color: "var(--metric-purple)" },
       { label: t("analytics.inputTokens"), value: totalStats.total_input_tokens, color: tokenColors.input.base },
       { label: t("analytics.outputTokens"), value: totalStats.total_output_tokens, color: tokenColors.output.base },
       { label: t("analytics.cacheCreation"), value: totalStats.total_cache_creation_tokens, color: tokenColors.cacheWrite.base },
+      { label: t("analytics.reasoning", "Reasoning"), value: totalStats.total_reasoning_tokens, color: tokenColors.reasoning.base },
       { label: t("analytics.totalMessages"), value: totalStats.message_count, color: "var(--muted-foreground)" },
     ];
 
@@ -273,6 +320,16 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
               <BillingBreakdownCard
                 billingTokens={totalStats.total_tokens}
                 conversationTokens={hasProjectConversationData ? conversationTotalTokens : null}
+                billingCost={
+                  projectCostSummary.pricedModels > 0
+                    ? projectCostSummary.totalEstimatedCost
+                    : null
+                }
+                conversationCost={
+                  projectConversationCostSummary && projectConversationCostSummary.pricedModels > 0
+                    ? projectConversationCostSummary.totalEstimatedCost
+                    : null
+                }
                 showProviderLimitHelp={showProviderLimitHelp}
               />
             </div>
@@ -430,6 +487,16 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
               conversationTokens={
                 hasSessionConversationData
                   ? sessionConversationStats?.total_tokens ?? 0
+                  : null
+              }
+              billingCost={
+                sessionCostSummary && sessionCostSummary.pricedModels > 0
+                  ? sessionCostSummary.totalEstimatedCost
+                  : null
+              }
+              conversationCost={
+                sessionConversationCostSummary && sessionConversationCostSummary.pricedModels > 0
+                  ? sessionConversationCostSummary.totalEstimatedCost
                   : null
               }
               showProviderLimitHelp={showProviderLimitHelp}

--- a/src/components/TokenStatsViewer.tsx
+++ b/src/components/TokenStatsViewer.tsx
@@ -284,12 +284,14 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
               {metrics.map((metric, i) => (
                 <Tooltip key={metric.label}>
                   <TooltipTrigger asChild>
-                    <div
+                    <button
+                      type="button"
+                      aria-label={`${metric.label}: ${metric.value.toLocaleString()}`}
                       className={cn(
-                        "relative p-4 rounded-xl text-center",
+                        "relative w-full appearance-none p-4 rounded-xl text-center text-inherit",
                         "bg-card/80 backdrop-blur-sm",
                         "border border-border/50",
-                        "transition-all duration-300",
+                        "transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                         "hover:border-border hover:shadow-md hover:scale-[1.02] cursor-default"
                       )}
                     >
@@ -307,7 +309,7 @@ export const TokenStatsViewer: React.FC<TokenStatsViewerProps> = ({
                       <div className="text-px12 font-medium text-muted-foreground uppercase tracking-wider mt-1">
                         {metric.label}
                       </div>
-                    </div>
+                    </button>
                   </TooltipTrigger>
                   <TooltipContent className="font-mono text-xs">
                     {metric.value.toLocaleString()}

--- a/src/components/messageRenderer/AssistantMessageDetails.tsx
+++ b/src/components/messageRenderer/AssistantMessageDetails.tsx
@@ -46,10 +46,14 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
   const nestedCacheCreationTokens1h = usage?.cache_creation?.ephemeral_1h_input_tokens ?? 0;
   const cacheCreationTokens1h = usage?.cache_creation_input_tokens_1h
     ?? nestedCacheCreationTokens1h;
+  const reportedCacheCreationTokens5m = usage?.cache_creation_input_tokens_5m
+    ?? nestedCacheCreationTokens5m;
   const cacheCreationTokens = usage?.cache_creation_input_tokens
-    ?? nestedCacheCreationTokens5m + nestedCacheCreationTokens1h;
+    ?? reportedCacheCreationTokens5m + cacheCreationTokens1h;
   const cacheCreationTokens5m = usage?.cache_creation_input_tokens_5m
-    ?? Math.max(cacheCreationTokens - cacheCreationTokens1h, 0);
+    ?? (usage?.cache_creation_input_tokens == null
+      ? reportedCacheCreationTokens5m
+      : Math.max(cacheCreationTokens - cacheCreationTokens1h, 0));
   const contextTokens =
     (usage?.input_tokens ?? 0) + cacheCreationTokens + (usage?.cache_read_input_tokens ?? 0);
   const estimatedCost =
@@ -133,12 +137,12 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
           <div
             id="token-usage-tooltip"
             role="tooltip"
-            className={`absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-52 bg-popover text-popover-foreground ${layout.smallText} ${layout.rounded} ${layout.containerPadding} opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none shadow-lg z-10 border border-border`}
+            className={`absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-52 bg-popover text-popover-foreground ${layout.smallText} ${layout.rounded} ${layout.containerPadding} opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none shadow-lg z-10 border border-border`}
           >
             <p><strong>{t('assistantMessageDetails.tokenUsage')}</strong></p>
             {usage.input_tokens ? <p>{t('assistantMessageDetails.input')}: {usage.input_tokens.toLocaleString()}</p> : null}
             {usage.output_tokens ? <p>{t('assistantMessageDetails.output')}: {usage.output_tokens.toLocaleString()}</p> : null}
-            {usage.cache_creation_input_tokens ? <p>{t('assistantMessageDetails.cacheCreation')}: {usage.cache_creation_input_tokens.toLocaleString()}</p> : null}
+            {cacheCreationTokens ? <p>{t('assistantMessageDetails.cacheCreation')}: {cacheCreationTokens.toLocaleString()}</p> : null}
             {usage.cache_read_input_tokens ? <p>{t('assistantMessageDetails.cacheRead')}: {usage.cache_read_input_tokens.toLocaleString()}</p> : null}
             {usage.reasoning_tokens ? <p>{t('assistantMessageDetails.reasoning', { defaultValue: 'Reasoning' })}: {usage.reasoning_tokens.toLocaleString()}</p> : null}
             {usage.service_tier ? <p>{t('assistantMessageDetails.tier')}: {usage.service_tier}</p> : null}

--- a/src/components/messageRenderer/AssistantMessageDetails.tsx
+++ b/src/components/messageRenderer/AssistantMessageDetails.tsx
@@ -31,7 +31,7 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
     return null;
   }
 
-  const { model, usage, costUSD, durationMs } = message;
+  const { model, usage, costUSD, durationMs, provider } = message;
 
   if (!model) {
     return null;
@@ -41,19 +41,60 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
   // missing but we have a model + usage payload, fall back to the same pricing
   // table the analytics dashboard uses so the cost slot doesn't disappear (#194).
   // Mark the value as estimated so users know it's not authoritative.
-  const explicitCost = costUSD !== undefined && costUSD > 0 ? costUSD : null;
+  const explicitCost = costUSD !== undefined && costUSD !== null ? costUSD : null;
+  const nestedCacheCreationTokens5m = usage?.cache_creation?.ephemeral_5m_input_tokens ?? 0;
+  const nestedCacheCreationTokens1h = usage?.cache_creation?.ephemeral_1h_input_tokens ?? 0;
+  const cacheCreationTokens1h = usage?.cache_creation_input_tokens_1h
+    ?? nestedCacheCreationTokens1h;
+  const cacheCreationTokens = usage?.cache_creation_input_tokens
+    ?? nestedCacheCreationTokens5m + nestedCacheCreationTokens1h;
+  const cacheCreationTokens5m = usage?.cache_creation_input_tokens_5m
+    ?? Math.max(cacheCreationTokens - cacheCreationTokens1h, 0);
+  const contextTokens =
+    (usage?.input_tokens ?? 0) + cacheCreationTokens + (usage?.cache_read_input_tokens ?? 0);
   const estimatedCost =
-    explicitCost == null && usage && hasExplicitModelPricing(model)
-      ? calculateModelPrice(
-          model,
-          usage.input_tokens ?? 0,
-          usage.output_tokens ?? 0,
-          usage.cache_creation_input_tokens ?? 0,
-          usage.cache_read_input_tokens ?? 0,
-        )
-      : 0;
-  const displayCost = explicitCost ?? (estimatedCost > 0 ? estimatedCost : null);
+    explicitCost == null && usage && hasExplicitModelPricing(model, provider)
+      ? (() => {
+          const options = {
+            providerId: provider,
+            serviceTier: usage.service_tier,
+            contextTokens,
+            reasoningTokens: usage.reasoning_tokens,
+          };
+          const baseCost = calculateModelPrice(
+            model,
+            usage.input_tokens ?? 0,
+            usage.output_tokens ?? 0,
+            cacheCreationTokens5m,
+            usage.cache_read_input_tokens ?? 0,
+            { ...options, cacheWriteTtl: "5m" },
+          );
+          const oneHourCost = cacheCreationTokens1h > 0
+            ? calculateModelPrice(
+                model,
+                0,
+                0,
+                cacheCreationTokens1h,
+                0,
+                { ...options, cacheWriteTtl: "1h", reasoningTokens: 0 },
+              )
+            : 0;
+          return baseCost == null || oneHourCost == null ? null : baseCost + oneHourCost;
+        })()
+      : null;
+  const displayCost = explicitCost ?? estimatedCost;
   const isEstimated = displayCost != null && explicitCost == null;
+  const hasUsage = usage != null && (
+    (usage.input_tokens ?? 0) > 0 ||
+    (usage.output_tokens ?? 0) > 0 ||
+    (usage.cache_creation_input_tokens ?? 0) > 0 ||
+    (usage.cache_creation_input_tokens_5m ?? 0) > 0 ||
+    (usage.cache_creation_input_tokens_1h ?? 0) > 0 ||
+    (usage.cache_creation?.ephemeral_5m_input_tokens ?? 0) > 0 ||
+    (usage.cache_creation?.ephemeral_1h_input_tokens ?? 0) > 0 ||
+    (usage.cache_read_input_tokens ?? 0) > 0 ||
+    (usage.reasoning_tokens ?? 0) > 0
+  );
 
   return (
     <div className={`flex items-center justify-start mt-1.5 ${layout.iconSpacing} ${layout.smallText} text-muted-foreground flex-wrap gap-y-1`}>
@@ -79,7 +120,7 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
       )}
 
       {/* Token usage tooltip */}
-      {usage && (usage.input_tokens || usage.output_tokens) && (
+      {usage && hasUsage && (
         <div className="relative group">
           <button
             type="button"
@@ -99,6 +140,7 @@ export const AssistantMessageDetails: React.FC<AssistantMessageDetailsProps> = (
             {usage.output_tokens ? <p>{t('assistantMessageDetails.output')}: {usage.output_tokens.toLocaleString()}</p> : null}
             {usage.cache_creation_input_tokens ? <p>{t('assistantMessageDetails.cacheCreation')}: {usage.cache_creation_input_tokens.toLocaleString()}</p> : null}
             {usage.cache_read_input_tokens ? <p>{t('assistantMessageDetails.cacheRead')}: {usage.cache_read_input_tokens.toLocaleString()}</p> : null}
+            {usage.reasoning_tokens ? <p>{t('assistantMessageDetails.reasoning', { defaultValue: 'Reasoning' })}: {usage.reasoning_tokens.toLocaleString()}</p> : null}
             {usage.service_tier ? <p>{t('assistantMessageDetails.tier')}: {usage.service_tier}</p> : null}
             {displayCost != null && (
               <p className="mt-1 pt-1 border-t border-border">

--- a/src/components/toolResultRenderer/ContentArrayRenderer.tsx
+++ b/src/components/toolResultRenderer/ContentArrayRenderer.tsx
@@ -119,6 +119,14 @@ export const ContentArrayRenderer = ({ toolResult, searchQuery }: ContentArrayRe
                   </span>
                 </div>
               )}
+              {typeof usage.reasoning_tokens === "number" && (
+                <div>
+                  <span className="text-muted-foreground">{t("analytics.reasoning", "Reasoning")}</span>
+                  <span className="font-medium text-foreground ml-1">
+                    {usage.reasoning_tokens.toLocaleString()}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/store/slices/boardSlice.ts
+++ b/src/store/slices/boardSlice.ts
@@ -148,6 +148,9 @@ export const createBoardSlice: StateCreator<
                         totalTokens: 0,
                         inputTokens: 0,
                         outputTokens: 0,
+                        cacheCreationTokens: 0,
+                        cacheReadTokens: 0,
+                        reasoningTokens: 0,
                         errorCount: derivedStats.errorCount, // Use derived count which is more robust
                         durationMs: 0,
                         toolCount: 0,
@@ -182,7 +185,15 @@ export const createBoardSlice: StateCreator<
                                 seenUsageKeys.add(usageKey);
                                 stats.inputTokens += usage.input_tokens || 0;
                                 stats.outputTokens += usage.output_tokens || 0;
-                                stats.totalTokens += (usage.input_tokens || 0) + (usage.output_tokens || 0);
+                                stats.cacheCreationTokens += usage.cache_creation_input_tokens || 0;
+                                stats.cacheReadTokens += usage.cache_read_input_tokens || 0;
+                                stats.reasoningTokens += usage.reasoning_tokens || 0;
+                                stats.totalTokens +=
+                                    (usage.input_tokens || 0) +
+                                    (usage.output_tokens || 0) +
+                                    (usage.cache_creation_input_tokens || 0) +
+                                    (usage.cache_read_input_tokens || 0) +
+                                    (usage.reasoning_tokens || 0);
                             }
                         }
 

--- a/src/test/globalStatsSlice.test.ts
+++ b/src/test/globalStatsSlice.test.ts
@@ -42,6 +42,7 @@ const buildGlobalSummary = (): GlobalStatsSummary => ({
     output: 1,
     cache_creation: 0,
     cache_read: 0,
+    reasoning: 0,
   },
   daily_stats: [],
   activity_heatmap: [],

--- a/src/test/messageSlice.tokenLoading.test.ts
+++ b/src/test/messageSlice.tokenLoading.test.ts
@@ -79,6 +79,7 @@ const buildProjectSummary = (): ProjectStatsSummary => ({
     output: 1,
     cache_creation: 0,
     cache_read: 0,
+    reasoning: 0,
   },
 });
 

--- a/src/types/board.types.ts
+++ b/src/types/board.types.ts
@@ -4,6 +4,9 @@ export interface BoardSessionStats {
     totalTokens: number;
     inputTokens: number;
     outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    reasoningTokens: number;
     errorCount: number;
     durationMs: number;
     toolCount: number;

--- a/src/types/core/message.ts
+++ b/src/types/core/message.ts
@@ -101,7 +101,14 @@ export interface MessagePayload {
     input_tokens?: number;
     output_tokens?: number;
     cache_creation_input_tokens?: number;
+    cache_creation_input_tokens_5m?: number;
+    cache_creation_input_tokens_1h?: number;
+    cache_creation?: {
+      ephemeral_5m_input_tokens?: number;
+      ephemeral_1h_input_tokens?: number;
+    };
     cache_read_input_tokens?: number;
+    reasoning_tokens?: number;
     service_tier?: string;
   };
 }
@@ -190,7 +197,14 @@ export interface ClaudeAssistantMessage extends BaseClaudeMessage {
     input_tokens?: number;
     output_tokens?: number;
     cache_creation_input_tokens?: number;
+    cache_creation_input_tokens_5m?: number;
+    cache_creation_input_tokens_1h?: number;
+    cache_creation?: {
+      ephemeral_5m_input_tokens?: number;
+      ephemeral_1h_input_tokens?: number;
+    };
     cache_read_input_tokens?: number;
+    reasoning_tokens?: number;
     service_tier?: string;
   };
   // Metrics (2025)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,7 @@ export type {
   DailyStats,
   ActivityHeatmap,
   ToolUsageStats,
+  ModelContextStats,
   ModelStats,
   DateRange,
   ProjectStatsSummary,

--- a/src/types/message.types.ts
+++ b/src/types/message.types.ts
@@ -105,7 +105,14 @@ export interface MessagePayload {
     input_tokens?: number;
     output_tokens?: number;
     cache_creation_input_tokens?: number;
+    cache_creation_input_tokens_5m?: number;
+    cache_creation_input_tokens_1h?: number;
+    cache_creation?: {
+      ephemeral_5m_input_tokens?: number;
+      ephemeral_1h_input_tokens?: number;
+    };
     cache_read_input_tokens?: number;
+    reasoning_tokens?: number;
     service_tier?: string;
   };
 }
@@ -188,7 +195,14 @@ export interface ClaudeAssistantMessage extends BaseClaudeMessage {
     input_tokens?: number;
     output_tokens?: number;
     cache_creation_input_tokens?: number;
+    cache_creation_input_tokens_5m?: number;
+    cache_creation_input_tokens_1h?: number;
+    cache_creation?: {
+      ephemeral_5m_input_tokens?: number;
+      ephemeral_1h_input_tokens?: number;
+    };
     cache_read_input_tokens?: number;
+    reasoning_tokens?: number;
     service_tier?: string;
   };
   // Metrics (2025)

--- a/src/types/stats.types.ts
+++ b/src/types/stats.types.ts
@@ -25,7 +25,7 @@ export interface SessionTokenStats {
   last_message_time: string;
   summary?: string;
   most_used_tools: ToolUsageStats[];
-  model_distribution: ModelStats[];
+  model_distribution?: ModelStats[];
 }
 
 /**
@@ -134,7 +134,7 @@ export interface ProjectStatsSummary {
   most_used_subagents: ToolUsageStats[];
   daily_stats: DailyStats[];
   activity_heatmap: ActivityHeatmap[];
-  model_distribution: ModelStats[];
+  model_distribution?: ModelStats[];
   token_distribution: {
     input: number;
     output: number;
@@ -198,6 +198,6 @@ export interface GlobalStatsSummary {
   /** Claude subagents (`Agent` tool) by invocation count (#321). */
   most_used_subagents: ToolUsageStats[];
   provider_distribution: ProviderUsageStats[];
-  model_distribution: ModelStats[];
+  model_distribution?: ModelStats[];
   top_projects: ProjectRanking[];
 }

--- a/src/types/stats.types.ts
+++ b/src/types/stats.types.ts
@@ -18,12 +18,14 @@ export interface SessionTokenStats {
   total_output_tokens: number;
   total_cache_creation_tokens: number;
   total_cache_read_tokens: number;
+  total_reasoning_tokens: number;
   total_tokens: number;
   message_count: number;
   first_message_time: string;
   last_message_time: string;
   summary?: string;
   most_used_tools: ToolUsageStats[];
+  model_distribution: ModelStats[];
 }
 
 /**
@@ -73,14 +75,33 @@ export interface ToolUsageStats {
 // Model Stats
 // ============================================================================
 
+export interface ModelContextStats {
+  /** Minimum prompt-context size represented by this bucket. Zero is default/short context. */
+  min_context_tokens: number;
+  token_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_creation_tokens_5m?: number;
+  cache_creation_tokens_1h?: number;
+  cache_read_tokens: number;
+  reasoning_tokens: number;
+}
+
 export interface ModelStats {
   model_name: string;
+  provider_id?: string;
+  service_tier?: string;
   message_count: number;
   token_count: number;
   input_tokens: number;
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  reasoning_tokens: number;
+  cost_usd?: number | null;
+  /** Per-request context-tier buckets used to avoid pricing an aggregate as one request. */
+  context_breakdown?: ModelContextStats[];
 }
 
 // ============================================================================
@@ -113,11 +134,13 @@ export interface ProjectStatsSummary {
   most_used_subagents: ToolUsageStats[];
   daily_stats: DailyStats[];
   activity_heatmap: ActivityHeatmap[];
+  model_distribution: ModelStats[];
   token_distribution: {
     input: number;
     output: number;
     cache_creation: number;
     cache_read: number;
+    reasoning: number;
   };
 }
 
@@ -165,6 +188,7 @@ export interface GlobalStatsSummary {
     output: number;
     cache_creation: number;
     cache_read: number;
+    reasoning: number;
   };
   daily_stats: DailyStats[];
   activity_heatmap: ActivityHeatmap[];


### PR DESCRIPTION
## Summary

- Correct provider/model pricing lookup and display for supported providers
- Preserve service tiers, per-request short/long context buckets, and 5m/1h cache usage through Rust aggregation and the analytics UI
- Normalize provider usage payloads, including Anthropic nested cache fields, OpenAI Fast/Priority tiers, reasoning tokens, and Qwen cached input tokens
- Avoid inventing token-only API estimates for subscription/proxy providers when no authoritative source cost is available
- Add regression coverage for pricing, context tiers, cache handling, provider identity, and unavailable pricing

## Root cause

Aggregated token rows previously lost the request context tier and provider billing identity. Several provider payload variants were also omitted or double-counted cached tokens, which could produce incorrect costs or misleading $0.00 estimates.

## Validation

- Rust: `cargo test -- --test-threads=1` (908 tests passed)
- Rust: `cargo clippy --all-targets --all-features -- -D warnings`
- Rust: `cargo fmt --all -- --check`
- Frontend: `pnpm vitest run` (88 files, 1,014 tests passed)
- Frontend: `pnpm tsc --build .`, `pnpm lint`, `pnpm build`
- `pnpm run i18n:validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics now show reasoning tokens, cache usage, model distributions, provider details, service tiers, and context breakdowns.
  * Added cost views with exact, estimated, and unavailable pricing indicators.
  * Global analytics can switch between cost-focused and token-focused metrics.
  * Message, session, and project views display reasoning-token usage.
* **Bug Fixes**
  * Improved token accounting to prevent cached tokens from being counted twice.
  * Enhanced pricing accuracy for context length, cache duration, service tiers, and reasoning tokens.
  * Added provider-specific usage and cost detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->