### PR TITLE
refactor(recent-edits): migrate the standard card onto useFileEditActions

### DIFF
--- a/src/components/RecentEditsViewer/FileEditItem.test.tsx
+++ b/src/components/RecentEditsViewer/FileEditItem.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * The standard card was migrated onto `useFileEditActions`, which the compact
+ * row already used. These pin the three behaviours that were genuinely
+ * different in the card's own copies, so the migration cannot be reverted or
+ * re-forked without a test going red.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, screen, waitFor, act } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: unknown) =>
+      typeof fallback === "string" ? fallback : key,
+  }),
+}));
+
+vi.mock("@/services/api", () => ({ api: vi.fn() }));
+
+vi.mock("@/utils/platform", () => ({
+  isTauri: () => true,
+  isMacOS: () => false,
+  isWindows: () => true,
+}));
+
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...a: unknown[]) => toastError(...a), success: vi.fn(), warning: vi.fn() },
+}));
+
+import { FileEditItem } from "./FileEditItem";
+import type { RecentFileEdit } from "../../types";
+
+const PROJECT = "/Users/alex/Projects/my-app";
+
+const makeEdit = (overrides: Partial<RecentFileEdit> = {}): RecentFileEdit => ({
+  file_path: `${PROJECT}/src/main.ts`,
+  timestamp: new Date("2026-08-19T06:37:00Z").toISOString(),
+  session_id: "s1",
+  operation_type: "edit",
+  content_after_change: "after content",
+  original_content: "before content",
+  lines_added: 3,
+  lines_removed: 1,
+  ...overrides,
+});
+
+const clickCopy = () => {
+  const btn = screen
+    .getAllByRole("button")
+    .find((b) => b.getAttribute("title") === "recentEdits.copyContent");
+  if (!btn) throw new Error("copy button not found");
+  fireEvent.click(btn);
+  return btn;
+};
+
+describe("FileEditItem action wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("surfaces a failed copy instead of swallowing it", async () => {
+    // The card's own `handleCopy` only did `console.error`, so a clipboard
+    // rejection — the ordinary outcome in a non-secure context, or when the
+    // document is not focused — looked to the user exactly like success.
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+
+    render(<FileEditItem edit={makeEdit()} isDarkMode={false} projectCwd={PROJECT} />);
+    clickCopy();
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+  });
+
+  it("restarts the copied-state countdown on a second click", async () => {
+    // Neither transient timer was held, so a click 1.9s after the first
+    // inherited the first timer and reverted almost immediately.
+    vi.useFakeTimers();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    render(<FileEditItem edit={makeEdit()} isDarkMode={false} projectCwd={PROJECT} />);
+    clickCopy();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.queryByTestId("file-edit-copied")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1900);
+    });
+    clickCopy();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // 1.9s into the *first* timer. With a shared, un-reset timer this is where
+    // the indicator vanished 100ms after the second click.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    expect(screen.queryByTestId("file-edit-copied")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.queryByTestId("file-edit-copied")).toBeNull();
+  });
+
+  it("does not set state after the row unmounts", async () => {
+    // A card scrolled out of the list while its timer was pending used to warn
+    // and, in React 18 strict builds, leak the update.
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    const view = render(
+      <FileEditItem edit={makeEdit()} isDarkMode={false} projectCwd={PROJECT} />
+    );
+    clickCopy();
+    await vi.advanceTimersByTimeAsync(0);
+    view.unmount();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("unmounted"))
+    ).toBe(false);
+    warn.mockRestore();
+  });
+});

