### PR TITLE
fix(lint): silence a Windows-only clippy false positive in rename

### DIFF
--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -373,6 +373,14 @@ fn strip_windows_extended_prefix(path: &Path) -> PathBuf {
 /// Normalize only the representation used for the allowlist boundary check.
 /// Windows paths are case-insensitive for normal filesystem access, while
 /// Unix paths retain their case-sensitive semantics.
+///
+/// The `return` in the Windows arm reads as needless to clippy, which only sees
+/// one arm at a time: on Windows the `cfg(not(windows))` tail is compiled away,
+/// so the block looks like it could just be the tail expression. Keeping the
+/// explicit `return` keeps the two arms symmetrical and independent of which
+/// one happens to come last. The lint only fires when compiling for Windows,
+/// which is why CI does not see it.
+#[allow(clippy::needless_return)]
 fn normalize_path_for_comparison(path: &Path) -> PathBuf {
     let stripped = strip_windows_extended_prefix(path);
 


### PR DESCRIPTION
## What & why

`normalize_path_for_comparison` in `src-tauri/src/commands/session/rename.rs` has two `cfg`-gated arms. On Windows the `cfg(not(windows))` tail is compiled away, so the Windows arm's explicit `return` looks to clippy like a `needless_return` — it only ever sees one arm. The lint fires only when compiling *for* Windows, which is why CI (ubuntu) has never seen it.

The repo's pre-commit hook runs `cargo clippy -- -D warnings`, so on a Windows machine this blocks **every** commit that touches `src-tauri/src/**/*.rs`, regardless of what the commit is about.

This adds `#[allow(clippy::needless_return)]` with a comment explaining why the `return` stays: keeping it makes the two arms symmetrical and independent of which one happens to be compiled last.

## Provenance

Cherry-pick of `c668db9` by @jprisant, authored while working on #515. The identical hunk currently rides on both #515 and #520; landing it here on its own means whichever of those rebases second drops a duplicate hunk instead of conflicting on it. Authorship is preserved.

@jprisant — once this is in, please drop the hunk from #515 and #520.

## Type

- [x] Bug fix (developer-facing: unblocks committing on Windows)

## Checklist

- [x] PR targets `develop`
- [x] `cargo fmt --all -- --check` clean
- [x] No user-facing strings, so no i18n work
- [x] No behavioural change: attribute and comment only, 8 added lines, 0 removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified platform-specific path normalization behavior and the rationale for retaining an explicit return statement.

* **Chores**
  * Resolved a Windows-only code quality warning without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->