### PR TITLE
fix: apply WebKit DMABUF workaround outside AppImage on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ debug.log*
 # Auto-generated AI context files
 **/*/CLAUDE.md
 .serena/memories/
+.memsearch
 
 # AFC plugin state (abandoned tooling — kept out of the repo)
 .claude/afc/

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,7 +130,7 @@ fn run_tauri() {
     // This is safe here because no threads exist yet at this point in startup.
     // Only set if not already configured by the user.
     #[cfg(target_os = "linux")]
-    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,28 +112,26 @@ pub fn run() {
 fn run_tauri() {
     configure_linux_ime_environment();
 
-    // Workaround for WebKitGTK GPU process crash in AppImage environments.
+    // Workaround for WebKitGTK GPU-process crashes on Linux.
     //
-    // AppImage bundles Ubuntu-compiled EGL/Mesa libs, but the system's
-    // WebKitGPUProcess (not bundled) inherits LD_LIBRARY_PATH and loads them,
-    // causing EGL_BAD_ALLOC on distros with newer Mesa (e.g. Arch Linux).
+    // AppImage: bundled Ubuntu-compiled EGL/Mesa libs conflict with the system
+    // WebKitGPUProcess (which inherits LD_LIBRARY_PATH), causing EGL_BAD_ALLOC
+    // on distros with newer Mesa (e.g. Arch Linux). The CI pipeline removes
+    // conflicting EGL libs from the AppImage (primary fix).
     //
-    // The CI pipeline removes conflicting EGL libs from the AppImage (primary fix).
-    // This env var is defense-in-depth for edge cases (NVIDIA driver quirks, etc.).
+    // Plain binaries: NVIDIA proprietary/open drivers on Wayland can crash at
+    // startup in the DMA-BUF renderer path with "Gdk-Message: Error 71
+    // (Protocol error) dispatching to Wayland display" (seen with WebKitGTK
+    // 2.52 + NVIDIA 610 + GNOME Wayland), so this is not gated on AppImage.
     //
     // See: https://github.com/jhlee0409/claude-code-history-viewer/issues/186
     // See: https://github.com/tauri-apps/tauri/issues/11988
     // Note: std::env::set_var becomes unsafe in Rust edition 2024.
     // This is safe here because no threads exist yet at this point in startup.
+    // Only set if not already configured by the user.
     #[cfg(target_os = "linux")]
-    if std::env::var("APPIMAGE")
-        .map(|v| !v.is_empty())
-        .unwrap_or(false)
-    {
-        // Only set if not already configured by the user
-        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
-            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-        }
+    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
 
     use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## What & why

On Linux with NVIDIA drivers under Wayland, the app crashes at startup:

```
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
```

The existing workaround (`WEBKIT_DISABLE_DMABUF_RENDERER=1`, added for #186) only activates when the `APPIMAGE` env var is present, so plain binaries — built from source or a future native package — hit the same WebKitGTK DMA-BUF crash with no mitigation.

Reproduced with: WebKitGTK 2.52.5, NVIDIA 610.57 (open kernel module), GNOME Wayland, Fedora 44.

## Fix

Drop the AppImage gate in `run_tauri()` and set the variable for all Linux launches. User override is preserved — the variable is only set when absent from the environment, exactly as before.

One-line behavioral change; no effect on macOS/Windows (`#[cfg(target_os = "linux")]`).

## Testing

- Without fix: bare binary crashes immediately on NVIDIA + GNOME Wayland
- With fix: bare binary launches and runs normally on the same machine
- Env-var matrix on the affected machine: `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_COMPOSITING_MODE=1` both work; `WEBKIT_SKIA_ENABLE_CPU_RENDERING=1` crashes; `GDK_BACKEND=x11` renders a blank window — confirming the DMABUF toggle is the right (least invasive) knob
- AppImage path unaffected: same variable, now just set unconditionally

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [ ] Refactor / perf
- [ ] Docs

## Test plan

- [ ] CI (clippy, fmt, cargo test)
- [ ] Regression check on a non-NVIDIA Linux box (variable is harmless there, but worth a launch test)

Refs #186
See: https://github.com/tauri-apps/tauri/issues/11988

## Checklist

- [x] PR targets **`develop`**, not `main`
- [ ] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [ ] **i18n**: any new user-facing string is `t()`-wrapped and the key exists in **all 5 languages** (`en, ko, ja, zh-CN, zh-TW`) — verified with `pnpm run i18n:validate`

Assisted-by: Claude:claude-fable-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux rendering reliability by applying a compatibility setting when no existing configuration is provided.
  * Preserved any value already set by the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->