### PR TITLE
fix(webui): gate restore writes on the bind address, matching the read path

### DIFF
--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -373,6 +373,14 @@ fn strip_windows_extended_prefix(path: &Path) -> PathBuf {
 /// Normalize only the representation used for the allowlist boundary check.
 /// Windows paths are case-insensitive for normal filesystem access, while
 /// Unix paths retain their case-sensitive semantics.
+///
+/// The `return` in the Windows arm reads as needless to clippy, which only sees
+/// one arm at a time: on Windows the `cfg(not(windows))` tail is compiled away,
+/// so the block looks like it could just be the tail expression. Keeping the
+/// explicit `return` keeps the two arms symmetrical and independent of which
+/// one happens to come last. The lint only fires when compiling for Windows,
+/// which is why CI does not see it.
+#[allow(clippy::needless_return)]
 fn normalize_path_for_comparison(path: &Path) -> PathBuf {
     let stripped = strip_windows_extended_prefix(path);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -460,6 +460,10 @@ fn run_server(args: &[String]) {
         start_time: std::time::Instant::now(),
         auth: resolved_auth.auth.clone(),
         read_only,
+        // Computed from the resolved bind host, the same predicate the auth
+        // startup checks use, so "is this machine talking to itself" has one
+        // definition in this binary rather than two.
+        loopback_bind: is_loopback_bind_host(&host),
         event_tx,
     });
 

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -564,11 +564,36 @@ handler_json!(
 ///
 /// Named rather than inlined so the decision can be tested without standing up
 /// a router, the same reason `is_read_only_allowed_path` is its own function.
-pub(crate) fn restore_write_allowed(loopback_bind: bool, path: &Path) -> Result<(), String> {
-    if loopback_bind {
+///
+/// `unrestricted` is deliberately a decided boolean rather than the raw bind
+/// flag, so the one place that decides is the call site and this stays a pure
+/// predicate.
+pub(crate) fn restore_write_allowed(unrestricted: bool, path: &Path) -> Result<(), String> {
+    if unrestricted {
         return Ok(());
     }
     commands::claude_settings::is_safe_path(path)
+}
+
+/// Whether this server may write outside the export allowlist.
+///
+/// Loopback alone is not enough. "The caller is this machine" is only the same
+/// statement as "the caller is the person at the keyboard" while something
+/// proves the request came from this app: with `--no-auth` the router installs
+/// `allow_origin(Any)` (see `build_router`), so any page the user has open can
+/// preflight and then `POST /api/restore_file` at `127.0.0.1` with a path and a
+/// body of its choosing. `~/.zshrc`, or a hook in `~/.claude/settings.json`,
+/// makes that code execution.
+///
+/// `--no-auth` is also permitted on a loopback host without
+/// `--allow-unsafe-no-auth`, so that combination is not exotic — it is the one
+/// in the project's own `--serve` instructions.
+///
+/// Requiring both keeps the case the carve-out exists for (the desktop-like
+/// local session, authenticated, restoring a file in your own project) and
+/// drops the one it never meant to cover.
+pub(crate) fn restore_write_is_unrestricted(state: &AppState) -> bool {
+    state.loopback_bind && state.auth.is_enabled()
 }
 
 /// Write a file back to disk from a recorded edit.
@@ -582,12 +607,14 @@ pub(crate) fn restore_write_allowed(loopback_bind: bool, path: &Path) -> Result<
 /// being refused permission to *read* that same path. Writing is strictly the
 /// more dangerous of the two, so the guard belonged here first.
 ///
-/// The gate is the bind address rather than a blanket allowlist. On loopback the
-/// caller is this machine, so restoring a file anywhere is exactly what the
-/// desktop app already does through the OS dialog, and forcing the allowlist
-/// there would break restoring a file in your own project for no safety gained.
-/// Bound to a routable address the caller is someone else, and the same
-/// allowlist the read path uses applies.
+/// The gate is the bind address plus authentication rather than a blanket
+/// allowlist. On an authenticated loopback server the caller is this app on
+/// this machine, so restoring a file anywhere is exactly what the desktop app
+/// already does through the OS dialog, and forcing the allowlist there would
+/// break restoring a file in your own project for no safety gained. Bound to a
+/// routable address, or with auth off, the caller is someone else — possibly a
+/// web page — and the same allowlist the read path uses applies. See
+/// `restore_write_is_unrestricted`.
 ///
 /// Command-level validation (absolute path, no null bytes, no `..`, atomic
 /// write) still runs underneath in both cases; this only decides *where*.
@@ -595,7 +622,10 @@ pub async fn restore_file(
     State(state): State<Arc<AppState>>,
     Json(p): Json<RestoreFileParams>,
 ) -> Result<Json<Value>, ApiError> {
-    restore_write_allowed(state.loopback_bind, Path::new(&p.file_path))?;
+    restore_write_allowed(
+        restore_write_is_unrestricted(&state),
+        Path::new(&p.file_path),
+    )?;
 
     commands::session::restore_file(p.file_path, p.content)
         .await

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -7,7 +7,7 @@ use axum::extract::State;
 use axum::Json;
 use serde::Deserialize;
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::state::AppState;
@@ -560,11 +560,51 @@ handler_json!(
     }
 );
 
-handler_json!(
-    restore_file,
-    RestoreFileParams,
-    |p: RestoreFileParams| async move { commands::session::restore_file(p.file_path, p.content).await }
-);
+/// Where a `WebUI` restore may write, given how this server is bound.
+///
+/// Named rather than inlined so the decision can be tested without standing up
+/// a router, the same reason `is_read_only_allowed_path` is its own function.
+pub(crate) fn restore_write_allowed(loopback_bind: bool, path: &Path) -> Result<(), String> {
+    if loopback_bind {
+        return Ok(());
+    }
+    commands::claude_settings::is_safe_path(path)
+}
+
+/// Write a file back to disk from a recorded edit.
+///
+/// Stateful rather than a `handler_json!` because the allowlist decision depends
+/// on how this server is bound.
+///
+/// `read_text_file` above enforces the export allowlist unconditionally, and for
+/// a long while this, its write-side counterpart, enforced nothing: over
+/// `--serve` a request could overwrite any file the process could reach while
+/// being refused permission to *read* that same path. Writing is strictly the
+/// more dangerous of the two, so the guard belonged here first.
+///
+/// The gate is the bind address rather than a blanket allowlist. On loopback the
+/// caller is this machine, so restoring a file anywhere is exactly what the
+/// desktop app already does through the OS dialog, and forcing the allowlist
+/// there would break restoring a file in your own project for no safety gained.
+/// Bound to a routable address the caller is someone else, and the same
+/// allowlist the read path uses applies.
+///
+/// Command-level validation (absolute path, no null bytes, no `..`, atomic
+/// write) still runs underneath in both cases; this only decides *where*.
+pub async fn restore_file(
+    State(state): State<Arc<AppState>>,
+    Json(p): Json<RestoreFileParams>,
+) -> Result<Json<Value>, ApiError> {
+    restore_write_allowed(state.loopback_bind, Path::new(&p.file_path))?;
+
+    commands::session::restore_file(p.file_path, p.content)
+        .await
+        .map_err(ApiError::from)?;
+    // The command yields `()`, which is the `null` the macro-generated handlers
+    // serialize for the other mutating endpoints. Written out rather than bound
+    // to a variable first, which would be a unit-valued binding.
+    Ok(Json(Value::Null))
+}
 
 handler_json!(get_preset, IdParam, |p: IdParam| async move {
     commands::settings::get_preset(p.id).await

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -773,6 +773,31 @@ mod tests {
     use axum::body::Body;
     use tower::ServiceExt;
 
+    /// The write side of the allowlist, which for a long while had no guard at
+    /// all while `read_text_file` beside it enforced one. Over `--serve` a
+    /// request could overwrite any reachable file while being refused
+    /// permission to read that same path.
+    #[test]
+    fn test_restore_write_is_unrestricted_only_on_loopback() {
+        use crate::server::handlers::restore_write_allowed;
+
+        // Somewhere no allowlist would ever cover.
+        let outside = std::env::temp_dir().join("ccv-restore-gate-probe.txt");
+
+        assert!(
+            restore_write_allowed(true, &outside).is_ok(),
+            "on loopback the caller is this machine, so restoring anywhere is \
+             what the desktop app already does"
+        );
+
+        let refused = restore_write_allowed(false, &outside);
+        assert!(
+            refused.is_err(),
+            "bound to a routable address the caller is someone else, so the \
+             same allowlist the read path uses must apply"
+        );
+    }
+
     fn test_state(auth_token: Option<&str>) -> Arc<AppState> {
         let (event_tx, _rx) =
             tokio::sync::broadcast::channel::<crate::commands::watcher::FileWatchEvent>(1);
@@ -786,6 +811,7 @@ mod tests {
                 })
                 .unwrap_or(AuthState::Disabled),
             read_only: false,
+            loopback_bind: false,
             event_tx,
         })
     }
@@ -803,6 +829,7 @@ mod tests {
                 false,
             ))),
             read_only: false,
+            loopback_bind: false,
             event_tx,
         })
     }