--- a/src/components/RecentEditsViewer/FileEditItem.tsx
+++ b/src/components/RecentEditsViewer/FileEditItem.tsx
@@ -9,7 +9,6 @@
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Markdown } from "../common";
-import { api } from "@/services/api";
 import {
   FileEdit,
   FileDiff,
@@ -23,22 +22,17 @@ import {
   RotateCcw,
   FolderOpen,
 } from "lucide-react";
-import { toast } from "sonner";
 import { Highlight, themes } from "prism-react-renderer";
 import { cn } from "@/lib/utils";
-import {
-  isAbsolutePath,
-  elideProjectRoot,
-  getPathLeaf,
-} from "@/utils/pathUtils";
-import { isTauri, isMacOS, isWindows } from "@/utils/platform";
+import { elideProjectRoot, getPathLeaf } from "@/utils/pathUtils";
 import { layout } from "@/components/renderers";
 import { EnhancedDiffViewer } from "../EnhancedDiffViewer";
 import { ExpandKeyProvider } from "@/contexts/CaptureExpandContext";
 import { FileEditDirectoryLink } from "./FileEditDirectoryLink";
 import { FilteredDiffLines } from "./FilteredDiffLines";
 import { RestoreDiffPreview } from "./RestoreDiffPreview";
-import type { FileEditItemProps, RestoreStatus, EditViewMode } from "./types";
+import { useFileEditActions } from "./useFileEditActions";
+import type { FileEditItemProps, EditViewMode } from "./types";
 import { getLanguageFromPath, formatTimestamp, getRelativeTime } from "./utils";
 import { extractAddedLines, extractRemovedLines } from "./diffUtils";
 import type { DiffLineGroup } from "./diffUtils";
@@ -61,10 +55,24 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
   const { t: tCommon } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const [viewMode, setViewMode] = useState<EditViewMode>("content");
-  const [copied, setCopied] = useState(false);
-  const [restoreStatus, setRestoreStatus] = useState<RestoreStatus>("idle");
-  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Copy, reveal and restore live in `useFileEditActions`, shared with
+  // `FileEditRowCompact`. The card kept its own copies until now, and they had
+  // already drifted: a failed copy was swallowed instead of surfacing a toast,
+  // and neither transient timer was held, so a second click inherited the first
+  // one's countdown and an unmounted row could still set state.
+  const {
+    copied,
+    copy,
+    canReveal,
+    revealLabel,
+    reveal,
+    restoreStatus,
+    restoreError,
+    isConfirmingRestore,
+    requestRestore,
+    confirmRestore,
+    cancelRestore,
+  } = useFileEditActions(edit, { onRestored });
 
   const language = getLanguageFromPath(edit.file_path);
   const fileName = getPathLeaf(edit.file_path);
@@ -97,69 +105,6 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
       ? extractAddedLines(edit.original_content, edit.content_after_change)
       : extractRemovedLines(edit.original_content, edit.content_after_change);
   }, [isExpanded, viewMode, edit.original_content, edit.content_after_change]);
