### PR TITLE
fix(recent-edits): invalidate the fetch cache when the watcher sees a change

### DIFF
--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -919,15 +919,20 @@ describe("recent-edits cache invalidation on file change", () => {
       },
     }));
 
-    const more = Promise.withResolvers<unknown>();
-    fetchRecentEdits.mockImplementationOnce(() => more.promise);
+    // Executor form, not `Promise.withResolvers`: the jsdom realm this suite
+    // runs in on CI does not provide it. Matches every other deferred case in
+    // this file.
+    let resolveMore: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveMore = resolve))
+    );
     const pending = useAppStore.getState().loadMoreRecentEdits(p.path);
 
     await act(async () => {
       useAppStore.getState().invalidateRecentEdits(p.path);
     });
     await act(async () => {
-      more.resolve({
+      resolveMore?.({
         ...payload(p.actual_path),
         files: [{ ...payload(p.actual_path).files[0], file_path: "late.ts" }],
       });

--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -807,3 +807,137 @@ describe("recent-edits failures respect ownership", () => {
     expect(useAppStore.getState().analytics.recentEditsError).toBeNull();
   });
 });
+
+/**
+ * Making the cache actually hit removed the accidental freshness the
+ * always-miss had been providing. Nothing in the watcher path invalidates it:
+ * `triggerProjectRefresh` reloads the session list through `selectProject`,
+ * which never touches analytics, and `resetAnalytics` runs only in
+ * `clearProjectSelection`. So a project could sit selected all day serving
+ * pre-edit rows, with the header refresh button the only way out.
+ */
+describe("recent-edits cache invalidation on file change", () => {
+  beforeEach(() => {
+    fetchRecentEdits.mockReset();
+    useAppStore.setState({ selectedProject: null, selectedSession: null });
+    useAppStore.getState().resetAnalytics();
+  });
+
+  it("refetches after the watcher reports the project changed", async () => {
+    const p = project("alpha");
+    fetchRecentEdits.mockResolvedValue(payload(p.actual_path));
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+
+    // Second visit with no file change still hits the cache — invalidation
+    // must not simply disable it.
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      useAppStore.getState().invalidateRecentEdits(p.path);
+    });
+
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the rows on screen while dropping the cache identity", async () => {
+    // Clearing the data instead would blank the panel under a user who is
+    // reading it, triggered by nothing but a background file event.
+    const p = project("alpha");
+    fetchRecentEdits.mockResolvedValue(payload(p.actual_path));
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    await act(async () => {
+      useAppStore.getState().invalidateRecentEdits(p.path);
+    });
+
+    const cached = useAppStore.getState().analytics.recentEdits;
+    expect(cached?.files.length).toBe(1);
+    expect(cached?.requestedProjectPath).toBeUndefined();
+  });
+
+  it("leaves another project's cache entry alone", async () => {
+    const a = project("alpha");
+    const b = project("beta");
+    fetchRecentEdits.mockResolvedValue(payload(a.actual_path));
+    useAppStore.setState({ selectedProject: a });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    // A background write under an unrelated project must not cost the
+    // selected one its cache.
+    await act(async () => {
+      useAppStore.getState().invalidateRecentEdits(b.path);
+    });
+
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops an in-flight load-more from appending to an invalidated list", async () => {
+    const p = project("alpha");
+    fetchRecentEdits.mockResolvedValueOnce(payload(p.actual_path));
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    useAppStore.setState((state) => ({
+      analytics: {
+        ...state.analytics,
+        recentEditsPagination: {
+          totalEditsCount: 100,
+          uniqueFilesCount: 100,
+          offset: 0,
+          limit: 20,
+          hasMore: true,
+          isLoadingMore: false,
+        },
+      },
+    }));
+
+    const more = Promise.withResolvers<unknown>();
+    fetchRecentEdits.mockImplementationOnce(() => more.promise);
+    const pending = useAppStore.getState().loadMoreRecentEdits(p.path);
+
+    await act(async () => {
+      useAppStore.getState().invalidateRecentEdits(p.path);
+    });
+    await act(async () => {
+      more.resolve({
+        ...payload(p.actual_path),
+        files: [{ ...payload(p.actual_path).files[0], file_path: "late.ts" }],
+      });
+      await pending;
+    });
+
+    const files = useAppStore.getState().analytics.recentEdits?.files ?? [];
+    expect(files.some((f) => f.file_path === "late.ts")).toBe(false);
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.isLoadingMore
+    ).toBe(false);
+  });
+});

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -54,6 +54,7 @@ export interface AnalyticsSliceActions {
   setAnalyticsRecentEditsError: (error: string | null) => void;
   loadRecentEdits: (projectPath: string) => Promise<PaginatedRecentEdits>;
   loadMoreRecentEdits: (projectPath: string) => Promise<void>;
+  invalidateRecentEdits: (projectPath: string) => void;
   resetAnalytics: () => void;
   clearAnalyticsErrors: () => void;
 }
