### PR TITLE
fix(project-tree): drop content-visibility on collapsed rows to restore icons on rapid filter toggling

### DIFF
--- a/src/components/ProjectTree/components/GroupedProjectList.tsx
+++ b/src/components/ProjectTree/components/GroupedProjectList.tsx
@@ -85,18 +85,16 @@ export const GroupedProjectList: React.FC<GroupedProjectListProps> = ({
     const isExpanded = isProjectExpanded(project.path);
     const showSessions = isExpanded && selectedProject?.path === project.path;
 
-    // Collapsed rows skip offscreen layout/paint entirely — with thousands of
-    // projects this is what keeps sidebar scrolling and search re-filters
-    // cheap without virtualizing the (a11y-tree-navigated, nested) list.
-    // The expanded row is excluded: content-visibility's paint containment
-    // would break the sticky selection bar and the nested virtualized
-    // session list inside it.
-    const rowStyle: React.CSSProperties | undefined = showSessions
-      ? undefined
-      : { contentVisibility: "auto", containIntrinsicSize: "auto 48px" };
+    // NOTE: collapsed rows previously used `content-visibility: auto` to skip
+    // offscreen paint (#460). Removed because WebKit (WKWebView/WebKitGTK)
+    // mis-tracks viewport intersection when the list mutates quickly — e.g.
+    // rapid provider-filter toggling — leaving some rows rendered without
+    // their chevron/folder icons until expansion forced a repaint. Collapsed
+    // rows are cheap to paint; search re-filter cost is covered by
+    // useDeferredValue, so the optimization is not worth the rendering bug.
 
     return (
-      <div key={project.path} role="none" style={rowStyle}>
+      <div key={project.path} role="none">
         <ProjectItem
           project={project}
           isExpanded={isExpanded}


### PR DESCRIPTION
# fix(project-tree): drop content-visibility on collapsed rows to restore icons on rapid filter toggling

> **Target branch: `develop`** (per repo convention — `main` is release-only)

## What & why

Rapidly toggling the provider filter chips makes the chevron and folder icons
disappear from some project rows in the sidebar; expanding a row brings them
back. Root cause: #460 applied `content-visibility: auto` to collapsed project
rows, and WebKit (WKWebView / WebKitGTK) mis-tracks viewport intersection when
the list mutates quickly — affected rows get their inline SVG icons skipped
for painting while the row box itself stays visible.

This PR removes the `content-visibility: auto` / `contain-intrinsic-size`
optimization from collapsed rows and documents the WebKit pitfall in a comment
so it is not reintroduced. Performance impact is negligible:

- a collapsed row is a single icon + one line of text; painting is cheap
- the user-perceivable part of #460 — `useDeferredValue` search filtering —
  is untouched and keeps working
- if project counts ever justify more work, virtualizing the outer list is
  the right tool, not `content-visibility`

## Commits

1. `fix(project-tree): remove content-visibility from collapsed rows`

Closes #511

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: no user-facing strings were added; `pnpm run i18n:validate` passes

## Validation

- `pnpm exec vitest run src/components/ProjectTree` (36 tests pass)
- `pnpm exec tsc --build .`
- `pnpm lint`
- Manual repro on macOS desktop build: rapidly toggling the Kimi provider chip
  no longer drops row icons


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project tree rendering for collapsed and expanded project rows.
  * Ensured rows display more consistently when navigating or expanding project groups.
  * Removed layout behavior that could cause inconsistent sizing or visibility in collapsed rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->