### PR TITLE
feat(kimi): read Kimi Code wire sessions alongside legacy kimi-cli

### DIFF
--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -58,6 +58,11 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(kimi_base) = crate::providers::kimi::get_base_path() {
         allowed.push(PathBuf::from(kimi_base).join("sessions"));
     }
+    // Kimi Code (the `~/.kimi-code` rewrite) sessions — surfaced through the
+    // same `kimi` provider.
+    if let Some(kimi_code_root) = crate::providers::kimi_code::default_root() {
+        allowed.push(kimi_code_root.join("sessions"));
+    }
     if let Some(vibe_base) = crate::providers::vibe::get_base_path() {
         allowed.push(PathBuf::from(vibe_base).join("logs/session"));
     }

--- a/src-tauri/src/commands/session/resume.rs
+++ b/src-tauri/src/commands/session/resume.rs
@@ -20,6 +20,8 @@ const RESUME_COMMAND_PREFIXES: &[&str] = &[
     "copilot --resume=",
     "forge conversation resume ",
     "kimi -r ",
+    // kimi-code resumes with `-S`; the legacy kimi-cli store uses `-r`.
+    "kimi -S ",
     "vibe --resume ",
 ];
 
@@ -187,6 +189,7 @@ mod tests {
             "copilot --resume=abc_123",
             "forge conversation resume abc123",
             "kimi -r abc123",
+            "kimi -S session_abc-123",
             "vibe --resume abc123",
         ] {
             assert!(validate_resume_command(command).is_ok(), "{command}");
@@ -215,6 +218,7 @@ mod tests {
             "copilot --resume=x; rm -rf ~",
             "claude --resume `whoami`",
             "kimi -r x && y",
+            "kimi -S x && y",
             "vibe --resume x | y",
             "codex resume $(x)",
             "copilot --resume=x\"y",

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -2880,8 +2880,12 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
                     return project.name;
                 }
             }
+            // Both stores answer to this provider id, so strip either
+            // scheme — otherwise a kimi-code workspace falls through and the
+            // whole `kimi-code://…` URI is shown as the project name.
             project_path