@@ -178,6 +179,30 @@ export const createAnalyticsSlice: StateCreator<
         // Bumping here, rather than at each call site, is what makes the
         // generation true for all three writers of the cache without any of
         // them having to remember.
+        recentEditsGeneration: state.analytics.recentEditsGeneration + 1,
+      },
+    }));
+  },
+
+  invalidateRecentEdits: (projectPath: string) => {
+    const cached = get().analytics.recentEdits;
+    // Only the entry fetched for this project is stale. An entry belonging to
+    // another project is somebody else's cache, and a `null` one has nothing
+    // to invalidate.
+    if (!cached || cached.requestedProjectPath !== projectPath) {
+      return;
+    }
+
+    set((state) => ({
+      analytics: {
+        ...state.analytics,
+        // The rows stay; only the identity that makes them reusable is
+        // dropped. Clearing the data instead would blank the panel under a
+        // user who is reading it, on nothing more than a background file
+        // event. The next visit misses the guard and refetches.
+        recentEdits: { ...cached, requestedProjectPath: undefined },
+        // Declaring the list stale has to stop a load-more that is already in
+        // flight from appending a page to it, the same way a refresh does.
         recentEditsGeneration: state.analytics.recentEditsGeneration + 1,
       },
     }));

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -287,6 +287,7 @@ export interface AppStoreActions {
   setAnalyticsRecentEditsError: (error: string | null) => void;
   loadRecentEdits: (projectPath: string) => Promise<import("../../types").PaginatedRecentEdits>;
   loadMoreRecentEdits: (projectPath: string) => Promise<void>;
+  invalidateRecentEdits: (projectPath: string) => void;
   resetAnalytics: () => void;
   clearAnalyticsErrors: () => void;
 

--- a/src/store/slices/watcherSlice.ts
+++ b/src/store/slices/watcherSlice.ts
@@ -241,6 +241,14 @@ export const createWatcherSlice: StateCreator<
       try {
         const { selectedProject, selectProject } = get();
 
+        // A session file changed, so any Recent Edits result cached for this
+        // project describes the state before that write. `selectProject` below
+        // reloads the session list but never touches analytics, so without
+        // this the cache — which only started actually hitting once its key
+        // was fixed — would serve pre-edit rows for as long as the project
+        // stays selected, with the header refresh button the only way out.
+        get().invalidateRecentEdits(projectPath);
+
         // If this is the currently selected project, reload its sessions
         if (selectedProject && selectedProject.path === projectPath) {
           await selectProject(selectedProject);

--- a/src/test/watcherSlice.test.ts
+++ b/src/test/watcherSlice.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { create } from "zustand";
 import {
   createWatcherSlice,
@@ -31,6 +31,7 @@ type TestStore = WatcherSlice & {
   selectSession: ReturnType<typeof vi.fn>;
   selectProject: ReturnType<typeof vi.fn>;
   setError: ReturnType<typeof vi.fn>;
+  invalidateRecentEdits: Mock;
 };
 
 const createTestStore = () =>
@@ -40,6 +41,7 @@ const createTestStore = () =>
     messages: [],
     selectSession: vi.fn().mockResolvedValue(undefined),
     selectProject: vi.fn().mockResolvedValue(undefined),
+    invalidateRecentEdits: vi.fn(),
     setError: vi.fn(),
     ...createWatcherSlice(
       set as Parameters<typeof createWatcherSlice>[0],
@@ -189,5 +191,45 @@ describe("watcherSlice refresh coalescing", () => {
       type: AppErrorType.UNKNOWN,
       message: "Failed to refresh session: Error: load failed",
     });
+  });
+});
+
+describe("watcherSlice recent-edits invalidation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-13T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("invalidates the Recent Edits cache for the project that changed", async () => {
+    // `selectProject` reloads the session list and never touches analytics, so
+    // this is the only place a file write can reach the cache. Without it the
+    // panel serves pre-edit rows for as long as the project stays selected.
+    const store = createTestStore();
+    store.setState({ selectedProject: { path: "/project" } });
+
+    await store.getState().triggerProjectRefresh("/project");
+
+    expect(store.getState().invalidateRecentEdits).toHaveBeenCalledWith(
+      "/project"
+    );
+  });
+
+  it("invalidates even when the changed project is not the selected one", async () => {
+    // The cache is keyed by the path it was fetched for, not by the current
+    // selection, so an entry can outlive its project being deselected and be
+    // served again on the way back.
+    const store = createTestStore();
+    store.setState({ selectedProject: { path: "/other" } });
+
+    await store.getState().triggerProjectRefresh("/project");
+
+    expect(store.getState().invalidateRecentEdits).toHaveBeenCalledWith(
+      "/project"
+    );
+    expect(store.getState().selectProject).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What & why

Follow-up to #514, which is already merged.

#514 fixed a cache guard that had never held — `project_cwd === project.path` compares the most frequent `cwd` in the session logs against the encoded Claude storage directory, so it was false for every project. Every visit to Recent Edits re-walked and re-parsed the whole project. Keying the entry on the requested `project.path` is the right fix and the measurements in that PR are sound.

The side effect is that the always-miss had been supplying freshness by accident, and nothing replaces it:

- `triggerProjectRefresh` (the watcher's project-level path) reloads the session list through `selectProject`, which never touches `analytics`.
- `resetAnalytics` runs in `clearProjectSelection`, not on a project switch and not on a file event.
- `refreshAllConversations` does refetch Recent Edits, but it is only reachable from the header refresh button.

So with a project selected and Recent Edits already visited once, edits written after that point never appear until the user manually refreshes.

## The change

`invalidateRecentEdits(projectPath)` on the analytics slice, called from `triggerProjectRefresh`.

It drops the entry's **identity**, not its data:

```ts
recentEdits: { ...cached, requestedProjectPath: undefined },
recentEditsGeneration: state.analytics.recentEditsGeneration + 1,
```

- Rows stay on screen. Clearing `recentEdits` outright would blank the panel under someone reading it, triggered by nothing more than a background file event.
- The next visit misses the guard and refetches, which is exactly the pre-#514 behaviour minus the always-miss.
- Bumping the generation is required, not cosmetic: it is what stops a load-more already in flight from appending its page onto a list that has just been declared stale. #514 built that mechanism; this reuses it.
- Scoped to the project that changed. An entry belonging to a different project is not this event's to invalidate.

## Deliberately not included

A live auto-refresh while the panel is on screen. That needs the ownership-guarded refetch path rather than plain invalidation, and it is a different change with a different risk profile. Filed separately.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no user-facing strings

## Tests

Six cases, each mutation-checked so it discriminates rather than decorates:

`src/hooks/analytics/useAnalyticsNavigation.test.ts`
- refetches after invalidation, and still caches a second visit with no file change (invalidation must not just disable the cache)
- keeps the rows while dropping the identity
- leaves another project's entry alone
- stops an in-flight load-more from appending to an invalidated list

`src/test/watcherSlice.test.ts`
- `triggerProjectRefresh` invalidates for the selected project
- and for a non-selected one, since a cache entry outlives its project being deselected

**Mutation check.** Making `invalidateRecentEdits` a no-op fails 3 of the hook tests; removing the call from `triggerProjectRefresh` fails both watcher tests. Neither mutation is silent.

**Gates.** `pnpm exec vitest run` 1052 passed (90 files), `pnpm exec tsc --build .` clean, `pnpm lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recent Edits now refreshes automatically after project files change.
  * Prevented outdated in-flight results from appearing after a refresh.
  * Preserved currently displayed edits while updated data loads.
  * Refreshes affect only the relevant project’s Recent Edits data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->