### PR TITLE
feat(providers): add Kimi Code CLI provider

### DIFF
--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -88,6 +88,7 @@ pub async fn scan_all_projects(
             "goose".to_string(),
             "grok".to_string(),
             "kimi".to_string(),
+            "kimi-code".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
             "openinterpreter".to_string(),
@@ -176,6 +177,7 @@ pub async fn scan_all_projects(
         ("goose", providers::goose::scan_projects),
         ("grok", providers::grok::scan_projects),
         ("kimi", providers::kimi::scan_projects),
+        ("kimi-code", providers::kimi_code::scan_projects),
         ("forgecode", providers::forgecode::scan_projects),
         ("opencode", providers::opencode::scan_projects),
         ("openinterpreter", providers::openinterpreter::scan_projects),
@@ -371,6 +373,7 @@ pub async fn load_provider_sessions(
         "goose" => providers::goose::load_sessions(&project_path, exclude),
         "grok" => providers::grok::load_sessions(&project_path, exclude),
         "kimi" => providers::kimi::load_sessions(&project_path, exclude),
+        "kimi-code" => providers::kimi_code::load_sessions(&project_path, exclude),
         "forgecode" => providers::forgecode::load_sessions(&project_path, exclude),
         "opencode" => providers::opencode::load_sessions(&project_path, exclude),
         "openinterpreter" => providers::openinterpreter::load_sessions(&project_path, exclude),
@@ -484,6 +487,7 @@ fn load_non_claude_messages(
         "goose" => providers::goose::load_messages(session_path),
         "grok" => providers::grok::load_messages(session_path),
         "kimi" => providers::kimi::load_messages(session_path),
+        "kimi-code" => providers::kimi_code::load_messages(session_path),
         "forgecode" => providers::forgecode::load_messages(session_path),
         "opencode" => providers::opencode::load_messages(session_path),
         "openinterpreter" => providers::openinterpreter::load_messages(session_path),
@@ -661,6 +665,7 @@ pub async fn search_all_providers(
             "goose".to_string(),
             "grok".to_string(),
             "kimi".to_string(),
+            "kimi-code".to_string(),
             "forgecode".to_string(),
             "opencode".to_string(),
             "openinterpreter".to_string(),
@@ -815,6 +820,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("Kimi search failed: {e}");
+            }
+        }
+    }
+
+    // Kimi Code CLI
+    if providers_to_search.iter().any(|p| p == "kimi-code") {
+        match providers::kimi_code::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Kimi Code search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -58,6 +58,9 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(kimi_base) = crate::providers::kimi::get_base_path() {
         allowed.push(PathBuf::from(kimi_base).join("sessions"));
     }
+    if let Some(kimi_code_base) = crate::providers::kimi_code::get_base_path() {
+        allowed.push(PathBuf::from(kimi_code_base).join("sessions"));
+    }
     if let Some(vibe_base) = crate::providers::vibe::get_base_path() {
         allowed.push(PathBuf::from(vibe_base).join("logs/session"));
     }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -45,6 +45,7 @@ enum StatsProvider {
     Llm,
     Grok,
     Kimi,
+    KimiCode,
     Antigravity,
     Copilot,
     Ompi,
@@ -104,6 +105,7 @@ fn stats_provider_id(provider: StatsProvider) -> &'static str {
         StatsProvider::Llm => "llm",
         StatsProvider::Grok => "grok",
         StatsProvider::Kimi => "kimi",
+        StatsProvider::KimiCode => "kimi-code",
         StatsProvider::Antigravity => "antigravity",
         StatsProvider::Copilot => "copilot",
         StatsProvider::Ompi => "ompi",
@@ -311,6 +313,7 @@ fn all_stats_providers() -> HashSet<StatsProvider> {
         StatsProvider::Llm,
         StatsProvider::Grok,
         StatsProvider::Kimi,
+        StatsProvider::KimiCode,
         StatsProvider::Antigravity,
         StatsProvider::Copilot,
         StatsProvider::Ompi,
@@ -355,6 +358,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
             "llm" => Some(StatsProvider::Llm),
             "grok" => Some(StatsProvider::Grok),
             "kimi" => Some(StatsProvider::Kimi),
+            "kimi-code" => Some(StatsProvider::KimiCode),
             "antigravity" => Some(StatsProvider::Antigravity),
             "copilot" => Some(StatsProvider::Copilot),
             "ompi" => Some(StatsProvider::Ompi),
@@ -418,6 +422,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::OpenCode
     } else if project_path.starts_with("grok://") {
         StatsProvider::Grok
+    } else if project_path.starts_with("kimicode://") {
+        StatsProvider::KimiCode
     } else if project_path.starts_with("kimi://") {
         StatsProvider::Kimi
     } else if project_path.starts_with("gemini://") {
@@ -520,6 +526,10 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
 
     if is_grok_path(session_path) {
         return StatsProvider::Grok;
+    }
+
+    if is_kimi_code_path(session_path) {
+        return StatsProvider::KimiCode;
     }
 
     if is_kimi_path(session_path) {
@@ -633,6 +643,12 @@ fn is_codebuddy_path_under(path: &str, home: &Path) -> bool {
 
 fn is_kimi_path(path: &str) -> bool {
     providers::kimi::get_base_path()
+        .map(|root| Path::new(path).starts_with(root))
+        .unwrap_or(false)
+}
+
+fn is_kimi_code_path(path: &str) -> bool {
+    providers::kimi_code::get_base_path()
         .map(|root| Path::new(path).starts_with(root))
         .unwrap_or(false)
 }
@@ -1504,6 +1520,7 @@ fn scan_stats_projects(
         StatsProvider::Llm => providers::llm::scan_projects(),
         StatsProvider::Grok => providers::grok::scan_projects(),
         StatsProvider::Kimi => providers::kimi::scan_projects(),
+        StatsProvider::KimiCode => providers::kimi_code::scan_projects(),
         StatsProvider::Antigravity => providers::antigravity::scan_projects(),
         StatsProvider::Copilot => providers::copilot::scan_projects(),
         StatsProvider::Ompi => providers::ompi::scan_projects(),
@@ -1543,6 +1560,7 @@ fn load_stats_sessions(
         StatsProvider::Llm => providers::llm::load_sessions(project_path, false),
         StatsProvider::Grok => providers::grok::load_sessions(project_path, false),
         StatsProvider::Kimi => providers::kimi::load_sessions(project_path, false),
+        StatsProvider::KimiCode => providers::kimi_code::load_sessions(project_path, false),
         StatsProvider::Antigravity => providers::antigravity::load_sessions(project_path, false),
         StatsProvider::Copilot => providers::copilot::load_sessions(project_path, false),
         StatsProvider::Ompi => providers::ompi::load_sessions(project_path, false),
@@ -1580,6 +1598,7 @@ fn load_stats_messages(
         StatsProvider::Llm => providers::llm::load_messages(session_path),
         StatsProvider::Grok => providers::grok::load_messages(session_path),
         StatsProvider::Kimi => providers::kimi::load_messages(session_path),
+        StatsProvider::KimiCode => providers::kimi_code::load_messages(session_path),
         StatsProvider::Antigravity => providers::antigravity::load_messages(session_path),
         StatsProvider::Copilot => providers::copilot::load_messages(session_path),
         StatsProvider::Ompi => providers::ompi::load_messages(session_path),
@@ -2881,6 +2900,21 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                 })
                 .unwrap_or_else(|| project_path.to_string())
         }
+        StatsProvider::KimiCode => {
+            if let Ok(projects) = providers::kimi_code::scan_projects() {
+                if let Some(project) = projects.into_iter().find(|p| p.path == project_path) {
+                    return project.name;
+                }
+            }
+            project_path
+                .strip_prefix("kimicode://")
+                .and_then(|p| {
+                    PathBuf::from(p)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| project_path.to_string())
+        }
         StatsProvider::Antigravity => {
             if let Ok(projects) = providers::antigravity::scan_projects() {
                 if let Some(project) = projects.into_iter().find(|p| p.path == project_path) {
@@ -3029,6 +3063,13 @@ fn resolve_provider_project_name_from_session(
                 return resolve_provider_project_name(provider, &project_path);
             }
             "kimi".to_string()
+        }
+        StatsProvider::KimiCode => {
+            if let Some(project_dir) = Path::new(session_path).parent() {
+                let project_path = format!("kimicode://{}", project_dir.to_string_lossy());
+                return resolve_provider_project_name(provider, &project_path);
+            }
+            "kimi-code".to_string()
         }
         StatsProvider::Antigravity => "Antigravity".to_string(),
         StatsProvider::Copilot => {
@@ -5033,6 +5074,13 @@ pub async fn get_global_stats_summary(
         file_stats.extend(kimi_stats);
     }
 
+    if providers_to_include.contains(&StatsProvider::KimiCode) {
+        let (kimi_code_stats, kimi_code_projects) =
+            collect_provider_global_file_stats(StatsProvider::KimiCode, mode, s_ref, e_ref);
+        project_names.extend(kimi_code_projects);
+        file_stats.extend(kimi_code_stats);
+    }
+
     if providers_to_include.contains(&StatsProvider::Antigravity) {
         let (antigravity_stats, antigravity_projects) =
             collect_provider_global_file_stats(StatsProvider::Antigravity, mode, s_ref, e_ref);
@@ -6188,7 +6236,7 @@ mod tests {
         let parsed = parse_active_stats_providers(Some(ids));
 
         assert_eq!(parsed, supported);
-        assert_eq!(supported.len(), 29);
+        assert_eq!(supported.len(), 30);
     }
 
     #[test]

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -274,6 +274,9 @@ fn extract_provider_paths(path: &Path) -> Option<(String, String)> {
             if let Some(paths) = extract_kimi_paths(path) {
                 return Some(paths);
             }
+            if let Some(paths) = extract_kimi_code_paths(path) {
+                return Some(paths);
+            }
             if let Some(paths) = extract_pi_family_paths(path) {
                 return Some(paths);
             }
@@ -285,9 +288,10 @@ fn extract_provider_paths(path: &Path) -> Option<(String, String)> {
             }
             extract_codex_paths(path)
         }
-        // Kimi state files and OpenCode storage files
+        // Kimi/Kimi Code state files and OpenCode storage files
         "json" => extract_vibe_paths(path)
             .or_else(|| extract_kimi_paths(path))
+            .or_else(|| extract_kimi_code_paths(path))
             .or_else(|| extract_opencode_paths(path)),
         // OpenCode SQLite database change — emit broad refresh for all OpenCode projects
         "db" | "db-wal" => extract_opencode_db_event(path),
@@ -495,6 +499,46 @@ fn extract_kimi_paths(path: &Path) -> Option<(String, String)> {
 
     Some((
         format!("kimi://{}", project_path.to_string_lossy()),
+        session_path.to_string_lossy().to_string(),
+    ))
+}
+
+/// Extract Kimi Code session identifiers from files under
+/// `~/.kimi-code/sessions/{workdir_key}/{session_id}/`.
+///
+/// Watched files: `state.json` directly in the session directory and the
+/// conversation log at `agents/main/wire.jsonl`.
+fn extract_kimi_code_paths(path: &Path) -> Option<(String, String)> {
+    let filename = path.file_name()?.to_str()?;
+    if !matches!(filename, "wire.jsonl" | "state.json") {
+        return None;
+    }
+
+    let sessions_root = crate::providers::kimi_code::get_base_path()
+        .map(PathBuf::from)
+        .map(|base| base.join("sessions"))?;
+    // Same canonicalization caveat as `extract_kimi_paths`: the watcher event
+    // path may not be canonical (e.g. macOS `/var` → `/private/var`).
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let relative = canonical_path.strip_prefix(&sessions_root).ok()?;
+    let parts: Vec<_> = relative.components().collect();
+
+    // state.json: <workdir_key>/<session_id>/state.json (3 parts)
+    // wire.jsonl: <workdir_key>/<session_id>/agents/main/wire.jsonl (5 parts)
+    let is_session_file = match (filename, parts.len()) {
+        ("state.json", 3) => true,
+        ("wire.jsonl", 5) => parts[2].as_os_str() == "agents" && parts[3].as_os_str() == "main",
+        _ => false,
+    };
+    if !is_session_file {
+        return None;
+    }
+
+    let project_path = sessions_root.join(parts[0].as_os_str());
+    let session_path = project_path.join(parts[1].as_os_str());
+
+    Some((
+        format!("kimicode://{}", project_path.to_string_lossy()),
         session_path.to_string_lossy().to_string(),
     ))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1031,6 +1031,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(kimi_code_base) = providers::kimi_code::get_base_path() {
+        let sessions = PathBuf::from(kimi_code_base).join("sessions");
+        if sessions.is_dir() {
+            paths.push(sessions);
+        }
+    }
+
     // Pi / oh-my-pi: get_base_path() is already the sessions root.
     if let Some(pi_base) = providers::pi::get_base_path() {
         let sessions = PathBuf::from(pi_base);

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -1,0 +1,1113 @@
+use super::ProviderInfo;
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::utils::{
+    build_provider_message, detect_git_worktree_info, is_symlink,
+    search_json_value_case_insensitive,
+};
+use chrono::{DateTime, TimeZone, Utc};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PROVIDER_ID: &str = "kimi-code";
+const SESSIONS_DIR: &str = "sessions";
+const SESSION_INDEX_FILE: &str = "session_index.jsonl";
+const STATE_FILE: &str = "state.json";
+const WIRE_FILE: &str = "agents/main/wire.jsonl";
+
+pub fn detect() -> Option<ProviderInfo> {
+    let base = get_base_path()?;
+    let sessions_path = Path::new(&base).join(SESSIONS_DIR);
+
+    Some(ProviderInfo {
+        id: PROVIDER_ID.to_string(),
+        display_name: "Kimi Code CLI".to_string(),
+        base_path: base,
+        is_available: sessions_path.exists() && sessions_path.is_dir(),
+    })
+}
+
+pub fn get_base_path() -> Option<String> {
+    if let Ok(env_val) = std::env::var("KIMI_CODE_HOME") {
+        let path = PathBuf::from(&env_val);
+        let absolute_path = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir().ok()?.join(path)
+        };
+        if absolute_path.exists() {
+            let normalized = absolute_path.canonicalize().unwrap_or(absolute_path);
+            return Some(normalized.to_string_lossy().to_string());
+        }
+    }
+
+    let default = dirs::home_dir()?.join(".kimi-code");
+    if default.exists() {
+        let normalized = default.canonicalize().unwrap_or(default);
+        Some(normalized.to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
+pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
+    crate::utils::require_absolute_path(base_path, "Kimi Code base path")?;
+    let base = Path::new(base_path);
+    let sessions_root = base.join(SESSIONS_DIR);
+
+    if is_symlink(&sessions_root) || !sessions_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let canonical_base = canonical_existing(base, "Kimi Code base path")?;
+    let mut projects = Vec::new();
+
+    for entry in fs::read_dir(&sessions_root)
+        .map_err(|e| format!("Failed to read Kimi Code sessions: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Kimi Code project entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let project_dir = entry.path();
+        if !path_is_inside(&project_dir, &canonical_base)? {
+            continue;
+        }
+
+        let mut infos = Vec::new();
+        for session_entry in fs::read_dir(&project_dir)
+            .map_err(|e| format!("Failed to read Kimi Code project dir: {e}"))?
+        {
+            let session_entry = session_entry
+                .map_err(|e| format!("Failed to read Kimi Code session entry: {e}"))?;
+            if session_entry
+                .file_type()
+                .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+            {
+                continue;
+            }
+            if let Some(info) = extract_session_info(base, &session_entry.path()) {
+                infos.push(info);
+            }
+        }
+
+        if infos.is_empty() {
+            continue;
+        }
+
+        let fallback_name = workdir_key_slug(
+            &project_dir
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        );
+        let fallback_name = if fallback_name.is_empty() {
+            "kimi-code".to_string()
+        } else {
+            fallback_name
+        };
+        let actual_path = infos
+            .iter()
+            .find_map(|info| info.cwd.clone())
+            .unwrap_or_else(|| fallback_name.clone());
+        let name = project_name_from_actual_path(&actual_path, &fallback_name);
+        let message_count = infos.iter().map(|info| info.message_count).sum();
+        let last_modified = infos
+            .iter()
+            .map(|info| info.last_modified.as_str())
+            .max()
+            .unwrap_or_default()
+            .to_string();
+
+        projects.push(ClaudeProject {
+            name,
+            path: format!("kimicode://{}", project_dir.to_string_lossy()),
+            actual_path: actual_path.clone(),
+            session_count: infos.len(),
+            message_count,
+            last_modified,
+            git_info: if Path::new(&actual_path).is_absolute() {
+                detect_git_worktree_info(&actual_path)
+            } else {
+                None
+            },
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            custom_directory_label: None,
+        });
+    }
+
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let base = get_base_path().ok_or("Kimi Code base path not found")?;
+    scan_projects_from_path(&base)
+}
+
+pub fn load_sessions(
+    project_path: &str,
+    exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let base = get_base_path().ok_or("Kimi Code base path not found")?;
+    load_sessions_from_base_path(&base, project_path, exclude_sidechain)
+}
+
+pub fn load_sessions_from_base_path(
+    base_path: &str,
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    crate::utils::require_absolute_path(base_path, "Kimi Code base path")?;
+    let base = Path::new(base_path);
+    let project_dir = resolve_project_dir(base, project_path)?;
+    let canonical_base = canonical_existing(base, "Kimi Code base path")?;
+    if !path_is_inside(&project_dir, &canonical_base)? {
+        return Err("Kimi Code project path is outside Kimi Code base path".to_string());
+    }
+
+    let fallback_project_name = workdir_key_slug(
+        &project_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default(),
+    );
+    let fallback_project_name = if fallback_project_name.is_empty() {
+        "kimi-code".to_string()
+    } else {
+        fallback_project_name
+    };
+
+    let mut sessions = Vec::new();
+    for entry in fs::read_dir(&project_dir)
+        .map_err(|e| format!("Failed to read Kimi Code project dir: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read Kimi Code session entry: {e}"))?;
+        if entry
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            continue;
+        }
+
+        let session_dir = entry.path();
+        let Some(info) = extract_session_info(base, &session_dir) else {
+            continue;
+        };
+        let project_name = info
+            .cwd
+            .as_deref()
+            .map(|cwd| project_name_from_actual_path(cwd, &fallback_project_name))
+            .unwrap_or_else(|| fallback_project_name.clone());
+
+        sessions.push(ClaudeSession {
+            session_id: session_dir.to_string_lossy().to_string(),
+            actual_session_id: info.session_id.clone(),
+            file_path: session_dir.to_string_lossy().to_string(),
+            project_name,
+            message_count: info.message_count,
+            first_message_time: info.first_message_time,
+            last_message_time: info.last_message_time,
+            last_modified: info.last_modified,
+            has_tool_use: info.has_tool_use,
+            has_errors: false,
+            summary: info.summary,
+            is_renamed: false,
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            entrypoint: None,
+        });
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(sessions)
+}
+
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Kimi Code base path not found")?;
+    load_messages_from_base_path(&base, session_path)
+}
+
+pub fn load_messages_from_base_path(
+    base_path: &str,
+    session_path: &str,
+) -> Result<Vec<ClaudeMessage>, String> {
+    crate::utils::require_absolute_path(base_path, "Kimi Code base path")?;
+    let base = Path::new(base_path);
+    let session_dir = PathBuf::from(session_path);
+    let canonical_base = canonical_existing(base, "Kimi Code base path")?;
+    if !session_dir.is_absolute() || !path_is_inside(&session_dir, &canonical_base)? {
+        return Err("Kimi Code session path is outside Kimi Code base path".to_string());
+    }
+    if is_symlink(&session_dir) || !session_dir.is_dir() {
+        return Err("Kimi Code session path is not a directory".to_string());
+    }
+
+    let session_id = session_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let values = read_jsonl_values(&session_dir.join(WIRE_FILE))?;
+    Ok(convert_wire_events(&values, &session_id).messages)
+}
+
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let base = get_base_path().ok_or("Kimi Code base path not found")?;
+    search_from_base_path(&base, query, limit)
+}
+
+pub fn search_from_base_path(
+    base_path: &str,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<ClaudeMessage>, String> {
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    for project in scan_projects_from_path(base_path)? {
+        for session in load_sessions_from_base_path(base_path, &project.path, false)? {
+            for mut message in load_messages_from_base_path(base_path, &session.file_path)? {
+                if let Some(content) = &message.content {
+                    if search_json_value_case_insensitive(content, &query_lower) {
+                        message.project_name = Some(project.name.clone());
+                        results.push(message);
+                        if results.len() >= limit {
+                            return Ok(results);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[derive(Debug, Clone)]
+struct SessionInfo {
+    session_id: String,
+    cwd: Option<String>,
+    message_count: usize,
+    first_message_time: String,
+    last_message_time: String,
+    last_modified: String,
+    has_tool_use: bool,
+    summary: Option<String>,
+}
+
+fn extract_session_info(base: &Path, session_dir: &Path) -> Option<SessionInfo> {
+    if is_symlink(session_dir) || !session_dir.is_dir() {
+        return None;
+    }
+    let wire_path = session_dir.join(WIRE_FILE);
+    if is_symlink(&wire_path) || !wire_path.is_file() {
+        return None;
+    }
+
+    let session_id = session_dir.file_name()?.to_string_lossy().to_string();
+    let state = read_json_file(&session_dir.join(STATE_FILE)).unwrap_or(Value::Null);
+    let title = state
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned);
+
+    let values = read_jsonl_values(&wire_path).ok()?;
+    let converted = convert_wire_events(&values, &session_id);
+    if converted.messages.is_empty() {
+        return None;
+    }
+
+    let cwd = find_work_dir_in_index(base, session_dir)
+        .or(converted.cwd_from_system_prompt)
+        .or_else(|| {
+            session_dir
+                .parent()
+                .and_then(|parent| parent.file_name())
+                .map(|name| workdir_key_slug(&name.to_string_lossy()))
+                .filter(|slug| !slug.is_empty())
+        });
+
+    let first_user = title
+        .is_none()
+        .then(|| {
+            converted.messages.iter().find_map(|message| {
+                if message.message_type != "user" {
+                    return None;
+                }
+                message.content.as_ref().and_then(extract_content_summary)
+            })
+        })
+        .flatten();
+
+    let first_message_time = converted
+        .messages
+        .first()
+        .map(|message| message.timestamp.clone())
+        .filter(|ts| !ts.is_empty())
+        .or_else(|| {
+            state
+                .get("createdAt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_default();
+    let last_message_time = converted
+        .messages
+        .last()
+        .map(|message| message.timestamp.clone())
+        .filter(|ts| !ts.is_empty())
+        .or_else(|| {
+            state
+                .get("updatedAt")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_else(|| first_message_time.clone());
+    let last_modified = if last_message_time.is_empty() {
+        file_modified_iso(&wire_path).unwrap_or_default()
+    } else {
+        last_message_time.clone()
+    };
+
+    Some(SessionInfo {
+        session_id,
+        cwd,
+        message_count: converted.messages.len(),
+        first_message_time,
+        last_message_time,
+        last_modified,
+        has_tool_use: converted.has_tool_use,
+        summary: title.or(first_user),
+    })
+}
+
+struct ConvertedWire {
+    messages: Vec<ClaudeMessage>,
+    has_tool_use: bool,
+    cwd_from_system_prompt: Option<String>,
+}
+
+/// Convert `wire.jsonl` events into provider messages.
+///
+/// Loop events (`step.begin` / `content.part` / `tool.call` / `step.end`) are
+/// aggregated per `stepUuid` and flushed as one assistant message when the
+/// matching `step.end` arrives (or at EOF for unterminated steps).
+/// `tool.result` becomes a standalone `tool` message. All other event types
+/// (`metadata`, `config.update`, `llm.*`, `usage.record`, `tools.*`,
+/// `permission.*`, `mcp.*`, `turn.prompt`, `turn.steer`, …) are skipped.
+fn convert_wire_events(values: &[Value], session_id: &str) -> ConvertedWire {
+    let mut messages = Vec::new();
+    let mut counter = 0u64;
+    let mut has_tool_use = false;
+    let mut cwd_from_system_prompt = None;
+    // Insertion-ordered step aggregation.
+    let mut step_order: Vec<String> = Vec::new();
+    let mut step_blocks: HashMap<String, Vec<Value>> = HashMap::new();
+    // tool.result events arrive mid-step (before `step.end`) and carry no
+    // `stepUuid`, so they are attributed to the step open at arrival time and
+    // buffered — emitting them immediately would place the result BEFORE the
+    // assistant message holding its tool_use, the reverse of every other
+    // provider's conversation order. Drained right after the step's flush.
+    let mut pending_results: Vec<PendingResult> = Vec::new();
+    // Timestamp of the most recent event — used when flushing steps that
+    // never saw their `step.end` before EOF.
+    let mut last_event_time = String::new();
+
+    let next_uuid = |value: &Value, counter: &mut u64| -> String {
+        *counter += 1;
+        value
+            .get("uuid")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("{session_id}-{counter}"))
+    };
+
+    for value in values {
+        let timestamp = value
+            .get("time")
+            .and_then(Value::as_f64)
+            .and_then(epoch_ms_to_iso)
+            .unwrap_or_default();
+        if !timestamp.is_empty() {
+            last_event_time.clone_from(&timestamp);
+        }
+
+        match value.get("type").and_then(Value::as_str).unwrap_or("") {
+            "context.append_message" => {
+                let message = value.get("message").cloned().unwrap_or(Value::Null);
+                if message.get("role").and_then(Value::as_str) != Some("user") {
+                    continue;
+                }
+                let uuid = message
+                    .get("uuid")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| next_uuid(value, &mut counter));
+                messages.push(build_provider_message(
+                    PROVIDER_ID,
+                    uuid,
+                    session_id,
+                    timestamp,
+                    "user",
+                    Some("user"),
+                    Some(content_to_blocks(message.get("content"))),
+                    None,
+                ));
+            }
+            "config.update" => {
+                if cwd_from_system_prompt.is_none() {
+                    cwd_from_system_prompt = value
+                        .get("systemPrompt")
+                        .and_then(Value::as_str)
+                        .and_then(extract_working_directory);
+                }
+            }
+            "context.append_loop_event" => {
+                let event = value.get("event").cloned().unwrap_or(Value::Null);
+                let step_uuid = event
+                    .get("stepUuid")
+                    .or_else(|| event.get("uuid"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+
+                match event.get("type").and_then(Value::as_str).unwrap_or("") {
+                    "step.begin" => {
+                        if !step_uuid.is_empty() && !step_blocks.contains_key(&step_uuid) {
+                            step_blocks.insert(step_uuid.clone(), Vec::new());
+                            step_order.push(step_uuid);
+                        }
+                    }
+                    "content.part" => {
+                        let part = event.get("part").cloned().unwrap_or(Value::Null);
+                        let block = match part.get("type").and_then(Value::as_str) {
+                            Some("think") => Some(json!({
+                                "type": "thinking",
+                                "thinking": part.get("think").and_then(Value::as_str).unwrap_or("")
+                            })),
+                            Some("text") => Some(json!({
+                                "type": "text",
+                                "text": part.get("text").and_then(Value::as_str).unwrap_or("")
+                            })),
+                            _ => None,
+                        };
+                        if let (Some(block), false) = (block, step_uuid.is_empty()) {
+                            let blocks =
+                                step_blocks.entry(step_uuid.clone()).or_insert_with(|| {
+                                    step_order.push(step_uuid.clone());
+                                    Vec::new()
+                                });
+                            blocks.push(block);
+                        }
+                    }
+                    "tool.call" => {
+                        has_tool_use = true;
+                        if !step_uuid.is_empty() {
+                            let tool_call_id = event
+                                .get("toolCallId")
+                                .and_then(Value::as_str)
+                                .map(ToOwned::to_owned)
+                                .unwrap_or_else(|| next_uuid(&event, &mut counter));
+                            let block = json!({
+                                "type": "tool_use",
+                                "id": tool_call_id,
+                                "name": event.get("name").and_then(Value::as_str).unwrap_or("tool"),
+                                "input": event.get("args").cloned().unwrap_or(Value::Null)
+                            });
+                            let blocks =
+                                step_blocks.entry(step_uuid.clone()).or_insert_with(|| {
+                                    step_order.push(step_uuid.clone());
+                                    Vec::new()
+                                });
+                            blocks.push(block);
+                        }
+                    }
+                    "tool.result" => {
+                        let tool_call_id = event
+                            .get("toolCallId")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        let output = event
+                            .get("result")
+                            .and_then(|result| result.get("output"))
+                            .cloned()
+                            .unwrap_or(Value::Null);
+                        let uuid = next_uuid(&event, &mut counter);
+                        if let Some(open_step) = step_order.last() {
+                            pending_results.push(PendingResult {
+                                step_uuid: open_step.clone(),
+                                uuid,
+                                timestamp,
+                                tool_call_id,
+                                output,
+                            });
+                        } else {
+                            // No open step (truncated file) — merge into an
+                            // earlier assistant message by tool_use id, or
+                            // fall back to a standalone tool message.
+                            let block = tool_result_block(&tool_call_id, output);
+                            if !merge_result_block(&mut messages, &block) {
+                                messages.push(build_tool_result_message(
+                                    uuid, session_id, timestamp, block,
+                                ));
+                            }
+                        }
+                    }
+                    "step.end" => {
+                        let flushed = flush_step(
+                            &step_uuid,
+                            &mut step_order,
+                            &mut step_blocks,
+                            &mut messages,
+                            session_id,
+                            &timestamp,
+                            &mut counter,
+                        );
+                        drain_step_results(
+                            &step_uuid,
+                            &mut pending_results,
+                            &mut messages,
+                            session_id,
+                            flushed,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Flush steps that never saw their `step.end` (e.g. truncated files).
+    for step_uuid in std::mem::take(&mut step_order) {
+        let flushed = flush_step(
+            &step_uuid,
+            &mut Vec::new(),
+            &mut step_blocks,
+            &mut messages,
+            session_id,
+            &last_event_time,
+            &mut counter,
+        );
+        drain_step_results(
+            &step_uuid,
+            &mut pending_results,
+            &mut messages,
+            session_id,
+            flushed,
+        );
+    }
+    // Results whose step never began (or whose stepUuid was lost) — merge by
+    // tool_use id when possible, else keep them as standalone tool messages
+    // in arrival order rather than dropping them.
+    for result in std::mem::take(&mut pending_results) {
+        let block = tool_result_block(&result.tool_call_id, result.output);
+        if !merge_result_block(&mut messages, &block) {
+            messages.push(build_tool_result_message(
+                result.uuid,
+                session_id,
+                result.timestamp,
+                block,
+            ));
+        }
+    }
+
+    ConvertedWire {
+        messages,
+        has_tool_use,
+        cwd_from_system_prompt,
+    }
+}
+
+/// A `tool.result` buffered until its step's assistant message is flushed.
+struct PendingResult {
+    step_uuid: String,
+    uuid: String,
+    timestamp: String,
+    tool_call_id: String,
+    output: Value,
+}
+
+fn tool_result_block(tool_call_id: &str, output: Value) -> Value {
+    json!({
+        "type": "tool_result",
+        "tool_use_id": tool_call_id,
+        "content": output
+    })
+}
+
+/// Append a `tool_result` block to the most recent assistant message holding
+/// the matching `tool_use` (same convention as codex / `copilot_cli`), so the
+/// unified tool card renders call and result together. Returns false when no
+/// earlier message carries that `tool_use`.
+fn merge_result_block(messages: &mut [ClaudeMessage], block: &Value) -> bool {
+    let tool_use_id = block
+        .get("tool_use_id")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    for prev in messages.iter_mut().rev() {
+        if prev.message_type != "assistant" {
+            continue;
+        }
+        let has_matching_tool_use = prev
+            .content
+            .as_ref()
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter().any(|item| {
+                    item.get("type").and_then(Value::as_str) == Some("tool_use")
+                        && item.get("id").and_then(Value::as_str) == Some(tool_use_id)
+                })
+            })
+            .unwrap_or(false);
+        if has_matching_tool_use {
+            append_content_block(prev, block.clone());
+            return true;
+        }
+    }
+    false
+}
+
+fn append_content_block(message: &mut ClaudeMessage, block: Value) {
+    match &mut message.content {
+        Some(Value::Array(arr)) => arr.push(block),
+        other => *other = Some(Value::Array(vec![block])),
+    }
+}
+
+/// Fallback for results that no assistant message claims: a standalone
+/// `tool` message (same shape as legacy kimi / vibe).
+fn build_tool_result_message(
+    uuid: String,
+    session_id: &str,
+    timestamp: String,
+    block: Value,
+) -> ClaudeMessage {
+    build_provider_message(
+        PROVIDER_ID,
+        uuid,
+        session_id,
+        timestamp,
+        "tool",
+        Some("tool"),
+        Some(Value::Array(vec![block])),
+        None,
+    )
+}
+
+/// Drain buffered tool results belonging to `step_uuid`, preserving arrival
+/// order. Called right after the step's flush; `flushed` is the index of the
+/// step's assistant message when one was emitted.
+fn drain_step_results(
+    step_uuid: &str,
+    pending_results: &mut Vec<PendingResult>,
+    messages: &mut Vec<ClaudeMessage>,
+    session_id: &str,
+    flushed: Option<usize>,
+) {
+    let mut i = 0;
+    while i < pending_results.len() {
+        if pending_results[i].step_uuid != step_uuid {
+            i += 1;
+            continue;
+        }
+        let result = pending_results.remove(i);
+        let block = tool_result_block(&result.tool_call_id, result.output);
+        let merged_into_step = match flushed {
+            Some(idx) => merge_result_block(&mut messages[idx..=idx], &block),
+            None => false,
+        };
+        if !merged_into_step && !merge_result_block(messages, &block) {
+            messages.push(build_tool_result_message(
+                result.uuid,
+                session_id,
+                result.timestamp,
+                block,
+            ));
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flush_step(
+    step_uuid: &str,
+    step_order: &mut Vec<String>,
+    step_blocks: &mut HashMap<String, Vec<Value>>,
+    messages: &mut Vec<ClaudeMessage>,
+    session_id: &str,
+    timestamp: &str,
+    counter: &mut u64,
+) -> Option<usize> {
+    let blocks = step_blocks.remove(step_uuid)?;
+    step_order.retain(|uuid| uuid != step_uuid);
+    if blocks.is_empty() {
+        return None;
+    }
+    *counter += 1;
+    messages.push(build_provider_message(
+        PROVIDER_ID,
+        format!("{session_id}-{counter}"),
+        session_id,
+        timestamp.to_string(),
+        "assistant",
+        Some("assistant"),
+        Some(Value::Array(blocks)),
+        None,
+    ));
+    Some(messages.len() - 1)
+}
+
+/// Look up the session's `workDir` in `session_index.jsonl` by matching the
+/// `sessionDir` entry (compared canonicalized on both sides).
+fn find_work_dir_in_index(base: &Path, session_dir: &Path) -> Option<String> {
+    let index_path = base.join(SESSION_INDEX_FILE);
+    if is_symlink(&index_path) || !index_path.is_file() {
+        return None;
+    }
+    let canonical_session = session_dir
+        .canonicalize()
+        .unwrap_or_else(|_| session_dir.to_path_buf());
+
+    for value in read_jsonl_values(&index_path).ok()? {
+        let entry_dir = value
+            .get("sessionDir")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if entry_dir.is_empty() {
+            continue;
+        }
+        let entry_path = PathBuf::from(entry_dir);
+        let canonical_entry = entry_path.canonicalize().unwrap_or(entry_path);
+        if canonical_entry == canonical_session {
+            return value
+                .get("workDir")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+        }
+    }
+    None
+}
+
+/// Extract the human-readable slug from a `wd_<slug>_<sha256-12>` key.
+fn workdir_key_slug(key: &str) -> String {
+    let stripped = key.strip_prefix("wd_").unwrap_or(key);
+    match stripped.rsplit_once('_') {
+        Some((slug, hash)) if hash.len() == 12 && hash.chars().all(|c| c.is_ascii_hexdigit()) => {
+            slug.to_string()
+        }
+        _ => stripped.to_string(),
+    }
+}
+
+/// Normalize user message content. Pure-text content becomes a plain string
+/// (Claude's simple string format) — wrapping a lone text block in an array
+/// renders the same text twice in the UI (bubble + text box), because the
+/// array renderer's `skipText` dedup only applies to assistant messages.
+fn content_to_blocks(content: Option<&Value>) -> Value {
+    match content {
+        Some(Value::Array(items)) => {
+            if let [item] = items.as_slice() {
+                if item.get("type").and_then(Value::as_str) == Some("text") {
+                    if let Some(text) = item.get("text").and_then(Value::as_str) {
+                        return Value::String(text.to_string());
+                    }
+                }
+            }
+            Value::Array(items.iter().map(normalize_content_block).collect())
+        }
+        Some(Value::String(text)) => Value::String(text.clone()),
+        Some(Value::Null) | None => Value::Array(Vec::new()),
+        Some(other) => Value::String(other.to_string()),
+    }
+}
+
+fn normalize_content_block(item: &Value) -> Value {
+    if item.get("type").and_then(Value::as_str) == Some("think") {
+        return json!({
+            "type": "thinking",
+            "thinking": item.get("think").and_then(Value::as_str).unwrap_or("")
+        });
+    }
+
+    item.clone()
+}
+
+fn extract_content_summary(content: &Value) -> Option<String> {
+    let text = if let Some(text) = content.as_str() {
+        text.to_string()
+    } else {
+        content
+            .as_array()?
+            .iter()
+            .find_map(|item| item.get("text").and_then(Value::as_str))
+            .unwrap_or("")
+            .to_string()
+    };
+
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(truncate_chars(trimmed, 200))
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    match text.char_indices().nth(max_chars) {
+        Some((idx, _)) => format!("{}...", &text[..idx]),
+        None => text.to_string(),
+    }
+}
+
+fn extract_working_directory(system_prompt: &str) -> Option<String> {
+    const MARKER: &str = "The current working directory is `";
+    let start = system_prompt.find(MARKER)? + MARKER.len();
+    let rest = &system_prompt[start..];
+    let end = rest.find('`')?;
+    let cwd = &rest[..end];
+    if is_absolute_working_directory(cwd) {
+        Some(cwd.to_string())
+    } else {
+        None
+    }
+}
+
+fn is_absolute_working_directory(cwd: &str) -> bool {
+    Path::new(cwd).is_absolute() || looks_like_windows_absolute_path(cwd)
+}
+
+fn looks_like_windows_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    // Drive-letter path: C:\ or C:/
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/')
+    {
+        return true;
+    }
+    // UNC path: \\server\share or //server/share
+    if bytes.len() >= 2 && matches!(bytes[0], b'\\' | b'/') && bytes[0] == bytes[1] {
+        return true;
+    }
+    false
+}
+
+fn read_json_file(path: &Path) -> Result<Value, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Kimi Code JSON file".to_string());
+    }
+    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read JSON file: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON file: {e}"))
+}
+
+fn read_jsonl_values(path: &Path) -> Result<Vec<Value>, String> {
+    if is_symlink(path) {
+        return Err("Refusing to read symlinked Kimi Code JSONL file".to_string());
+    }
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read JSONL file: {e}"))?;
+    let mut values = Vec::new();
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        if let Ok(value) = serde_json::from_str::<Value>(line) {
+            values.push(value);
+        }
+    }
+    Ok(values)
+}
+
+/// Epoch **milliseconds** → RFC3339 (the `time` field in `wire.jsonl` is in
+/// milliseconds, unlike the seconds-based timestamps of other providers).
+fn epoch_ms_to_iso(millis: f64) -> Option<String> {
+    // Valid range: 1970-2100 (Unix milliseconds 0 ~ 4_102_444_800_000)
+    if !(0.0..=4_102_444_800_000.0).contains(&millis) {
+        return None;
+    }
+    let whole = millis.trunc() as i64;
+    Utc.timestamp_millis_opt(whole)
+        .single()
+        .map(|dt| dt.to_rfc3339())
+}
+
+fn file_modified_iso(path: &Path) -> Option<String> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .map(|time| {
+            let dt: DateTime<Utc> = time.into();
+            dt.to_rfc3339()
+        })
+}
+
+fn resolve_project_dir(base: &Path, project_path: &str) -> Result<PathBuf, String> {
+    let raw = project_path
+        .strip_prefix("kimicode://")
+        .unwrap_or(project_path);
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err("Kimi Code project path must be absolute".to_string());
+    }
+    if is_symlink(&path) || !path.is_dir() {
+        return Err("Kimi Code project path is not a directory".to_string());
+    }
+    let sessions_root = base.join(SESSIONS_DIR);
+    if !path.starts_with(&sessions_root) {
+        return Err("Kimi Code project path is outside Kimi Code sessions directory".to_string());
+    }
+    Ok(path)
+}
+
+fn canonical_existing(path: &Path, label: &str) -> Result<PathBuf, String> {
+    path.canonicalize()
+        .map_err(|e| format!("Failed to resolve {label}: {e}"))
+}
+
+fn path_is_inside(path: &Path, canonical_base: &Path) -> Result<bool, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve path: {e}"))?;
+    Ok(canonical.starts_with(canonical_base))
+}
+
+fn project_name_from_actual_path(actual_path: &str, fallback: &str) -> String {
+    Path::new(actual_path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::fs;
+    use tempfile::TempDir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: std::ffi::OsString) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.original.as_ref() {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[test]
+    fn epoch_ms_to_iso_converts_millisecond_timestamps() {
+        assert_eq!(
+            epoch_ms_to_iso(1_784_600_295_956.0).as_deref(),
+            Some("2026-07-21T02:18:15.956+00:00")
+        );
+        assert_eq!(
+            epoch_ms_to_iso(0.0).as_deref(),
+            Some("1970-01-01T00:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn epoch_ms_to_iso_rejects_out_of_range_values() {
+        assert!(epoch_ms_to_iso(-1.0).is_none());
+        assert!(epoch_ms_to_iso(4_102_444_800_001.0).is_none());
+    }
+
+    #[test]
+    fn extract_working_directory_reads_marker_from_system_prompt() {
+        let prompt = "You are Kimi Code CLI.\nThe current working directory is `/Users/max/repo`.\nMore text.";
+        assert_eq!(
+            extract_working_directory(prompt).as_deref(),
+            Some("/Users/max/repo")
+        );
+    }
+
+    #[test]
+    fn workdir_key_slug_strips_prefix_and_hash() {
+        assert_eq!(
+            workdir_key_slug("wd_claude-code-haha_83f822167b2e"),
+            "claude-code-haha"
+        );
+        assert_eq!(workdir_key_slug("wd_plain"), "plain");
+        assert_eq!(workdir_key_slug("wd_a_b_nothex12zz"), "a_b_nothex12zz");
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_prefers_kimi_code_home_env() {
+        let temp = TempDir::new().unwrap();
+        let base_dir = temp.path().join("kimi-code-home");
+        fs::create_dir_all(&base_dir).unwrap();
+        let _env = EnvVarGuard::set("KIMI_CODE_HOME", base_dir.as_os_str().to_owned());
+        let path = get_base_path().unwrap();
+        assert_eq!(
+            std::path::PathBuf::from(path),
+            base_dir.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn get_base_path_returns_none_when_default_dir_absent() {
+        let _env = EnvVarGuard::remove("KIMI_CODE_HOME");
+        if dirs::home_dir()
+            .map(|h| h.join(".kimi-code").exists())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        assert!(get_base_path().is_none());
+    }
+
+    #[test]
+    fn find_work_dir_in_index_matches_session_dir() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        let session_dir = base
+            .join("sessions")
+            .join("wd_demo-project_a1b2c3d4e5f6")
+            .join("session_abc");
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(
+            base.join(SESSION_INDEX_FILE),
+            format!(
+                "{{\"sessionId\":\"session_other\",\"sessionDir\":\"/somewhere/else\",\"workDir\":\"/other\"}}\n{{\"sessionId\":\"session_abc\",\"sessionDir\":\"{}\",\"workDir\":\"/Users/dev/demo-project\"}}\n",
+                session_dir.display()
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            find_work_dir_in_index(base, &session_dir).as_deref(),
+            Some("/Users/dev/demo-project")
+        );
+        assert!(find_work_dir_in_index(base, &base.join("sessions")).is_none());
+    }
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -21,6 +21,8 @@ pub mod gemini;
 pub mod goose;
 pub mod grok;
 pub mod kimi;
+/// Kimi Code CLI (new version) — `~/.kimi-code/sessions/<wd_key>/<session>/agents/main/wire.jsonl`.
+pub mod kimi_code;
 pub mod kiro;
 pub mod llm;
 pub mod ompi;
@@ -67,6 +69,9 @@ pub enum ProviderId {
     /// xAI Grok CLI (`~/.grok/sessions`).
     Grok,
     Kimi,
+    /// Kimi Code CLI (new version, `~/.kimi-code`) — distinct from legacy `kimi`.
+    #[serde(rename = "kimi-code")]
+    KimiCode,
     ForgeCode,
     Kiro,
     /// Simon Willison's `llm` CLI (`~/.../io.datasette.llm/logs.db`).
@@ -110,6 +115,7 @@ impl ProviderId {
             Self::Goose => "goose",
             Self::Grok => "grok",
             Self::Kimi => "kimi",
+            Self::KimiCode => "kimi-code",
             Self::ForgeCode => "forgecode",
             Self::Kiro => "kiro",
             Self::Llm => "llm",
@@ -144,6 +150,7 @@ impl ProviderId {
             "goose" => Some(Self::Goose),
             "grok" => Some(Self::Grok),
             "kimi" => Some(Self::Kimi),
+            "kimi-code" => Some(Self::KimiCode),
             "forgecode" => Some(Self::ForgeCode),
             "kiro" => Some(Self::Kiro),
             "llm" => Some(Self::Llm),
@@ -179,6 +186,7 @@ impl ProviderId {
             Self::Goose => "Goose",
             Self::Grok => "Grok CLI",
             Self::Kimi => "Kimi CLI",
+            Self::KimiCode => "Kimi Code CLI",
             Self::ForgeCode => "ForgeCode",
             Self::Kiro => "Kiro CLI",
             Self::Llm => "llm",
@@ -231,6 +239,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = kimi::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = kimi_code::detect() {
         providers.push(info);
     }
     if let Some(info) = forgecode::detect() {

--- a/src-tauri/tests/fixtures/kimi-code/session_index.jsonl
+++ b/src-tauri/tests/fixtures/kimi-code/session_index.jsonl
@@ -1,0 +1,2 @@
+{"sessionId":"session_11111111-1111-4111-8111-111111111111","sessionDir":"/nonexistent/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_11111111-1111-4111-8111-111111111111","workDir":"/Users/dev/demo-project"}
+{"sessionId":"session_22222222-2222-4222-8222-222222222222","sessionDir":"/nonexistent/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_22222222-2222-4222-8222-222222222222","workDir":"/Users/dev/demo-project"}

--- a/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_11111111-1111-4111-8111-111111111111/agents/main/wire.jsonl
+++ b/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_11111111-1111-4111-8111-111111111111/agents/main/wire.jsonl
@@ -1,0 +1,21 @@
+{"type":"metadata","version":1,"time":1784600295000}
+{"type":"config.update","profileName":"agent","systemPrompt":"You are Kimi Code CLI.\nThe current working directory is `/Users/dev/demo-project`.\nMore text.","time":1784600296000}
+{"type":"turn.prompt","input":[{"type":"text","text":"Implement the Kimi Code provider"}],"origin":{"kind":"user"},"time":1784600297000}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"Implement the Kimi Code provider"}],"toolCalls":[],"origin":{"kind":"user"}},"time":1784600298000}
+{"type":"llm.request","time":1784600298500}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-1","turnId":"0","step":1},"time":1784600299000}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part-1","turnId":"0","step":1,"stepUuid":"step-1","part":{"type":"think","think":"I should inspect the provider registry first."}},"time":1784600300000}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part-2","turnId":"0","step":1,"stepUuid":"step-1","part":{"type":"text","text":"Let me look at the existing providers."}},"time":1784600301000}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"tool_abc123","turnId":"0","step":1,"stepUuid":"step-1","toolCallId":"tool_abc123","name":"Grep","args":{"pattern":"kimi","output_mode":"files_with_matches"},"description":"Searching for 'kimi'"},"time":1784600302000}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"tool_abc123","toolCallId":"tool_abc123","result":{"output":"src/providers/kimi.rs"}},"time":1784600303000}
+{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"tool_def456","turnId":"0","step":1,"stepUuid":"step-1","toolCallId":"tool_def456","name":"Read","args":{"file_path":"src/providers/kimi.rs"},"description":"Reading kimi.rs"},"time":1784600303500}
+{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"tool_def456","toolCallId":"tool_def456","result":{"output":"pub fn scan()"}},"time":1784600303800}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-1","turnId":"0","step":1,"usage":{"inputOther":100,"output":20}},"time":1784600304000}
+{"type":"usage.record","time":1784600304500}
+{"type":"permission.set_mode","mode":"auto","time":1784600304600}
+{"type":"mcp.tools_discovered","time":1784600304700}
+{"type":"tools.set_active_tools","time":1784600304800}
+{"type":"context.append_message","message":{"role":"user","content":"Now add tests.","origin":{"kind":"user"}},"time":1784600306000}
+{"type":"turn.steer","input":[{"type":"text","text":"Now add tests."}],"origin":{"kind":"user"},"time":1784600306100}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-2","turnId":"1","step":1},"time":1784600307000}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part-3","turnId":"1","step":1,"stepUuid":"step-2","part":{"type":"text","text":"Done."}},"time":1784600308000}

--- a/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_11111111-1111-4111-8111-111111111111/state.json
+++ b/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_11111111-1111-4111-8111-111111111111/state.json
@@ -1,0 +1,14 @@
+{
+  "createdAt": "2026-07-21T02:17:56.338Z",
+  "updatedAt": "2026-07-21T02:18:24.000Z",
+  "title": "Implement Kimi Code provider",
+  "isCustomTitle": false,
+  "agents": {
+    "main": {
+      "homedir": "/nonexistent/agents/main",
+      "type": "main",
+      "parentAgentId": null
+    }
+  },
+  "custom": {}
+}

--- a/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_22222222-2222-4222-8222-222222222222/agents/main/wire.jsonl
+++ b/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_22222222-2222-4222-8222-222222222222/agents/main/wire.jsonl
@@ -1,0 +1,5 @@
+{"type":"metadata","version":1,"time":1784600399000}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"Second session prompt"}],"origin":{"kind":"user"}},"time":1784600400000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-1","turnId":"0","step":1},"time":1784600401000}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part-1","turnId":"0","step":1,"stepUuid":"step-1","part":{"type":"text","text":"Second reply."}},"time":1784600402000}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-1","turnId":"0","step":1,"usage":{"inputOther":10,"output":5}},"time":1784600403000}

--- a/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_22222222-2222-4222-8222-222222222222/state.json
+++ b/src-tauri/tests/fixtures/kimi-code/sessions/wd_demo-project_a1b2c3d4e5f6/session_22222222-2222-4222-8222-222222222222/state.json
@@ -1,0 +1,8 @@
+{
+  "createdAt": "2026-07-21T02:19:56.000Z",
+  "updatedAt": "2026-07-21T02:20:03.000Z",
+  "title": "",
+  "isCustomTitle": false,
+  "agents": {},
+  "custom": {}
+}

--- a/src-tauri/tests/kimi_code_provider_test.rs
+++ b/src-tauri/tests/kimi_code_provider_test.rs
@@ -1,0 +1,172 @@
+use claude_code_history_viewer_lib::providers;
+
+#[test]
+fn kimi_code_provider_scans_projects_from_sessions_tree() {
+    let base = fixture_base();
+
+    let projects = providers::kimi_code::scan_projects_from_path(base.to_str().unwrap())
+        .expect("scan_projects_from_path should parse fixture");
+
+    assert_eq!(projects.len(), 1);
+    let project = &projects[0];
+    assert_eq!(project.name, "demo-project");
+    assert_eq!(
+        project.path,
+        format!(
+            "kimicode://{}",
+            base.join("sessions/wd_demo-project_a1b2c3d4e5f6").display()
+        )
+    );
+    // cwd comes from the systemPrompt marker when the session_index entry does
+    // not match, falling back to the workDirKey slug — both resolve to the
+    // same project name here.
+    assert!(
+        project.actual_path == "/Users/dev/demo-project" || project.actual_path == "demo-project",
+        "unexpected actual_path: {}",
+        project.actual_path
+    );
+    assert_eq!(project.session_count, 2);
+    assert_eq!(project.message_count, 6);
+    assert_eq!(project.provider.as_deref(), Some("kimi-code"));
+    assert_eq!(project.storage_type.as_deref(), Some("jsonl"));
+}
+
+#[test]
+fn kimi_code_provider_loads_sessions_with_titles_and_timestamps() {
+    let base = fixture_base();
+    let project_path = format!(
+        "kimicode://{}",
+        base.join("sessions/wd_demo-project_a1b2c3d4e5f6").display()
+    );
+
+    let sessions = providers::kimi_code::load_sessions_from_base_path(
+        base.to_str().unwrap(),
+        &project_path,
+        false,
+    )
+    .expect("load_sessions_from_base_path should parse fixture");
+
+    assert_eq!(sessions.len(), 2);
+    // Sessions are sorted by last_modified descending — session 2 is newer.
+    let first = &sessions[0];
+    assert_eq!(
+        first.actual_session_id,
+        "session_22222222-2222-4222-8222-222222222222"
+    );
+    // Empty state.json title falls back to the first user message text.
+    assert_eq!(first.summary.as_deref(), Some("Second session prompt"));
+    assert!(!first.has_tool_use);
+    assert_eq!(first.message_count, 2);
+    assert_eq!(first.last_message_time, "2026-07-21T02:20:03+00:00");
+
+    let second = &sessions[1];
+    assert_eq!(
+        second.actual_session_id,
+        "session_11111111-1111-4111-8111-111111111111"
+    );
+    assert_eq!(
+        second.summary.as_deref(),
+        Some("Implement Kimi Code provider")
+    );
+    assert!(second.has_tool_use);
+    assert_eq!(second.message_count, 4);
+    assert_eq!(second.first_message_time, "2026-07-21T02:18:18+00:00");
+    assert_eq!(second.last_message_time, "2026-07-21T02:18:28+00:00");
+    assert_eq!(second.provider.as_deref(), Some("kimi-code"));
+}
+
+#[test]
+fn kimi_code_provider_loads_messages_without_internal_events() {
+    let base = fixture_base();
+    let session_dir = base
+        .join("sessions/wd_demo-project_a1b2c3d4e5f6/session_11111111-1111-4111-8111-111111111111");
+
+    let messages = providers::kimi_code::load_messages_from_base_path(
+        base.to_str().unwrap(),
+        session_dir.to_str().unwrap(),
+    )
+    .expect("load_messages_from_base_path should parse fixture");
+
+    assert_eq!(messages.len(), 4);
+    assert!(messages
+        .iter()
+        .all(|m| m.provider.as_deref() == Some("kimi-code")));
+
+    // Pure-text user messages use plain string content (Claude's simple
+    // string format) — an array would render twice in the UI (bubble + box).
+    assert_eq!(messages[0].message_type, "user");
+    assert_eq!(messages[0].timestamp, "2026-07-21T02:18:18+00:00");
+    assert_eq!(
+        messages[0].content.as_ref().unwrap(),
+        &serde_json::json!("Implement the Kimi Code provider")
+    );
+
+    // Loop events of step-1 are aggregated into one assistant message,
+    // timestamped by its step.end. Tool results are MERGED into the same
+    // message's content array right after their tool_use blocks (codex /
+    // copilot_cli convention) so the unified tool card renders call+result
+    // together instead of a pending card plus a separate system message.
+    assert_eq!(messages[1].message_type, "assistant");
+    assert_eq!(messages[1].timestamp, "2026-07-21T02:18:24+00:00");
+    let blocks = messages[1].content.as_ref().unwrap().as_array().unwrap();
+    assert_eq!(blocks.len(), 6);
+    assert_eq!(blocks[0]["type"], "thinking");
+    assert_eq!(
+        blocks[0]["thinking"],
+        "I should inspect the provider registry first."
+    );
+    assert_eq!(blocks[1]["type"], "text");
+    assert_eq!(blocks[1]["text"], "Let me look at the existing providers.");
+    assert_eq!(blocks[2]["type"], "tool_use");
+    assert_eq!(blocks[2]["id"], "tool_abc123");
+    assert_eq!(blocks[2]["name"], "Grep");
+    assert_eq!(blocks[2]["input"]["pattern"], "kimi");
+    assert_eq!(blocks[3]["type"], "tool_use");
+    assert_eq!(blocks[3]["id"], "tool_def456");
+    assert_eq!(blocks[3]["name"], "Read");
+    assert_eq!(blocks[3]["input"]["file_path"], "src/providers/kimi.rs");
+    assert_eq!(blocks[4]["type"], "tool_result");
+    assert_eq!(blocks[4]["tool_use_id"], "tool_abc123");
+    assert_eq!(blocks[4]["content"], "src/providers/kimi.rs");
+    assert_eq!(blocks[5]["type"], "tool_result");
+    assert_eq!(blocks[5]["tool_use_id"], "tool_def456");
+    assert_eq!(blocks[5]["content"], "pub fn scan()");
+
+    // String message content stays a plain string.
+    assert_eq!(messages[2].message_type, "user");
+    assert_eq!(
+        messages[2].content.as_ref().unwrap(),
+        &serde_json::json!("Now add tests.")
+    );
+
+    // step-2 never saw its step.end — flushed at EOF with the last event time.
+    assert_eq!(messages[3].message_type, "assistant");
+    assert_eq!(messages[3].timestamp, "2026-07-21T02:18:28+00:00");
+    assert_eq!(
+        messages[3].content.as_ref().unwrap(),
+        &serde_json::json!([{ "type": "text", "text": "Done." }])
+    );
+}
+
+#[test]
+fn kimi_code_provider_searches_messages_from_base_path() {
+    let base = fixture_base();
+
+    let results = providers::kimi_code::search_from_base_path(
+        base.to_str().unwrap(),
+        "inspect the provider registry",
+        10,
+    )
+    .expect("search_from_base_path should parse fixture");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].message_type, "assistant");
+    assert_eq!(results[0].project_name.as_deref(), Some("demo-project"));
+}
+
+fn fixture_base() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("kimi-code")
+}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -156,6 +156,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       goose: 0,
       grok: 0,
       kimi: 0,
+      "kimi-code": 0,
       kiro: 0,
       llm: 0,
       opencode: 0,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -132,6 +132,7 @@
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimiCode": "Kimi Code CLI",
   "common.provider.detectError": "Failed to detect providers. Keeping the previous provider settings.",
   "common.provider.saveError": "Failed to save discovered provider settings. Please try again.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -132,6 +132,7 @@
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimiCode": "Kimi Code CLI",
   "common.provider.detectError": "プロバイダーの検出に失敗しました。以前のプロバイダー設定を維持します。",
   "common.provider.saveError": "検出したプロバイダー設定を保存できませんでした。もう一度お試しください。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -132,6 +132,7 @@
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimiCode": "Kimi Code CLI",
   "common.provider.detectError": "프로바이더 감지에 실패했습니다. 기존 프로바이더 설정을 유지합니다.",
   "common.provider.saveError": "검색한 프로바이더 설정을 저장하지 못했습니다. 다시 시도해주세요.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -132,6 +132,7 @@
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimiCode": "Kimi Code CLI",
   "common.provider.detectError": "检测提供商失败，将保留之前的提供商设置。",
   "common.provider.saveError": "无法保存已发现的提供商设置，请重试。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -132,6 +132,7 @@
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
   "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimiCode": "Kimi Code CLI",
   "common.provider.detectError": "偵測提供者失敗，將保留先前的提供者設定。",
   "common.provider.saveError": "無法儲存已找到的提供者設定，請再試一次。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-08-15T17:10:04.379Z
- * 총 키 개수: 1887
+ * 생성 시간: 2026-08-20T03:53:21.319Z
+ * 총 키 개수: 1888
  * Namespace 수: 11
  */
 
@@ -40,7 +40,7 @@ export type I18nNamespace =
   | 'recentEdits';
 
 /**
- * common namespace의 번역 키 (183개)
+ * common namespace의 번역 키 (184개)
  * 파일: locales/{lang}/common.json
  */
 export type CommonKeys =
@@ -125,6 +125,7 @@ export type CommonKeys =
   | 'common.provider.goose'
   | 'common.provider.grok'
   | 'common.provider.kimi'
+  | 'common.provider.kimiCode'
   | 'common.provider.kiro'
   | 'common.provider.llm'
   | 'common.provider.ompi'
@@ -2380,6 +2381,7 @@ export type TranslationKey =
   | 'common.provider.goose'
   | 'common.provider.grok'
   | 'common.provider.kimi'
+  | 'common.provider.kimiCode'
   | 'common.provider.kiro'
   | 'common.provider.llm'
   | 'common.provider.ompi'

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeProviderIds,
   supportsConversationBreakdown,
   supportsNativeRename,
+  supportsResumeCommand,
   supportsSessionDeletion,
 } from "@/utils/providers";
 
@@ -64,6 +65,7 @@ describe("providers utils", () => {
       "goose",
       "grok",
       "kimi",
+      "kimi-code",
       "kiro",
       "llm",
       "ompi",
@@ -108,6 +110,19 @@ describe("providers utils", () => {
       "common.provider.kimi:Kimi CLI"
     );
     expect(getResumeCommand("kimi", "abc-123")).toBe("kimi -r abc-123");
+  });
+
+  it("returns the kimi --session resume flag for kimi-code sessions", () => {
+    expect(getProviderLabel((key, fallback) => `${key}:${fallback}`, "kimi-code")).toBe(
+      "common.provider.kimiCode:Kimi Code CLI"
+    );
+    expect(supportsResumeCommand("kimi-code")).toBe(true);
+    expect(getResumeCommand("kimi-code", "session_abc-123")).toBe(
+      "kimi --session session_abc-123"
+    );
+    expect(getResumeCommand("kimi-code", "session_abc", "/Users/foo/proj")).toBe(
+      "cd '/Users/foo/proj' && kimi --session session_abc"
+    );
   });
 
   it("returns the vibe resume flag for vibe sessions", () => {

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kimi-code" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,7 +1,7 @@
 import type { ProviderId } from "../types";
 import { isWindows } from "./platform";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kimi-code", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 // WSL provider loaders use UNC-backed paths and are not interchangeable with
@@ -35,6 +35,7 @@ const PROVIDER_TRANSLATIONS: Record<
   goose: { key: "common.provider.goose", fallback: "Goose" },
   grok: { key: "common.provider.grok", fallback: "Grok CLI" },
   kimi: { key: "common.provider.kimi", fallback: "Kimi CLI" },
+  "kimi-code": { key: "common.provider.kimiCode", fallback: "Kimi Code CLI" },
   kiro: { key: "common.provider.kiro", fallback: "Kiro CLI" },
   llm: { key: "common.provider.llm", fallback: "llm" },
   ompi: { key: "common.provider.ompi", fallback: "oh-my-pi" },
@@ -182,6 +183,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  "kimi-code": {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: true,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   kiro: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
@@ -297,6 +305,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "goose":
     case "grok":
     case "kimi":
+    case "kimi-code":
     case "forgecode":
     case "kiro":
     case "llm":
@@ -417,6 +426,10 @@ export function getResumeCommand(
     case "kimi":
       resume = `kimi -r ${sessionId}`;
       break;
+    case "kimi-code":
+      // New Kimi Code CLI: `-r`/`--resume` is a hidden alias for `--session`.
+      resume = `kimi --session ${sessionId}`;
+      break;
     case "vibe":
       resume = `vibe --resume ${sessionId}`;
       break;
@@ -477,6 +490,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   goose: "bg-red-500/15 text-red-600 dark:text-red-400",
   grok: "bg-zinc-800/15 text-zinc-800 dark:text-zinc-200",
   kimi: "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-300",
+  "kimi-code": "bg-fuchsia-600/15 text-fuchsia-700 dark:text-fuchsia-300",
   kiro: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
   llm: "bg-slate-500/15 text-slate-600 dark:text-slate-400",
   ompi: "bg-teal-600/15 text-teal-700 dark:text-teal-300",


### PR DESCRIPTION
Add Kimi Code CLI (`~/.kimi-code`) as a new provider: session browsing, global/project stats, and UI/i18n registration in all 5 languages.

## Changes
- `src-tauri/src/providers/kimi_code.rs`: new backend provider (scan projects, load sessions/messages from `~/.kimi-code/sessions`, `KIMI_CODE_HOME` override supported)
- `src-tauri/src/commands/stats.rs`: register `KimiCode` in provider detection and the shared stats dispatch helpers
- Frontend: `kimi-code` added to `ProviderId` / `PROVIDER_IDS`
- i18n: `common.provider.kimiCode` added to en / ko / ja / zh-CN / zh-TW
- Stats provider count test updated (29 → 30)

## Verification
- Branch synced with `main` @ v1.24.1 (merge commit included; conflicts resolved in favor of the new stats dispatch helpers, with `KimiCode` arms added)
- Quality gates green: `tsc --build`, vitest 1025 passed, `i18n:validate`, `cargo test -- --test-threads=1` 918 passed, clippy `-D warnings`, `cargo fmt --check`
- Verified against real data on macOS: 15 Kimi Code sessions detected; messages, thinking blocks, and terminal tool calls render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kimi Code CLI provider.
  * Kimi Code projects, sessions, messages, statistics, and global search are now discoverable.
  * Added session monitoring and automatic project detection for Kimi Code activity.
  * Added the ability to resume Kimi Code sessions.
  * Added provider counts, filtering, labels, and localized names across supported languages.
* **Bug Fixes**
  * Improved handling of incomplete or malformed session events during loading and search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->