### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -510,6 +510,6 @@ claude-code-history-viewer://session-title/auth%20bug
 
 このプロジェクトが役に立ったら、スターをお願いします！
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.com/#jhlee0409/claude-code-history-viewer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.dera.page/#jhlee0409/claude-code-history-viewer&Date)
 
 </div>

--- a/README.ko.md
+++ b/README.ko.md
@@ -510,6 +510,6 @@ claude-code-history-viewer://session-title/auth%20bug
 
 이 프로젝트가 도움이 되었다면 스타를 고려해주세요!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.com/#jhlee0409/claude-code-history-viewer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.dera.page/#jhlee0409/claude-code-history-viewer&Date)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -510,6 +510,6 @@ See [Development Commands](CLAUDE.md#development-commands) for the full list of 
 
 If this project helps you, consider giving it a star!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.com/#jhlee0409/claude-code-history-viewer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.dera.page/#jhlee0409/claude-code-history-viewer&Date)
 
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -510,6 +510,6 @@ claude-code-history-viewer://session-title/auth%20bug
 
 如果这个项目对您有帮助,请给它一个星标!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.com/#jhlee0409/claude-code-history-viewer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.dera.page/#jhlee0409/claude-code-history-viewer&Date)
 
 </div>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -510,6 +510,6 @@ claude-code-history-viewer://session-title/auth%20bug
 
 如果這個專案對您有幫助，請考慮給它一顆星星！
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.com/#jhlee0409/claude-code-history-viewer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jhlee0409/claude-code-history-viewer&type=Date)](https://star-history.dera.page/#jhlee0409/claude-code-history-viewer&Date)
 
 </div>


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying service relies on GitHub's stargazer API, which now restricts access.

This PR updates the chart across all README versions (en, ko, ja, zh-CN, zh-TW) to use a working alternative that pulls data from a different source and requires no API token, restoring the star history display.