### PR TITLE
fix(recent-edits): key the fetch cache on the requested project path

### DIFF
--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for the Recent Edits fetch cache.
+ *
+ * The cache guard in `switchToRecentEdits` used to compare the cached
+ * `project_cwd` (the most frequent `cwd` seen in the session logs) against
+ * `project.path` (the encoded Claude storage directory). Those two values are
+ * never equal, so every visit to Recent Edits re-walked and re-parsed every
+ * JSONL file in the project. Measured across 28 real projects, the guard held
+ * 0 times.
+ *
+ * The guard now compares `requestedProjectPath`, which is the `project.path`
+ * the cached result was actually fetched for.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const fetchRecentEdits = vi.fn();
+vi.mock("../../services/analyticsApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/analyticsApi")>();
+  return { ...actual, fetchRecentEdits: (...args: unknown[]) => fetchRecentEdits(...args) };
+});
+
+import { useAppStore } from "../../store/useAppStore";
+import { useAnalyticsNavigation } from "./useAnalyticsNavigation";
+import type { ClaudeProject } from "../../types";
+
+const project = (name: string): ClaudeProject => ({
+  name,
+  // The encoded Claude storage path.
+  path: "C:\\Users\\jpris\\.claude\\projects\\E--Projects-" + name,
+  // The decoded filesystem path. Deliberately different from `path`.
+  actual_path: "E:\\Projects\\" + name,
+  session_count: 1,
+  message_count: 1,
+  last_modified: "2026-08-21T00:00:00.000Z",
+});
+
+const payload = (cwd: string) => ({
+  files: [
+    {
+      file_path: cwd + "\\src\\main.ts",
+      timestamp: "2026-08-21T00:00:00.000Z",
+      session_id: "s1",
+      operation_type: "edit" as const,
+      content_after_change: "after",
+      lines_added: 1,
+      lines_removed: 0,
+    },
+  ],
+  total_edits_count: 1,
+  unique_files_count: 1,
+  // The backend reports the real working directory, never the storage path.
+  project_cwd: cwd,
+  offset: 0,
+  limit: 20,
+  has_more: false,
+});
+
+describe("switchToRecentEdits cache", () => {
+  beforeEach(() => {
+    fetchRecentEdits.mockReset();
+    useAppStore.setState({ selectedProject: null, selectedSession: null });
+    useAppStore.getState().resetAnalytics();
+  });
+
+  it("does not refetch when the same project is opened twice", async () => {
+    const p = project("alpha");
+    fetchRecentEdits.mockResolvedValue(payload(p.actual_path));
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when a different project is opened", async () => {
+    const a = project("alpha");
+    const b = project("beta");
+    fetchRecentEdits.mockImplementation((path: string) =>
+      Promise.resolve(payload(path.includes("alpha") ? a.actual_path : b.actual_path))
+    );
+
+    useAppStore.setState({ selectedProject: a });
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      useAppStore.setState({ selectedProject: b });
+    });
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(2);
+  });
+
+  it("still caches when project_cwd diverges from actual_path", async () => {
+    // Measured on real data: project_cwd is the most frequent `cwd` in the
+    // session logs, so it can point at a subdirectory of the project (sessions
+    // run from inside it), at a previous location (a moved project), or differ
+    // only by drive-letter case. In a 28-project sample it disagreed with
+    // actual_path 3 times. Matching on either derived path would silently
+    // reintroduce the always-miss for those projects.
+    const p = project("gamma");
+    fetchRecentEdits.mockResolvedValue(
+      payload(p.actual_path + "\\_local\\initial-plan")
+    );
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+  });
+
+  it("records the requested project path on the cached result", async () => {
+    const p = project("alpha");
+    fetchRecentEdits.mockResolvedValue(payload(p.actual_path));
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    const cached = useAppStore.getState().analytics.recentEdits;
+    expect(cached?.requestedProjectPath).toBe(p.path);
+    // The guard must not fall back to either derived path. Both are wrong:
+    // project_cwd never equals path, and it is not reliably equal to
+    // actual_path either.
+    expect(cached?.project_cwd).not.toBe(p.path);
+  });
+});

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -429,3 +429,141 @@ describe("switchToRecentEdits request identity", () => {
     );
   });
 });
+
+/**
+ * Round 4. The load-more commit proved *whose* project a page belonged to but
+ * not *which version* of the list it was fetched against, so a refresh landing
+ * mid-flight let a later page append onto a list it did not continue.
+ */
+describe("loadMoreRecentEdits generation", () => {
+  const rows = (names: string[]) =>
+    names.map((file_path) => ({
+      file_path,
+      timestamp: "2026-08-21T00:00:00.000Z",
+      session_id: "s1",
+      operation_type: "edit" as const,
+      content_after_change: "after",
+      lines_added: 1,
+      lines_removed: 0,
+    }));
+
+  const pageOf = (names: string[], offset: number, hasMore: boolean) => ({
+    files: rows(names),
+    total_edits_count: 100,
+    unique_files_count: 100,
+    project_cwd: "E:\\Projects\\alpha",
+    offset,
+    limit: 20,
+    has_more: hasMore,
+  });
+
+  /** Load page 1 for `p` and leave the cursor open. */
+  const seedFirstPage = async (p: ReturnType<typeof project>) => {
+    fetchRecentEdits.mockResolvedValueOnce(pageOf(["a.ts", "b.ts"], 0, true));
+    useAppStore.setState({ selectedProject: p });
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+  };
+
+  beforeEach(() => {
+    fetchRecentEdits.mockReset();
+    useAppStore.setState({ selectedProject: null, selectedSession: null });
+    useAppStore.getState().resetAnalytics();
+  });
+
+  it("discards a page whose list was replaced while it was in flight (R2)", async () => {
+    // The replacement has the same length and the same owner, so neither the
+    // ownership guard nor a length comparison can catch it. Only a generation
+    // can.
+    const p = project("alpha");
+    await seedFirstPage(p);
+
+    let resolveMore: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveMore = resolve))
+    );
+    const pending = useAppStore.getState().loadMoreRecentEdits(p.path);
+
+    await act(async () => {
+      useAppStore.getState().setAnalyticsRecentEdits({
+        files: rows(["fresh-a.ts", "fresh-b.ts"]),
+        total_edits_count: 100,
+        unique_files_count: 100,
+        project_cwd: "E:\\Projects\\alpha",
+        requestedProjectPath: p.path,
+      });
+    });
+
+    await act(async () => {
+      resolveMore?.(pageOf(["late.ts"], 2, true));
+      await pending;
+    });
+
+    expect(
+      (useAppStore.getState().analytics.recentEdits?.files ?? []).map(
+        (f) => f.file_path
+      )
+    ).toEqual(["fresh-a.ts", "fresh-b.ts"]);
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(false);
+  });
+
+  it("does not rebuild a cleared cache out of a later page (R3)", async () => {
+    // A page landing on a cleared cache used to append onto nothing and claim
+    // the result as the whole list. If the refresh that cleared the cache then
+    // failed, that later-page-only list passed the cache-hit test forever.
+    const p = project("alpha");
+    await seedFirstPage(p);
+
+    let resolveMore: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveMore = resolve))
+    );
+    const pending = useAppStore.getState().loadMoreRecentEdits(p.path);
+
+    await act(async () => {
+      useAppStore.getState().setAnalyticsRecentEdits(null);
+    });
+
+    await act(async () => {
+      resolveMore?.(pageOf(["late.ts"], 2, true));
+      await pending;
+    });
+
+    expect(useAppStore.getState().analytics.recentEdits).toBeNull();
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(false);
+  });
+
+  it("asks for the page after the rows it holds, not after the stored cursor (R4)", async () => {
+    // A refresh that replaces the list without resetting the cursor leaves the
+    // two disagreeing. Deriving the offset from the rows actually held cannot
+    // desync, which is the same rule the dock panel already follows.
+    const p = project("alpha");
+    await seedFirstPage(p);
+
+    useAppStore.setState((state) => ({
+      analytics: {
+        ...state.analytics,
+        recentEditsPagination: {
+          ...state.analytics.recentEditsPagination,
+          offset: 60,
+        },
+      },
+    }));
+
+    fetchRecentEdits.mockResolvedValueOnce(pageOf(["c.ts"], 2, false));
+    await act(async () => {
+      await useAppStore.getState().loadMoreRecentEdits(p.path);
+    });
+
+    expect(fetchRecentEdits).toHaveBeenLastCalledWith(
+      p.path,
+      expect.objectContaining({ offset: 2 })
+    );
+  });
+});

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -374,3 +374,58 @@ describe("switchToRecentEdits cache", () => {
     expect(cached?.project_cwd).not.toBe(p.path);
   });
 });