-                .strip_prefix("kimi://")
+                .strip_prefix(providers::kimi_code::SCHEME)
+                .or_else(|| project_path.strip_prefix("kimi://"))
                 .and_then(|p| {
                     PathBuf::from(p)
                         .file_name()
@@ -6054,6 +6058,10 @@ mod tests {
             StatsProvider::Kimi
         );
         assert_eq!(
+            detect_project_provider("kimi-code:///Users/jack/.kimi-code/sessions/wd_demo_abc123"),
+            StatsProvider::Kimi
+        );
+        assert_eq!(
             detect_project_provider("copilot-cli:///Users/jack/workspace"),
             StatsProvider::Copilot
         );
@@ -6597,6 +6605,20 @@ mod tests {
         assert_eq!(
             resolve_provider_project_name_from_session(StatsProvider::Kimi, session_path),
             "project-hash"
+        );
+    }
+
+    #[test]
+    fn test_kimi_code_project_name_falls_back_to_workspace_directory() {
+        // When the store is not scannable (no ~/.kimi-code on this machine,
+        // or the workspace was removed), the name falls back to the last
+        // path segment — which requires stripping the kimi-code scheme.
+        assert_eq!(
+            resolve_provider_project_name(
+                StatsProvider::Kimi,
+                "kimi-code:///tmp/.kimi-code/sessions/wd_demo_abc123"
+            ),
+            "wd_demo_abc123"
         );
     }
 

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -420,6 +420,9 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::Grok
     } else if project_path.starts_with("kimi://") {
         StatsProvider::Kimi
+    } else if project_path.starts_with("kimi-code://") {
+        // Kimi Code workspaces surface through the kimi provider.
+        StatsProvider::Kimi
     } else if project_path.starts_with("gemini://") {
         StatsProvider::Gemini
     } else if project_path.starts_with("cursor://") {
@@ -632,9 +635,14 @@ fn is_codebuddy_path_under(path: &str, home: &Path) -> bool {
 }
 
 fn is_kimi_path(path: &str) -> bool {
+    // Covers the old CLI store (`~/.kimi`) and the kimi-code rewrite's
+    // `~/.kimi-code` sessions — both surface through the kimi provider.
     providers::kimi::get_base_path()
         .map(|root| Path::new(path).starts_with(root))
         .unwrap_or(false)
+        || providers::kimi_code::default_root()
+            .map(|root| Path::new(path).starts_with(root.join("sessions")))
+            .unwrap_or(false)
 }
 
 /// Whether `path` lies under the oh-my-pi sessions store root
@@ -3025,7 +3033,18 @@ fn resolve_provider_project_name_from_session(
         }
         StatsProvider::Kimi => {
             if let Some(project_dir) = Path::new(session_path).parent() {
-                let project_path = format!("kimi://{}", project_dir.to_string_lossy());
+                // Kimi-code session dirs live under `~/.kimi-code/sessions`
+                // and group under `kimi-code://` workspace paths; the old
+                // CLI layout uses `kimi://`.
+                let scheme = if providers::kimi_code::default_root()
+                    .map(|root| project_dir.starts_with(root.join("sessions")))
+                    .unwrap_or(false)
+                {
+                    providers::kimi_code::SCHEME
+                } else {
+                    "kimi://"
+                };
+                let project_path = format!("{scheme}{}", project_dir.to_string_lossy());
                 return resolve_provider_project_name(provider, &project_path);
             }
             "kimi".to_string()

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -274,6 +274,9 @@ fn extract_provider_paths(path: &Path) -> Option<(String, String)> {
             if let Some(paths) = extract_kimi_paths(path) {
                 return Some(paths);
             }
+            if let Some(paths) = extract_kimi_code_paths(path) {
+                return Some(paths);
+            }
             if let Some(paths) = extract_pi_family_paths(path) {
                 return Some(paths);
             }
@@ -288,6 +291,7 @@ fn extract_provider_paths(path: &Path) -> Option<(String, String)> {
         // Kimi state files and OpenCode storage files
         "json" => extract_vibe_paths(path)
             .or_else(|| extract_kimi_paths(path))
+            .or_else(|| extract_kimi_code_paths(path))
             .or_else(|| extract_opencode_paths(path)),
         // OpenCode SQLite database change — emit broad refresh for all OpenCode projects
         "db" | "db-wal" => extract_opencode_db_event(path),
@@ -495,6 +499,43 @@ fn extract_kimi_paths(path: &Path) -> Option<(String, String)> {
 
     Some((
         format!("kimi://{}", project_path.to_string_lossy()),
+        session_path.to_string_lossy().to_string(),
+    ))
+}
+
+/// Extract Kimi Code session identifiers from files under
+/// `~/.kimi-code/sessions/{wd_workspace}/{session_id}/` — either the session
+/// `state.json` (3 path components) or an agent `wire.jsonl` journal
+/// (`agents/<id>/wire.jsonl`, 5 components).
+fn extract_kimi_code_paths(path: &Path) -> Option<(String, String)> {
+    let filename = path.file_name()?.to_str()?;
+    if !matches!(filename, "wire.jsonl" | "state.json") {
+        return None;
+    }
+
+    let sessions_root =
+        crate::providers::kimi_code::default_root().map(|base| base.join("sessions"))?;
+    // Same canonicalization rationale as `extract_kimi_paths`.
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let relative = canonical_path.strip_prefix(&sessions_root).ok()?;
+    let parts: Vec<_> = relative.components().collect();
+    let valid_depth = match filename {
+        "state.json" => parts.len() == 3,
+        _ => parts.len() == 5 && parts[2].as_os_str() == "agents",
+    };
+    if !valid_depth {
+        return None;
+    }
+
+    let project_path = sessions_root.join(parts[0].as_os_str());
+    let session_path = project_path.join(parts[1].as_os_str());
+
+    Some((
+        format!(
+            "{}{}",
+            crate::providers::kimi_code::SCHEME,
+            project_path.to_string_lossy()
+        ),
         session_path.to_string_lossy().to_string(),
     ))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1031,10 +1031,15 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
-    // Kimi Code (the `~/.kimi-code` rewrite) sessions.
+    // Kimi Code (the `~/.kimi-code` rewrite) sessions. Symlinked sessions
+    // roots are not registered — `is_dir()` follows symlinks, and watching
+    // through one would observe directories outside the store.
     if let Some(kimi_code_root) = providers::kimi_code::default_root() {
         let sessions = kimi_code_root.join("sessions");
-        if sessions.is_dir() {
+        let is_real_dir = std::fs::symlink_metadata(&sessions)
+            .map(|meta| meta.file_type().is_dir())
+            .unwrap_or(false);
+        if is_real_dir {
             paths.push(sessions);
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1031,6 +1031,14 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    // Kimi Code (the `~/.kimi-code` rewrite) sessions.
+    if let Some(kimi_code_root) = providers::kimi_code::default_root() {
+        let sessions = kimi_code_root.join("sessions");
+        if sessions.is_dir() {
+            paths.push(sessions);
+        }
+    }
+
     // Pi / oh-my-pi: get_base_path() is already the sessions root.
     if let Some(pi_base) = providers::pi::get_base_path() {
         let sessions = PathBuf::from(pi_base);

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -161,8 +161,11 @@ pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     match get_base_path() {
         Some(base) => {
             let mut projects = scan_projects_from_path(&base)?;
-            // Kimi-code workspaces coexist with the old CLI's sessions.
+            // Kimi-code workspaces coexist with the old CLI's sessions;
+            // re-sort the merged list so both stores interleave by
+            // last_modified instead of kimi-code always trailing.
             projects.extend(super::kimi_code::scan_projects());
+            projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
             Ok(projects)
         }
         // A kimi-code-only install still surfaces through this provider.

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -16,14 +16,33 @@ const STATE_FILE: &str = "state.json";
 const WIRE_FILE: &str = "wire.jsonl";
 
 pub fn detect() -> Option<ProviderInfo> {
-    let base = get_base_path()?;
-    let sessions_path = Path::new(&base).join(SESSIONS_DIR);
-
+    // The kimi-code store (`~/.kimi-code`) is surfaced through this same
+    // provider; a kimi-code-only install still counts (antigravity-cli
+    // pattern) and its root becomes the reported base path.
+    let code_available = super::kimi_code::is_available();
+    if let Some(base) = get_base_path() {
+        let sessions_path = Path::new(&base).join(SESSIONS_DIR);
+        if !code_available && !sessions_path.is_dir() {
+            return None;
+        }
+        return Some(ProviderInfo {
+            id: PROVIDER_ID.to_string(),
+            display_name: "Kimi".to_string(),
+            base_path: base,
+            is_available: true,
+        });
+    }
+    if !code_available {
+        return None;
+    }
+    let base = super::kimi_code::default_root()?
+        .to_string_lossy()
+        .to_string();
     Some(ProviderInfo {
         id: PROVIDER_ID.to_string(),
-        display_name: "Kimi CLI".to_string(),
+        display_name: "Kimi".to_string(),
         base_path: base,
-        is_available: sessions_path.exists() && sessions_path.is_dir(),
+        is_available: true,
     })
 }
 
@@ -139,14 +158,27 @@ pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, St
 }
 
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
-    let base = get_base_path().ok_or("Kimi base path not found")?;
-    scan_projects_from_path(&base)
+    match get_base_path() {
+        Some(base) => {
+            let mut projects = scan_projects_from_path(&base)?;
+            // Kimi-code workspaces coexist with the old CLI's sessions.
+            projects.extend(super::kimi_code::scan_projects());
+            Ok(projects)
+        }
+        // A kimi-code-only install still surfaces through this provider.
+        None => Ok(super::kimi_code::scan_projects()),
+    }
 }
 
 pub fn load_sessions(
     project_path: &str,
     exclude_sidechain: bool,
 ) -> Result<Vec<ClaudeSession>, String> {
+    // Kimi-code workspace paths carry the `kimi-code://` scheme and route
+    // to the wire-based loader; everything else is the old CLI layout.
+    if let Some(workspace) = project_path.strip_prefix(super::kimi_code::SCHEME) {
+        return super::kimi_code::load_sessions(workspace);
+    }
     let base = get_base_path().ok_or("Kimi base path not found")?;
     load_sessions_from_base_path(&base, project_path, exclude_sidechain)
 }
@@ -215,6 +247,10 @@ pub fn load_sessions_from_base_path(
 }
 
 pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    // Session dirs under the kimi-code store route to the wire loader.
+    if super::kimi_code::owns_session_path(session_path) {
+        return super::kimi_code::load_messages(session_path);
+    }
     let base = get_base_path().ok_or("Kimi base path not found")?;
     load_messages_from_base_path(&base, session_path)
 }
@@ -262,8 +298,17 @@ pub fn load_messages_from_base_path(
 }
 
 pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
-    let base = get_base_path().ok_or("Kimi base path not found")?;
-    search_from_base_path(&base, query, limit)
+    let mut results = match get_base_path() {
+        Some(base) => search_from_base_path(&base, query, limit)?,
+        None => Vec::new(),
+    };
+    // Kimi-code conversations carry real content — search them too.
+    if results.len() < limit {
+        let remaining = limit - results.len();
+        let code_results = super::kimi_code::search(query, remaining);
+        results.extend(code_results);
+    }
+    Ok(results)
 }
 
 pub fn search_from_base_path(

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -45,7 +45,7 @@
 //! content, and is skipped. Parsing is tolerant: malformed lines are
 //! skipped, never propagated as scan errors.
 
-use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
 use crate::utils::{build_provider_message, is_symlink, search_json_value_case_insensitive};
 use chrono::{TimeZone, Utc};
 use serde_json::{json, Value};
@@ -572,6 +572,9 @@ struct FoldedMessage {
     partial: bool,
     timestamp: String,
     model: Option<String>,
+    /// Token counts from the `usage.record` events emitted inside this
+    /// assistant step. Always `None` on non-assistant messages.
+    usage: Option<TokenUsage>,
 }
 
 impl FoldedMessage {
@@ -696,6 +699,13 @@ pub(crate) fn fold_wire_messages(
                     state.deferred.clear();
                 }
             }
+            // Emitted between `step.begin` and the step's content parts —
+            // the counts belong to the assistant turn being streamed.
+            "usage.record" => {
+                if let Some(usage) = record.get("usage") {
+                    fold_usage_record(&mut history, usage);
+                }
+            }
             "context.apply_compaction" => {
                 fold_apply_compaction(&mut history, &mut state, &record, &last_ts);
             }
@@ -712,6 +722,40 @@ pub(crate) fn fold_wire_messages(
         .enumerate()
         .filter_map(|(index, message)| convert_folded_message(message, session_id, index as u64))
         .collect()
+}
+
+/// Add one `usage.record`'s counts to the assistant step it belongs to.
+///
+/// On disk there is exactly one record per open step, but the counts are
+/// summed rather than assigned so a step that issued several requests totals
+/// correctly. A record with no assistant to attach to is dropped — there is
+/// no turn for the viewer to bill it to.
+fn fold_usage_record(history: &mut [FoldedMessage], usage: &Value) {
+    let Some(target) = history
+        .iter_mut()
+        .rev()
+        .find(|message| message.partial || message.role == "assistant")
+    else {
+        return;
+    };
+    if target.role != "assistant" {
+        return;
+    }
+
+    let field = |name: &str| usage.get(name).and_then(Value::as_u64).map(|v| v as u32);
+    let add = |current: Option<u32>, extra: Option<u32>| match (current, extra) {
+        (None, None) => None,
+        (a, b) => Some(a.unwrap_or(0).saturating_add(b.unwrap_or(0))),
+    };
+
+    let total = target.usage.get_or_insert_with(TokenUsage::default);
+    total.input_tokens = add(total.input_tokens, field("inputOther"));
+    total.output_tokens = add(total.output_tokens, field("output"));
+    total.cache_read_input_tokens = add(total.cache_read_input_tokens, field("inputCacheRead"));
+    total.cache_creation_input_tokens = add(
+        total.cache_creation_input_tokens,
+        field("inputCacheCreation"),
+    );
 }
 
 /// `ContextAppendMessage` fold: append unless a tool exchange is open, in
@@ -754,6 +798,7 @@ fn fold_append_message(
         partial: false,
         timestamp: timestamp.to_string(),
         model: state.model.clone(),
+        usage: None,
     };
 
     if state.pending.is_empty() {
@@ -785,6 +830,7 @@ fn fold_loop_event(
                 partial: true,
                 timestamp: timestamp.to_string(),
                 model: state.model.clone(),
+                usage: None,
             });
         }
         "content.part" => {
@@ -835,6 +881,7 @@ fn fold_loop_event(
                 partial: false,
                 timestamp: timestamp.to_string(),
                 model: None,
+                usage: None,
             });
             flush_deferred(history, state);
         }
@@ -897,6 +944,7 @@ fn close_pending(history: &mut Vec<FoldedMessage>, state: &mut FoldState, timest
             partial: false,
             timestamp: timestamp.to_string(),
             model: None,
+            usage: None,
         });
     }
     flush_deferred(history, state);
@@ -1014,6 +1062,7 @@ fn fold_apply_compaction(
             partial: false,
             timestamp: timestamp.to_string(),
             model: None,
+            usage: None,
         });
     }
 }
@@ -1054,7 +1103,7 @@ fn convert_folded_message(
             for call in &message.tool_calls {
                 blocks.push(call.clone());
             }
-            Some(build_provider_message(
+            let mut converted = build_provider_message(
                 PROVIDER_ID,
                 uuid,
                 session_id,
@@ -1063,7 +1112,9 @@ fn convert_folded_message(
                 Some("assistant"),
                 Some(Value::Array(blocks)),
                 message.model,
-            ))
+            );
+            converted.usage = message.usage;
+            Some(converted)
         }
         "tool" => {
             // Pull the output marker back out into the tool_result shape.
@@ -1903,6 +1954,71 @@ mod tests {
             .expect_err("symlinked session dir must be rejected");
         // The real session still loads.
         assert!(load_messages_from_root(&root, &session_dir.to_string_lossy()).is_ok());
+    }
+
+    /// `usage.record` lands inside the open assistant step (step.begin →
+    /// llm.request → usage.record → parts → step.end), which is where the
+    /// token counts belong for the analytics dashboard.
+    #[test]
+    fn usage_records_attach_to_the_open_assistant_step() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        sessions_root(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_usage",
+            &default_state(),
+            &[
+                r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"hi"}],"origin":{"kind":"user"},"id":"msg_u1"},"time":1786959458516}"#,
+                r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1","turnId":"0","step":1},"time":1786959458517}"#,
+                r#"{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":4735,"output":79,"inputCacheRead":18944,"inputCacheCreation":12},"usageScope":"turn","time":1786959458518}"#,
+                r#"{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"p1","stepUuid":"s1","part":{"type":"text","text":"hello"}},"time":1786959458519}"#,
+                r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1","turnId":"0","step":1,"finishReason":"end_turn"},"time":1786959458520}"#,
+            ],
+        );
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+        assert_eq!(messages.len(), 2);
+        assert!(
+            messages[0].usage.is_none(),
+            "the user prompt carries no usage"
+        );
+        let usage = messages[1].usage.as_ref().expect("assistant usage");
+        assert_eq!(usage.input_tokens, Some(4735));
+        assert_eq!(usage.output_tokens, Some(79));
+        assert_eq!(usage.cache_read_input_tokens, Some(18944));
+        assert_eq!(usage.cache_creation_input_tokens, Some(12));
+    }
+
+    /// One record per step is the shape on disk, but a step that issued more
+    /// than one request must total rather than keep only the last.
+    #[test]
+    fn usage_records_accumulate_within_one_step() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        sessions_root(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_usage_multi",
+            &default_state(),
+            &[
+                r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1","turnId":"0","step":1},"time":1786959458517}"#,
+                r#"{"type":"usage.record","usage":{"inputOther":10,"output":1,"inputCacheRead":100,"inputCacheCreation":0},"usageScope":"turn","time":1786959458518}"#,
+                r#"{"type":"usage.record","usage":{"inputOther":20,"output":2,"inputCacheRead":200,"inputCacheCreation":0},"usageScope":"turn","time":1786959458519}"#,
+                r#"{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"p1","stepUuid":"s1","part":{"type":"text","text":"hello"}},"time":1786959458520}"#,
+                r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1","turnId":"0","step":1,"finishReason":"end_turn"},"time":1786959458521}"#,
+            ],
+        );
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+        let usage = messages[0].usage.as_ref().expect("assistant usage");
+        assert_eq!(usage.input_tokens, Some(30));
+        assert_eq!(usage.output_tokens, Some(3));
+        assert_eq!(usage.cache_read_input_tokens, Some(300));
     }
 
     /// Pasted images persist as `image_url` parts pointing at a

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -674,14 +674,18 @@ pub(crate) fn fold_wire_messages(
             }
             "context.undo" => {
                 let count = record.get("count").and_then(Value::as_u64).unwrap_or(1) as usize;
-                apply_undo_cut(&mut history, count);
-                // The cut removed the assistant holding the open tool
-                // exchange, so its pending calls and any messages deferred
-                // behind that exchange are gone with it — keeping them
-                // would resurrect interrupted results for calls that no
-                // longer exist.
-                state.pending.clear();
-                state.deferred.clear();
+                let cut = apply_undo_cut(&mut history, count);
+                if cut {
+                    // The cut removed the assistant holding the open tool
+                    // exchange, so its pending calls and any messages
+                    // deferred behind that exchange are gone with it —
+                    // keeping them would resurrect interrupted results for
+                    // calls that no longer exist. Only clear on an actual
+                    // cut: a no-op undo (compaction boundary / no anchor)
+                    // must keep the live exchange state intact.
+                    state.pending.clear();
+                    state.deferred.clear();
+                }
             }
             "context.apply_compaction" => {
                 fold_apply_compaction(&mut history, &mut state, &record, &last_ts);
@@ -895,10 +899,11 @@ fn flush_deferred(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
 /// The agent core's `computeUndoCut`: walk back counting undo anchors
 /// (user prompts); the cut removes the anchor and everything after it, and
 /// extends backwards over injections the prompt owns. The walk stops at a
-/// compaction boundary.
-fn apply_undo_cut(history: &mut Vec<FoldedMessage>, count: usize) {
+/// compaction boundary. Returns `true` only when history was actually cut
+/// (`false` for a compaction-boundary stop or no matching anchor).
+fn apply_undo_cut(history: &mut Vec<FoldedMessage>, count: usize) -> bool {
     if history.is_empty() {
-        return;
+        return false;
     }
     let mut remaining = count;
     let mut cut_index: Option<usize> = None;
@@ -910,7 +915,7 @@ fn apply_undo_cut(history: &mut Vec<FoldedMessage>, count: usize) {
         let message = &history[i];
         match message.origin_kind() {
             Some("injection") => continue,
-            Some("compaction_summary") => return,
+            Some("compaction_summary") => return false,
             _ => {}
         }
         if message.is_undo_anchor() {
@@ -937,8 +942,12 @@ fn apply_undo_cut(history: &mut Vec<FoldedMessage>, count: usize) {
         }
     }
 
-    if let Some(cut) = cut_index {
-        history.truncate(cut);
+    match cut_index {
+        Some(cut) => {
+            history.truncate(cut);
+            true
+        }
+        None => false,
     }
 }
 
@@ -1674,6 +1683,45 @@ mod tests {
         assert!(
             !messages.iter().any(|m| m.message_type == "tool"),
             "no ghost interrupted result for the undone tool call"
+        );
+    }
+
+    #[test]
+    fn no_op_undo_keeps_deferred_messages_alive() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            // A compaction boundary makes later undos no-ops.
+            r#"{"type":"context.apply_compaction","contextSummary":"summary","compactedCount":1,"time":1786959458515}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1786959458516}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.call","stepUuid":"s1","toolCallId":"tool_z","name":"Read","args":{"path":"a"}},"time":1786959458517}"#,
+            // Queued behind the open exchange…
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"queued"}],"toolCalls":[]},"time":1786959458518}"#,
+            // …and the undo walks into the compaction boundary → no cut.
+            // The deferred message must survive and flush after the
+            // exchange closes.
+            r#"{"type":"context.undo","count":1,"time":1786959458519}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"tool_z","result":{"output":"ok"}},"time":1786959458520}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1"},"time":1786959458521}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        let texts: Vec<&str> = messages
+            .iter()
+            .filter(|m| m.message_type == "user")
+            .filter_map(|m| {
+                m.content
+                    .as_ref()
+                    .and_then(Value::as_array)
+                    .and_then(|blocks| blocks[0].get("text").and_then(Value::as_str))
+            })
+            .collect();
+        assert!(
+            texts.contains(&"queued"),
+            "no-op undo must not drop the deferred message, got {texts:?}"
         );
     }
 

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -242,7 +242,9 @@ pub(crate) fn load_messages_from_root(
         .map(|name| name.to_string_lossy().to_string())
         .ok_or("Kimi Code session path has no directory name")?;
 
-    let wire = main_wire_path(&session_dir);
+    let Some(wire) = main_wire_path(&session_dir) else {
+        return Ok(Vec::new());
+    };
     let fallback_ts = read_state_json(&session_dir)
         .and_then(|state| {
             state
@@ -255,9 +257,9 @@ pub(crate) fn load_messages_from_root(
 
     Ok(fold_wire_messages(
         &wire,
+        blobs_dir_for(&session_dir),
         &session_id,
         &fallback_ts,
-        BlobPolicy::Resolve,
     ))
 }
 
@@ -365,8 +367,8 @@ impl CodeSession {
 /// Fold one session directory's main wire into a `CodeSession`; `None` when
 /// the session has no readable wire or produces no viewer messages.
 fn build_session(session_dir: &Path) -> Option<CodeSession> {
-    let wire = main_wire_path(session_dir);
-    if is_symlink(&wire) || !wire.is_file() {
+    let wire = main_wire_path(session_dir)?;
+    if !wire.is_file() {
         return None;
     }
 
@@ -379,8 +381,9 @@ fn build_session(session_dir: &Path) -> Option<CodeSession> {
         .or_else(|| file_modified_iso(&wire))
         .unwrap_or_default();
 
-    // Scanning and search only read text metadata back out of the fold.
-    let messages = fold_wire_messages(&wire, &session_id, &fallback_ts, BlobPolicy::Skip);
+    // Scanning and search only read text metadata back out of the fold, so
+    // they pass no blob store and leave `blobref:` parts verbatim.
+    let messages = fold_wire_messages(&wire, None, &session_id, &fallback_ts);
     if messages.is_empty() {
         return None;
     }
@@ -475,11 +478,29 @@ fn list_session_dirs(workspace_dir: &Path) -> Vec<PathBuf> {
     dirs
 }
 
-fn main_wire_path(session_dir: &Path) -> PathBuf {
-    session_dir
-        .join(AGENTS_DIR)
-        .join(MAIN_AGENT)
-        .join(WIRE_FILE)
+/// Join `components` onto `base`, rejecting a symlink at every step.
+///
+/// Checking only the leaf is not enough: a symlinked `agents`, `main` or
+/// `blobs` directory redirects the read outside the session store while the
+/// file at the end stays a perfectly ordinary one.
+fn join_without_symlinks(base: &Path, components: &[&str]) -> Option<PathBuf> {
+    let mut path = base.to_path_buf();
+    for component in components {
+        path.push(component);
+        if is_symlink(&path) {
+            return None;
+        }
+    }
+    Some(path)
+}
+
+fn main_wire_path(session_dir: &Path) -> Option<PathBuf> {
+    join_without_symlinks(session_dir, &[AGENTS_DIR, MAIN_AGENT, WIRE_FILE])
+}
+
+/// The blob store beside a session's main wire.
+fn blobs_dir_for(session_dir: &Path) -> Option<PathBuf> {
+    join_without_symlinks(session_dir, &[AGENTS_DIR, MAIN_AGENT, BLOBS_DIR])
 }
 
 fn read_state_json(session_dir: &Path) -> Option<Value> {
@@ -611,26 +632,14 @@ impl FoldedMessage {
     }
 }
 
-/// Whether the fold inlines `blobref:` images from the session's blob store.
-///
-/// Only the viewer needs the bytes. Scanning and search fold every journal
-/// too, but read nothing back out of an image part — resolving there would
-/// read and base64-encode every blob in the store only to discard it.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum BlobPolicy {
-    Resolve,
-    Skip,
-}
-
 /// Replay state — mirrors `loopEventFold.ts`'s `FoldCtx` plus the current
 /// model alias from the latest `profile.bind`/`llm.request` record.
 struct FoldState {
     pending: Vec<String>,
     deferred: Vec<FoldedMessage>,
     model: Option<String>,
-    /// `<session>/agents/<agent>/blobs` — where `blobref:` image parts
-    /// resolve to. Sits beside the wire being folded; `None` under
-    /// `BlobPolicy::Skip`.
+    /// The session's blob store, where `blobref:` image parts resolve to.
+    /// `None` on the scan and search paths, which need no image bytes.
     blobs_dir: Option<PathBuf>,
 }
 
@@ -638,11 +647,18 @@ struct FoldState {
 ///
 /// Best-effort: malformed lines and unknown record types are skipped — a
 /// partial journal must never fail the whole session.
+/// Replay `wire.jsonl` into viewer messages.
+///
+/// `blobs_dir` is the session's blob store, or `None` to leave `blobref:`
+/// image parts verbatim. Only the viewer needs the bytes: scanning and
+/// search fold every journal too but read nothing back out of an image
+/// part, so resolving there would read and base64-encode every blob in the
+/// store only to discard the result.
 fn fold_wire_messages(
     wire_path: &Path,
+    blobs_dir: Option<PathBuf>,
     session_id: &str,
     fallback_ts: &str,
-    blobs: BlobPolicy,
 ) -> Vec<ClaudeMessage> {
     if is_symlink(wire_path) || !wire_path.is_file() {
         return Vec::new();
@@ -659,8 +675,7 @@ fn fold_wire_messages(
         pending: Vec::new(),
         deferred: Vec::new(),
         model: None,
-        blobs_dir: (blobs == BlobPolicy::Resolve)
-            .then(|| wire_path.parent().unwrap_or(Path::new("")).join(BLOBS_DIR)),
+        blobs_dir,
     };
     let mut last_ts = fallback_ts.to_string();
 
@@ -2162,6 +2177,96 @@ mod tests {
         assert_eq!(parts[0]["source"]["type"], "base64");
         assert_eq!(parts[0]["source"]["media_type"], "image/jpeg");
         assert_eq!(parts[0]["source"]["data"], "QUJD");
+    }
+
+    /// Rejecting only the `wire.jsonl` leaf is not enough: a symlinked
+    /// `agents` or `main` directory redirects the read outside the store
+    /// while the journal itself is a perfectly ordinary file.
+    #[test]
+    fn symlinked_journal_directories_are_rejected() {
+        use std::os::unix::fs as unix_fs;
+
+        for link_at in [AGENTS_DIR, MAIN_AGENT] {
+            let temp = TempDir::new().expect("temp dir");
+            let root = code_root(&temp);
+            let session_dir = root.join(SESSIONS_DIR).join("wd_a").join("session_x");
+            fs::create_dir_all(&session_dir).expect("create session dir");
+            fs::write(session_dir.join(STATE_FILE), default_state()).expect("write state");
+
+            // A real journal planted outside the store.
+            let outside = temp.path().join("outside");
+            let (link_src, link_dst) = if link_at == AGENTS_DIR {
+                fs::create_dir_all(outside.join(MAIN_AGENT)).expect("create outside");
+                fs::write(
+                    outside.join(MAIN_AGENT).join(WIRE_FILE),
+                    full_turn_wire().join("\n"),
+                )
+                .expect("write outside wire");
+                (outside.clone(), session_dir.join(AGENTS_DIR))
+            } else {
+                fs::create_dir_all(&outside).expect("create outside");
+                fs::write(outside.join(WIRE_FILE), full_turn_wire().join("\n"))
+                    .expect("write outside wire");
+                fs::create_dir_all(session_dir.join(AGENTS_DIR)).expect("create agents");
+                (
+                    outside.clone(),
+                    session_dir.join(AGENTS_DIR).join(MAIN_AGENT),
+                )
+            };
+            unix_fs::symlink(&link_src, &link_dst).expect("create symlink");
+
+            let messages = load_messages_from_root(&root, &session_dir.to_string_lossy())
+                .expect("load messages");
+            assert!(
+                messages.is_empty(),
+                "a symlinked `{link_at}` directory must not be traversed"
+            );
+            assert!(
+                scan_projects_from_root(&sessions_root(&root)).is_empty(),
+                "scanning must skip a session behind a symlinked `{link_at}`"
+            );
+        }
+    }
+
+    /// Same for the blob store: the leaf check misses a symlinked `blobs`
+    /// directory pointing at arbitrary files.
+    #[test]
+    fn symlinked_blob_directory_is_not_followed() {
+        use std::os::unix::fs as unix_fs;
+
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        sessions_root(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_blob_link",
+            &default_state(),
+            &[
+                r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"image_url","imageUrl":{"url":"blobref:image/png;deadbeef"}}],"origin":{"kind":"user"},"id":"msg_u1"},"time":1786959458516}"#,
+            ],
+        );
+
+        let outside = temp.path().join("outside-blobs");
+        fs::create_dir_all(&outside).expect("create outside blobs");
+        fs::write(outside.join("deadbeef"), [0x89u8, 0x50, 0x4e, 0x47]).expect("write blob");
+        unix_fs::symlink(
+            &outside,
+            session_dir.join(AGENTS_DIR).join(MAIN_AGENT).join("blobs"),
+        )
+        .expect("create symlink");
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+        let parts = messages[0]
+            .content
+            .as_ref()
+            .and_then(Value::as_array)
+            .expect("content array");
+        assert_eq!(
+            parts[0]["type"], "image_url",
+            "a symlinked blob store must not be read"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -402,9 +402,9 @@ fn build_session(session_dir: &Path) -> Option<CodeSession> {
         .and_then(|custom| custom.get("vscode_legacy_approval"))
         .is_some()
     {
-        "kimi-vscode"
+        "kimi-code-vscode"
     } else {
-        "kimi-cli"
+        "kimi-code-cli"
     };
 
     Some(CodeSession {
@@ -1368,7 +1368,7 @@ mod tests {
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_id, "session_one");
         // default_state carries no vscode custom marker → CLI entrypoint.
-        assert_eq!(sessions[0].entrypoint.as_deref(), Some("kimi-cli"));
+        assert_eq!(sessions[0].entrypoint.as_deref(), Some("kimi-code-cli"));
         assert_eq!(
             sessions[0].message_count, 4,
             "user + assistant + tool + assistant"
@@ -1404,9 +1404,12 @@ mod tests {
         let by_id = |id: &str| sessions.iter().find(|s| s.session_id == id).unwrap();
         assert_eq!(
             by_id("session_vs").entrypoint.as_deref(),
-            Some("kimi-vscode")
+            Some("kimi-code-vscode")
         );
-        assert_eq!(by_id("session_cli").entrypoint.as_deref(), Some("kimi-cli"));
+        assert_eq!(
+            by_id("session_cli").entrypoint.as_deref(),
+            Some("kimi-code-cli")
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -1,0 +1,1683 @@
+//! Kimi Code (`kimi-code`, the 2026 rewrite of `kimi-cli`) session store,
+//! surfaced through the existing `kimi` provider — the new CLI writes to
+//! `~/.kimi-code`, a sibling of the old CLI's `~/.kimi` root, and both
+//! layouts may coexist on one machine (antigravity/antigravity-cli pattern).
+//!
+//! Layout (from `packages/agent-core-v2` sources of the kimi-code repo):
+//!
+//! ```text
+//! ~/.kimi-code/                       # KIMI_CODE_HOME overrides this root
+//! ├── workspaces.json                 # { "workspaces": { "wd_<hash>": { root, name, … } } }
+//! └── sessions/
+//!     └── wd_<hash>/                  # one workspace directory
+//!         └── session_<uuid>/
+//!             ├── state.json          # { id, version: 2, cwd, title, lastPrompt,
+//!             │                       #   createdAt, updatedAt, … }
+//!             └── agents/
+//!                 └── main/wire.jsonl # per-agent event journal (protocol 1.5)
+//! ```
+//!
+//! `wire.jsonl` is a flat JSONL journal: one record per line, each shaped
+//! `{ "type": <event>, …payload, "time": <epoch-ms> }`. The conversation is
+//! rebuilt by replaying the `context.*` vocabulary exactly like the agent
+//! core's `contextMemory` fold (`loopEventFold.ts`):
+//!
+//! - `context.append_message` — a fully formed message (`role`, `content[]`,
+//!   `toolCalls[]`, optional `origin`, `id`) appended to the context. Only
+//!   user/system-side messages are written this way; assistant turns are
+//!   streamed as loop events.
+//! - `context.append_loop_event` — one streaming event inside a turn:
+//!   `step.begin` (open a partial assistant), `content.part` (append a
+//!   `text` / `think` / media part), `tool.call` (append a tool call and
+//!   mark it pending), `tool.result` (push a `tool` message for the pending
+//!   call), `step.end` (settle the assistant: pending calls without results
+//!   become interrupted tool messages; an assistant with no tool calls and
+//!   only vacuous content is dropped).
+//! - `context.clear` — reset the context, `context.undo` — cut the last
+//!   `count` undo anchors (user prompts) with everything after them,
+//!   `context.apply_compaction` — replace the compacted prefix with a
+//!   summary message.
+//!
+//! A `context.append_message` arriving while tool results are still pending
+//! is deferred until the exchange closes (assistant↔tool adjacency).
+//! Everything else (`turn.*`, `llm.*`, `usage.record`, `permission.*`,
+//! `profile.bind`, `plugin.*`, …) is session machinery, not conversation
+//! content, and is skipped. Parsing is tolerant: malformed lines are
+//! skipped, never propagated as scan errors.
+
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession};
+use crate::utils::{build_provider_message, is_symlink, search_json_value_case_insensitive};
+use chrono::{TimeZone, Utc};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The kimi-code layout is exposed through the existing `kimi` provider id
+/// (see module docs) — a new id would require the full frontend registry +
+/// i18n sweep for what is the same product.
+const PROVIDER_ID: &str = "kimi";
+/// Scheme prefix distinguishing kimi-code workspace paths from the old
+/// CLI's `kimi://<dir>` paths inside the shared `kimi` provider.
+pub(crate) const SCHEME: &str = "kimi-code://";
+const SESSIONS_DIR: &str = "sessions";
+const AGENTS_DIR: &str = "agents";
+/// The primary agent of a session; subagent wires are sidechains and are
+/// not surfaced (same policy as the old CLI reader).
+const MAIN_AGENT: &str = "main";
+const WIRE_FILE: &str = "wire.jsonl";
+const STATE_FILE: &str = "state.json";
+const WORKSPACES_FILE: &str = "workspaces.json";
+const SUMMARY_MAX_CHARS: usize = 200;
+
+/// Default kimi-code home. Mirrors the agent core's bootstrap: the
+/// `KIMI_CODE_HOME` env var overrides `~/.kimi-code`.
+pub(crate) fn default_root() -> Option<PathBuf> {
+    if let Ok(env_val) = std::env::var("KIMI_CODE_HOME") {
+        let path = PathBuf::from(&env_val);
+        let absolute = if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir().ok()?.join(path)
+        };
+        if absolute.exists() {
+            return Some(absolute.canonicalize().unwrap_or(absolute));
+        }
+        return None;
+    }
+    let default = dirs::home_dir()?.join(".kimi-code");
+    default
+        .exists()
+        .then(|| default.canonicalize().unwrap_or(default))
+}
+
+/// The sessions root (`<root>/sessions`), when it exists as a directory.
+fn sessions_root(root: &Path) -> Option<PathBuf> {
+    let root = root.join(SESSIONS_DIR);
+    (!is_symlink(&root) && root.is_dir()).then_some(root)
+}
+
+/// True when the default kimi-code root looks like a kimi-code store.
+pub(crate) fn is_available() -> bool {
+    default_root()
+        .and_then(|root| sessions_root(&root))
+        .is_some_and(|root| has_any_session_dir(&root))
+}
+
+/// At least one `wd_*/session_*` directory exists under the sessions root.
+fn has_any_session_dir(sessions_root: &Path) -> bool {
+    list_workspace_dirs(sessions_root)
+        .iter()
+        .any(|dir| !list_session_dirs(dir).is_empty())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider interface (default-root wrappers)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kimi-code projects, one per `wd_<hash>` workspace directory. Tolerant: a
+/// missing or unreadable store yields an empty list, never an error.
+pub fn scan_projects() -> Vec<ClaudeProject> {
+    default_root()
+        .and_then(|root| sessions_root(&root))
+        .map(|root| scan_projects_from_root(&root))
+        .unwrap_or_default()
+}
+
+/// Sessions for one workspace — the `kimi-code://`-stripped workspace dir.
+pub fn load_sessions(workspace_dir: &str) -> Result<Vec<ClaudeSession>, String> {
+    let Some(root) = default_root() else {
+        return Ok(Vec::new());
+    };
+    let workspace = resolve_workspace_dir(&root, workspace_dir)?;
+    Ok(load_sessions_from_dir(&workspace))
+}
+
+/// True when `session_path` is a valid kimi-code session directory under
+/// the default root — used by the shared provider to route `load_messages`.
+pub(crate) fn owns_session_path(session_path: &str) -> bool {
+    let Some(root) = default_root() else {
+        return false;
+    };
+    validate_session_dir(&root, session_path).is_ok()
+}
+
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let root = default_root().ok_or("Kimi Code root not found")?;
+    load_messages_from_root(&root, session_path)
+}
+
+/// Content search across kimi-code conversations. Tolerant: errors degrade
+/// to an empty result set.
+pub fn search(query: &str, limit: usize) -> Vec<ClaudeMessage> {
+    default_root()
+        .and_then(|root| sessions_root(&root))
+        .map(|root| search_from_root(&root, query, limit))
+        .unwrap_or_default()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Root-parameterized implementation (fixture-testable)
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub(crate) fn scan_projects_from_root(sessions_root: &Path) -> Vec<ClaudeProject> {
+    // Workspace roots come from workspaces.json (`root`/`name`); per-session
+    // state.json cwd values are the fallback for unindexed workspaces.
+    let workspace_map = read_workspace_roots(sessions_root.parent().unwrap_or(sessions_root));
+
+    let mut projects = Vec::new();
+    for workspace_dir in list_workspace_dirs(sessions_root) {
+        let sessions: Vec<ClaudeSession> = list_session_dirs(&workspace_dir)
+            .into_iter()
+            .filter_map(|dir| build_session(&dir))
+            .map(CodeSession::into_claude_session)
+            .collect();
+        if sessions.is_empty() {
+            continue;
+        }
+
+        let workspace_id = workspace_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let actual_path = workspace_map
+            .get(&workspace_id)
+            .cloned()
+            .or_else(|| read_state_cwd(&workspace_dir))
+            .unwrap_or_else(|| workspace_id.clone());
+        let name = project_name_for_root(&actual_path, &workspace_id);
+        let message_count = sessions.iter().map(|s| s.message_count).sum();
+        let last_modified = sessions
+            .iter()
+            .map(|s| s.last_modified.as_str())
+            .max()
+            .unwrap_or_default()
+            .to_string();
+
+        projects.push(ClaudeProject {
+            name,
+            path: format!("{SCHEME}{}", workspace_dir.to_string_lossy()),
+            actual_path: actual_path.clone(),
+            session_count: sessions.len(),
+            message_count,
+            last_modified,
+            git_info: if Path::new(&actual_path).is_absolute() {
+                crate::utils::detect_git_worktree_info(&actual_path)
+            } else {
+                None
+            },
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            custom_directory_label: None,
+        });
+    }
+
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    projects
+}
+
+pub(crate) fn load_sessions_from_dir(workspace_dir: &Path) -> Vec<ClaudeSession> {
+    let mut sessions: Vec<ClaudeSession> = list_session_dirs(workspace_dir)
+        .into_iter()
+        .filter_map(|dir| build_session(&dir))
+        .map(CodeSession::into_claude_session)
+        .collect();
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    sessions
+}
+
+pub(crate) fn load_messages_from_root(
+    root: &Path,
+    session_path: &str,
+) -> Result<Vec<ClaudeMessage>, String> {
+    let session_dir = validate_session_dir(root, session_path)?;
+    let session_id = session_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .ok_or("Kimi Code session path has no directory name")?;
+
+    let wire = main_wire_path(&session_dir);
+    let fallback_ts = read_state_json(&session_dir)
+        .and_then(|state| {
+            state
+                .get("createdAt")
+                .and_then(Value::as_u64)
+                .and_then(ms_to_rfc3339)
+        })
+        .or_else(|| file_modified_iso(&wire))
+        .unwrap_or_default();
+
+    Ok(fold_wire_messages(&wire, &session_id, &fallback_ts))
+}
+
+pub(crate) fn search_from_root(
+    sessions_root: &Path,
+    query: &str,
+    limit: usize,
+) -> Vec<ClaudeMessage> {
+    let query_lower = query.to_lowercase();
+    let workspace_map = read_workspace_roots(sessions_root.parent().unwrap_or(sessions_root));
+
+    let mut results = Vec::new();
+    for workspace_dir in list_workspace_dirs(sessions_root) {
+        let project_name = project_name_for_workspace(&workspace_dir, &workspace_map);
+        for session_dir in list_session_dirs(&workspace_dir) {
+            let Some(session) = build_session(&session_dir) else {
+                continue;
+            };
+            for mut message in session.messages {
+                let matches = message.content.as_ref().is_some_and(|content| {
+                    search_json_value_case_insensitive(content, &query_lower)
+                });
+                if matches {
+                    message.project_name = Some(project_name.clone());
+                    results.push(message);
+                    if results.len() >= limit {
+                        return results;
+                    }
+                }
+            }
+        }
+    }
+    results
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session scanning
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One scanned session: the folded messages plus the metadata the viewer
+/// list needs.
+struct CodeSession {
+    session_id: String,
+    dir: PathBuf,
+    summary: Option<String>,
+    first_message_time: String,
+    last_message_time: String,
+    messages: Vec<ClaudeMessage>,
+    /// Originating client value for `ClaudeSession.entrypoint`, following
+    /// the Claude Code pattern (`cli` / `claude-vscode` / …): the VS Code
+    /// extension stamps `custom.vscode_legacy_approval` into `state.json`
+    /// (`apps/vscode/src/runtime/legacy-approval.ts`), everything else ran
+    /// in the terminal.
+    entrypoint: String,
+}
+
+impl CodeSession {
+    fn into_claude_session(self) -> ClaudeSession {
+        let has_tool_use = self.messages.iter().any(|message| {
+            message
+                .content
+                .as_ref()
+                .and_then(Value::as_array)
+                .is_some_and(|blocks| {
+                    blocks
+                        .iter()
+                        .any(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
+                })
+        });
+
+        ClaudeSession {
+            session_id: self.session_id.clone(),
+            actual_session_id: self.session_id,
+            file_path: self.dir.to_string_lossy().to_string(),
+            project_name: String::new(),
+            message_count: self.messages.len(),
+            first_message_time: self.first_message_time,
+            last_message_time: self.last_message_time.clone(),
+            last_modified: self.last_message_time,
+            has_tool_use,
+            has_errors: false,
+            summary: self.summary,
+            is_renamed: false,
+            provider: Some(PROVIDER_ID.to_string()),
+            storage_type: Some("jsonl".to_string()),
+            entrypoint: Some(self.entrypoint),
+        }
+    }
+}
+
+/// Fold one session directory's main wire into a `CodeSession`; `None` when
+/// the session has no readable wire or produces no viewer messages.
+fn build_session(session_dir: &Path) -> Option<CodeSession> {
+    let wire = main_wire_path(session_dir);
+    if is_symlink(&wire) || !wire.is_file() {
+        return None;
+    }
+
+    let session_id = session_dir.file_name()?.to_string_lossy().to_string();
+    let state = read_state_json(session_dir);
+    let fallback_ts = state
+        .as_ref()
+        .and_then(|s| s.get("createdAt").and_then(Value::as_u64))
+        .and_then(ms_to_rfc3339)
+        .or_else(|| file_modified_iso(&wire))
+        .unwrap_or_default();
+
+    let messages = fold_wire_messages(&wire, &session_id, &fallback_ts);
+    if messages.is_empty() {
+        return None;
+    }
+
+    let first_message_time = messages
+        .first()
+        .map(|m| m.timestamp.clone())
+        .unwrap_or_default();
+    let last_message_time = messages
+        .last()
+        .map(|m| m.timestamp.clone())
+        .unwrap_or_default();
+
+    let title = state
+        .as_ref()
+        .and_then(|s| {
+            s.get("title")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+        })
+        .map(ToOwned::to_owned);
+    let summary = title
+        .or_else(|| first_user_text(&messages))
+        .map(|text| truncate_chars(&text, SUMMARY_MAX_CHARS));
+
+    let entrypoint = if state
+        .as_ref()
+        .and_then(|s| s.get("custom"))
+        .and_then(|custom| custom.get("vscode_legacy_approval"))
+        .is_some()
+    {
+        "kimi-vscode"
+    } else {
+        "kimi-cli"
+    };
+
+    Some(CodeSession {
+        session_id,
+        dir: session_dir.to_path_buf(),
+        summary,
+        first_message_time,
+        last_message_time,
+        messages,
+        entrypoint: entrypoint.to_string(),
+    })
+}
+
+/// `wd_*` directories under the sessions root, sorted for stable output.
+fn list_workspace_dirs(sessions_root: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(sessions_root) else {
+        return Vec::new();
+    };
+    let mut dirs: Vec<PathBuf> = entries
+        .flatten()
+        .filter(|entry| {
+            entry
+                .file_type()
+                .is_ok_and(|ft| !ft.is_symlink() && ft.is_dir())
+        })
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("wd_"))
+        })
+        .collect();
+    dirs.sort();
+    dirs
+}
+
+/// `session_*` directories under one workspace dir, sorted for stable output.
+fn list_session_dirs(workspace_dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(workspace_dir) else {
+        return Vec::new();
+    };
+    let mut dirs: Vec<PathBuf> = entries
+        .flatten()
+        .filter(|entry| {
+            entry
+                .file_type()
+                .is_ok_and(|ft| !ft.is_symlink() && ft.is_dir())
+        })
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("session_"))
+        })
+        .collect();
+    dirs.sort();
+    dirs
+}
+
+fn main_wire_path(session_dir: &Path) -> PathBuf {
+    session_dir
+        .join(AGENTS_DIR)
+        .join(MAIN_AGENT)
+        .join(WIRE_FILE)
+}
+
+fn read_state_json(session_dir: &Path) -> Option<Value> {
+    let path = session_dir.join(STATE_FILE);
+    if is_symlink(&path) || !path.is_file() {
+        return None;
+    }
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// First non-empty `state.json` `cwd` among a workspace's sessions — the
+/// fallback project root when `workspaces.json` has no entry.
+fn read_state_cwd(workspace_dir: &Path) -> Option<String> {
+    list_session_dirs(workspace_dir)
+        .into_iter()
+        .find_map(|dir| {
+            read_state_json(&dir)?
+                .get("cwd")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+}
+
+/// `workspaces.json` → `wd_<id>` → workspace root path.
+fn read_workspace_roots(root: &Path) -> HashMap<String, String> {
+    let path = root.join(WORKSPACES_FILE);
+    if is_symlink(&path) || !path.is_file() {
+        return HashMap::new();
+    }
+    let Ok(content) = fs::read_to_string(path) else {
+        return HashMap::new();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&content) else {
+        return HashMap::new();
+    };
+
+    value
+        .get("workspaces")
+        .and_then(Value::as_object)
+        .map(|workspaces| {
+            workspaces
+                .iter()
+                .filter_map(|(id, info)| {
+                    info.get("root")
+                        .and_then(Value::as_str)
+                        .filter(|root| !root.is_empty())
+                        .map(|root| (id.clone(), root.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn project_name_for_root(root: &str, workspace_id: &str) -> String {
+    Path::new(root)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| workspace_id.to_string())
+}
+
+fn project_name_for_workspace(
+    workspace_dir: &Path,
+    workspace_map: &HashMap<String, String>,
+) -> String {
+    let id = workspace_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_default();
+    workspace_map
+        .get(&id)
+        .map(|root| project_name_for_root(root, &id))
+        .unwrap_or_else(|| id)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire fold — the contextMemory/loopEventFold replay, in Rust
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A folded context message with the timestamp of the record that produced
+/// it (the fold itself carries no time).
+struct FoldedMessage {
+    role: String,
+    content: Vec<Value>,
+    tool_calls: Vec<Value>,
+    tool_call_id: Option<String>,
+    is_error: Option<bool>,
+    /// The wire message `id` (e.g. `msg_…`) — links prompt-owned injections
+    /// back to their anchor during the undo cut.
+    id: Option<String>,
+    /// The wire `origin` object — drives the undo-anchor cut.
+    origin: Option<Value>,
+    /// `true` while the assistant message is still absorbing loop events
+    /// (`step.begin` opened it, `step.end` has not settled it).
+    partial: bool,
+    timestamp: String,
+    model: Option<String>,
+}
+
+impl FoldedMessage {
+    fn origin_kind(&self) -> Option<&str> {
+        self.origin
+            .as_ref()
+            .and_then(|origin| origin.get("kind"))
+            .and_then(Value::as_str)
+    }
+
+    /// The agent core's `isUndoAnchor`: a user message the user themself
+    /// triggered (plain, or via user-slash skill/plugin commands).
+    fn is_undo_anchor(&self) -> bool {
+        if self.role != "user" {
+            return false;
+        }
+        match self.origin_kind() {
+            None | Some("user") => true,
+            Some("skill_activation" | "plugin_command") => {
+                self.origin
+                    .as_ref()
+                    .and_then(|origin| origin.get("trigger"))
+                    .and_then(Value::as_str)
+                    == Some("user-slash")
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Replay state — mirrors `loopEventFold.ts`'s `FoldCtx` plus the current
+/// model alias from the latest `profile.bind`/`llm.request` record.
+struct FoldState {
+    pending: Vec<String>,
+    deferred: Vec<FoldedMessage>,
+    model: Option<String>,
+}
+
+/// Replay `wire.jsonl` into viewer messages.
+///
+/// Best-effort: malformed lines and unknown record types are skipped — a
+/// partial journal must never fail the whole session.
+pub(crate) fn fold_wire_messages(
+    wire_path: &Path,
+    session_id: &str,
+    fallback_ts: &str,
+) -> Vec<ClaudeMessage> {
+    if is_symlink(wire_path) || !wire_path.is_file() {
+        return Vec::new();
+    }
+    let Ok(content) = fs::read_to_string(wire_path) else {
+        return Vec::new();
+    };
+
+    let mut history: Vec<FoldedMessage> = Vec::new();
+    let mut state = FoldState {
+        pending: Vec::new(),
+        deferred: Vec::new(),
+        model: None,
+    };
+    let mut last_ts = fallback_ts.to_string();
+
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(record) = serde_json::from_str::<Value>(line) else {
+            continue; // torn/malformed tail — skip like the agent core does
+        };
+        if let Some(ts) = record
+            .get("time")
+            .and_then(Value::as_u64)
+            .and_then(ms_to_rfc3339)
+        {
+            last_ts = ts;
+        }
+        let record_type = record.get("type").and_then(Value::as_str).unwrap_or("");
+        match record_type {
+            "profile.bind" | "llm.request" => {
+                let alias = record
+                    .get("modelAlias")
+                    .and_then(Value::as_str)
+                    .or_else(|| record.get("model").and_then(Value::as_str));
+                if let Some(alias) = alias {
+                    state.model = Some(alias.to_string());
+                }
+            }
+            "context.append_message" => {
+                if let Some(message) = record.get("message") {
+                    fold_append_message(&mut history, &mut state, message, &last_ts);
+                }
+            }
+            "context.append_loop_event" => {
+                if let Some(event) = record.get("event") {
+                    fold_loop_event(&mut history, &mut state, event, &last_ts);
+                }
+            }
+            "context.clear" => {
+                history.clear();
+                state.pending.clear();
+                state.deferred.clear();
+            }
+            "context.undo" => {
+                let count = record.get("count").and_then(Value::as_u64).unwrap_or(1) as usize;
+                apply_undo_cut(&mut history, count);
+            }
+            "context.apply_compaction" => {
+                fold_apply_compaction(&mut history, &mut state, &record, &last_ts);
+            }
+            _ => {}
+        }
+    }
+
+    // A journal cut mid-turn (crash) may still hold a partial assistant or
+    // open tool exchange — settle it exactly like a `step.end` would.
+    settle_open_step(&mut history, &mut state);
+
+    history
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, message)| convert_folded_message(message, session_id, index as u64))
+        .collect()
+}
+
+/// `ContextAppendMessage` fold: append unless a tool exchange is open, in
+/// which case defer until the exchange closes.
+fn fold_append_message(
+    history: &mut Vec<FoldedMessage>,
+    state: &mut FoldState,
+    message: &Value,
+    timestamp: &str,
+) {
+    let role = message.get("role").and_then(Value::as_str).unwrap_or("");
+    if role.is_empty() {
+        return;
+    }
+    let content = match message.get("content") {
+        Some(Value::Array(items)) => items.iter().map(normalize_content_part).collect::<Vec<_>>(),
+        Some(Value::String(text)) => vec![json!({ "type": "text", "text": text })],
+        _ => Vec::new(),
+    };
+    let tool_calls = message
+        .get("toolCalls")
+        .and_then(Value::as_array)
+        .map(|calls| calls.iter().map(convert_tool_call).collect())
+        .unwrap_or_default();
+
+    let folded = FoldedMessage {
+        role: role.to_string(),
+        content,
+        tool_calls,
+        tool_call_id: message
+            .get("toolCallId")
+            .and_then(Value::as_str)
+            .map(String::from),
+        is_error: message.get("isError").and_then(Value::as_bool),
+        id: message.get("id").and_then(Value::as_str).map(String::from),
+        origin: message.get("origin").cloned(),
+        partial: false,
+        timestamp: timestamp.to_string(),
+        model: state.model.clone(),
+    };
+
+    if state.pending.is_empty() {
+        history.push(folded);
+    } else {
+        state.deferred.push(folded);
+    }
+}
+
+/// `ContextAppendLoopEvent` fold — the streaming turn vocabulary.
+fn fold_loop_event(
+    history: &mut Vec<FoldedMessage>,
+    state: &mut FoldState,
+    event: &Value,
+    timestamp: &str,
+) {
+    let event_type = event.get("type").and_then(Value::as_str).unwrap_or("");
+    match event_type {
+        "step.begin" => {
+            settle_open_step(history, state);
+            history.push(FoldedMessage {
+                role: "assistant".to_string(),
+                content: Vec::new(),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+                is_error: None,
+                id: None,
+                origin: None,
+                partial: true,
+                timestamp: timestamp.to_string(),
+                model: state.model.clone(),
+            });
+        }
+        "content.part" => {
+            if let Some(part) = event.get("part") {
+                if let Some(open) = history.iter_mut().rev().find(|m| m.partial) {
+                    open.content.push(normalize_content_part(part));
+                }
+            }
+        }
+        "tool.call" => {
+            let id = event
+                .get("toolCallId")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let call = json!({
+                "type": "tool_use",
+                "id": id,
+                "name": event.get("name").and_then(Value::as_str).unwrap_or("tool"),
+                "input": event.get("args").cloned().unwrap_or_else(|| json!({})),
+            });
+            // Mirrors the fold: the call is pending even when no assistant
+            // step is open; the block itself needs an open step to land on.
+            state.pending.push(id);
+            if let Some(open) = history.iter_mut().rev().find(|m| m.partial) {
+                open.tool_calls.push(call);
+            }
+        }
+        "tool.result" => {
+            let Some(id) = event.get("toolCallId").and_then(Value::as_str) else {
+                return;
+            };
+            if !state.pending.iter().any(|pending| pending == id) {
+                return; // result without a recorded call — skip like the fold
+            }
+            state.pending.retain(|pending| pending != id);
+            let result = event.get("result").cloned().unwrap_or(Value::Null);
+            let output = result.get("output").cloned().unwrap_or(Value::Null);
+            history.push(FoldedMessage {
+                role: "tool".to_string(),
+                content: vec![output_marker(&output)],
+                tool_calls: Vec::new(),
+                tool_call_id: Some(id.to_string()),
+                is_error: result.get("isError").and_then(Value::as_bool),
+                id: None,
+                origin: None,
+                partial: false,
+                timestamp: timestamp.to_string(),
+                model: None,
+            });
+            flush_deferred(history, state);
+        }
+        "step.end" => {
+            settle_open_step(history, state);
+        }
+        _ => {}
+    }
+}
+
+/// Tool result outputs ride on the message as a marker part so the fold
+/// structure stays flat; conversion turns it into the viewer's
+/// `tool_result` shape.
+fn output_marker(output: &Value) -> Value {
+    json!({ "__kimi_code_output": output })
+}
+
+fn extract_output_marker(part: &Value) -> Option<&Value> {
+    part.get("__kimi_code_output")
+}
+
+/// `step.end` / crash-tail semantics: pending calls become interrupted
+/// tool messages, then the open assistant is dropped when it recorded
+/// nothing sendable, or sealed otherwise, and deferred messages flush.
+fn settle_open_step(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
+    close_pending(history, state);
+
+    if let Some(index) = history.iter().rposition(|message| message.partial) {
+        let vacuous = history[index].tool_calls.is_empty()
+            && history[index]
+                .content
+                .iter()
+                .all(|part| is_vacuous_content_part(part) && extract_output_marker(part).is_none());
+        if vacuous {
+            history.remove(index);
+        } else {
+            history[index].partial = false;
+        }
+    }
+
+    flush_deferred(history, state);
+}
+
+fn close_pending(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
+    if state.pending.is_empty() {
+        return;
+    }
+    let interrupted = json!(
+        "Tool execution was interrupted before its result was recorded. Do not assume the tool completed successfully."
+    );
+    for id in std::mem::take(&mut state.pending) {
+        history.push(FoldedMessage {
+            role: "tool".to_string(),
+            content: vec![output_marker(&interrupted)],
+            tool_calls: Vec::new(),
+            tool_call_id: Some(id),
+            is_error: Some(true),
+            id: None,
+            origin: None,
+            partial: false,
+            timestamp: String::new(),
+            model: None,
+        });
+    }
+    flush_deferred(history, state);
+}
+
+fn flush_deferred(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
+    if !state.pending.is_empty() || state.deferred.is_empty() {
+        return;
+    }
+    history.append(&mut state.deferred);
+}
+
+/// The agent core's `computeUndoCut`: walk back counting undo anchors
+/// (user prompts); the cut removes the anchor and everything after it, and
+/// extends backwards over injections the prompt owns. The walk stops at a
+/// compaction boundary.
+fn apply_undo_cut(history: &mut Vec<FoldedMessage>, count: usize) {
+    if history.is_empty() {
+        return;
+    }
+    let mut remaining = count;
+    let mut cut_index: Option<usize> = None;
+
+    for i in (0..history.len()).rev() {
+        if remaining == 0 {
+            break;
+        }
+        let message = &history[i];
+        match message.origin_kind() {
+            Some("injection") => continue,
+            Some("compaction_summary") => return,
+            _ => {}
+        }
+        if message.is_undo_anchor() {
+            remaining -= 1;
+            let mut cut = i;
+            // Extend over prompt-owned injections directly above the anchor
+            // (`injection.ownerPromptId === prompt.id` — the message id).
+            while cut > 0 {
+                let above = &history[cut - 1];
+                let owned = above.origin_kind() == Some("injection")
+                    && above
+                        .origin
+                        .as_ref()
+                        .and_then(|origin| origin.get("ownerPromptId"))
+                        .and_then(Value::as_str)
+                        .zip(message.id.as_deref())
+                        .is_some_and(|(owner, prompt_id)| owner == prompt_id);
+                if !owned {
+                    break;
+                }
+                cut -= 1;
+            }
+            cut_index = Some(cut);
+        }
+    }
+
+    if let Some(cut) = cut_index {
+        history.truncate(cut);
+    }
+}
+
+/// `ContextApplyCompaction` fold (viewer approximation): the compacted
+/// prefix is replaced by a summary message. The agent core keeps a tail of
+/// recent user messages; for history viewing the summary marker plus the
+/// fresh continuation is the faithful-enough reduction. The summary is
+/// tagged `compaction_summary` so a later undo stops at this boundary,
+/// exactly like the core.
+fn fold_apply_compaction(
+    history: &mut Vec<FoldedMessage>,
+    state: &mut FoldState,
+    record: &Value,
+    timestamp: &str,
+) {
+    let summary = record
+        .get("contextSummary")
+        .or_else(|| record.get("summary"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let text = match &summary {
+        Value::String(text) => Some(text.clone()),
+        Value::Object(message) => message
+            .get("content")
+            .and_then(Value::as_array)
+            .and_then(|parts| {
+                parts
+                    .iter()
+                    .find_map(|part| part.get("text").and_then(Value::as_str))
+            })
+            .map(String::from),
+        _ => None,
+    };
+
+    history.clear();
+    state.pending.clear();
+    state.deferred.clear();
+
+    if let Some(text) = text.filter(|text| !text.trim().is_empty()) {
+        history.push(FoldedMessage {
+            role: "user".to_string(),
+            content: vec![json!({
+                "type": "text",
+                "text": format!("[Compacted context summary]\n\n{text}")
+            })],
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+            is_error: None,
+            id: None,
+            origin: Some(json!({ "kind": "compaction_summary" })),
+            partial: false,
+            timestamp: timestamp.to_string(),
+            model: None,
+        });
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Folded message → viewer message
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn convert_folded_message(
+    message: FoldedMessage,
+    session_id: &str,
+    index: u64,
+) -> Option<ClaudeMessage> {
+    let uuid = format!("{session_id}-{index}");
+    let timestamp = message.timestamp.clone();
+
+    match message.role.as_str() {
+        "user" | "system" => {
+            // System-side appends (injections, notices) render as user
+            // turns, the same mapping the old CLI reader uses.
+            let mut blocks = message.content;
+            for call in &message.tool_calls {
+                blocks.push(call.clone());
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp,
+                "user",
+                Some("user"),
+                Some(Value::Array(blocks)),
+                None,
+            ))
+        }
+        "assistant" => {
+            let mut blocks = message.content;
+            for call in &message.tool_calls {
+                blocks.push(call.clone());
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp,
+                "assistant",
+                Some("assistant"),
+                Some(Value::Array(blocks)),
+                message.model,
+            ))
+        }
+        "tool" => {
+            // Pull the output marker back out into the tool_result shape.
+            let content = message
+                .content
+                .iter()
+                .find_map(extract_output_marker)
+                .cloned()
+                .unwrap_or(Value::Null);
+            let mut block = json!({
+                "type": "tool_result",
+                "tool_use_id": message.tool_call_id.unwrap_or_default(),
+                "content": content,
+            });
+            if message.is_error == Some(true) {
+                block["is_error"] = json!(true);
+            }
+            Some(build_provider_message(
+                PROVIDER_ID,
+                uuid,
+                session_id,
+                timestamp,
+                "tool",
+                Some("tool"),
+                Some(json!([block])),
+                None,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Normalize a wire content part for the viewer: `think` → the viewer's
+/// `thinking` shape (same mapping as the old CLI reader).
+fn normalize_content_part(part: &Value) -> Value {
+    if part.get("type").and_then(Value::as_str) == Some("think") {
+        return json!({
+            "type": "thinking",
+            "thinking": part.get("think").and_then(Value::as_str).unwrap_or(""),
+        });
+    }
+    part.clone()
+}
+
+/// Wire `toolCalls` entries (`{type: "function", id, name, arguments}` where
+/// `arguments` is a JSON *string* or null) → viewer `tool_use` blocks.
+fn convert_tool_call(call: &Value) -> Value {
+    let name = call.get("name").and_then(Value::as_str).unwrap_or("tool");
+    let input = call.get("arguments").cloned().unwrap_or(Value::Null);
+    let input = match input {
+        Value::String(text) => serde_json::from_str(&text).unwrap_or(json!({ "input": text })),
+        Value::Null => json!({}),
+        other => other,
+    };
+    json!({
+        "type": "tool_use",
+        "id": call.get("id").and_then(Value::as_str).unwrap_or(""),
+        "name": name,
+        "input": input,
+    })
+}
+
+/// The agent core's vacuous-content predicate: empty/whitespace text or an
+/// unsigned empty thinking block; media parts always carry content.
+fn is_vacuous_content_part(part: &Value) -> bool {
+    match part.get("type").and_then(Value::as_str) {
+        Some("text") => part
+            .get("text")
+            .and_then(Value::as_str)
+            .is_some_and(|text| text.trim().is_empty()),
+        Some("think" | "thinking") => {
+            let field = if part.get("think").is_some() {
+                "think"
+            } else {
+                "thinking"
+            };
+            part.get("encrypted").is_none()
+                && part
+                    .get(field)
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| text.trim().is_empty())
+        }
+        _ => false,
+    }
+}
+
+fn first_user_text(messages: &[ClaudeMessage]) -> Option<String> {
+    messages
+        .iter()
+        .find(|message| message.message_type == "user")
+        .and_then(|message| message.content.as_ref())
+        .and_then(Value::as_array)
+        .and_then(|blocks| {
+            blocks
+                .iter()
+                .find_map(|block| block.get("text").and_then(Value::as_str))
+        })
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    match text.char_indices().nth(max_chars) {
+        Some((idx, _)) => format!("{}...", &text[..idx]),
+        None => text.to_string(),
+    }
+}
+
+fn ms_to_rfc3339(ms: u64) -> Option<String> {
+    Utc.timestamp_millis_opt(i64::try_from(ms).ok()?)
+        .single()
+        .map(|dt| dt.to_rfc3339())
+}
+
+fn file_modified_iso(path: &Path) -> Option<String> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .map(|time| {
+            let dt: chrono::DateTime<Utc> = time.into();
+            dt.to_rfc3339()
+        })
+}
+
+/// Resolve the `kimi-code://`-stripped workspace path to a real directory
+/// under the store's sessions root — canonical-form comparison so a
+/// symlinked workspace dir cannot redirect reads outside the store.
+fn resolve_workspace_dir(root: &Path, workspace_path: &str) -> Result<PathBuf, String> {
+    let workspace = Path::new(workspace_path);
+    if !workspace.is_absolute() {
+        return Err("Kimi Code workspace path must be absolute".to_string());
+    }
+    if is_symlink(workspace) || !workspace.is_dir() {
+        return Err("Kimi Code workspace path is not a directory".to_string());
+    }
+
+    let canonical_root = root
+        .join(SESSIONS_DIR)
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve Kimi Code sessions root: {e}"))?;
+    let canonical_workspace = workspace
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve Kimi Code workspace path: {e}"))?;
+    if !canonical_workspace.starts_with(&canonical_root) {
+        return Err("Kimi Code workspace path is outside the sessions directory".to_string());
+    }
+
+    Ok(canonical_workspace)
+}
+
+/// Reject anything that is not a real, non-symlink `sessions/wd_*/session_*`
+/// directory under the kimi-code root — canonical-form comparison so a
+/// symlinked session dir cannot redirect reads outside the store.
+fn validate_session_dir(root: &Path, session_path: &str) -> Result<PathBuf, String> {
+    let session_dir = Path::new(session_path);
+    if !session_dir.is_absolute() {
+        return Err("Kimi Code session path must be absolute".to_string());
+    }
+    if is_symlink(session_dir) || !session_dir.is_dir() {
+        return Err("Kimi Code session path is not a directory".to_string());
+    }
+
+    let sessions_root = root.join(SESSIONS_DIR);
+    let canonical_root = sessions_root
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve Kimi Code sessions root: {e}"))?;
+    let canonical_session = session_dir
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve Kimi Code session path: {e}"))?;
+    if !canonical_session.starts_with(&canonical_root) {
+        return Err("Kimi Code session path is outside the sessions directory".to_string());
+    }
+
+    Ok(canonical_session)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Root of a fixture kimi-code store: `<temp>/.kimi-code`.
+    fn code_root(temp: &TempDir) -> PathBuf {
+        let root = temp.path().join(".kimi-code");
+        fs::create_dir_all(&root).expect("create kimi-code root");
+        root
+    }
+
+    fn sessions_root(root: &Path) -> PathBuf {
+        let sessions = root.join(SESSIONS_DIR);
+        fs::create_dir_all(&sessions).expect("create sessions root");
+        sessions
+    }
+
+    fn write_workspace_map(root: &Path) {
+        fs::write(
+            root.join(WORKSPACES_FILE),
+            r#"{"version":1,"workspaces":{"wd_demo_abc123":{"root":"/tmp/demo-project","name":"demo-project","created_at":"2026-08-01T00:00:00.000Z","last_opened_at":"2026-08-02T00:00:00.000Z"}}}"#,
+        )
+        .expect("write workspaces.json");
+    }
+
+    fn write_session(
+        root: &Path,
+        workspace: &str,
+        session: &str,
+        state_json: &str,
+        wire_lines: &[&str],
+    ) -> PathBuf {
+        let session_dir = root.join(SESSIONS_DIR).join(workspace).join(session);
+        let wire_dir = session_dir.join(AGENTS_DIR).join(MAIN_AGENT);
+        fs::create_dir_all(&wire_dir).expect("create wire dir");
+        fs::write(session_dir.join(STATE_FILE), state_json).expect("write state.json");
+        fs::write(wire_dir.join(WIRE_FILE), wire_lines.join("\n")).expect("write wire.jsonl");
+        session_dir
+    }
+
+    fn default_state() -> String {
+        r#"{"id":"session_x","version":2,"cwd":"/tmp/demo-project","archived":false,"agents":{"main":{"type":"main"}},"title":"","createdAt":1786957369672,"updatedAt":1787034652121}"#
+            .to_string()
+    }
+
+    /// A full turn: user prompt, one thinking part + a tool call, the tool
+    /// result inside the same step, then the closing assistant text — the
+    /// documented loop vocabulary in its real on-disk order.
+    fn full_turn_wire() -> Vec<&'static str> {
+        vec![
+            r#"{"type":"metadata","protocol_version":"1.5","created_at":1786959458480}"#,
+            r#"{"type":"profile.bind","modelAlias":"kimi-code/k3","profileName":"agent","time":1786959458490}"#,
+            r#"{"type":"turn.prompt","input":[{"type":"text","text":"Read the file"}],"origin":{"kind":"user"},"time":1786959458516}"#,
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"Read the file"}],"toolCalls":[],"origin":{"kind":"user"},"id":"msg_u1"},"time":1786959458516}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1","turnId":"0","step":1},"time":1786959458517}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"p1","stepUuid":"s1","part":{"type":"think","think":"user wants the file"}},"time":1786959458518}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"t1","stepUuid":"s1","toolCallId":"tool_a","name":"Read","args":{"path":"src/main.rs"}},"time":1786959458519}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"t1","toolCallId":"tool_a","result":{"output":"fn main() {}"}},"time":1786959458520}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1","turnId":"0","step":1,"finishReason":"tool_use"},"time":1786959458521}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s2","turnId":"0","step":2},"time":1786959458522}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"p2","stepUuid":"s2","part":{"type":"text","text":"Here is main.rs"}},"time":1786959458523}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s2","turnId":"0","step":2,"finishReason":"end_turn"},"time":1786959458524}"#,
+            "{ not json — torn tail is skipped",
+        ]
+    }
+
+    #[test]
+    fn scan_projects_groups_sessions_by_workspace_directory() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        write_workspace_map(&root);
+        write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_one",
+            &default_state(),
+            &full_turn_wire(),
+        );
+        // Not in workspaces.json → falls back to state.json cwd.
+        let other_state =
+            r#"{"id":"session_y","version":2,"cwd":"/Users/jack/other","createdAt":1786957369672}"#;
+        write_session(
+            &root,
+            "wd_other_zzz",
+            "session_two",
+            other_state,
+            &full_turn_wire(),
+        );
+        // A workspace with no valid sessions is not a project.
+        fs::create_dir_all(sessions_root(&root).join("wd_empty")).expect("empty workspace");
+
+        let mut projects = scan_projects_from_root(&sessions_root(&root));
+        projects.sort_by(|a, b| a.path.cmp(&b.path));
+
+        assert_eq!(projects.len(), 2);
+        // Path order: `wd_demo_abc123` < `wd_other_zzz`.
+        // Named workspace root (workspaces.json) wins for the indexed one…
+        assert_eq!(projects[0].name, "demo-project");
+        assert_eq!(
+            projects[0].path,
+            format!("{SCHEME}{}/sessions/wd_demo_abc123", root.display())
+        );
+        assert_eq!(projects[0].actual_path, "/tmp/demo-project");
+        assert_eq!(projects[0].session_count, 1);
+        assert_eq!(projects[0].provider.as_deref(), Some("kimi"));
+        // …state.json cwd is the fallback for the unindexed one.
+        assert_eq!(projects[1].name, "other");
+        assert_eq!(projects[1].actual_path, "/Users/jack/other");
+    }
+
+    #[test]
+    fn scan_projects_falls_back_to_state_cwd_without_workspace_map() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let state = r#"{"id":"session_x","version":2,"cwd":"/Users/jack/my-repo","createdAt":1786957369672}"#;
+        write_session(
+            &root,
+            "wd_solo_123",
+            "session_one",
+            state,
+            &full_turn_wire(),
+        );
+
+        let projects = scan_projects_from_root(&sessions_root(&root));
+
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "my-repo");
+        assert_eq!(projects[0].actual_path, "/Users/jack/my-repo");
+    }
+
+    #[test]
+    fn load_sessions_reports_metadata_and_entrypoint() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        write_workspace_map(&root);
+        write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_one",
+            &default_state(),
+            &full_turn_wire(),
+        );
+
+        let sessions = load_sessions_from_dir(&sessions_root(&root).join("wd_demo_abc123"));
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "session_one");
+        // default_state carries no vscode custom marker → CLI entrypoint.
+        assert_eq!(sessions[0].entrypoint.as_deref(), Some("kimi-cli"));
+        assert_eq!(
+            sessions[0].message_count, 4,
+            "user + assistant + tool + assistant"
+        );
+        assert!(sessions[0].has_tool_use);
+        // No title in state.json → summary falls back to first user text.
+        assert_eq!(sessions[0].summary.as_deref(), Some("Read the file"));
+        assert!(sessions[0].first_message_time.starts_with("2026-08"));
+    }
+
+    #[test]
+    fn load_sessions_marks_vscode_sessions_by_state_custom_marker() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let vscode_state = r#"{"id":"session_x","version":2,"cwd":"/tmp/demo","custom":{"vscode_legacy_approval":{"yolo":false,"afk":false}},"createdAt":1786957369672}"#;
+        write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_vs",
+            vscode_state,
+            &full_turn_wire(),
+        );
+        write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_cli",
+            &default_state(),
+            &full_turn_wire(),
+        );
+
+        let sessions = load_sessions_from_dir(&sessions_root(&root).join("wd_demo_abc123"));
+
+        let by_id = |id: &str| sessions.iter().find(|s| s.session_id == id).unwrap();
+        assert_eq!(
+            by_id("session_vs").entrypoint.as_deref(),
+            Some("kimi-vscode")
+        );
+        assert_eq!(by_id("session_cli").entrypoint.as_deref(), Some("kimi-cli"));
+    }
+
+    #[test]
+    fn load_sessions_prefers_state_title_over_first_user_text() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let state = r#"{"id":"session_x","version":2,"cwd":"/tmp/demo","title":"Custom title","createdAt":1786957369672}"#;
+        write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_one",
+            state,
+            &full_turn_wire(),
+        );
+
+        let sessions = load_sessions_from_dir(&sessions_root(&root).join("wd_demo_abc123"));
+
+        assert_eq!(sessions[0].summary.as_deref(), Some("Custom title"));
+    }
+
+    #[test]
+    fn fold_maps_loop_events_to_viewer_messages() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        write_workspace_map(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_one",
+            &default_state(),
+            &full_turn_wire(),
+        );
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 4);
+
+        // User message from context.append_message.
+        assert_eq!(messages[0].message_type, "user");
+        assert_eq!(
+            messages[0].content.as_ref().unwrap()[0]["text"],
+            "Read the file"
+        );
+
+        // First assistant step: thinking part + tool_use block.
+        assert_eq!(messages[1].message_type, "assistant");
+        assert_eq!(messages[1].model.as_deref(), Some("kimi-code/k3"));
+        let blocks = messages[1].content.as_ref().unwrap();
+        assert_eq!(blocks[0]["type"], "thinking");
+        assert_eq!(blocks[0]["thinking"], "user wants the file");
+        assert_eq!(blocks[1]["type"], "tool_use");
+        assert_eq!(blocks[1]["name"], "Read");
+        assert_eq!(blocks[1]["input"]["path"], "src/main.rs");
+
+        // Tool result message.
+        assert_eq!(messages[2].message_type, "tool");
+        let result = &messages[2].content.as_ref().unwrap()[0];
+        assert_eq!(result["type"], "tool_result");
+        assert_eq!(result["tool_use_id"], "tool_a");
+        assert_eq!(result["content"], "fn main() {}");
+
+        // Second assistant step: plain text.
+        assert_eq!(messages[3].message_type, "assistant");
+        assert_eq!(
+            messages[3].content.as_ref().unwrap()[0]["text"],
+            "Here is main.rs"
+        );
+    }
+
+    #[test]
+    fn fold_drops_vacuous_assistant_step() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"hi"}],"toolCalls":[]},"time":1786959458516}"#,
+            // Step with only whitespace text → dropped on settle.
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"content.part","stepUuid":"s1","part":{"type":"text","text":"   "}},"time":1786959458518}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1"},"time":1786959458519}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 1, "only the user message survives");
+    }
+
+    #[test]
+    fn fold_interrupted_tool_call_settles_with_error_result() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"run it"}],"toolCalls":[]},"time":1786959458516}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.call","stepUuid":"s1","toolCallId":"tool_b","name":"Bash","args":{"command":"ls"}},"time":1786959458518}"#,
+            // Journal ends mid-exchange: no tool.result, no step.end.
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[2].message_type, "tool");
+        let result = &messages[2].content.as_ref().unwrap()[0];
+        assert_eq!(result["is_error"], true);
+        assert!(result["content"].as_str().unwrap().contains("interrupted"));
+    }
+
+    #[test]
+    fn fold_defers_user_message_until_tool_exchange_closes() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"first"}],"toolCalls":[]},"time":1786959458516}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.call","stepUuid":"s1","toolCallId":"tool_c","name":"Read","args":{"path":"a"}},"time":1786959458518}"#,
+            // Queued follow-up arrives while the tool exchange is open…
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"second"}],"toolCalls":[]},"time":1786959458519}"#,
+            // …and must land after the tool result, not before it.
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"tool_c","result":{"output":"data"}},"time":1786959458520}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1"},"time":1786959458521}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        let roles: Vec<&str> = messages.iter().map(|m| m.message_type.as_str()).collect();
+        assert_eq!(roles, vec!["user", "assistant", "tool", "user"]);
+    }
+
+    #[test]
+    fn fold_undo_cuts_the_last_user_turn_not_just_one_message() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"one"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m1"},"time":1786959458516}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"content.part","stepUuid":"s1","part":{"type":"text","text":"answer one"}},"time":1786959458518}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1"},"time":1786959458519}"#,
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"two"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m2"},"time":1786959458520}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s2"},"time":1786959458521}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"content.part","stepUuid":"s2","part":{"type":"text","text":"answer two"}},"time":1786959458522}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s2"},"time":1786959458523}"#,
+            // Undo one turn → the whole second turn (user + answer) goes.
+            r#"{"type":"context.undo","count":1,"time":1786959458524}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].content.as_ref().unwrap()[0]["text"], "one");
+        assert_eq!(
+            messages[1].content.as_ref().unwrap()[0]["text"],
+            "answer one"
+        );
+    }
+
+    #[test]
+    fn fold_undo_stops_at_compaction_boundary() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.apply_compaction","contextSummary":"summary","compactedCount":3,"time":1786959458515}"#,
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"post-compaction"}],"toolCalls":[],"origin":{"kind":"user"}},"time":1786959458516}"#,
+            // Undo beyond the boundary does nothing (walk stops there).
+            r#"{"type":"context.undo","count":5,"time":1786959458520}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 2, "summary + post-compaction prompt stay");
+    }
+
+    #[test]
+    fn fold_applies_clear_and_compaction() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"one"}],"toolCalls":[]},"time":1786959458516}"#,
+            r#"{"type":"context.apply_compaction","contextSummary":"Earlier discussion about setup.","compactedCount":1,"time":1786959458519}"#,
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"after compaction"}],"toolCalls":[]},"time":1786959458520}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 2);
+        let first_text = messages[0].content.as_ref().unwrap()[0]["text"]
+            .as_str()
+            .unwrap();
+        assert!(first_text.contains("Compacted context summary"));
+        assert!(first_text.contains("Earlier discussion about setup."));
+        assert_eq!(
+            messages[1].content.as_ref().unwrap()[0]["text"],
+            "after compaction"
+        );
+    }
+
+    #[test]
+    fn tool_arguments_string_form_is_parsed() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"assistant","content":[],"toolCalls":[{"type":"function","id":"tool_s","name":"Bash","arguments":"{\"command\":\"pwd\"}"}]},"time":1786959458516}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 1);
+        let block = &messages[0].content.as_ref().unwrap()[0];
+        assert_eq!(block["type"], "tool_use");
+        assert_eq!(block["input"]["command"], "pwd");
+    }
+
+    #[test]
+    fn search_matches_folded_content_and_respects_limit() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        write_workspace_map(&root);
+        write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_one",
+            &default_state(),
+            &full_turn_wire(),
+        );
+
+        let results = search_from_root(&sessions_root(&root), "main.rs", 10);
+        // Both the tool args and the closing assistant text match.
+        assert_eq!(results.len(), 2);
+        assert!(results
+            .iter()
+            .all(|message| message.project_name.as_deref() == Some("demo-project")));
+
+        assert!(search_from_root(&sessions_root(&root), "no-such-token", 10).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    /// A symlinked session directory pointing outside the store must be
+    /// rejected by the path guard, not read through.
+    fn load_messages_rejects_symlinked_session_dir() {
+        use std::os::unix::fs as unix_fs;
+
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        write_workspace_map(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_one",
+            &default_state(),
+            &full_turn_wire(),
+        );
+
+        let outside = TempDir::new().expect("outside dir");
+        let outside_root = code_root(&outside);
+        let outside_session = write_session(
+            &outside_root,
+            "wd_evil",
+            "session_x",
+            &default_state(),
+            &full_turn_wire(),
+        );
+
+        let link = root
+            .join(SESSIONS_DIR)
+            .join("wd_demo_abc123")
+            .join("session_link");
+        unix_fs::symlink(&outside_session, &link).expect("create symlink");
+
+        load_messages_from_root(&root, &link.to_string_lossy())
+            .expect_err("symlinked session dir must be rejected");
+        // The real session still loads.
+        assert!(load_messages_from_root(&root, &session_dir.to_string_lossy()).is_ok());
+    }
+
+    #[test]
+    fn sessions_without_wire_are_skipped() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        // state.json but no agents/main/wire.jsonl.
+        let session_dir = root.join(SESSIONS_DIR).join("wd_a").join("session_x");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        fs::write(session_dir.join(STATE_FILE), default_state()).expect("write state");
+
+        let projects = scan_projects_from_root(&sessions_root(&root));
+        assert!(projects.is_empty());
+    }
+}

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -51,6 +51,7 @@ use chrono::{TimeZone, Utc};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::fs;
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 
 /// The kimi-code layout is exposed through the existing `kimi` provider id