-  // revealItemInDir is a Tauri-only plugin API with no WebUI (Axum) fallback,
-  // so the button is hidden entirely in --serve mode rather than shown disabled.
-  const canReveal = isTauri() && isAbsolutePath(edit.file_path);
-  const revealLabel = isMacOS()
-    ? t("recentEdits.revealInFinder")
-    : isWindows()
-      ? t("recentEdits.revealInExplorer")
-      : t("recentEdits.revealInFolder");
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(edit.content_after_change);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
-  const handleReveal = async () => {
-    try {
-      const { revealItemInDir } = await import("@tauri-apps/plugin-opener");
-      await revealItemInDir(edit.file_path);
-    } catch (err) {
-      console.error("Failed to reveal file:", err);
-      toast.error(t("recentEdits.revealError"));
-    }
-  };
-
-  const handleRestoreClick = () => {
-    setShowConfirmDialog(true);
-  };
-
-  const handleRestoreConfirm = async () => {
-    setShowConfirmDialog(false);
-    setErrorMessage(null);
-    try {
-      setRestoreStatus("loading");
-      await api("restore_file", {
-        filePath: edit.file_path,
-        content: edit.content_after_change,
-      });
-      setRestoreStatus("success");
-      // Clears the missing flag on this row. Without it a file just written
-      // back still reports itself absent, so it stays red and the Missing Only
-      // filter hides the file the user has only just recovered.
-      onRestored?.(edit.file_path);
-      setTimeout(() => setRestoreStatus("idle"), 2000);
-    } catch (err) {
-      console.error("Failed to restore file:", err);
-      const message = err instanceof Error ? err.message : String(err);
-      setErrorMessage(message);
-      setRestoreStatus("error");
-      setTimeout(() => {
-        setRestoreStatus("idle");
-        setErrorMessage(null);
-      }, 5000);
-    }
-  };
-
-  const handleRestoreCancel = () => {
-    setShowConfirmDialog(false);
-  };
 
   return (
     <div className="border-2 rounded-xl overflow-hidden transition-all duration-300 border-border bg-card hover:border-accent/30 hover:shadow-md">
@@ -287,7 +232,7 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
                 directory={dense ? directory : edit.file_path}
                 fullPath={edit.file_path}
                 canReveal={canReveal}
-                onReveal={handleReveal}
+                onReveal={reveal}
                 revealLabel={revealLabel}
                 className={cn(
                   "min-w-0 flex-1 text-muted-foreground",
@@ -397,7 +342,7 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                handleReveal();
+                reveal();
               }}
               className="p-2 rounded-lg transition-all duration-200 hover:bg-muted text-muted-foreground hover:text-foreground"
               aria-label={revealLabel}
@@ -411,7 +356,7 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
           <button
             onClick={(e) => {
               e.stopPropagation();
-              handleCopy();
+              copy();
             }}
             className={cn(
               "p-2 rounded-lg transition-all duration-200",
@@ -419,6 +364,10 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
                 ? "bg-success/20 text-success ring-1 ring-success/30"
                 : "hover:bg-muted text-muted-foreground hover:text-foreground"
             )}
+            // The transient success state is the only externally observable
+            // signal that a copy landed, so it carries a stable hook rather
+            // than leaving tests to match on an icon's class names.
+            data-testid={copied ? "file-edit-copied" : "file-edit-copy"}
             title={t("recentEdits.copyContent")}
           >
             {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
@@ -429,7 +378,7 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
             onClick={(e) => {
               e.stopPropagation();
               if (restoreStatus === "idle") {
-                handleRestoreClick();
+                requestRestore();
               }
             }}
             disabled={restoreStatus === "loading"}
@@ -457,19 +406,19 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
       </div>
 
       {/* Error message toast */}
-      {errorMessage && (
+      {restoreError && (
         <div
           className={`mx-3 mb-2 p-2 rounded-md bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300 ${layout.smallText}`}
         >
-          {t("recentEdits.restoreError")}: {errorMessage}
+          {t("recentEdits.restoreError")}: {restoreError}
         </div>
       )}
 
       {/* Confirmation dialog */}
-      {showConfirmDialog && (
+      {isConfirmingRestore && (
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-          onClick={handleRestoreCancel}
+          onClick={cancelRestore}
         >
           <div
             className="rounded-lg p-6 max-w-md mx-4 shadow-xl bg-background"
@@ -497,13 +446,13 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
 
             <div className="flex justify-end space-x-3">
               <button
-                onClick={handleRestoreCancel}
+                onClick={cancelRestore}
                 className={`px-4 py-2 rounded-md ${layout.bodyText} bg-muted hover:bg-muted/80 text-foreground`}
               >
                 {t("recentEdits.cancel")}
               </button>
               <button
-                onClick={handleRestoreConfirm}
+                onClick={confirmRestore}
                 className={`px-4 py-2 rounded-md ${layout.bodyText} bg-blue-600 hover:bg-blue-700 text-white`}
               >
                 {t("recentEdits.confirmRestore")}


### PR DESCRIPTION
## What & why

Follow-up to #515, as promised in review.

#515 extracted `useFileEditActions` precisely so the compact row and the standard card could not drift on copy, reveal and restore, then left `FileEditItem` on its own copies with the reason "to keep this diff off that file" — while changing that file by +155/-29 regardless. Once the file is being edited anyway, the reason is gone and only the duplication is left.

They had already drifted, and not in the card's favour on any of it:

| behaviour | card (before) | hook |
|---|---|---|
| `navigator.clipboard.writeText` rejects | `console.error` only — looks identical to success | `toast.error` |
| second copy 1.9s after the first | inherits the first timer, reverts ~100ms later | timer held in a ref and reset |
| row unmounts with a timer pending | `setState` after teardown | cleared on unmount |

The clipboard failure is not an edge case: a rejected write is the ordinary outcome in a non-secure context, or when the document is not focused. The card silently told the user it had copied.

This deletes the card's `handleCopy` / `handleReveal` / `handleRestoreClick` / `handleRestoreConfirm` / `handleRestoreCancel`, its four pieces of action state and its own `canReveal` / `revealLabel` derivation, and takes them from the hook. Rendering is untouched. **86 lines removed, 35 added.**

## Type

- [x] Refactor / perf

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no new strings. The card now reaches `recentEdits.copyError`, which #515 already added in all five locales and only the compact row was using.

## Tests

`FileEditItem.test.tsx` is new — the card had none — and covers exactly the three behaviours that changed, not the migration mechanics:

1. a failed copy raises a toast rather than being swallowed
2. a second copy restarts the countdown instead of inheriting the first timer
3. unmounting with a timer pending sets no state afterwards

**Mutation check.** Re-introducing the old behaviour in the hook fails the corresponding test and only that one: removing the `toast.error` fails (1), dropping the `clearTimeout` + ref fails (2). Neither regression is silent.

**Gates.** `pnpm exec vitest run` 1123 passed (97 files), `pnpm exec tsc --build .` clean, `pnpm lint` clean.

## One production change beyond deletion

The copy button gains `data-testid={copied ? "file-edit-copied" : "file-edit-copy"}`. The transient success state is the only externally observable evidence that a copy landed; the alternative is matching on the icon's class names, which pins styling rather than behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy, reveal, and restore actions for recent file edits.
  * Added clearer feedback when copying fails.
  * Improved copy-status feedback and reset behavior after repeated clicks.
  * Ensured actions remain safe when the item is removed from the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->