+
+/**
+ * Round 4. `switchToRecentEdits` guarded its commit on the selected project,
+ * which cannot tell two requests for the *same* project apart. The request
+ * sequence it already keeps was consulted only in the `finally`.
+ */
+describe("switchToRecentEdits request identity", () => {
+  beforeEach(() => {
+    fetchRecentEdits.mockReset();
+    useAppStore.setState({ selectedProject: null, selectedSession: null });
+    useAppStore.getState().resetAnalytics();
+  });
+
+  it("does not let a slow load overwrite a newer one for the same project (R1)", async () => {
+    // Refreshing while the first load is still in flight starts a second
+    // request for the same project. The project-path guard passes for both, so
+    // the slower one used to land last and win.
+    const p = project("alpha");
+    useAppStore.setState({ selectedProject: p });
+
+    let resolveFirst: ((value: unknown) => void) | undefined;
+    let resolveSecond: ((value: unknown) => void) | undefined;
+    fetchRecentEdits
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveFirst = resolve))
+      )
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveSecond = resolve))
+      );
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+
+    let first: Promise<void> | undefined;
+    let second: Promise<void> | undefined;
+    await act(async () => {
+      first = result.current.switchToRecentEdits();
+      second = result.current.switchToRecentEdits();
+    });
+
+    // The newer request answers first.
+    await act(async () => {
+      resolveSecond?.(payload("FRESH"));
+      await second;
+    });
+    // The older one answers late, for the project that is still selected.
+    await act(async () => {
+      resolveFirst?.(payload("STALE"));
+      await first;
+    });
+
+    expect(useAppStore.getState().analytics.recentEdits?.project_cwd).toBe(
+      "FRESH"
+    );
+  });
+});

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -607,6 +607,64 @@ describe("loadMoreRecentEdits generation", () => {
       )
     ).toEqual(["fresh-a.ts", "fresh-b.ts"]);
   });