@@ -316,6 +317,20 @@ impl CodeSession {
                         .any(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
                 })
         });
+        // Error results surface as `is_error` tool_result blocks (folded
+        // from `tool.result` records or interrupted-pending compensation).
+        let has_errors = self.messages.iter().any(|message| {
+            message
+                .content
+                .as_ref()
+                .and_then(Value::as_array)
+                .is_some_and(|blocks| {
+                    blocks.iter().any(|block| {
+                        block.get("type").and_then(Value::as_str) == Some("tool_result")
+                            && block.get("is_error").and_then(Value::as_bool) == Some(true)
+                    })
+                })
+        });
 
         ClaudeSession {
             session_id: self.session_id.clone(),
@@ -327,7 +342,7 @@ impl CodeSession {
             last_message_time: self.last_message_time.clone(),
             last_modified: self.last_message_time,
             has_tool_use,
-            has_errors: false,
+            has_errors,
             summary: self.summary,
             is_renamed: false,
             provider: Some(PROVIDER_ID.to_string()),
@@ -602,9 +617,12 @@ pub(crate) fn fold_wire_messages(
     if is_symlink(wire_path) || !wire_path.is_file() {
         return Vec::new();
     }
-    let Ok(content) = fs::read_to_string(wire_path) else {
+    // Streamed line-by-line: scan folds every session's journal, so whole
+    // journal buffering would multiply peak memory by the session count.
+    let Ok(file) = fs::File::open(wire_path) else {
         return Vec::new();
     };
+    let reader = std::io::BufReader::new(file);
 
     let mut history: Vec<FoldedMessage> = Vec::new();
     let mut state = FoldState {
@@ -614,8 +632,11 @@ pub(crate) fn fold_wire_messages(
     };
     let mut last_ts = fallback_ts.to_string();
 
-    for line in content.lines().filter(|line| !line.trim().is_empty()) {
-        let Ok(record) = serde_json::from_str::<Value>(line) else {
+    for line in reader.lines().map_while(Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<Value>(&line) else {
             continue; // torn/malformed tail — skip like the agent core does
         };
         if let Some(ts) = record
@@ -654,6 +675,13 @@ pub(crate) fn fold_wire_messages(
             "context.undo" => {
                 let count = record.get("count").and_then(Value::as_u64).unwrap_or(1) as usize;
                 apply_undo_cut(&mut history, count);
+                // The cut removed the assistant holding the open tool
+                // exchange, so its pending calls and any messages deferred
+                // behind that exchange are gone with it — keeping them
+                // would resurrect interrupted results for calls that no
+                // longer exist.
+                state.pending.clear();
+                state.deferred.clear();
             }
             "context.apply_compaction" => {
                 fold_apply_compaction(&mut history, &mut state, &record, &last_ts);
@@ -664,7 +692,7 @@ pub(crate) fn fold_wire_messages(
 
     // A journal cut mid-turn (crash) may still hold a partial assistant or
     // open tool exchange — settle it exactly like a `step.end` would.
-    settle_open_step(&mut history, &mut state);
+    settle_open_step(&mut history, &mut state, &last_ts);
 
     history
         .into_iter()
@@ -729,7 +757,7 @@ fn fold_loop_event(
     let event_type = event.get("type").and_then(Value::as_str).unwrap_or("");
     match event_type {
         "step.begin" => {
-            settle_open_step(history, state);
+            settle_open_step(history, state, timestamp);
             history.push(FoldedMessage {
                 role: "assistant".to_string(),
                 content: Vec::new(),
@@ -794,7 +822,7 @@ fn fold_loop_event(
             flush_deferred(history, state);
         }
         "step.end" => {
-            settle_open_step(history, state);
+            settle_open_step(history, state, timestamp);
         }
         _ => {}
     }
@@ -814,8 +842,8 @@ fn extract_output_marker(part: &Value) -> Option<&Value> {
 /// `step.end` / crash-tail semantics: pending calls become interrupted
 /// tool messages, then the open assistant is dropped when it recorded
 /// nothing sendable, or sealed otherwise, and deferred messages flush.
-fn settle_open_step(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
-    close_pending(history, state);
+fn settle_open_step(history: &mut Vec<FoldedMessage>, state: &mut FoldState, timestamp: &str) {
+    close_pending(history, state, timestamp);
 
     if let Some(index) = history.iter().rposition(|message| message.partial) {
         let vacuous = history[index].tool_calls.is_empty()
@@ -833,7 +861,7 @@ fn settle_open_step(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
     flush_deferred(history, state);
 }
 
-fn close_pending(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
+fn close_pending(history: &mut Vec<FoldedMessage>, state: &mut FoldState, timestamp: &str) {
     if state.pending.is_empty() {
         return;
     }
@@ -850,7 +878,7 @@ fn close_pending(history: &mut Vec<FoldedMessage>, state: &mut FoldState) {
             id: None,
             origin: None,
             partial: false,
-            timestamp: String::new(),
+            timestamp: timestamp.to_string(),
             model: None,
         });
     }
@@ -1139,56 +1167,46 @@ fn file_modified_iso(path: &Path) -> Option<String> {
         })
 }
 
-/// Resolve the `kimi-code://`-stripped workspace path to a real directory
-/// under the store's sessions root — canonical-form comparison so a
-/// symlinked workspace dir cannot redirect reads outside the store.
-fn resolve_workspace_dir(root: &Path, workspace_path: &str) -> Result<PathBuf, String> {
-    let workspace = Path::new(workspace_path);
-    if !workspace.is_absolute() {
-        return Err("Kimi Code workspace path must be absolute".to_string());
+/// Resolve `path` to its canonical form and require that it stays inside
+/// `<root>/sessions`. Rejects relative paths and symlinked entries — a
+/// symlinked directory cannot redirect reads outside the store. This
+/// guarantees containment only; it does not check the `wd_*/session_*`
+/// naming shape (a contained path without a readable `agents/main/wire.jsonl`
+/// simply yields no messages).
+fn resolve_within_sessions(root: &Path, path: &str, label: &str) -> Result<PathBuf, String> {
+    let target = Path::new(path);
+    if !target.is_absolute() {
+        return Err(format!("Kimi Code {label} path must be absolute"));
     }
-    if is_symlink(workspace) || !workspace.is_dir() {
-        return Err("Kimi Code workspace path is not a directory".to_string());
+    if is_symlink(target) || !target.is_dir() {
+        return Err(format!("Kimi Code {label} path is not a directory"));
     }
 
     let canonical_root = root
         .join(SESSIONS_DIR)
         .canonicalize()
         .map_err(|e| format!("Failed to resolve Kimi Code sessions root: {e}"))?;
-    let canonical_workspace = workspace
+    let canonical_target = target
         .canonicalize()
-        .map_err(|e| format!("Failed to resolve Kimi Code workspace path: {e}"))?;
-    if !canonical_workspace.starts_with(&canonical_root) {
-        return Err("Kimi Code workspace path is outside the sessions directory".to_string());
+        .map_err(|e| format!("Failed to resolve Kimi Code {label} path: {e}"))?;
+    if !canonical_target.starts_with(&canonical_root) {
+        return Err(format!(
+            "Kimi Code {label} path is outside the sessions directory"
+        ));
     }
 
-    Ok(canonical_workspace)
+    Ok(canonical_target)
 }
 
-/// Reject anything that is not a real, non-symlink `sessions/wd_*/session_*`
-/// directory under the kimi-code root — canonical-form comparison so a
-/// symlinked session dir cannot redirect reads outside the store.
+/// Resolve the `kimi-code://`-stripped workspace path to a real directory
+/// under the store's sessions root.
+fn resolve_workspace_dir(root: &Path, workspace_path: &str) -> Result<PathBuf, String> {
+    resolve_within_sessions(root, workspace_path, "workspace")
+}
+
+/// Resolve a session directory under the store's sessions root.
 fn validate_session_dir(root: &Path, session_path: &str) -> Result<PathBuf, String> {
-    let session_dir = Path::new(session_path);
-    if !session_dir.is_absolute() {
-        return Err("Kimi Code session path must be absolute".to_string());
-    }
-    if is_symlink(session_dir) || !session_dir.is_dir() {
-        return Err("Kimi Code session path is not a directory".to_string());
-    }
-
-    let sessions_root = root.join(SESSIONS_DIR);
-    let canonical_root = sessions_root
-        .canonicalize()
-        .map_err(|e| format!("Failed to resolve Kimi Code sessions root: {e}"))?;
-    let canonical_session = session_dir
-        .canonicalize()
-        .map_err(|e| format!("Failed to resolve Kimi Code session path: {e}"))?;
-    if !canonical_session.starts_with(&canonical_root) {
-        return Err("Kimi Code session path is outside the sessions directory".to_string());
-    }
-
-    Ok(canonical_session)
+    resolve_within_sessions(root, session_path, "session")
 }
 
 #[cfg(test)]
@@ -1559,6 +1577,104 @@ mod tests {
             load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
 
         assert_eq!(messages.len(), 2, "summary + post-compaction prompt stay");
+    }
+
+    #[test]
+    fn fold_undo_extends_over_prompt_owned_injections() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"keep"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m1"},"time":1786959458516}"#,
+            // Owned by m2 → must be cut together with m2.
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"owned injection"}],"toolCalls":[],"origin":{"kind":"injection","ownerPromptId":"m2"},"id":"i1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"drop"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m2"},"time":1786959458518}"#,
+            r#"{"type":"context.undo","count":1,"time":1786959458519}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "the owned injection is cut with its prompt"
+        );
+        assert_eq!(messages[0].content.as_ref().unwrap()[0]["text"], "keep");
+    }
+
+    #[test]
+    fn fold_undo_keeps_injections_owned_by_another_prompt() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"keep"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m1"},"time":1786959458516}"#,
+            // Owned by m1 → NOT cut by undoing m2.
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"foreign injection"}],"toolCalls":[],"origin":{"kind":"injection","ownerPromptId":"m1"},"id":"i1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"drop"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m2"},"time":1786959458518}"#,
+            r#"{"type":"context.undo","count":1,"time":1786959458519}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 2, "the foreign injection survives");
+        assert_eq!(
+            messages[1].content.as_ref().unwrap()[0]["text"],
+            "foreign injection"
+        );
+    }
+
+    #[test]
+    fn interrupted_tool_message_carries_the_current_timestamp() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"run"}],"toolCalls":[]},"time":1786959458516}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.call","stepUuid":"s1","toolCallId":"tool_x","name":"Bash","args":{"command":"ls"}},"time":1786959458518}"#,
+            // Journal cut mid-exchange: no tool.result, no step.end. The
+            // final settle must stamp the interrupted message with the last
+            // seen time, not an empty string (session sorting depends on it).
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        let interrupted = messages.last().expect("interrupted tool message");
+        assert!(!interrupted.timestamp.is_empty());
+        assert!(interrupted.timestamp.starts_with("2026-08"));
+    }
+
+    #[test]
+    fn undo_during_open_tool_exchange_drops_pending_and_deferred() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let wire = vec![
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"keep"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m0"},"time":1786959458515}"#,
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"first"}],"toolCalls":[],"origin":{"kind":"user"},"id":"m1"},"time":1786959458516}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1786959458517}"#,
+            r#"{"type":"context.append_loop_event","event":{"type":"tool.call","stepUuid":"s1","toolCallId":"tool_y","name":"Read","args":{"path":"a"}},"time":1786959458518}"#,
+            // A follow-up queues behind the open exchange…
+            r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"second"}],"toolCalls":[]},"time":1786959458519}"#,
+            // …then the m1 turn is undone mid-exchange. The pending call
+            // and the deferred message must vanish with the cut, not
+            // resurrect an interrupted result afterwards.
+            r#"{"type":"context.undo","count":1,"time":1786959458520}"#,
+        ];
+        let session_dir = write_session(&root, "wd_a", "session_x", &default_state(), &wire);
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+
+        assert_eq!(messages.len(), 1, "only the pre-anchor user prompt remains");
+        assert_eq!(messages[0].content.as_ref().unwrap()[0]["text"], "keep");
+        assert!(
+            !messages.iter().any(|m| m.message_type == "tool"),
+            "no ghost interrupted result for the undone tool call"
+        );
     }
 
     #[test]

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -69,6 +69,11 @@ const MAIN_AGENT: &str = "main";
 const WIRE_FILE: &str = "wire.jsonl";
 const STATE_FILE: &str = "state.json";
 const WORKSPACES_FILE: &str = "workspaces.json";
