### PR TITLE
fix(search): prioritize Codex conversation matches

### DIFF
--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -1,6 +1,6 @@
 use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, MessagePage};
 use crate::providers;
-use crate::utils::parse_rfc3339_utc;
+use crate::utils::{parse_rfc3339_utc, search_result_priority};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
@@ -40,6 +40,26 @@ fn select_wsl_search_providers(
         .filter(|provider| is_wsl_search_provider(provider.as_str()))
         .cloned()
         .collect()
+}
+
+fn compare_global_search_results(
+    a: &ClaudeMessage,
+    b: &ClaudeMessage,
+    query_lower: &str,
+) -> Ordering {
+    search_result_priority(a, query_lower)
+        .cmp(&search_result_priority(b, query_lower))
+        .then_with(|| {
+            match (
+                parse_rfc3339_utc(&a.timestamp),
+                parse_rfc3339_utc(&b.timestamp),
+            ) {
+                (Some(a_ts), Some(b_ts)) => b_ts.cmp(&a_ts),
+                (Some(_), None) => Ordering::Less,
+                (None, Some(_)) => Ordering::Greater,
+                (None, None) => b.timestamp.cmp(&a.timestamp),
+            }
+        })
 }
 
 /// Detect all available providers
@@ -731,7 +751,7 @@ pub async fn search_all_providers(
 
     // Codex
     if providers_to_search.iter().any(|p| p == "codex") {
-        match providers::codex::search(&query, max_results) {
+        match providers::codex::search(&query, max_results, &search_filters) {
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Codex search failed: {e}");
@@ -1098,18 +1118,10 @@ pub async fn search_all_providers(
 
     all_results = crate::commands::session::apply_search_filters(all_results, &search_filters);
 
-    // Sort by parsed timestamp descending (robust to `Z` vs `+00:00` formats)
-    all_results.sort_by(|a, b| {
-        match (
-            parse_rfc3339_utc(&a.timestamp),
-            parse_rfc3339_utc(&b.timestamp),
-        ) {
-            (Some(a_ts), Some(b_ts)) => b_ts.cmp(&a_ts),
-            (Some(_), None) => Ordering::Less,
-            (None, Some(_)) => Ordering::Greater,
-            (None, None) => b.timestamp.cmp(&a.timestamp),
-        }
-    });
+    // Prefer the user's matching prompts, then displayable assistant text,
+    // while preserving tool-only matches after conversational results.
+    let query_lower = query.to_lowercase();
+    all_results.sort_by(|a, b| compare_global_search_results(a, b, &query_lower));
     all_results.truncate(max_results);
 
     Ok(all_results)
@@ -1302,6 +1314,45 @@ mod tests {
         let mut msg = make_message(message_type, content);
         msg.uuid = uuid.to_string();
         msg
+    }
+
+    #[test]
+    fn global_search_ranking_prefers_conversation_roles_over_tool_matches() {
+        let mut user = make_message_with_uuid(
+            "user-text",
+            "user",
+            serde_json::json!([{ "type": "text", "text": "wallpaper prompt" }]),
+        );
+        user.timestamp = "2026-02-19T10:00:00Z".to_string();
+
+        let mut assistant = make_message_with_uuid(
+            "assistant-text",
+            "assistant",
+            serde_json::json!([{ "type": "text", "text": "wallpaper answer" }]),
+        );
+        assistant.timestamp = "2026-02-19T11:00:00Z".to_string();
+
+        let mut tool = make_message_with_uuid(
+            "tool-match",
+            "assistant",
+            serde_json::json!([{
+                "type": "tool_use",
+                "name": "Bash",
+                "input": { "command": "rg wallpaper" }
+            }]),
+        );
+        tool.timestamp = "2026-02-19T12:00:00Z".to_string();
+
+        let mut results = [tool, assistant, user];
+        results.sort_by(|a, b| compare_global_search_results(a, b, "wallpaper"));
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|message| message.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["user-text", "assistant-text", "tool-match"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -1,21 +1,22 @@
 use super::ProviderInfo;
 use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
 use crate::utils::{
-    build_provider_message, estimate_message_count_from_size, find_line_ranges,
-    search_json_value_case_insensitive,
+    build_provider_message, estimate_message_count_from_size, find_line_ranges, par_map_bounded,
+    search_json_value_case_insensitive, search_result_priority,
 };
 use chrono::{DateTime, Utc};
-use memchr::{memchr_iter, memmem};
+use memchr::{memchr2_iter, memchr_iter, memmem};
 use memmap2::Mmap;
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::Path;
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
-use crate::commands::session::NativeRenameResult;
+use crate::commands::session::{apply_search_filters, NativeRenameResult};
 
 const STATE_DB_FILENAME: &str = "state_5.sqlite";
 
@@ -531,8 +532,124 @@ pub(crate) fn parse_rollout_file(canonical_path: &Path) -> Result<Vec<ClaudeMess
     Ok(messages)
 }
 
-/// Search Codex sessions for a query string
-pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+fn project_name_for_rollout(rollout_path: &Path) -> Option<String> {
+    let cwd = extract_session_cwd(rollout_path).ok().flatten()?;
+    Path::new(&cwd)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .or_else(|| (!cwd.is_empty()).then_some(cwd))
+}
+
+fn bytes_contain_query_case_insensitive(haystack: &[u8], query: &[u8]) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    if haystack.len() < query.len() {
+        return false;
+    }
+
+    let first_lower = query[0].to_ascii_lowercase();
+    let first_upper = query[0].to_ascii_uppercase();
+    let matches_at = |start: usize| {
+        haystack
+            .get(start..start + query.len())
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(query))
+    };
+
+    if first_lower == first_upper {
+        memchr_iter(first_lower, haystack).any(matches_at)
+    } else {
+        memchr2_iter(first_lower, first_upper, haystack).any(matches_at)
+    }
+}
+
+fn rollout_might_contain_query(rollout_path: &Path, query_lower: &str) -> bool {
+    let Ok(bytes) = read_rollout_bytes(rollout_path) else {
+        return false;
+    };
+
+    for &(start, end) in &find_line_ranges(&bytes) {
+        let line = &bytes[start..end];
+        let line_matches = if query_lower.is_ascii() {
+            bytes_contain_query_case_insensitive(line, query_lower.as_bytes())
+        } else {
+            String::from_utf8_lossy(line)
+                .to_lowercase()
+                .contains(query_lower)
+        };
+        if !line_matches {
+            continue;
+        }
+
+        let mut buf = line.to_vec();
+        let Ok(value) = simd_json::from_slice::<Value>(&mut buf) else {
+            continue;
+        };
+        let line_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+        let Some(payload) = value.get("payload") else {
+            continue;
+        };
+
+        let searchable = match line_type {
+            "response_item" => {
+                let payload_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
+                if payload_type == "message" {
+                    let role = payload
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .unwrap_or("user");
+                    if role != "user" && role != "assistant" {
+                        continue;
+                    }
+                }
+                search_json_value_case_insensitive(payload, query_lower)
+            }
+            "event_msg" => {
+                let event_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
+                event_type != "user_message"
+                    && event_type != "agent_message"
+                    && search_json_value_case_insensitive(payload, query_lower)
+            }
+            "compacted" => "conversation compacted".contains(query_lower),
+            _ => false,
+        };
+        if searchable {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn is_searchable_codex_result(message: &ClaudeMessage) -> bool {
+    !matches!(message.role.as_deref(), Some("developer" | "system"))
+}
+
+fn compare_search_timestamps_desc(a: &ClaudeMessage, b: &ClaudeMessage) -> Ordering {
+    match (
+        DateTime::parse_from_rfc3339(&a.timestamp),
+        DateTime::parse_from_rfc3339(&b.timestamp),
+    ) {
+        (Ok(a_ts), Ok(b_ts)) => b_ts.cmp(&a_ts),
+        (Ok(_), Err(_)) => Ordering::Less,
+        (Err(_), Ok(_)) => Ordering::Greater,
+        (Err(_), Err(_)) => b.timestamp.cmp(&a.timestamp),
+    }
+}
+
+fn retain_newest_search_results(results: &mut Vec<ClaudeMessage>, limit: usize) {
+    if results.len() > limit {
+        results.sort_unstable_by(compare_search_timestamps_desc);
+        results.truncate(limit);
+    }
+}
+
+/// Search Codex sessions for a query string.
+///
+/// Filters are applied before the result cap, and displayable conversation
+/// text is kept ahead of tool-only matches so verbose tool transcripts cannot
+/// crowd the user's prompt or the assistant's reply out of global search.
+pub fn search(query: &str, limit: usize, filters: &Value) -> Result<Vec<ClaudeMessage>, String> {
     let session_dirs = get_existing_session_dirs()?;
 
     if session_dirs.is_empty() {
@@ -540,31 +657,67 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
     }
 
     let query_lower = query.to_lowercase();
-    let mut results = Vec::new();
+    let mut ranked_results: [Vec<ClaudeMessage>; 4] = std::array::from_fn(|_| Vec::new());
+    let rollout_paths: Vec<PathBuf> = session_dirs
+        .into_iter()
+        .flat_map(|session_dir| {
+            WalkDir::new(session_dir)
+                .min_depth(1)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_type().is_file())
+                .filter(|entry| is_discoverable_rollout(entry.path()))
+                .map(walkdir::DirEntry::into_path)
+        })
+        .collect();
 
-    for session_dir in session_dirs {
-        for entry in WalkDir::new(session_dir)
-            .min_depth(1)
+    let candidate_paths: Vec<PathBuf> = par_map_bounded(rollout_paths, |rollout_path| {
+        rollout_might_contain_query(&rollout_path, &query_lower).then_some(rollout_path)
+    })
+    .into_iter()
+    .flatten()
+    .collect();
+
+    let matches_by_file = par_map_bounded(candidate_paths, |rollout_path| {
+        let Ok(messages) = load_messages(&rollout_path.to_string_lossy()) else {
+            return Vec::new();
+        };
+        let mut file_results: Vec<ClaudeMessage> = messages
             .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| e.file_type().is_file())
-            .filter(|e| is_discoverable_rollout(e.path()))
-        {
-            let rollout_path = entry.path();
+            .filter(|msg| {
+                is_searchable_codex_result(msg)
+                    && msg.content.as_ref().is_some_and(|content| {
+                        search_json_value_case_insensitive(content, &query_lower)
+                    })
+            })
+            .collect();
 
-            if let Ok(messages) = load_messages(&rollout_path.to_string_lossy()) {
-                for msg in messages {
-                    if results.len() >= limit {
-                        return Ok(results);
-                    }
-
-                    if let Some(content) = &msg.content {
-                        if search_json_value_case_insensitive(content, &query_lower) {
-                            results.push(msg);
-                        }
-                    }
-                }
+        if !file_results.is_empty() {
+            let project_name = project_name_for_rollout(&rollout_path);
+            for msg in &mut file_results {
+                msg.project_name.clone_from(&project_name);
             }
+        }
+        apply_search_filters(file_results, filters)
+    });
+
+    for file_results in matches_by_file {
+        for msg in file_results {
+            let priority = search_result_priority(&msg, &query_lower);
+            ranked_results[priority].push(msg);
+        }
+        for bucket in &mut ranked_results {
+            retain_newest_search_results(bucket, limit);
+        }
+    }
+
+    let mut results = Vec::new();
+    for mut bucket in ranked_results {
+        bucket.sort_unstable_by(compare_search_timestamps_desc);
+        bucket.truncate(limit.saturating_sub(results.len()));
+        results.extend(bucket);
+        if results.len() == limit {
+            break;
         }
     }
 
@@ -3392,6 +3545,167 @@ mod tests {
             .join("\n");
         fs::write(&rollout_path, format!("{body}\n")).expect("rollout fixture should be written");
         rollout_path
+    }
+
+    #[test]
+    #[serial]
+    fn search_prioritizes_conversation_text_over_tool_matches() {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let sessions_dir = tmp.path().join("sessions/2026/08/13");
+        fs::create_dir_all(&sessions_dir).expect("sessions directory should be created");
+
+        let mut lines = vec![session_meta_line_with(
+            "2026-08-13T08:00:00Z",
+            "sess-wallpaper",
+            "/tmp/windows_remote_dev",
+        )];
+        for index in 0..101 {
+            lines.push(json!({
+                "timestamp": format!("2026-08-13T08:00:{:02}Z", index % 60),
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "id": format!("tool-{index}"),
+                    "call_id": format!("call-{index}"),
+                    "name": "exec_command",
+                    "arguments": json!({ "cmd": format!("rg wallpaper file-{index}") }).to_string()
+                }
+            }));
+        }
+        lines.push(user_message_line(
+            "2026-08-13T09:00:00Z",
+            "Please diagnose the Windows wallpaper problem.",
+        ));
+        write_rollout_lines(
+            &sessions_dir,
+            "rollout-2026-08-13T08-00-00-sess-wallpaper.jsonl",
+            &lines,
+        );
+
+        let _guard = EnvVarGuard::set("CODEX_HOME", tmp.path());
+        let results = search("wallpaper", 1, &json!({})).expect("Codex search should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert!(crate::utils::search_message_text_case_insensitive(
+            &results[0],
+            "wallpaper"
+        ));
+        assert_eq!(results[0].message_type, "user");
+        assert_eq!(
+            results[0].project_name.as_deref(),
+            Some("windows_remote_dev")
+        );
+    }
+
+    #[test]
+    fn search_prefilter_matches_ascii_case_insensitively() {
+        assert!(bytes_contain_query_case_insensitive(
+            br#"{"text":"Windows Wallpaper Engine"}"#,
+            b"wallpaper"
+        ));
+        assert!(bytes_contain_query_case_insensitive(
+            br#"{"text":"WALLPAPER"}"#,
+            b"wallpaper"
+        ));
+        assert!(!bytes_contain_query_case_insensitive(
+            br#"{"text":"window manager"}"#,
+            b"wallpaper"
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn search_ignores_developer_instruction_matches() {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let sessions_dir = tmp.path().join("sessions/2026/08/13");
+        fs::create_dir_all(&sessions_dir).expect("sessions directory should be created");
+        write_rollout_lines(
+            &sessions_dir,
+            "rollout-2026-08-13T08-00-00-developer-only.jsonl",
+            &[
+                session_meta_line_with(
+                    "2026-08-13T08:00:00Z",
+                    "sess-developer-only",
+                    "/tmp/project",
+                ),
+                json!({
+                    "timestamp": "2026-08-13T08:00:01Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "developer",
+                        "content": [{
+                            "type": "input_text",
+                            "text": "Internal wallpaper instruction"
+                        }]
+                    }
+                }),
+                user_message_line("2026-08-13T08:00:02Z", "A different question"),
+            ],
+        );
+
+        let _guard = EnvVarGuard::set("CODEX_HOME", tmp.path());
+        let results = search("wallpaper", 100, &json!({})).expect("Codex search should succeed");
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn search_applies_role_and_project_filters_before_limit() {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let sessions_dir = tmp.path().join("sessions/2026/08/13");
+        fs::create_dir_all(&sessions_dir).expect("sessions directory should be created");
+
+        write_rollout_lines(
+            &sessions_dir,
+            "rollout-2026-08-13T08-00-00-selected.jsonl",
+            &[
+                session_meta_line_with(
+                    "2026-08-13T08:00:00Z",
+                    "sess-selected",
+                    "/tmp/windows_remote_dev",
+                ),
+                user_message_line(
+                    "2026-08-13T08:00:01Z",
+                    "The selected wallpaper conversation.",
+                ),
+            ],
+        );
+        write_rollout_lines(
+            &sessions_dir,
+            "rollout-2026-08-13T09-00-00-newer.jsonl",
+            &[
+                session_meta_line_with("2026-08-13T09:00:00Z", "sess-newer", "/tmp/other_project"),
+                json!({
+                    "timestamp": "2026-08-13T09:00:01Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{
+                            "type": "output_text",
+                            "text": "A newer wallpaper conversation."
+                        }]
+                    }
+                }),
+            ],
+        );
+
+        let _guard = EnvVarGuard::set("CODEX_HOME", tmp.path());
+        let filters = json!({
+            "messageType": "user",
+            "projects": ["windows_remote_dev"]
+        });
+        let results = search("wallpaper", 1, &filters).expect("Codex search should succeed");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].session_id, "sess-selected");
+        assert_eq!(results[0].message_type, "user");
+        assert_eq!(
+            results[0].project_name.as_deref(),
+            Some("windows_remote_dev")
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -570,14 +570,16 @@ fn rollout_might_contain_query(rollout_path: &Path, query_lower: &str) -> bool {
 
     for &(start, end) in &find_line_ranges(&bytes) {
         let line = &bytes[start..end];
-        let line_matches = if query_lower.is_ascii() {
+        let raw_match = if query_lower.is_ascii() {
             bytes_contain_query_case_insensitive(line, query_lower.as_bytes())
         } else {
             String::from_utf8_lossy(line)
                 .to_lowercase()
                 .contains(query_lower)
         };
-        if !line_matches {
+        // A JSON escape can hide a decoded match from the raw byte scan, for
+        // example `\u0077allpaper`. Parse escaped lines before rejecting them.
+        if !raw_match && !line.contains(&b'\\') {
             continue;
         }
 
@@ -3611,6 +3613,22 @@ mod tests {
             br#"{"text":"window manager"}"#,
             b"wallpaper"
         ));
+    }
+
+    #[test]
+    fn search_prefilter_matches_json_escaped_text() {
+        let tmp = TempDir::new().expect("temp dir should be created");
+        let rollout_path = tmp.path().join("rollout-escaped.jsonl");
+        fs::write(
+            &rollout_path,
+            concat!(
+                r#"{"timestamp":"2026-08-13T08:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"\u0077allpaper"}]}}"#,
+                "\n"
+            ),
+        )
+        .expect("rollout should be written");
+
+        assert!(rollout_might_contain_query(&rollout_path, "wallpaper"));
     }
 
     #[test]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -173,6 +173,38 @@ pub fn search_json_value_case_insensitive(value: &serde_json::Value, query_lower
     }
 }
 
+/// Returns whether the query matches text that the global-search result card
+/// can preview directly, rather than only nested tool input or output.
+///
+/// `query_lower` must already be lowercased by the caller.
+pub fn search_message_text_case_insensitive(message: &ClaudeMessage, query_lower: &str) -> bool {
+    match message.content.as_ref() {
+        Some(Value::String(text)) => text.to_lowercase().contains(query_lower),
+        Some(Value::Array(items)) => items.iter().any(|item| {
+            item.get("type").and_then(Value::as_str) == Some("text")
+                && item
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| text.to_lowercase().contains(query_lower))
+        }),
+        _ => false,
+    }
+}
+
+/// Relevance tier for global-search results: user text, assistant text, other
+/// previewable text, then tool-only matches. Timestamps break ties later.
+pub fn search_result_priority(message: &ClaudeMessage, query_lower: &str) -> usize {
+    if !search_message_text_case_insensitive(message, query_lower) {
+        return 3;
+    }
+
+    match message.message_type.as_str() {
+        "user" => 0,
+        "assistant" => 1,
+        _ => 2,
+    }
+}
+
 // ===== Git Worktree Detection =====
 
 /// Decode Claude session storage path to actual project path


### PR DESCRIPTION
## What & why

Codex global search stopped as soon as it collected `maxResults` raw matches. Tool transcripts and developer instructions could therefore fill the cap before an older user prompt was reached. Provider filters were also applied only after that cap, and Codex results did not include a project name.

This change:

- applies role and project filters before limiting Codex results
- ranks matching user text, assistant text, other previewable text, then tool-only matches
- excludes developer and system instructions from Codex search results
- attaches the session project name so project filtering works
- uses a bounded parallel prefilter without dropping matches hidden by JSON escapes

On a local history corpus, a known prompt that was previously outside the 100-result cap now appears as the second result with the correct project.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [x] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm exec vitest run` and Rust tests)
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: no user-facing strings were added; `pnpm run i18n:validate` passes

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1` (917 unit tests and 12 integration tests passed; 5 data-dependent integration tests ignored)
- `pnpm exec vitest run` (1017 tests passed)
- `pnpm exec tsc --build .`
- `pnpm lint`
- `pnpm run i18n:validate`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved global search with case-insensitive and escaped-text matching.
  * Added Codex search filters for projects and message types.
  * Search results now prioritize relevant user and assistant messages over tool-only matches.
  * Improved search responsiveness when scanning Codex conversations.

* **Bug Fixes**
  * Corrected result ordering and filtering so newer, more relevant matches appear first.
  * Excluded developer and system messages from Codex search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->