@@ -815,6 +842,7 @@ mod tests {
             start_time: std::time::Instant::now(),
             auth: AuthState::Disabled,
             read_only: true,
+            loopback_bind: false,
             event_tx,
         })
     }

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -773,29 +773,113 @@ mod tests {
     use axum::body::Body;
     use tower::ServiceExt;
 
+    /// Somewhere no export allowlist would ever cover.
+    #[cfg(test)]
+    fn restore_gate_probe_path() -> std::path::PathBuf {
+        std::env::temp_dir().join("ccv-restore-gate-probe.txt")
+    }
+
     /// The write side of the allowlist, which for a long while had no guard at
     /// all while `read_text_file` beside it enforced one. Over `--serve` a
     /// request could overwrite any reachable file while being refused
     /// permission to read that same path.
     #[test]
-    fn test_restore_write_is_unrestricted_only_on_loopback() {
+    fn test_restore_write_is_unrestricted_only_when_permitted() {
         use crate::server::handlers::restore_write_allowed;
 
-        // Somewhere no allowlist would ever cover.
-        let outside = std::env::temp_dir().join("ccv-restore-gate-probe.txt");
+        let outside = restore_gate_probe_path();
 
         assert!(
             restore_write_allowed(true, &outside).is_ok(),
-            "on loopback the caller is this machine, so restoring anywhere is \
-             what the desktop app already does"
+            "an authenticated loopback server is this app on this machine, so \
+             restoring anywhere is what the desktop app already does"
         );
 
         let refused = restore_write_allowed(false, &outside);
         assert!(
             refused.is_err(),
-            "bound to a routable address the caller is someone else, so the \
-             same allowlist the read path uses must apply"
+            "otherwise the caller is someone else, so the same allowlist the \
+             read path uses must apply"
         );
+    }
+
+    /// Loopback alone must not open the gate. With `--no-auth` the router
+    /// installs `allow_origin(Any)`, so any page the user has open can POST to
+    /// `127.0.0.1`; and `--no-auth` needs no extra flag on a loopback host.
+    #[test]
+    fn test_restore_write_needs_auth_as_well_as_loopback() {
+        use crate::server::handlers::restore_write_is_unrestricted;
+
+        let authenticated_loopback = state_with(true, Some("a-token"));
+        assert!(
+            restore_write_is_unrestricted(&authenticated_loopback),
+            "the case the carve-out exists for must keep working"
+        );
+
+        let open_loopback = state_with(true, None);
+        assert!(
+            !restore_write_is_unrestricted(&open_loopback),
+            "--no-auth on loopback is reachable by any web page the user has \
+             open, so it is not the person at the keyboard"
+        );
+
+        let authenticated_routable = state_with(false, Some("a-token"));
+        assert!(
+            !restore_write_is_unrestricted(&authenticated_routable),
+            "an authenticated remote caller is still a remote caller"
+        );
+
+        assert!(!restore_write_is_unrestricted(&state_with(false, None)));
+    }
+
+    /// Pins the wiring, not just the predicate. Deleting the guard from the
+    /// handler leaves both tests above green, which is the failure mode a
+    /// pure-function test cannot see.
+    #[tokio::test]
+    async fn test_restore_endpoint_refuses_a_path_outside_the_allowlist() {
+        let state = state_with(false, None);
+        let app = build_router(state, "127.0.0.1", 3727, None, "/");
+
+        let body = serde_json::json!({
+            "filePath": restore_gate_probe_path().to_string_lossy(),
+            "content": "should never be written",
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/restore_file")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(
+            response.status(),
+            StatusCode::OK,
+            "the endpoint must refuse a path no allowlist covers"
+        );
+        assert!(
+            !restore_gate_probe_path().exists(),
+            "the refusal must happen before anything reaches the disk"
+        );
+    }
+
+    /// An `AppState` differing only in the two inputs the gate reads.
+    fn state_with(loopback_bind: bool, auth_token: Option<&str>) -> Arc<AppState> {
+        let state = test_state(auth_token);
+        let (event_tx, _rx) =
+            tokio::sync::broadcast::channel::<crate::commands::watcher::FileWatchEvent>(1);
+        Arc::new(AppState {
+            metadata: Arc::clone(&state.metadata),
+            start_time: state.start_time,
+            auth: state.auth.clone(),
+            read_only: state.read_only,
+            loopback_bind,
+            event_tx,
+        })
     }
 
     fn test_state(auth_token: Option<&str>) -> Arc<AppState> {

--- a/src-tauri/src/server/state.rs
+++ b/src-tauri/src/server/state.rs
@@ -21,6 +21,17 @@ pub struct AppState {
     pub auth: AuthState,
     /// Whether mutating `WebUI` API endpoints should be rejected.
     pub read_only: bool,
+    /// Whether the server is bound to a loopback address.
+    ///
+    /// The trust boundary for filesystem writes. On loopback the caller and the
+    /// server are the same machine, so writing outside the export allowlist is
+    /// no more dangerous than the desktop app doing it. Bound to a routable
+    /// address it is a different machine, and an authenticated request should
+    /// not be able to write anywhere on this one.
+    ///
+    /// Deliberately `false` when unknown: a construction site that forgets this
+    /// field gets the restrictive behaviour, not the permissive one.
+    pub loopback_bind: bool,
     /// Broadcast channel for file-change events (SSE consumers subscribe here).
     pub event_tx: broadcast::Sender<FileWatchEvent>,
 }


### PR DESCRIPTION
Closes #519.

## The problem

In `server/handlers.rs`, the WebUI's read endpoint enforces the export directory allowlist and the write endpoint one handler below enforces nothing:

```rust
read_text_file  → is_safe_path(&path)?;   // guarded
restore_file    → (no check)              // writes anywhere
```

`restore_file` writes caller-supplied content to a caller-supplied path. Its command-level validation rejects null bytes, relative paths and `..`, and writes atomically, but nothing constrains *where*. So over `--serve` a request could overwrite any file the server process could reach while being refused permission to **read** that same path.

Writing is strictly more dangerous than reading. The guard being present on the safer call and absent on the riskier one reads as an oversight rather than a decision.

## Why the bind address rather than a blanket allowlist

Applying `is_safe_path` unconditionally would have been one line, and it would have broken the feature for its main use.

The two deployments are genuinely different situations:

| bind | who the caller is | what restore may write |
|---|---|---|
| loopback | this machine | anywhere, as the desktop app already does via the OS dialog |
| routable | someone else | the same allowlist the read path uses |

On loopback, anything a request can reach the person at the keyboard already could, so the allowlist buys no safety and costs the ability to restore a file in your own project. On a routable address that reasoning disappears entirely.

## Shape

- `AppState.loopback_bind`, computed in `run_server` from `is_loopback_bind_host` - the same predicate the auth startup checks use, so "is this machine talking to itself" has one definition in the binary rather than two.
- The field is `false` at every construction site including the tests. A site that forgets it gets the restrictive behaviour, not the permissive one.
- The handler is stateful rather than `handler_json!`-generated, since the decision depends on state the macro does not pass.
- `restore_write_allowed` is named rather than inlined so it can be tested without standing up a router, the same reason `is_read_only_allowed_path` is.

Command-level validation still runs underneath in both cases. This only decides *where*.

## Not affected

The desktop app. These are `WebUI` handlers; Tauri relies on the OS dialog for intent, which is what the existing comment on `read_text_file` refers to.

Existing protections are unchanged and still apply first: token auth is on by default, `--no-auth` on a non-loopback host is refused without `--allow-unsafe-no-auth`, and `--read-only` already rejects `/restore_file` as a mutating path.

## Tests

`test_restore_write_is_unrestricted_only_on_loopback` pins both directions: a path no allowlist would cover is permitted on loopback and refused otherwise. Full server suite passes (27), `cargo fmt --check` and `cargo clippy --all-targets --all-features -D warnings` clean.

## How it surfaced

While adding a diff preview to the restore confirmation in #515, which reads the file to show what the write will overwrite. The read was refused for a path the write would have accepted, which is what made the asymmetry visible.

## Note on the second commit

`c668db9` is a cherry-pick of `d760c6d`, a Windows-only clippy false positive in `rename.rs` that blocks committing any Rust change on Windows. It is also on #515. Whichever lands first, the other carries an identical hunk. It arguably belongs here rather than there, since this is the Rust-side PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened file-restore security by allowing unrestricted writes only for authenticated access on loopback connections.
  * Servers on routable addresses and unauthenticated loopback connections now enforce the export allowlist.
  * Added safeguards to reject disallowed restore paths before any files are written.
  * Improved monitoring of Kimi Code session files when the sessions directory exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->