+/// Content-addressed store for pasted images, beside each agent's wire.
+const BLOBS_DIR: &str = "blobs";
+/// Largest blob inlined as base64 into a message (8 MiB). Bigger images are
+/// left as their raw `image_url` part instead of being held in memory.
+const MAX_INLINE_BLOB_BYTES: u64 = 8 * 1024 * 1024;
 const SUMMARY_MAX_CHARS: usize = 200;
 
 /// Default kimi-code home. Mirrors the agent core's bootstrap: the
@@ -603,6 +608,9 @@ struct FoldState {
     pending: Vec<String>,
     deferred: Vec<FoldedMessage>,
     model: Option<String>,
+    /// `<session>/agents/<agent>/blobs` — where `blobref:` image parts
+    /// resolve to. Sits beside the wire being folded.
+    blobs_dir: PathBuf,
 }
 
 /// Replay `wire.jsonl` into viewer messages.
@@ -629,6 +637,7 @@ pub(crate) fn fold_wire_messages(
         pending: Vec::new(),
         deferred: Vec::new(),
         model: None,
+        blobs_dir: wire_path.parent().unwrap_or(Path::new("")).join(BLOBS_DIR),
     };
     let mut last_ts = fallback_ts.to_string();
 
@@ -718,7 +727,10 @@ fn fold_append_message(
         return;
     }
     let content = match message.get("content") {
-        Some(Value::Array(items)) => items.iter().map(normalize_content_part).collect::<Vec<_>>(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(|part| normalize_content_part(part, &state.blobs_dir))
+            .collect::<Vec<_>>(),
         Some(Value::String(text)) => vec![json!({ "type": "text", "text": text })],
         _ => Vec::new(),
     };
@@ -777,8 +789,9 @@ fn fold_loop_event(
         }
         "content.part" => {
             if let Some(part) = event.get("part") {
+                let normalized = normalize_content_part(part, &state.blobs_dir);
                 if let Some(open) = history.iter_mut().rev().find(|m| m.partial) {
-                    open.content.push(normalize_content_part(part));
+                    open.content.push(normalized);
                 }
             }
         }
@@ -1085,14 +1098,71 @@ fn convert_folded_message(
 
 /// Normalize a wire content part for the viewer: `think` → the viewer's
 /// `thinking` shape (same mapping as the old CLI reader).
-fn normalize_content_part(part: &Value) -> Value {
-    if part.get("type").and_then(Value::as_str) == Some("think") {
-        return json!({
+fn normalize_content_part(part: &Value, blobs_dir: &Path) -> Value {
+    match part.get("type").and_then(Value::as_str) {
+        Some("think") => json!({
             "type": "thinking",
             "thinking": part.get("think").and_then(Value::as_str).unwrap_or(""),
-        });
+        }),
+        // Pasted images. Unresolvable refs are left verbatim: an `image`
+        // block with no usable source renders as nothing at all, so the raw
+        // part is the more honest fallback.
+        Some("image_url") => part
+            .get("imageUrl")
+            .and_then(|image| image.get("url"))
+            .and_then(Value::as_str)
+            .and_then(|url| image_source_from_url(url, blobs_dir))
+            .map(|source| json!({ "type": "image", "source": source }))
+            .unwrap_or_else(|| part.clone()),
+        _ => part.clone(),
     }
-    part.clone()
+}
+
+/// Resolve a kimi-code image URL into a Claude-shaped `image` source.
+///
+/// Three forms occur: `blobref:<media-type>;<sha256>` (the persisted form —
+/// bytes live in the session's blob store), an inline `data:` URL, and a
+/// plain remote URL.
+fn image_source_from_url(url: &str, blobs_dir: &Path) -> Option<Value> {
+    if let Some(rest) = url.strip_prefix("blobref:") {
+        let (media_type, digest) = rest.split_once(';')?;
+        // Content-addressed: the digest is the file name, so reject anything
+        // that could escape the blob store.
+        if digest.is_empty() || !digest.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return None;
+        }
+        let blob = blobs_dir.join(digest);
+        if is_symlink(&blob) {
+            return None;
+        }
+        // Guard peak memory: scanning folds every session, and base64 adds
+        // another third on top of the file itself.
+        let too_large = fs::metadata(&blob).is_ok_and(|meta| meta.len() > MAX_INLINE_BLOB_BYTES);
+        if too_large {
+            return None;
+        }
+        let bytes = fs::read(&blob).ok()?;
+        return Some(json!({
+            "type": "base64",
+            "media_type": media_type,
+            "data": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes),
+        }));
+    }
+
+    if let Some(rest) = url.strip_prefix("data:") {
+        let (media_type, data) = rest.split_once(";base64,")?;
+        return Some(json!({
+            "type": "base64",
+            "media_type": media_type,
+            "data": data,
+        }));
+    }
+
+    if url.starts_with("http://") || url.starts_with("https://") {
+        return Some(json!({ "type": "url", "url": url }));
+    }
+
+    None
 }
 
 /// Wire `toolCalls` entries (`{type: "function", id, name, arguments}` where
@@ -1833,6 +1903,80 @@ mod tests {
             .expect_err("symlinked session dir must be rejected");
         // The real session still loads.
         assert!(load_messages_from_root(&root, &session_dir.to_string_lossy()).is_ok());
+    }
+
+    /// Pasted images persist as `image_url` parts pointing at a
+    /// content-addressed blob next to the wire; the viewer only understands
+    /// Claude-shaped `image` blocks, so the fold resolves them.
+    #[test]
+    fn image_url_parts_are_converted_to_claude_image_blocks() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        sessions_root(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_img",
+            &default_state(),
+            &[
+                r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"look"},{"type":"image_url","imageUrl":{"url":"blobref:image/png;deadbeef"}},{"type":"image_url","imageUrl":{"url":"blobref:image/png;missing"}},{"type":"image_url","imageUrl":{"url":"https://example.com/a.png"}}],"origin":{"kind":"user"},"id":"msg_u1"},"time":1786959458516}"#,
+            ],
+        );
+        // The blob store sits beside the wire: <session>/agents/main/blobs/<sha>.
+        let blobs = session_dir.join(AGENTS_DIR).join(MAIN_AGENT).join("blobs");
+        fs::create_dir_all(&blobs).expect("create blobs dir");
+        fs::write(blobs.join("deadbeef"), [0x89u8, 0x50, 0x4e, 0x47]).expect("write blob");
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+        let parts = messages[0]
+            .content
+            .as_ref()
+            .and_then(Value::as_array)
+            .expect("content array");
+
+        assert_eq!(parts[1]["type"], "image");
+        assert_eq!(parts[1]["source"]["type"], "base64");
+        assert_eq!(parts[1]["source"]["media_type"], "image/png");
+        assert_eq!(parts[1]["source"]["data"], "iVBORw==");
+
+        // An unresolvable blobref stays verbatim rather than becoming an
+        // `image` block the renderer would silently drop.
+        assert_eq!(parts[2]["type"], "image_url");
+
+        assert_eq!(parts[3]["type"], "image");
+        assert_eq!(parts[3]["source"]["type"], "url");
+        assert_eq!(parts[3]["source"]["url"], "https://example.com/a.png");
+    }
+
+    /// Inline data URLs carry the bytes directly — no blob lookup needed.
+    #[test]
+    fn image_url_data_urls_are_converted_to_base64_image_blocks() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        sessions_root(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_data_url",
+            &default_state(),
+            &[
+                r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"image_url","imageUrl":{"url":"data:image/jpeg;base64,QUJD"}}],"origin":{"kind":"user"},"id":"msg_u1"},"time":1786959458516}"#,
+            ],
+        );
+
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+        let parts = messages[0]
+            .content
+            .as_ref()
+            .and_then(Value::as_array)
+            .expect("content array");
+
+        assert_eq!(parts[0]["type"], "image");
+        assert_eq!(parts[0]["source"]["type"], "base64");
+        assert_eq!(parts[0]["source"]["media_type"], "image/jpeg");
+        assert_eq!(parts[0]["source"]["data"], "QUJD");
     }
 
     #[test]

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -253,7 +253,12 @@ pub(crate) fn load_messages_from_root(
         .or_else(|| file_modified_iso(&wire))
         .unwrap_or_default();
 
-    Ok(fold_wire_messages(&wire, &session_id, &fallback_ts))
+    Ok(fold_wire_messages(
+        &wire,
+        &session_id,
+        &fallback_ts,
+        BlobPolicy::Resolve,
+    ))
 }
 
 pub(crate) fn search_from_root(
@@ -374,7 +379,8 @@ fn build_session(session_dir: &Path) -> Option<CodeSession> {
         .or_else(|| file_modified_iso(&wire))
         .unwrap_or_default();
 
-    let messages = fold_wire_messages(&wire, &session_id, &fallback_ts);
+    // Scanning and search only read text metadata back out of the fold.
+    let messages = fold_wire_messages(&wire, &session_id, &fallback_ts, BlobPolicy::Skip);
     if messages.is_empty() {
         return None;
     }
@@ -605,6 +611,17 @@ impl FoldedMessage {
     }
 }
 
+/// Whether the fold inlines `blobref:` images from the session's blob store.
+///
+/// Only the viewer needs the bytes. Scanning and search fold every journal
+/// too, but read nothing back out of an image part — resolving there would
+/// read and base64-encode every blob in the store only to discard it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BlobPolicy {
+    Resolve,
+    Skip,
+}
+
 /// Replay state — mirrors `loopEventFold.ts`'s `FoldCtx` plus the current
 /// model alias from the latest `profile.bind`/`llm.request` record.
 struct FoldState {
@@ -612,18 +629,20 @@ struct FoldState {
     deferred: Vec<FoldedMessage>,
     model: Option<String>,
     /// `<session>/agents/<agent>/blobs` — where `blobref:` image parts
-    /// resolve to. Sits beside the wire being folded.
-    blobs_dir: PathBuf,
+    /// resolve to. Sits beside the wire being folded; `None` under
+    /// `BlobPolicy::Skip`.
+    blobs_dir: Option<PathBuf>,
 }
 
 /// Replay `wire.jsonl` into viewer messages.
 ///
 /// Best-effort: malformed lines and unknown record types are skipped — a
 /// partial journal must never fail the whole session.
-pub(crate) fn fold_wire_messages(
+fn fold_wire_messages(
     wire_path: &Path,
     session_id: &str,
     fallback_ts: &str,
+    blobs: BlobPolicy,
 ) -> Vec<ClaudeMessage> {
     if is_symlink(wire_path) || !wire_path.is_file() {
         return Vec::new();
@@ -640,7 +659,8 @@ pub(crate) fn fold_wire_messages(
         pending: Vec::new(),
         deferred: Vec::new(),
         model: None,
-        blobs_dir: wire_path.parent().unwrap_or(Path::new("")).join(BLOBS_DIR),
+        blobs_dir: (blobs == BlobPolicy::Resolve)
+            .then(|| wire_path.parent().unwrap_or(Path::new("")).join(BLOBS_DIR)),
     };
     let mut last_ts = fallback_ts.to_string();
 
@@ -773,7 +793,7 @@ fn fold_append_message(
     let content = match message.get("content") {
         Some(Value::Array(items)) => items
             .iter()
-            .map(|part| normalize_content_part(part, &state.blobs_dir))
+            .map(|part| normalize_content_part(part, state.blobs_dir.as_deref()))
             .collect::<Vec<_>>(),
         Some(Value::String(text)) => vec![json!({ "type": "text", "text": text })],
         _ => Vec::new(),
@@ -835,7 +855,7 @@ fn fold_loop_event(
         }
         "content.part" => {
             if let Some(part) = event.get("part") {
-                let normalized = normalize_content_part(part, &state.blobs_dir);
+                let normalized = normalize_content_part(part, state.blobs_dir.as_deref());
                 if let Some(open) = history.iter_mut().rev().find(|m| m.partial) {
                     open.content.push(normalized);
                 }
@@ -1149,7 +1169,7 @@ fn convert_folded_message(
 
 /// Normalize a wire content part for the viewer: `think` → the viewer's
 /// `thinking` shape (same mapping as the old CLI reader).
-fn normalize_content_part(part: &Value, blobs_dir: &Path) -> Value {
+fn normalize_content_part(part: &Value, blobs_dir: Option<&Path>) -> Value {
     match part.get("type").and_then(Value::as_str) {
         Some("think") => json!({
             "type": "thinking",
@@ -1174,8 +1194,10 @@ fn normalize_content_part(part: &Value, blobs_dir: &Path) -> Value {
 /// Three forms occur: `blobref:<media-type>;<sha256>` (the persisted form —
 /// bytes live in the session's blob store), an inline `data:` URL, and a
 /// plain remote URL.
-fn image_source_from_url(url: &str, blobs_dir: &Path) -> Option<Value> {
+fn image_source_from_url(url: &str, blobs_dir: Option<&Path>) -> Option<Value> {
     if let Some(rest) = url.strip_prefix("blobref:") {
+        // Under `BlobPolicy::Skip` the part is left verbatim.
+        let blobs_dir = blobs_dir?;
         let (media_type, digest) = rest.split_once(';')?;
         // Content-addressed: the digest is the file name, so reject anything
         // that could escape the blob store.
@@ -1186,8 +1208,8 @@ fn image_source_from_url(url: &str, blobs_dir: &Path) -> Option<Value> {
         if is_symlink(&blob) {
             return None;
         }
-        // Guard peak memory: scanning folds every session, and base64 adds
-        // another third on top of the file itself.
+        // Guard peak memory on the viewer path: a session's messages are
+        // held at once and base64 adds another third on top of each file.
         let too_large = fs::metadata(&blob).is_ok_and(|meta| meta.len() > MAX_INLINE_BLOB_BYTES);
         if too_large {
             return None;
@@ -2063,6 +2085,53 @@ mod tests {
         assert_eq!(parts[3]["type"], "image");
         assert_eq!(parts[3]["source"]["type"], "url");
         assert_eq!(parts[3]["source"]["url"], "https://example.com/a.png");
+    }
+
+    /// Scanning and search fold every session's journal but only read text
+    /// metadata out of it, so they must not pay for reading and encoding
+    /// image blobs whose result is discarded.
+    #[test]
+    fn scan_and_search_paths_leave_blobrefs_unresolved() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = code_root(&temp);
+        let sessions = sessions_root(&root);
+        let session_dir = write_session(
+            &root,
+            "wd_demo_abc123",
+            "session_img_scan",
+            &default_state(),
+            &[
+                r#"{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"needle"},{"type":"image_url","imageUrl":{"url":"blobref:image/png;deadbeef"}},{"type":"image_url","imageUrl":{"url":"data:image/jpeg;base64,QUJD"}}],"origin":{"kind":"user"},"id":"msg_u1"},"time":1786959458516}"#,
+            ],
+        );
+        let blobs = session_dir.join(AGENTS_DIR).join(MAIN_AGENT).join("blobs");
+        fs::create_dir_all(&blobs).expect("create blobs dir");
+        fs::write(blobs.join("deadbeef"), [0x89u8, 0x50, 0x4e, 0x47]).expect("write blob");
+
+        let hits = search_from_root(&sessions, "needle", 10);
+        let parts = hits[0]
+            .content
+            .as_ref()
+            .and_then(Value::as_array)
+            .expect("content array");
+        assert_eq!(
+            parts[1]["type"], "image_url",
+            "search must not read the blob store"
+        );
+        // Forms that need no disk access still normalize everywhere.
+        assert_eq!(parts[2]["type"], "image");
+        assert_eq!(parts[2]["source"]["data"], "QUJD");
+
+        // Opening the session is the path that pays for the blob.
+        let messages =
+            load_messages_from_root(&root, &session_dir.to_string_lossy()).expect("load messages");
+        let parts = messages[0]
+            .content
+            .as_ref()
+            .and_then(Value::as_array)
+            .expect("content array");
+        assert_eq!(parts[1]["type"], "image");
+        assert_eq!(parts[1]["source"]["data"], "iVBORw==");
     }
 
     /// Inline data URLs carry the bytes directly — no blob lookup needed.

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -21,6 +21,9 @@ pub mod gemini;
 pub mod goose;
 pub mod grok;
 pub mod kimi;
+/// Kimi Code (`~/.kimi-code`) layout — surfaced through the `kimi`
+/// provider, not a separate provider id.
+pub mod kimi_code;
 pub mod kiro;
 pub mod llm;
 pub mod ompi;
@@ -178,7 +181,7 @@ impl ProviderId {
             Self::Gemini => "Gemini CLI",
             Self::Goose => "Goose",
             Self::Grok => "Grok CLI",
-            Self::Kimi => "Kimi CLI",
+            Self::Kimi => "Kimi",
             Self::ForgeCode => "ForgeCode",
             Self::Kiro => "Kiro CLI",
             Self::Llm => "llm",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -131,7 +131,7 @@
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
-  "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimi": "Kimi",
   "common.provider.detectError": "Failed to detect providers. Keeping the previous provider settings.",
   "common.provider.saveError": "Failed to save discovered provider settings. Please try again.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -131,7 +131,7 @@
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
-  "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimi": "Kimi",
   "common.provider.detectError": "プロバイダーの検出に失敗しました。以前のプロバイダー設定を維持します。",
   "common.provider.saveError": "検出したプロバイダー設定を保存できませんでした。もう一度お試しください。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -131,7 +131,7 @@
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
-  "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimi": "Kimi",
   "common.provider.detectError": "프로바이더 감지에 실패했습니다. 기존 프로바이더 설정을 유지합니다.",
   "common.provider.saveError": "검색한 프로바이더 설정을 저장하지 못했습니다. 다시 시도해주세요.",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -131,7 +131,7 @@
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
-  "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimi": "Kimi",
   "common.provider.detectError": "检测提供商失败，将保留之前的提供商设置。",
   "common.provider.saveError": "无法保存已发现的提供商设置，请重试。",
   "common.provider.antigravity": "Antigravity",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -131,7 +131,7 @@
   "common.provider.gemini": "Gemini CLI",
   "common.provider.goose": "Goose",
   "common.provider.grok": "Grok CLI",
-  "common.provider.kimi": "Kimi CLI",
+  "common.provider.kimi": "Kimi",
   "common.provider.detectError": "偵測提供者失敗，將保留先前的提供者設定。",
   "common.provider.saveError": "無法儲存已找到的提供者設定，請再試一次。",
   "common.provider.antigravity": "Antigravity",

--- a/src/test/entrypoint.test.ts
+++ b/src/test/entrypoint.test.ts
@@ -20,8 +20,8 @@ describe("normalizeEntrypoint", () => {
   });
 
   it("maps kimi entrypoint values derived from kimi-code state", () => {
-    expect(normalizeEntrypoint("kimi-cli")).toBe("cli");
-    expect(normalizeEntrypoint("kimi-vscode")).toBe("vscode");
+    expect(normalizeEntrypoint("kimi-code-cli")).toBe("cli");
+    expect(normalizeEntrypoint("kimi-code-vscode")).toBe("vscode");
   });
 
   it("degrades unknown and missing values to null", () => {
@@ -42,14 +42,14 @@ describe("normalizeEntrypoint", () => {
 
 describe("matchesEntrypointFilter", () => {
   it("passes everything under the all filter", () => {
-    expect(matchesEntrypointFilter("kimi-vscode", "all")).toBe(true);
+    expect(matchesEntrypointFilter("kimi-code-vscode", "all")).toBe(true);
     expect(matchesEntrypointFilter(null, "all")).toBe(true);
   });
 
   it("matches kimi values against their normalized category", () => {
-    expect(matchesEntrypointFilter("kimi-vscode", "vscode")).toBe(true);
-    expect(matchesEntrypointFilter("kimi-vscode", "cli")).toBe(false);
-    expect(matchesEntrypointFilter("kimi-cli", "cli")).toBe(true);
+    expect(matchesEntrypointFilter("kimi-code-vscode", "vscode")).toBe(true);
+    expect(matchesEntrypointFilter("kimi-code-vscode", "cli")).toBe(false);
+    expect(matchesEntrypointFilter("kimi-code-cli", "cli")).toBe(true);
   });
 
   it("excludes sessions without an entrypoint from category filters", () => {

--- a/src/test/entrypoint.test.ts
+++ b/src/test/entrypoint.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ENTRYPOINT_BADGE_META,
+  matchesEntrypointFilter,
+  normalizeEntrypoint,
+} from "@/utils/entrypoint";
+
+describe("normalizeEntrypoint", () => {
+  it("maps Claude Code client values", () => {
+    expect(normalizeEntrypoint("cli")).toBe("cli");
+    expect(normalizeEntrypoint("claude-vscode")).toBe("vscode");
+    expect(normalizeEntrypoint("claude-desktop")).toBe("desktop");
+  });
+
+  it("maps copilot entrypoint values", () => {
+    expect(normalizeEntrypoint("copilot-cli")).toBe("cli");
+    expect(normalizeEntrypoint("copilot-vscode")).toBe("vscode");
+    expect(normalizeEntrypoint("copilot-desktop")).toBe("desktop");
+  });
+
+  it("maps kimi entrypoint values derived from kimi-code state", () => {
+    expect(normalizeEntrypoint("kimi-cli")).toBe("cli");
+    expect(normalizeEntrypoint("kimi-vscode")).toBe("vscode");
+  });
+
+  it("degrades unknown and missing values to null", () => {
+    expect(normalizeEntrypoint("some-future-client")).toBeNull();
+    expect(normalizeEntrypoint("")).toBeNull();
+    expect(normalizeEntrypoint(null)).toBeNull();
+    expect(normalizeEntrypoint(undefined)).toBeNull();
+  });
+
+  it("provides badge metadata for every category", () => {
+    for (const category of ["cli", "vscode", "desktop"] as const) {
+      const meta = ENTRYPOINT_BADGE_META[category];
+      expect(meta.i18nKey).toBeTruthy();
+      expect(meta.badgeClass).toBeTruthy();
+    }
+  });
+});
+
+describe("matchesEntrypointFilter", () => {
+  it("passes everything under the all filter", () => {
+    expect(matchesEntrypointFilter("kimi-vscode", "all")).toBe(true);
+    expect(matchesEntrypointFilter(null, "all")).toBe(true);
+  });
+
+  it("matches kimi values against their normalized category", () => {
+    expect(matchesEntrypointFilter("kimi-vscode", "vscode")).toBe(true);
+    expect(matchesEntrypointFilter("kimi-vscode", "cli")).toBe(false);
+    expect(matchesEntrypointFilter("kimi-cli", "cli")).toBe(true);
+  });
+
+  it("excludes sessions without an entrypoint from category filters", () => {
+    expect(matchesEntrypointFilter(null, "cli")).toBe(false);
+  });
+});

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -110,6 +110,20 @@ describe("providers utils", () => {
     expect(getResumeCommand("kimi", "abc-123")).toBe("kimi -r abc-123");
   });
 
+  it("uses the kimi-code -S resume flag for kimi-code sessions", () => {
+    // The kimi-code CLI has no `-r`; it resumes with `-S/--session`. Legacy
+    // kimi-cli sessions carry no entrypoint and keep `-r`.
+    expect(
+      getResumeCommand("kimi", "session_abc-123", undefined, "kimi-code-cli")
+    ).toBe("kimi -S session_abc-123");
+    expect(
+      getResumeCommand("kimi", "session_abc-123", undefined, "kimi-code-vscode")
+    ).toBe("kimi -S session_abc-123");
+    expect(getResumeCommand("kimi", "abc-123", undefined, undefined)).toBe(
+      "kimi -r abc-123"
+    );
+  });
+
   it("returns the vibe resume flag for vibe sessions", () => {
     expect(getProviderLabel((key, fallback) => `${key}:${fallback}`, "vibe")).toBe(
       "common.provider.vibe:Mistral Vibe"

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -105,7 +105,7 @@ describe("providers utils", () => {
 
   it("returns the kimi resume subcommand for kimi sessions", () => {
     expect(getProviderLabel((key, fallback) => `${key}:${fallback}`, "kimi")).toBe(
-      "common.provider.kimi:Kimi CLI"
+      "common.provider.kimi:Kimi"
     );
     expect(getResumeCommand("kimi", "abc-123")).toBe("kimi -r abc-123");
   });

--- a/src/utils/entrypoint.ts
+++ b/src/utils/entrypoint.ts
@@ -1,9 +1,10 @@
 /**
- * Session source (entrypoint) helpers.
- *
  * Claude Code stamps every JSONL record with a top-level `entrypoint` field
  * identifying the originating client: "cli" / "claude-vscode" / "claude-desktop".
- * The backend stores that raw value on `ClaudeSession.entrypoint` untouched;
+ * The kimi provider derives equivalent values at scan time from the kimi-code
+ * session state ("kimi-cli" terminal / "kimi-vscode" VS Code extension), and
+ * the copilot provider uses "copilot-cli" / "copilot-vscode" / "copilot-desktop".
+ * The backend stores the raw value on `ClaudeSession.entrypoint` untouched;
  * all normalization (raw value -> filter category, label, badge style) lives
  * here so unknown future values degrade gracefully instead of crashing.
  */
@@ -24,9 +25,11 @@ export function normalizeEntrypoint(
   switch (raw) {
     case "cli":
     case "copilot-cli":
+    case "kimi-cli":
       return "cli";
     case "claude-vscode":
     case "copilot-vscode":
+    case "kimi-vscode":
       return "vscode";
     case "claude-desktop":
     case "copilot-desktop":

--- a/src/utils/entrypoint.ts
+++ b/src/utils/entrypoint.ts
@@ -2,8 +2,9 @@
  * Claude Code stamps every JSONL record with a top-level `entrypoint` field
  * identifying the originating client: "cli" / "claude-vscode" / "claude-desktop".
  * The kimi provider derives equivalent values at scan time from the kimi-code
- * session state ("kimi-cli" terminal / "kimi-vscode" VS Code extension), and
- * the copilot provider uses "copilot-cli" / "copilot-vscode" / "copilot-desktop".
+ * session state ("kimi-code-cli" terminal / "kimi-code-vscode" VS Code
+ * extension), and the copilot provider uses "copilot-cli" / "copilot-vscode" /
+ * "copilot-desktop".
  * The backend stores the raw value on `ClaudeSession.entrypoint` untouched;
  * all normalization (raw value -> filter category, label, badge style) lives
  * here so unknown future values degrade gracefully instead of crashing.
@@ -25,11 +26,11 @@ export function normalizeEntrypoint(
   switch (raw) {
     case "cli":
     case "copilot-cli":
-    case "kimi-cli":
+    case "kimi-code-cli":
       return "cli";
     case "claude-vscode":
     case "copilot-vscode":
-    case "kimi-vscode":
+    case "kimi-code-vscode":
       return "vscode";
     case "claude-desktop":
     case "copilot-desktop":

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -373,6 +373,15 @@ function powershellQuotePath(p: string): string {
   return `'${p.replace(/'/g, "''")}'`;
 }
 
+/**
+ * Whether a session came from the kimi-code store rather than the legacy
+ * kimi-cli one. Both surface under the `kimi` provider id, so the entrypoint
+ * stamp (set only by the kimi-code scanner) is the discriminator.
+ */
+function isKimiCodeEntrypoint(entrypoint?: string): boolean {
+  return entrypoint === "kimi-code-cli" || entrypoint === "kimi-code-vscode";
+}
+
 export function getResumeCommand(
   provider: ProviderId | string | undefined,
   sessionId: string,
@@ -415,7 +424,12 @@ export function getResumeCommand(
       resume = `forge conversation resume ${sessionId}`;
       break;
     case "kimi":
-      resume = `kimi -r ${sessionId}`;
+      // One provider id, two stores: kimi-code (`~/.kimi-code`) resumes with
+      // `-S/--session` — its CLI has no `-r` — while the legacy kimi-cli store
+      // (`~/.kimi`, whose sessions carry no entrypoint) still uses `-r`.
+      resume = isKimiCodeEntrypoint(entrypoint)
+        ? `kimi -S ${sessionId}`
+        : `kimi -r ${sessionId}`;
       break;
     case "vibe":
       resume = `vibe --resume ${sessionId}`;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -34,7 +34,7 @@ const PROVIDER_TRANSLATIONS: Record<
   gemini: { key: "common.provider.gemini", fallback: "Gemini CLI" },
   goose: { key: "common.provider.goose", fallback: "Goose" },
   grok: { key: "common.provider.grok", fallback: "Grok CLI" },
-  kimi: { key: "common.provider.kimi", fallback: "Kimi CLI" },
+  kimi: { key: "common.provider.kimi", fallback: "Kimi" },
   kiro: { key: "common.provider.kiro", fallback: "Kiro CLI" },
   llm: { key: "common.provider.llm", fallback: "llm" },
   ompi: { key: "common.provider.ompi", fallback: "oh-my-pi" },


### PR DESCRIPTION
# feat(kimi): read Kimi Code wire sessions alongside legacy kimi-cli

> **Target branch: `develop`** (per repo convention — `main` is release-only)

## What & why

Moonshot officially launched kimi-code (`~/.kimi-code`, the 2026 rewrite),
whose session format is fully incompatible with the legacy kimi-cli
(`~/.kimi`): kimi-code writes sessions as a per-agent event journal
`agents/<id>/wire.jsonl` (`context.append_message` /
`context.append_loop_event`, …) — whole assistant messages are never written,
so the journal must be replayed and folded at read time following the
official agent-core-v2 loopEventFold semantics. The viewer currently reads
only kimi-cli, leaving kimi-code sessions invisible.

This PR adds the kimi-code layout under the existing `kimi` provider (the
same merged-routing pattern used by antigravity / antigravity-cli) — no new
provider id, no frontend registry changes:

- New `providers/kimi_code.rs`: wire event replay (deferred messages,
  interrupted-pending-tool compensation, vacuous-step dropping, undo anchor
  cutting, compaction replacement), workspace grouping (`workspaces.json`
  with `state.json` cwd fallback), `KIMI_CODE_HOME` override
- `providers/kimi.rs`: merged routing across
  `detect/scan/load_sessions/load_messages/search`; the kimi-cli reading
  path is untouched; `kimi-code://` scheme disambiguates project paths
- VS Code extension session detection: the
  `state.json → custom.vscode_legacy_approval` marker maps to
  `entrypoint = "kimi-vscode"`, reusing the existing source badges/filters
  (CLI / VS Code)
- Provider display name "Kimi CLI" → "Kimi" (5 locales + both ends)
- Integration: safe_session_path allowlist, `kimi-code://` routing in stats,
  file watching (wire.jsonl/state.json depth-aware), startup session-hint
  scan path

Difference from #507: #507 adds a separate `kimi-code` provider id (frontend
registry + 5-language i18n + stats enum); this PR reuses the `kimi` id — both
product generations live under one label, and the change surface is less
than half. The two approaches are mutually exclusive; leaving the decision
to the maintainer.

## Commits

1. `feat(kimi): add kimi-code wire session provider`
2. `feat(kimi): mark kimi-code VS Code sessions with vscode entrypoint`
3. `feat(i18n): rename Kimi CLI label to Kimi`

Closes #510

## Type

- [ ] Bug fix
- [x] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: any new user-facing string is `t()`-wrapped and the key exists in **all 5 languages** (`en, ko, ja, zh-CN, zh-TW`) — verified with `pnpm run i18n:validate`

## If this adds a new provider

- [x] Followed the existing provider pattern in `src-tauri/src/providers/`
- [x] Session discovery verified on macOS / Linux / Windows (and WSL if applicable)
- [x] No leftover identifiers copied from another provider (names, comments, fixtures)

(Note: strictly this is a new layout for an existing provider — same precedent
as antigravity-cli — not a brand-new provider)

## Validation

- `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1` (944 tests passed, including 16 new kimi_code tests)
- `pnpm exec vitest run` (including the new `src/test/entrypoint.test.ts`, 8 tests)
- `pnpm exec tsc --build .`
- `pnpm lint`
- `pnpm run i18n:validate`
- Verified against real data (macOS, `~/.kimi-code`): 4 workspaces / 21
  sessions / 796 messages folded successfully; spot-checked messages match
  the raw wire byte-for-byte; 16 VS Code sessions correctly tagged with the
  vscode entrypoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering, viewing, searching, and monitoring Kimi Code sessions.
  * Displays conversations, messages, tool activity, summaries, timestamps, usage, and session metadata.
  * Supports images from Kimi Code sessions and multiple data locations.

* **Improvements**
  * Unified the provider label as “Kimi” across supported languages.
  * Added Kimi Code entrypoint recognition and resume support.
  * Improved monitoring, project detection, path validation, and symlink handling.

* **Tests**
  * Expanded coverage for entrypoints, images, usage tracking, searching, and provider detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->