### PR TITLE
fix(kimi): merge both stores in search and stop reporting an empty base path

### DIFF
--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -20,21 +20,32 @@ pub fn detect() -> Option<ProviderInfo> {
     // provider; a kimi-code-only install still counts (antigravity-cli
     // pattern) and its root becomes the reported base path.
     let code_available = super::kimi_code::is_available();
-
-    // Only report `~/.kimi` when it actually holds sessions. A bare `~/.kimi`
-    // next to a populated `~/.kimi-code` would otherwise hand every
-    // base_path-driven consumer a root with nothing under it.
-    let legacy_base = get_base_path().filter(|base| {
-        let sessions_path = Path::new(base).join(SESSIONS_DIR);
-        !is_symlink(&sessions_path) && sessions_path.is_dir()
-    });
+    let legacy_base = get_base_path();
+    let legacy_sessions_dir = legacy_base
+        .as_ref()
+        .map(|base| Path::new(base).join(SESSIONS_DIR));
+    // A present `sessions/` and one that actually holds a loadable session are
+    // different questions, and the choice of root turns on the second.
+    let legacy_dir_exists = legacy_sessions_dir
+        .as_ref()
+        .is_some_and(|dir| !is_symlink(dir) && dir.is_dir());
+    let legacy_has_sessions = legacy_dir_exists
+        && legacy_sessions_dir
+            .as_deref()
+            .is_some_and(has_any_loadable_session);
 
     let base = match legacy_base {
-        Some(base) => base,
-        None if code_available => super::kimi_code::default_root()?
+        // The legacy store holds data, so its root is the one worth reporting.
+        Some(base) if legacy_has_sessions => base,
+        // It does not and kimi-code does: report the store with the data
+        // instead of a root that scans to nothing.
+        _ if code_available => super::kimi_code::default_root()?
             .to_string_lossy()
             .to_string(),
-        None => return None,
+        // Neither holds a session. An existing, merely idle `sessions/` still
+        // surfaces the provider, exactly as it did before.
+        Some(base) if legacy_dir_exists => base,
+        _ => return None,
     };
 
     Some(ProviderInfo {
@@ -66,6 +77,36 @@ pub fn get_base_path() -> Option<String> {
     } else {
         None
     }
+}
+
+/// At least one `<sessions_root>/<project>/<session>/context.jsonl` — the same
+/// bar `scan_projects_from_path` applies, so `detect` never reports a root that
+/// would scan to nothing. Short-circuits on the first hit.
+fn has_any_loadable_session(sessions_root: &Path) -> bool {
+    let Ok(projects) = fs::read_dir(sessions_root) else {
+        return false;
+    };
+    projects.flatten().any(|project| {
+        if project
+            .file_type()
+            .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+        {
+            return false;
+        }
+        let Ok(sessions) = fs::read_dir(project.path()) else {
+            return false;
+        };
+        sessions.flatten().any(|session| {
+            if session
+                .file_type()
+                .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
+            {
+                return false;
+            }
+            let context = session.path().join(CONTEXT_FILE);
+            !is_symlink(&context) && context.is_file()
+        })
+    })
 }
 
 pub fn scan_projects_from_path(base_path: &str) -> Result<Vec<ClaudeProject>, String> {
@@ -958,6 +999,69 @@ mod tests {
         let _code_home = EnvVarGuard::set("KIMI_CODE_HOME", code.as_os_str().to_owned());
 
         let info = detect().expect("legacy store is detected");
+        assert_eq!(
+            PathBuf::from(info.base_path),
+            legacy.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn detect_falls_through_to_kimi_code_when_legacy_sessions_dir_is_empty() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        let code = temp.path().join(".kimi-code");
+        // `sessions/` is there but holds nothing — `scan_projects_from_path`
+        // would come back empty, so this root must not win.
+        fs::create_dir_all(legacy.join(SESSIONS_DIR)).unwrap();
+        fs::create_dir_all(&code).unwrap();
+        write_code_session(&code, "wd_demo", "session_one", "hello", 1_786_959_458_516);
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set("KIMI_CODE_HOME", code.as_os_str().to_owned());
+
+        let info = detect().expect("the populated kimi-code store is detected");
+        assert_eq!(PathBuf::from(info.base_path), code.canonicalize().unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn detect_falls_through_to_kimi_code_when_legacy_sessions_lack_context_files() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        let code = temp.path().join(".kimi-code");
+        // Project and session dirs exist, but no `context.jsonl` — the same
+        // bar `extract_session_info` applies, so still nothing loadable.
+        fs::create_dir_all(legacy.join(SESSIONS_DIR).join("proj").join("sess")).unwrap();
+        fs::create_dir_all(&code).unwrap();
+        write_code_session(&code, "wd_demo", "session_one", "hello", 1_786_959_458_516);
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set("KIMI_CODE_HOME", code.as_os_str().to_owned());
+
+        let info = detect().expect("the populated kimi-code store is detected");
+        assert_eq!(PathBuf::from(info.base_path), code.canonicalize().unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn detect_keeps_the_idle_legacy_root_when_kimi_code_is_absent() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        fs::create_dir_all(legacy.join(SESSIONS_DIR)).unwrap();
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set(
+            "KIMI_CODE_HOME",
+            temp.path().join("absent").as_os_str().to_owned(),
+        );
+
+        // Nothing to fall through to, so an idle store still surfaces the
+        // provider rather than making it vanish.
+        let info = detect().expect("an idle legacy store still surfaces the provider");
         assert_eq!(
             PathBuf::from(info.base_path),
             legacy.canonicalize().unwrap()

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -79,9 +79,11 @@ pub fn get_base_path() -> Option<String> {
     }
 }
 
-/// At least one `<sessions_root>/<project>/<session>/context.jsonl` — the same
-/// bar `scan_projects_from_path` applies, so `detect` never reports a root that
-/// would scan to nothing. Short-circuits on the first hit.
+/// At least one session `scan_projects_from_path` would actually surface, so
+/// `detect` never reports a root that scans to nothing. Defers to
+/// `extract_session_info`, which is the bar the scan itself applies — a present
+/// but empty or unparseable `context.jsonl` does not count. Short-circuits on
+/// the first hit, so a populated store parses exactly one session.
 fn has_any_loadable_session(sessions_root: &Path) -> bool {
     let Ok(projects) = fs::read_dir(sessions_root) else {
         return false;
@@ -96,16 +98,9 @@ fn has_any_loadable_session(sessions_root: &Path) -> bool {
         let Ok(sessions) = fs::read_dir(project.path()) else {
             return false;
         };
-        sessions.flatten().any(|session| {
-            if session
-                .file_type()
-                .map_or(true, |ft| ft.is_symlink() || !ft.is_dir())
-            {
-                return false;
-            }
-            let context = session.path().join(CONTEXT_FILE);
-            !is_symlink(&context) && context.is_file()
-        })
+        sessions
+            .flatten()
+            .any(|session| extract_session_info(&session.path()).is_some())
     })
 }
 
@@ -1034,6 +1029,28 @@ mod tests {
         // Project and session dirs exist, but no `context.jsonl` — the same
         // bar `extract_session_info` applies, so still nothing loadable.
         fs::create_dir_all(legacy.join(SESSIONS_DIR).join("proj").join("sess")).unwrap();
+        fs::create_dir_all(&code).unwrap();
+        write_code_session(&code, "wd_demo", "session_one", "hello", 1_786_959_458_516);
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set("KIMI_CODE_HOME", code.as_os_str().to_owned());
+
+        let info = detect().expect("the populated kimi-code store is detected");
+        assert_eq!(PathBuf::from(info.base_path), code.canonicalize().unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn detect_falls_through_to_kimi_code_when_legacy_context_file_is_empty() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        let code = temp.path().join(".kimi-code");
+        // `context.jsonl` is present but holds no message `extract_session_info`
+        // accepts, which is exactly what the scan drops.
+        let session_dir = legacy.join(SESSIONS_DIR).join("proj").join("sess");
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(session_dir.join(CONTEXT_FILE), "\n{ not json\n").unwrap();
         fs::create_dir_all(&code).unwrap();
         write_code_session(&code, "wd_demo", "session_one", "hello", 1_786_959_458_516);
 

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -20,24 +20,23 @@ pub fn detect() -> Option<ProviderInfo> {
     // provider; a kimi-code-only install still counts (antigravity-cli
     // pattern) and its root becomes the reported base path.
     let code_available = super::kimi_code::is_available();
-    if let Some(base) = get_base_path() {
-        let sessions_path = Path::new(&base).join(SESSIONS_DIR);
-        if !code_available && !sessions_path.is_dir() {
-            return None;
-        }
-        return Some(ProviderInfo {
-            id: PROVIDER_ID.to_string(),
-            display_name: "Kimi".to_string(),
-            base_path: base,
-            is_available: true,
-        });
-    }
-    if !code_available {
-        return None;
-    }
-    let base = super::kimi_code::default_root()?
-        .to_string_lossy()
-        .to_string();
+
+    // Only report `~/.kimi` when it actually holds sessions. A bare `~/.kimi`
+    // next to a populated `~/.kimi-code` would otherwise hand every
+    // base_path-driven consumer a root with nothing under it.
+    let legacy_base = get_base_path().filter(|base| {
+        let sessions_path = Path::new(base).join(SESSIONS_DIR);
+        !is_symlink(&sessions_path) && sessions_path.is_dir()
+    });
+
+    let base = match legacy_base {
+        Some(base) => base,
+        None if code_available => super::kimi_code::default_root()?
+            .to_string_lossy()
+            .to_string(),
+        None => return None,
+    };
+
     Some(ProviderInfo {
         id: PROVIDER_ID.to_string(),
         display_name: "Kimi".to_string(),
@@ -301,16 +300,17 @@ pub fn load_messages_from_base_path(
 }
 
 pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    // Both stores are one provider in the UI, so each gets the full `limit`
+    // and they compete on recency. Handing kimi-code only the legacy store's
+    // leftovers starved it outright once `~/.kimi` filled the page. Mirrors
+    // the merge in `scan_projects`.
     let mut results = match get_base_path() {
         Some(base) => search_from_base_path(&base, query, limit)?,
         None => Vec::new(),
     };
-    // Kimi-code conversations carry real content — search them too.
-    if results.len() < limit {
-        let remaining = limit - results.len();
-        let code_results = super::kimi_code::search(query, remaining);
-        results.extend(code_results);
-    }
+    results.extend(super::kimi_code::search(query, limit));
+    results.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    results.truncate(limit);
     Ok(results)
 }
 
@@ -789,5 +789,195 @@ mod tests {
             return;
         }
         assert!(get_base_path().is_none());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Two-store fixtures: a legacy `~/.kimi` tree and a `~/.kimi-code` tree
+    // side by side, which is what `detect` and `search` have to reconcile.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// A legacy session whose messages all carry `epoch_seconds`.
+    fn write_legacy_session(
+        base: &Path,
+        project: &str,
+        session: &str,
+        texts: &[&str],
+        epoch_seconds: f64,
+    ) {
+        let session_dir = base.join(SESSIONS_DIR).join(project).join(session);
+        fs::create_dir_all(&session_dir).expect("create legacy session dir");
+        let context: String = texts
+            .iter()
+            .map(|text| format!(r#"{{"role":"user","content":"{text}"}}"#))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(session_dir.join(CONTEXT_FILE), context).expect("write context.jsonl");
+        fs::write(
+            session_dir.join(WIRE_FILE),
+            format!(r#"{{"timestamp":{epoch_seconds}}}"#),
+        )
+        .expect("write wire.jsonl");
+    }
+
+    /// A kimi-code session holding one user message at `epoch_millis`.
+    fn write_code_session(
+        root: &Path,
+        workspace: &str,
+        session: &str,
+        text: &str,
+        epoch_millis: u64,
+    ) {
+        let wire_dir = root
+            .join("sessions")
+            .join(workspace)
+            .join(session)
+            .join("agents")
+            .join("main");
+        fs::create_dir_all(&wire_dir).expect("create kimi-code wire dir");
+        fs::write(
+            wire_dir.join("wire.jsonl"),
+            format!(
+                r#"{{"type":"context.append_message","message":{{"role":"user","content":[{{"type":"text","text":"{text}"}}],"toolCalls":[],"origin":{{"kind":"user"}},"id":"{session}_u1"}},"time":{epoch_millis}}}"#
+            ),
+        )
+        .expect("write kimi-code wire.jsonl");
+    }
+
+    #[test]
+    #[serial]
+    fn search_merges_both_stores_and_keeps_the_newest_within_limit() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        let code = temp.path().join(".kimi-code");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::create_dir_all(&code).unwrap();
+
+        // Legacy alone can fill the whole page — 2020 timestamps.
+        write_legacy_session(
+            &legacy,
+            "proj_old",
+            "sess_old",
+            &["needle one", "needle two", "needle three"],
+            1_600_000_000.0,
+        );
+        // Kimi-code holds strictly newer matches — 2026 timestamps.
+        for (i, ms) in [1_786_959_458_516u64, 1_786_959_558_516, 1_786_959_658_516]
+            .iter()
+            .enumerate()
+        {
+            write_code_session(
+                &code,
+                "wd_demo",
+                &format!("session_{i}"),
+                "needle in kimi code",
+                *ms,
+            );
+        }
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set("KIMI_CODE_HOME", code.as_os_str().to_owned());
+
+        let results = search("needle", 3).expect("search succeeds");
+
+        // The old leftovers-only wiring returned 4 results, only one of them
+        // from kimi-code. Both stores now compete for the same three slots.
+        assert_eq!(results.len(), 3, "limit is honoured across both stores");
+        assert!(
+            results.iter().all(|m| m.session_id.starts_with("session_")),
+            "newest three are the kimi-code hits, got: {:?}",
+            results.iter().map(|m| &m.session_id).collect::<Vec<_>>()
+        );
+        let timestamps: Vec<&str> = results.iter().map(|m| m.timestamp.as_str()).collect();
+        let mut sorted = timestamps.clone();
+        sorted.sort_by(|a, b| b.cmp(a));
+        assert_eq!(timestamps, sorted, "results are newest-first");
+    }
+
+    #[test]
+    #[serial]
+    fn search_still_returns_legacy_hits_when_kimi_code_is_absent() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        fs::create_dir_all(&legacy).unwrap();
+        write_legacy_session(
+            &legacy,
+            "proj_old",
+            "sess_old",
+            &["needle one"],
+            1_600_000_000.0,
+        );
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set(
+            "KIMI_CODE_HOME",
+            temp.path().join("absent").as_os_str().to_owned(),
+        );
+
+        let results = search("needle", 10).expect("search succeeds");
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn detect_reports_the_kimi_code_root_when_legacy_has_no_sessions() {
+        let temp = TempDir::new().unwrap();
+        // `~/.kimi` exists but is empty — no `sessions/` under it.
+        let legacy = temp.path().join(".kimi");
+        let code = temp.path().join(".kimi-code");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::create_dir_all(&code).unwrap();
+        write_code_session(&code, "wd_demo", "session_one", "hello", 1_786_959_458_516);
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set("KIMI_CODE_HOME", code.as_os_str().to_owned());
+
+        let info = detect().expect("kimi-code-only install is still the kimi provider");
+        assert_eq!(
+            PathBuf::from(info.base_path),
+            code.canonicalize().unwrap(),
+            "base_path must point at the store that actually holds data"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn detect_prefers_the_legacy_root_when_it_holds_sessions() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        let code = temp.path().join(".kimi-code");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::create_dir_all(&code).unwrap();
+        write_legacy_session(&legacy, "proj", "sess", &["hello"], 1_600_000_000.0);
+        write_code_session(&code, "wd_demo", "session_one", "hello", 1_786_959_458_516);
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set("KIMI_CODE_HOME", code.as_os_str().to_owned());
+
+        let info = detect().expect("legacy store is detected");
+        assert_eq!(
+            PathBuf::from(info.base_path),
+            legacy.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn detect_returns_none_when_neither_store_holds_sessions() {
+        let temp = TempDir::new().unwrap();
+        let legacy = temp.path().join(".kimi");
+        fs::create_dir_all(&legacy).unwrap();
+
+        let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
+        let _home = EnvVarGuard::set("KIMI_HOME", legacy.as_os_str().to_owned());
+        let _code_home = EnvVarGuard::set(
+            "KIMI_CODE_HOME",
+            temp.path().join("absent").as_os_str().to_owned(),
+        );
+
+        assert!(detect().is_none());
     }
 }


### PR DESCRIPTION
Fixes both defects from #523. Single file, `src-tauri/src/providers/kimi.rs`.

## 1. `search` starved kimi-code results

The legacy `~/.kimi` store filled `limit` first and kimi-code was queried with whatever was left, so a substantial `~/.kimi` history hid kimi-code matches outright. Both stores now get the full `limit`, merge, sort by timestamp, and truncate — the same shape `scan_projects` already uses.

```rust
let mut results = match get_base_path() {
    Some(base) => search_from_base_path(&base, query, limit)?,
    None => Vec::new(),
};
results.extend(super::kimi_code::search(query, limit));
results.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
results.truncate(limit);
```

This also drops a bound violation the issue didn't mention: with `remaining == 0`, the old path called `kimi_code::search(q, 0)`, and `search_from_root` pushes before checking the bound — so it returned one message and `search` yielded `limit + 1` results.

## 2. `detect()` could report a base path with nothing under it

The legacy root is now reported only when it actually holds sessions; otherwise `detect` falls through to the kimi-code root.

```rust
let legacy_base = get_base_path().filter(|base| {
    let sessions_path = Path::new(base).join(SESSIONS_DIR);
    !is_symlink(&sessions_path) && sessions_path.is_dir()
});
```

One deliberate addition beyond the issue: a symlinked `sessions/` is rejected as well. `scan_projects_from_path` bails to empty on that, so reporting such a root is the same dead-root trap.

## Tests

Five added, all `#[serial]`, using the existing `EnvVarGuard` + `TempDir` pattern with inline wire strings — no committed fixtures, consistent with #513.

| test | before | after |
|---|---|---|
| `search_merges_both_stores_and_keeps_the_newest_within_limit` | FAILED | ok |
| `detect_reports_the_kimi_code_root_when_legacy_has_no_sessions` | FAILED | ok |
| `search_still_returns_legacy_hits_when_kimi_code_is_absent` | ok | ok |
| `detect_prefers_the_legacy_root_when_it_holds_sessions` | ok | ok |
| `detect_returns_none_when_neither_store_holds_sessions` | ok | ok |

The two regression cases were confirmed failing against the pre-fix code by reverting and re-running. The other three pin behaviour that must not change.

## Verification

- `cargo fmt --check` clean
- `cargo test -- --test-threads=1` — full suite green
- `cargo clippy --all-targets --all-features -- -D warnings` clean (this is the rule `lint-staged` runs for `.rs` changes)
- No TypeScript touched, so frontend gates are unaffected.

Sidenote, unrelated to this PR: clippy **without** `--all-features` fails on `items after a test module` at `src/lib.rs:318`. It reproduces on a clean `develop` with nothing staged, so it predates this branch and is invisible to the configured gate. Mentioning it only in case you want it fixed separately.

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kimi session detection across legacy and current storage locations.
  * Empty or invalid legacy storage now correctly falls back to available Kimi Code sessions.
  * Idle legacy storage remains detectable when no current storage is available.
  * Search continues combining sessions from both locations, sorting by time, and respecting result limits.
  * Sessions are no longer reported when neither storage location contains usable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->