+
+  it("does not let a superseded page clear a newer one's loading flag (R8)", async () => {
+    // The flag is global. A late request clearing it re-enables Show More while
+    // a newer request is still running, and the extra click costs a full walk
+    // of the project's logs even though the generation check throws its rows
+    // away.
+    const a = project("alpha");
+    const b = project("beta");
+    await seedFirstPage(a);
+
+    let resolveA: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveA = resolve))
+    );
+    const pendingA = useAppStore.getState().loadMoreRecentEdits(a.path);
+
+    // The user moves to another project and its first page lands, which
+    // rewrites pagination and leaves Show More available again.
+    fetchRecentEdits.mockResolvedValueOnce(pageOf(["b1.ts", "b2.ts"], 0, true));
+    useAppStore.setState({ selectedProject: b });
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    let resolveB: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveB = resolve))
+    );
+    const pendingB = useAppStore.getState().loadMoreRecentEdits(b.path);
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(true);
+
+    await act(async () => {
+      resolveA?.(pageOf(["late.ts"], 2, true));
+      await pendingA;
+    });
+
+    // Still loading: the request that owns the flag has not finished.
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(true);
+
+    await act(async () => {
+      resolveB?.(pageOf(["b3.ts"], 2, false));
+      await pendingB;
+    });
+
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(false);
+    expect(
+      (useAppStore.getState().analytics.recentEdits?.files ?? []).map(
+        (f) => f.file_path
+      )
+    ).toEqual(["b1.ts", "b2.ts", "b3.ts"]);
+  });
 });
 
 /**

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -256,6 +256,106 @@ describe("switchToRecentEdits cache", () => {
     expect(fetchRecentEdits).toHaveBeenCalledTimes(callsBefore);
   });
 
+  it("caches a legitimately empty result (A1)", async () => {
+    // `files.length > 0` made a project with no edits miss the cache on every
+    // visit and re-walk its whole JSONL set. With request identity on the entry,
+    // an empty list is a valid answer rather than an absent one.
+    const p = project("empty");
+    fetchRecentEdits.mockResolvedValue({
+      ...payload(p.actual_path),
+      files: [],
+      total_edits_count: 0,
+      unique_files_count: 0,
+    });
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a blank project path on load-more (A2)", async () => {
+    // Pagination has to be loadable, or `canLoadMore` returns early and the
+    // test passes without ever reaching the guard under test.
+    useAppStore.setState((state) => ({
+      analytics: {
+        ...state.analytics,
+        recentEditsPagination: {
+          totalEditsCount: 100,
+          uniqueFilesCount: 100,
+          offset: 0,
+          limit: 20,
+          hasMore: true,
+          isLoadingMore: false,
+        },
+      },
+    }));
+
+    await act(async () => {
+      await useAppStore.getState().loadMoreRecentEdits("");
+    });
+
+    expect(fetchRecentEdits).not.toHaveBeenCalled();
+  });
+
+  it("does not land a load-more page for a deselected project (A3)", async () => {
+    // The pre-await guard only proves ownership when the request starts. Without
+    // a post-await check, project A's page lands under B's pagination state.
+    const a = project("alpha");
+    const b = project("beta");
+    fetchRecentEdits.mockResolvedValueOnce(payload(a.actual_path));
+    useAppStore.setState({ selectedProject: a });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    useAppStore.setState((state) => ({
+      analytics: {
+        ...state.analytics,
+        recentEditsPagination: {
+          totalEditsCount: 100,
+          uniqueFilesCount: 100,
+          offset: 0,
+          limit: 20,
+          hasMore: true,
+          isLoadingMore: false,
+        },
+      },
+    }));
+
+    let resolveMore;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveMore = resolve))
+    );
+    const pending = useAppStore.getState().loadMoreRecentEdits(a.path);
+
+    await act(async () => {
+      useAppStore.setState({ selectedProject: b });
+    });
+    await act(async () => {
+      resolveMore?.({
+        ...payload(a.actual_path),
+        files: [{ ...payload(a.actual_path).files[0], file_path: "late.ts" }],
+      });
+      await pending;
+    });
+
+    const files = useAppStore.getState().analytics.recentEdits?.files ?? [];
+    expect(files.some((f) => f.file_path === "late.ts")).toBe(false);
+    // And the flag must not be stranded, or every future page is blocked.
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(false);
+  });
+
   it("records the requested project path on the cached result", async () => {
     const p = project("alpha");
     fetchRecentEdits.mockResolvedValue(payload(p.actual_path));

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../services/analyticsApi", async (importOriginal) => {
   return { ...actual, fetchRecentEdits: (...args: unknown[]) => fetchRecentEdits(...args) };
 });
 
+import { toast } from "sonner";
 import { useAppStore } from "../../store/useAppStore";
 import { useAnalyticsNavigation } from "./useAnalyticsNavigation";
 import type { ClaudeProject } from "../../types";
@@ -565,5 +566,88 @@ describe("loadMoreRecentEdits generation", () => {
       p.path,
       expect.objectContaining({ offset: 2 })
     );
+  });
+});
+
+/**
+ * Round 4. Both fetch paths validated ownership before writing a *result* and
+ * neither validated it before writing a *failure*, so a late rejection could
+ * paint an error over a view the user had already moved to.
+ */
+describe("recent-edits failures respect ownership", () => {
+  beforeEach(() => {
+    fetchRecentEdits.mockReset();
+    vi.mocked(toast.error).mockClear();
+    useAppStore.setState({ selectedProject: null, selectedSession: null });
+    useAppStore.getState().resetAnalytics();
+  });
+
+  it("does not paint a stale load-more failure over the current view (R5)", async () => {
+    const a = project("alpha");
+    const b = project("beta");
+    fetchRecentEdits.mockResolvedValueOnce({
+      ...payload(a.actual_path),
+      has_more: true,
+      total_edits_count: 100,
+      unique_files_count: 100,
+    });
+    useAppStore.setState({ selectedProject: a });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    let rejectMore: ((reason: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((_resolve, reject) => (rejectMore = reject))
+    );
+    const pending = useAppStore.getState().loadMoreRecentEdits(a.path);
+
+    await act(async () => {
+      useAppStore.setState({ selectedProject: b });
+    });
+    await act(async () => {
+      rejectMore?.(new Error("backend went away"));
+      await pending;
+    });
+
+    expect(useAppStore.getState().analytics.recentEditsError).toBeNull();
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+    // The flag still has to clear, or the next project's Show More is dead.
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(false);
+  });
+
+  it("does not paint a stale first-load failure over the current view (R6)", async () => {
+    const a = project("alpha");
+    const b = project("beta");
+    useAppStore.setState({ selectedProject: a });
+
+    let rejectFirst: ((reason: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((_resolve, reject) => (rejectFirst = reject))
+    );
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    let settled: string | undefined;
+    let pending: Promise<unknown> | undefined;
+    await act(async () => {
+      pending = result.current
+        .switchToRecentEdits()
+        .catch(() => (settled = "rejected"));
+    });
+
+    await act(async () => {
+      useAppStore.setState({ selectedProject: b });
+    });
+    await act(async () => {
+      rejectFirst?.(new Error("backend went away"));
+      await pending;
+    });
+
+    expect(settled).toBe("rejected");
+    expect(useAppStore.getState().analytics.recentEditsError).toBeNull();
   });
 });

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -567,6 +567,46 @@ describe("loadMoreRecentEdits generation", () => {
       expect.objectContaining({ offset: 2 })
     );
   });
+
+  it("does not reuse a generation across a reset (R7)", async () => {
+    // `resetAnalytics` restored the whole initial state, generation included,
+    // so the counter went back to 0 and its values became reusable. Clearing
+    // the selection and choosing the same project again then rebuilt the list
+    // under a generation a request already in flight had captured.
+    const p = project("alpha");
+    await seedFirstPage(p);
+
+    let resolveMore: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveMore = resolve))
+    );
+    const pending = useAppStore.getState().loadMoreRecentEdits(p.path);
+
+    await act(async () => {
+      useAppStore.setState({ selectedProject: null });
+      useAppStore.getState().resetAnalytics();
+    });
+
+    fetchRecentEdits.mockResolvedValueOnce(
+      pageOf(["fresh-a.ts", "fresh-b.ts"], 0, true)
+    );
+    useAppStore.setState({ selectedProject: p });
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    await act(async () => {
+      resolveMore?.(pageOf(["late.ts"], 2, true));
+      await pending;
+    });
+
+    expect(
+      (useAppStore.getState().analytics.recentEdits?.files ?? []).map(
+        (f) => f.file_path
+      )
+    ).toEqual(["fresh-a.ts", "fresh-b.ts"]);
+  });
 });
 
 /**

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -665,6 +665,64 @@ describe("loadMoreRecentEdits generation", () => {
       )
     ).toEqual(["b1.ts", "b2.ts", "b3.ts"]);
   });
+
+  it("keeps a newer same-project request's loading state intact (R9)", async () => {
+    // The cross-project version of this is R8. The same-project one reaches
+    // the identical exit through a different door: a refresh rewrites
+    // pagination, which frees Show More for a second request against the very
+    // same project while the first is still in flight.
+    const p = project("alpha");
+    await seedFirstPage(p);
+
+    let resolveFirst: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveFirst = resolve))
+    );
+    const first = useAppStore.getState().loadMoreRecentEdits(p.path);
+
+    // A refresh of the same project: clear, then reload page 1.
+    fetchRecentEdits.mockResolvedValueOnce(
+      pageOf(["fresh-a.ts", "fresh-b.ts"], 0, true)
+    );
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      useAppStore.getState().setAnalyticsRecentEdits(null);
+      await result.current.switchToRecentEdits();
+    });
+
+    let resolveSecond: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveSecond = resolve))
+    );
+    const second = useAppStore.getState().loadMoreRecentEdits(p.path);
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(true);
+
+    await act(async () => {
+      resolveFirst?.(pageOf(["stale.ts"], 2, true));
+      await first;
+    });
+
+    // The older request settled, but it does not own the flag any more.
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(true);
+
+    await act(async () => {
+      resolveSecond?.(pageOf(["fresh-c.ts"], 2, false));
+      await second;
+    });
+
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(false);
+    expect(
+      (useAppStore.getState().analytics.recentEdits?.files ?? []).map(
+        (f) => f.file_path
+      )
+    ).toEqual(["fresh-a.ts", "fresh-b.ts", "fresh-c.ts"]);
+  });
 });
 
 /**

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -192,6 +192,35 @@ describe("switchToRecentEdits cache", () => {
     ).not.toBe(a.path);
   });
 
+  it("does not strand the loading flag when its project is deselected (C4)", async () => {
+    // Second-pass finding. The C3 ownership guard made the finally clear the
+    // flag only when the requesting project is still selected. If the user
+    // switches away and never opens Recent Edits for the new project, nothing
+    // else clears it: `resetAnalytics` runs in `clearProjectSelection`, not on a
+    // project switch, so the page view keeps a spinner up forever.
+    const a = project("alpha");
+    const b = project("beta");
+    let resolveA;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveA = resolve))
+    );
+
+    useAppStore.setState({ selectedProject: a });
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    const pending = result.current.switchToRecentEdits();
+    expect(useAppStore.getState().analytics.isLoadingRecentEdits).toBe(true);
+
+    await act(async () => {
+      useAppStore.setState({ selectedProject: b });
+    });
+    await act(async () => {
+      resolveA?.(payload(a.actual_path));
+      await pending;
+    });
+
+    expect(useAppStore.getState().analytics.isLoadingRecentEdits).toBe(false);
+  });
+
   it("refuses to extend a cache entry from another project (C2)", async () => {
     const a = project("alpha");
     const b = project("beta");

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -141,6 +141,92 @@ describe("switchToRecentEdits cache", () => {
     expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
   });
 
+  it("refetches after a refresh clears the cache (C1)", async () => {
+    // `refreshAnalytics` clears the cache and calls switchToRecentEdits in the
+    // same tick. Reading the cache from the render closure sees the pre-clear
+    // value, reports a hit, and leaves the view empty. This only became
+    // reachable once the guard started actually holding.
+    const p = project("alpha");
+    fetchRecentEdits.mockResolvedValue(payload(p.actual_path));
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refreshAnalytics();
+    });
+
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(2);
+    expect(useAppStore.getState().analytics.recentEdits?.files.length).toBe(1);
+  });
+
+  it("does not write a result for a project that is no longer selected (C3)", async () => {
+    const a = project("alpha");
+    const b = project("beta");
+    let resolveA;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveA = resolve))
+    );
+
+    useAppStore.setState({ selectedProject: a });
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    const pending = result.current.switchToRecentEdits();
+
+    await act(async () => {
+      useAppStore.setState({ selectedProject: b });
+    });
+
+    await act(async () => {
+      resolveA?.(payload(a.actual_path));
+      await pending;
+    });
+
+    // A landed last but B is selected, so A must not install itself as the
+    // cache under its own key.
+    expect(
+      useAppStore.getState().analytics.recentEdits?.requestedProjectPath
+    ).not.toBe(a.path);
+  });
+
+  it("refuses to extend a cache entry from another project (C2)", async () => {
+    const a = project("alpha");
+    const b = project("beta");
+    fetchRecentEdits.mockResolvedValue(payload(a.actual_path));
+    useAppStore.setState({ selectedProject: a });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    useAppStore.setState({
+      analytics: {
+        ...useAppStore.getState().analytics,
+        recentEditsPagination: {
+          totalEditsCount: 100,
+          uniqueFilesCount: 100,
+          offset: 0,
+          limit: 20,
+          hasMore: true,
+          isLoadingMore: false,
+        },
+      },
+    });
+    const callsBefore = fetchRecentEdits.mock.calls.length;
+
+    await act(async () => {
+      await useAppStore.getState().loadMoreRecentEdits(b.path);
+    });
+
+    // Appending B's page onto A's rows would tag the mixture with B's identity
+    // and the guard would then accept it forever.
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(callsBefore);
+  });
+
   it("records the requested project path on the cached result", async () => {
     const p = project("alpha");
     fetchRecentEdits.mockResolvedValue(payload(p.actual_path));

--- a/src/hooks/analytics/useAnalyticsNavigation.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.ts
@@ -196,7 +196,15 @@ export function useAnalyticsNavigation() {
       // The user may have switched projects while this was in flight. Writing
       // anyway would show one project's edits under another's identity, and the
       // cache guard would then treat that as a valid hit indefinitely.
-      if (useAppStore.getState().selectedProject?.path !== project.path) {
+      //
+      // The sequence check is the other half of the same rule. A project path
+      // cannot tell two requests for the *same* project apart, so refreshing
+      // while the first load was still running let the slower of the two land
+      // last and overwrite the newer result, cursor included.
+      if (
+        recentEditsRequestSeq !== requestId ||
+        useAppStore.getState().selectedProject?.path !== project.path
+      ) {
         return;
       }
 

--- a/src/hooks/analytics/useAnalyticsNavigation.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.ts
@@ -188,6 +188,13 @@ export function useAnalyticsNavigation() {
     }
 
     const requestId = ++recentEditsRequestSeq;
+    // One predicate for both outcomes. A late failure is every bit as capable
+    // of writing over a newer request's state as a late success is, and the
+    // two paths disagreeing about what ownership means is how that gets
+    // missed.
+    const stillOwnsRecentEdits = () =>
+      recentEditsRequestSeq === requestId &&
+      useAppStore.getState().selectedProject?.path === project.path;
 
     try {
       setAnalyticsLoadingRecentEdits(true);
@@ -201,10 +208,7 @@ export function useAnalyticsNavigation() {
       // cannot tell two requests for the *same* project apart, so refreshing
       // while the first load was still running let the slower of the two land
       // last and overwrite the newer result, cursor included.
-      if (
-        recentEditsRequestSeq !== requestId ||
-        useAppStore.getState().selectedProject?.path !== project.path
-      ) {
+      if (!stillOwnsRecentEdits()) {
         return;
       }
 
@@ -234,7 +238,9 @@ export function useAnalyticsNavigation() {
         error instanceof Error
           ? error.message
           : t("common.hooks.recentEditsLoadFailed");
-      setAnalyticsRecentEditsError(errorMessage);
+      if (stillOwnsRecentEdits()) {
+        setAnalyticsRecentEditsError(errorMessage);
+      }
       console.error("Failed to load recent edits:", error);
       throw error;
     } finally {

--- a/src/hooks/analytics/useAnalyticsNavigation.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.ts
@@ -164,7 +164,7 @@ export function useAnalyticsNavigation() {
     const hasCachedRecentEdits =
       analytics.recentEdits &&
       analytics.recentEdits.files.length > 0 &&
-      analytics.recentEdits.project_cwd === project.path;
+      analytics.recentEdits.requestedProjectPath === project.path;
 
     if (hasCachedRecentEdits) {
       return;
@@ -179,6 +179,7 @@ export function useAnalyticsNavigation() {
         total_edits_count: result.total_edits_count,
         unique_files_count: result.unique_files_count,
         project_cwd: result.project_cwd,
+        requestedProjectPath: project.path,
       });
 
       useAppStore.setState((state) => ({

--- a/src/hooks/analytics/useAnalyticsNavigation.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.ts
@@ -4,6 +4,15 @@ import { toast } from "sonner";
 import { useAppStore } from "../../store/useAppStore";
 import { AppErrorType, type MetricMode, type StatsMode } from "../../types";
 
+/**
+ * Sequence number for Recent Edits fetches, so a request can tell whether it is
+ * still the most recent one.
+ *
+ * Module scope rather than a ref: several components mount this hook, and a
+ * per-instance ref would let two of them each believe they are the latest.
+ */
+let recentEditsRequestSeq = 0;
+
 export function useAnalyticsNavigation() {
   const { t } = useTranslation();
   const {
@@ -176,6 +185,8 @@ export function useAnalyticsNavigation() {
       return;
     }
 
+    const requestId = ++recentEditsRequestSeq;
+
     try {
       setAnalyticsLoadingRecentEdits(true);
       const result = await loadRecentEdits(project.path);
@@ -217,9 +228,13 @@ export function useAnalyticsNavigation() {
       console.error("Failed to load recent edits:", error);
       throw error;
     } finally {
-      // Only the request that still owns the selection clears the flag, so a
-      // late loser cannot report a newer request as finished.
-      if (useAppStore.getState().selectedProject?.path === project.path) {
+      // Clear on the *latest* request rather than on the selected project.
+      // Keying this to the selection stranded the flag: a request whose project
+      // was deselected would never clear it, and nothing else does, because
+      // `resetAnalytics` runs in `clearProjectSelection` rather than on a
+      // project switch. Keying it to the sequence still stops a late loser from
+      // reporting a newer request as finished.
+      if (recentEditsRequestSeq === requestId) {
         setAnalyticsLoadingRecentEdits(false);
       }
     }

--- a/src/hooks/analytics/useAnalyticsNavigation.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.ts
@@ -176,10 +176,12 @@ export function useAnalyticsNavigation() {
     // longer exists, leaving the view empty. That was survivable only while the
     // guard never held.
     const cached = useAppStore.getState().analytics.recentEdits;
+    // No `files.length` condition: with request identity on the entry, an empty
+    // result is a valid answer ("this project has no edits") rather than an
+    // absent one. Requiring a non-empty list made such a project miss the cache
+    // on every visit and re-walk its whole JSONL set forever.
     const hasCachedRecentEdits =
-      cached &&
-      cached.files.length > 0 &&
-      cached.requestedProjectPath === project.path;
+      cached && cached.requestedProjectPath === project.path;
 
     if (hasCachedRecentEdits) {
       return;

--- a/src/hooks/analytics/useAnalyticsNavigation.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.ts
@@ -161,10 +161,16 @@ export function useAnalyticsNavigation() {
     setAnalyticsCurrentView("recentEdits");
     clearAnalyticsErrors();
 
+    // Read the cache at call time rather than from the render closure.
+    // `refreshAnalytics` clears it and then calls this in the same tick, so a
+    // closed-over value is a render behind and reports a hit on data that no
+    // longer exists, leaving the view empty. That was survivable only while the
+    // guard never held.
+    const cached = useAppStore.getState().analytics.recentEdits;
     const hasCachedRecentEdits =
-      analytics.recentEdits &&
-      analytics.recentEdits.files.length > 0 &&
-      analytics.recentEdits.requestedProjectPath === project.path;
+      cached &&
+      cached.files.length > 0 &&
+      cached.requestedProjectPath === project.path;
 
     if (hasCachedRecentEdits) {
       return;
@@ -173,6 +179,13 @@ export function useAnalyticsNavigation() {
     try {
       setAnalyticsLoadingRecentEdits(true);
       const result = await loadRecentEdits(project.path);
+
+      // The user may have switched projects while this was in flight. Writing
+      // anyway would show one project's edits under another's identity, and the
+      // cache guard would then treat that as a valid hit indefinitely.
+      if (useAppStore.getState().selectedProject?.path !== project.path) {
+        return;
+      }
 
       setAnalyticsRecentEdits({
         files: result.files,
@@ -204,11 +217,14 @@ export function useAnalyticsNavigation() {
       console.error("Failed to load recent edits:", error);
       throw error;
     } finally {
-      setAnalyticsLoadingRecentEdits(false);
+      // Only the request that still owns the selection clears the flag, so a
+      // late loser cannot report a newer request as finished.
+      if (useAppStore.getState().selectedProject?.path === project.path) {
+        setAnalyticsLoadingRecentEdits(false);
+      }
     }
   }, [
     t,
-    analytics.recentEdits,
     setAnalyticsCurrentView,
     clearAnalyticsErrors,
     setAnalyticsLoadingRecentEdits,

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -214,6 +214,18 @@ export const createAnalyticsSlice: StateCreator<
       return;
     }
 
+    // The cached rows and the pagination cursor may belong to a different
+    // project than the one being asked for. Appending here would staple one
+    // project's page onto another's rows and then tag the mixture with a
+    // request identity that looks valid to the cache guard.
+    if (
+      recentEdits &&
+      recentEdits.requestedProjectPath !== undefined &&
+      recentEdits.requestedProjectPath !== projectPath
+    ) {
+      return;
+    }
+
     // Set loading state
     set((state) => ({
       analytics: {

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -245,6 +245,7 @@ export const createAnalyticsSlice: StateCreator<
             total_edits_count: result.total_edits_count,
             unique_files_count: result.unique_files_count,
             project_cwd: result.project_cwd,
+            requestedProjectPath: projectPath,
           },
           recentEditsPagination: {
             totalEditsCount: result.total_edits_count,

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -207,6 +207,12 @@ export const createAnalyticsSlice: StateCreator<
   },
 
   loadMoreRecentEdits: async (projectPath: string) => {
+    // Required parameters are guarded at the top, per the repo checklist. An
+    // empty path would otherwise reach the backend as an invalid argument.
+    if (!projectPath.trim()) {
+      return;
+    }
+
     const { analytics } = get();
     const { recentEditsPagination, recentEdits } = analytics;
 
@@ -245,8 +251,33 @@ export const createAnalyticsSlice: StateCreator<
         limit: RECENT_EDITS_PAGE_SIZE,
       });
 
+      // The pre-await guard above only proves ownership at the moment the
+      // request started. The other two cache writers already re-check after
+      // their await; this one did not, so a page fetched for project A could
+      // still land after the user selected B, under B's pagination state.
+      const latest = get();
+      if (
+        latest.selectedProject?.path !== projectPath ||
+        (latest.analytics.recentEdits?.requestedProjectPath !== undefined &&
+          latest.analytics.recentEdits.requestedProjectPath !== projectPath)
+      ) {
+        // Clear the flag on the way out. Only one load-more can be in flight
+        // (the guard above plus `canLoadMore`), so leaving it set would block
+        // every future page for the project the user actually switched to.
+        set((state) => ({
+          analytics: {
+            ...state.analytics,
+            recentEditsPagination: {
+              ...state.analytics.recentEditsPagination,
+              isLoadingMore: false,
+            },
+          },
+        }));
+        return;
+      }
+
       // Append new files to existing list
-      const existingFiles = recentEdits?.files ?? [];
+      const existingFiles = latest.analytics.recentEdits?.files ?? [];
       const newFiles = [...existingFiles, ...result.files];
 
       set((state) => ({

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -324,11 +324,31 @@ export const createAnalyticsSlice: StateCreator<
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error("Failed to load more recent edits:", error);
-      toast.error(`Failed to load more edits: ${message}`);
+
+      // The same predicate the success path uses. Reporting a failure is a
+      // write to state shared with whatever is on screen now, so a request the
+      // user has already navigated away from must not do it.
+      const latest = get();
+      const stillOwns =
+        latest.selectedProject?.path === projectPath &&
+        latest.analytics.recentEdits?.requestedProjectPath === projectPath &&
+        latest.analytics.recentEditsGeneration === generation;
+
+      if (stillOwns) {
+        toast.error(`Failed to load more edits: ${message}`);
+      }
+
+      // The flag clears either way. It is global, only one load-more can be in
+      // flight, and a cache hit returns without resetting pagination, so
+      // leaving it set strands Show More for whatever is selected next. A
+      // duplicate request unlocked this way cannot corrupt the list: its
+      // commit fails the generation check.
       set((state) => ({
         analytics: {
           ...state.analytics,
-          recentEditsError: `Failed to load more edits: ${message}`,
+          ...(stillOwns
+            ? { recentEditsError: `Failed to load more edits: ${message}` }
+            : {}),
           recentEditsPagination: {
             ...state.analytics.recentEditsPagination,
             isLoadingMore: false,

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -18,7 +18,7 @@ import type { StateCreator } from "zustand";
 import { toast } from "sonner";
 import type { FullAppStore } from "./types";
 import { fetchRecentEdits } from "../../services/analyticsApi";
-import { canLoadMore, getNextOffset } from "../../utils/pagination";
+import { canLoadMore } from "../../utils/pagination";
 
 const RECENT_EDITS_PAGE_SIZE = 20;
 
@@ -168,6 +168,10 @@ export const createAnalyticsSlice: StateCreator<
       analytics: {
         ...state.analytics,
         recentEdits: edits,
+        // Bumping here, rather than at each call site, is what makes the
+        // generation true for all three writers of the cache without any of
+        // them having to remember.
+        recentEditsGeneration: state.analytics.recentEditsGeneration + 1,
       },
     }));
   },
@@ -224,11 +228,12 @@ export const createAnalyticsSlice: StateCreator<
     // project than the one being asked for. Appending here would staple one
     // project's page onto another's rows and then tag the mixture with a
     // request identity that looks valid to the cache guard.
-    if (
-      recentEdits &&
-      recentEdits.requestedProjectPath !== undefined &&
-      recentEdits.requestedProjectPath !== projectPath
-    ) {
+    //
+    // An exact match, rather than "not some other owner": an absent cache is
+    // not something to extend either, because there is no page to continue.
+    // Every writer records the path it fetched for, so a legitimate caller
+    // always has one.
+    if (recentEdits?.requestedProjectPath !== projectPath) {
       return;
     }
 
@@ -243,8 +248,16 @@ export const createAnalyticsSlice: StateCreator<
       },
     }));
 
+    // The version of the list this page is being fetched to continue.
+    const generation = analytics.recentEditsGeneration;
+
     try {
-      const nextOffset = getNextOffset(recentEditsPagination);
+      // The rows already held ARE the next offset. A stored cursor is a second
+      // copy of that fact, and the two desync the moment the list is replaced
+      // without the cursor being reset, which `setAnalyticsRecentEdits` cannot
+      // do because it does not own the cursor. The dock panel already derives
+      // its offset this way.
+      const nextOffset = recentEdits.files.length;
 
       const result = await fetchRecentEdits(projectPath, {
         offset: nextOffset,
@@ -256,10 +269,14 @@ export const createAnalyticsSlice: StateCreator<
       // their await; this one did not, so a page fetched for project A could
       // still land after the user selected B, under B's pagination state.
       const latest = get();
+      // Ownership answers "whose list is this". The generation answers "which
+      // version of it", which ownership cannot: a refresh can replace the list
+      // with one of the same length under the same owner, and this page does
+      // not continue that one.
       if (
         latest.selectedProject?.path !== projectPath ||
-        (latest.analytics.recentEdits?.requestedProjectPath !== undefined &&
-          latest.analytics.recentEdits.requestedProjectPath !== projectPath)
+        latest.analytics.recentEdits?.requestedProjectPath !== projectPath ||
+        latest.analytics.recentEditsGeneration !== generation
       ) {
         // Clear the flag on the way out. Only one load-more can be in flight
         // (the guard above plus `canLoadMore`), so leaving it set would block
@@ -276,8 +293,9 @@ export const createAnalyticsSlice: StateCreator<
         return;
       }
 
-      // Append new files to existing list
-      const existingFiles = latest.analytics.recentEdits?.files ?? [];
+      // Append new files to existing list. The guard above has already proven
+      // this cache is present, owned and current.
+      const existingFiles = latest.analytics.recentEdits.files;
       const newFiles = [...existingFiles, ...result.files];
 
       set((state) => ({
@@ -290,6 +308,9 @@ export const createAnalyticsSlice: StateCreator<
             project_cwd: result.project_cwd,
             requestedProjectPath: projectPath,
           },
+          // This write is a new version of the list too, so a second page
+          // racing this one cannot also commit.
+          recentEditsGeneration: state.analytics.recentEditsGeneration + 1,
           recentEditsPagination: {
             totalEditsCount: result.total_edits_count,
             uniqueFilesCount: result.unique_files_count,

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -22,6 +22,13 @@ import { canLoadMore } from "../../utils/pagination";
 
 const RECENT_EDITS_PAGE_SIZE = 20;
 
+/**
+ * Identifies the newest load-more request. Deliberately module state rather
+ * than store state: it is not something any view renders, and the navigation
+ * hook keeps its own request sequence the same way.
+ */
+let recentEditsLoadMoreSeq = 0;
+
 // ============================================================================
 // State Interface
 // ============================================================================
@@ -238,6 +245,7 @@ export const createAnalyticsSlice: StateCreator<
     }
 
     // Set loading state
+    const requestId = ++recentEditsLoadMoreSeq;
     set((state) => ({
       analytics: {
         ...state.analytics,
@@ -247,6 +255,27 @@ export const createAnalyticsSlice: StateCreator<
         },
       },
     }));
+
+    // Only the newest request may release the flag. It is global, so a
+    // superseded request clearing it re-enables Show More while a newer one is
+    // still running, and the extra click costs a full walk of the project's
+    // logs even though the generation check would discard its rows.
+    //
+    // Ownership here is "newest", not "same project". A request nobody has
+    // superseded still releases the flag on its way out, which is what keeps
+    // it from being stranded when its own project is deselected.
+    const releaseLoadingFlag = () => {
+      if (recentEditsLoadMoreSeq !== requestId) return;
+      set((state) => ({
+        analytics: {
+          ...state.analytics,
+          recentEditsPagination: {
+            ...state.analytics.recentEditsPagination,
+            isLoadingMore: false,
+          },
+        },
+      }));
+    };
 
     // The version of the list this page is being fetched to continue.
     const generation = analytics.recentEditsGeneration;
@@ -274,22 +303,12 @@ export const createAnalyticsSlice: StateCreator<
       // with one of the same length under the same owner, and this page does
       // not continue that one.
       if (
+        recentEditsLoadMoreSeq !== requestId ||
         latest.selectedProject?.path !== projectPath ||
         latest.analytics.recentEdits?.requestedProjectPath !== projectPath ||
         latest.analytics.recentEditsGeneration !== generation
       ) {
-        // Clear the flag on the way out. Only one load-more can be in flight
-        // (the guard above plus `canLoadMore`), so leaving it set would block
-        // every future page for the project the user actually switched to.
-        set((state) => ({
-          analytics: {
-            ...state.analytics,
-            recentEditsPagination: {
-              ...state.analytics.recentEditsPagination,
-              isLoadingMore: false,
-            },
-          },
-        }));
+        releaseLoadingFlag();
         return;
       }
 
@@ -330,31 +349,22 @@ export const createAnalyticsSlice: StateCreator<
       // user has already navigated away from must not do it.
       const latest = get();
       const stillOwns =
+        recentEditsLoadMoreSeq === requestId &&
         latest.selectedProject?.path === projectPath &&
         latest.analytics.recentEdits?.requestedProjectPath === projectPath &&
         latest.analytics.recentEditsGeneration === generation;
 
       if (stillOwns) {
         toast.error(`Failed to load more edits: ${message}`);
+        set((state) => ({
+          analytics: {
+            ...state.analytics,
+            recentEditsError: `Failed to load more edits: ${message}`,
+          },
+        }));
       }
 
-      // The flag clears either way. It is global, only one load-more can be in
-      // flight, and a cache hit returns without resetting pagination, so
-      // leaving it set strands Show More for whatever is selected next. A
-      // duplicate request unlocked this way cannot corrupt the list: its
-      // commit fails the generation check.
-      set((state) => ({
-        analytics: {
-          ...state.analytics,
-          ...(stillOwns
-            ? { recentEditsError: `Failed to load more edits: ${message}` }
-            : {}),
-          recentEditsPagination: {
-            ...state.analytics.recentEditsPagination,
-            isLoadingMore: false,
-          },
-        },
-      }));
+      releaseLoadingFlag();
     }
   },
 

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -359,7 +359,16 @@ export const createAnalyticsSlice: StateCreator<
   },
 
   resetAnalytics: () => {
-    set({ analytics: initialAnalyticsState });
+    // Everything else goes back to its initial value, but the generation is a
+    // counter rather than a value: restoring it to 0 makes its numbers
+    // reusable, and a request in flight that captured the old 1 would then be
+    // accepted by the new 1. It only ever moves forward.
+    set((state) => ({
+      analytics: {
+        ...initialAnalyticsState,
+        recentEditsGeneration: state.analytics.recentEditsGeneration + 1,
+      },
+    }));
   },
 
   clearAnalyticsErrors: () => {

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -609,6 +609,7 @@ export const createProjectSlice: StateCreator<
           total_edits_count: recentEdits.total_edits_count,
           unique_files_count: recentEdits.unique_files_count,
           project_cwd: recentEdits.project_cwd,
+          requestedProjectPath: refreshedProject.path,
         });
       } else if (refreshedState.analytics.currentView === "board") {
         refreshedState.clearBoard();

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -604,13 +604,18 @@ export const createProjectSlice: StateCreator<
         const recentEdits = await refreshedState.loadRecentEdits(
           refreshedProject.path
         );
-        refreshedState.setAnalyticsRecentEdits({
-          files: recentEdits.files,
-          total_edits_count: recentEdits.total_edits_count,
-          unique_files_count: recentEdits.unique_files_count,
-          project_cwd: recentEdits.project_cwd,
-          requestedProjectPath: refreshedProject.path,
-        });
+        // Same ownership rule as the navigation hook: if the selection moved on
+        // while this was in flight, writing would show one project's edits
+        // under another's identity.
+        if (get().selectedProject?.path === refreshedProject.path) {
+          refreshedState.setAnalyticsRecentEdits({
+            files: recentEdits.files,
+            total_edits_count: recentEdits.total_edits_count,
+            unique_files_count: recentEdits.unique_files_count,
+            project_cwd: recentEdits.project_cwd,
+            requestedProjectPath: refreshedProject.path,
+          });
+        }
       } else if (refreshedState.analytics.currentView === "board") {
         refreshedState.clearBoard();
         await refreshedState.loadBoardSessions(get().sessions);

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -36,6 +36,12 @@ export interface AnalyticsState {
   sessionComparison: SessionComparison | null;
   recentEdits: RecentEditsResult | null;
   recentEditsPagination: RecentEditsPagination;
+  /**
+   * Bumped on every write to `recentEdits`, a clear included. A page fetched
+   * against an older generation no longer continues the list on screen, so it
+   * must not be appended to it.
+   */
+  recentEditsGeneration: number;
 
   recentEditsSearchQuery: string;
 
@@ -105,6 +111,7 @@ export const initialAnalyticsState: AnalyticsState = {
   sessionComparison: null,
   recentEdits: null,
   recentEditsPagination: initialRecentEditsPagination,
+  recentEditsGeneration: 0,
   recentEditsSearchQuery: "",
   isLoadingProjectSummary: false,
   isLoadingSessionComparison: false,

--- a/src/types/edit.types.ts
+++ b/src/types/edit.types.ts
@@ -29,6 +29,19 @@ export interface RecentEditsResult {
   total_edits_count: number;
   unique_files_count: number;
   project_cwd?: string;
+  /**
+   * Cache identity: the `project.path` this result was fetched for. Camel-cased
+   * because the backend never sends it; the snake_case fields above mirror the
+   * payload.
+   *
+   * Do not cache-match on `project_cwd` instead. It is the most frequent `cwd`
+   * observed in the session logs, so it never equals `project.path`, and it is
+   * not reliably equal to `project.actual_path` either: they diverge for moved
+   * projects, for drive-letter case differences on Windows, and when sessions
+   * ran in a subdirectory of the project. It is also absent for providers with
+   * virtual paths.
+   */
+  requestedProjectPath?: string;
 }
 
 /**


### PR DESCRIPTION
## What & why

The Recent Edits fetch cache never hit. Every visit re-walked and re-parsed every JSONL file in the project.

The guard compared two values that can never be equal:

```ts
analytics.recentEdits.project_cwd === project.path
```

- `project.path` is the encoded Claude storage directory (`~/.claude/projects/-Users-jack-my-project`).
- `project_cwd` is the most frequent `cwd` recorded in the session logs, i.e. a real filesystem path (`edits.rs`).

This replaces the comparison with request identity: the cached result now carries the `project.path` it was fetched for.

Closes #

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [ ] Refactor / perf
- [ ] Docs

## Measured, not inferred

The real `scan_projects` and `get_recent_edits` were run through the `--serve` binary against a real `~/.claude` folder (84 projects), and the guard was evaluated against the actual returned values.

| comparison | holds |
|---|---|
| `project_cwd === project.path` (before) | **0 / 28** |
| `project_cwd === project.actual_path` | 25 / 28 |
| `requestedProjectPath === project.path` (this PR) | 28 / 28 |

### Why not just compare `project.actual_path`

That is the obvious one-line fix and it is not sufficient. It failed on 3 of the 28 sampled projects, each for a different reason:

1. **Moved project.** `project_cwd` under `product-on-purpose`, `actual_path` under `prisant-labs`.
2. **Drive-letter case.** `E:\...` versus `e:\...`. A strict `===` fails on case alone.
3. **Sessions run in a subdirectory.** `project_cwd` was `...\_local\initial-plan`, `actual_path` the project root.

It is also wrong by construction for ForgeCode and OpenCode, where `project_cwd` is deliberately `None`.

An `actual_path` comparison would have looked correct while still always-missing for a minority of projects, which is harder to notice than the current obvious bug.

## Evidence from a real rendered view

`--serve --no-auth --host 127.0.0.1`, driven by Playwright: select a project, open Recent Edits, switch to Analytics, open Recent Edits again. Counting `POST /api/get_recent_edits`:

| | fetches for two visits | console errors |
|---|---|---|
| before | **2** | 0 |
| after | **1** | 0 |

## Adversarial review

An independent Codex pass over this change found three further defects, all fixed here, each with a regression test verified to fail without its fix.

The important one: **making a cache that never hit actually hit exposed a latent bug.** `refreshAnalytics` clears the cache and calls `switchToRecentEdits` in the same tick, and the guard read the cache from the render closure, which is a render behind. It reported a hit on data that had just been cleared and left the Recent Edits view empty. Refresh worked before this PR only because the guard never held. The guard now reads the store at call time.

The other two are pre-existing races this change made more expensive: load-more could staple one project's page onto another's rows, and none of the three cache writers checked they still owned the response. An identity field that looks trustworthy lets a stale or mixed result survive as a valid cache hit, where previously it was simply refetched away.

A follow-up self-review found one more: the ownership guard initially stranded the loading flag when a request's project was deselected, since `resetAnalytics` runs in `clearProjectSelection` rather than on a project switch. It is now keyed to a request sequence.

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior: 8 cases in `useAnalyticsNavigation.test.ts`, each mutation-checked
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: no new user-facing strings in this PR

## If this adds a frontend-callable backend command

Not applicable. Frontend only, no backend change, so no Tauri/Axum parity work is required.

## Tests

The suite was mutation-checked so it discriminates every candidate fix:

| guard under test | result |
|---|---|
| `project_cwd === project.path` (the bug) | test fails: "expected 1 times, but got 2 times" |
| `project_cwd === project.actual_path` | divergence test fails |
| `requestedProjectPath === project.path` | all pass |

`pnpm exec vitest run`: 1025 tests passing.

## Note for the reviewer

Related, lands separately: the Recent Edits dockable panel branch. The two can merge in either order; both touch `src/types/edit.types.ts` (different interfaces), so expect at most a trivial conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHDyJsNgK6ZxLndv6jinS1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Recent Edits caching, including reliable reuse of empty results for the active project.
  - Prevented results from appearing after switching projects or refreshing conversations.
  - Fixed pagination offsets and kept pages associated with the correct project.
  - Prevented outdated requests from overwriting newer results, errors, or loading indicators.
  - Improved analytics refresh and reset handling for consistent project alignment.
  - Suppressed irrelevant errors when a project is deselected during loading.
  - Ensured newer requests continue displaying the correct loading state while older requests finish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->