### PR TITLE
fix(watcher): keep the open session selected when its file changes

### DIFF
--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -59,6 +59,7 @@ export interface ProjectSliceActions {
   scanProjects: () => Promise<void>;
   refreshAllConversations: () => Promise<void>;
   selectProject: (project: ClaudeProject) => Promise<void>;
+  reloadProjectSessions: (project: ClaudeProject) => Promise<void>;
   loadMoreSessions: () => Promise<void>;
   clearProjectSelection: (options?: WebUINavigationOptions) => void;
   setClaudePath: (path: string) => Promise<void>;
@@ -636,17 +637,38 @@ export const createProjectSlice: StateCreator<
   },
 
   selectProject: async (project: ClaudeProject) => {
-    const requestId = nextRequestId("selectProject");
     // Selection is scoped to a single project's session list; switching
-    // projects abandons any in-progress multi-selection.
+    // projects abandons any in-progress multi-selection and any session that
+    // belonged to the project being left.
     get().exitSessionSelectionMode();
+    set({ selectedSession: null });
+    await get().reloadProjectSessions(project);
+  },
+
+  /**
+   * Load a project's first page of sessions without touching the selection.
+   *
+   * Split out of `selectProject` for the file watcher. `selectProject` nulls
+   * `selectedSession` because it is written for "the user picked a different
+   * project", and the watcher was reusing it to refresh the *current* one — so
+   * every write to an open session's JSONL dropped the app to the empty state
+   * (#508). The session refresh that would have restored it is on a 1500ms
+   * quiet period while this reload fires at 250ms, so the selection was always
+   * already gone.
+   *
+   * A matching session in the reloaded page replaces the held one, so its
+   * message count and timestamps refresh in the list. A session that is *not*
+   * in the page is left selected rather than cleared: this is only the first
+   * page, so absence means "not on page 1", not "deleted".
+   */
+  reloadProjectSessions: async (project: ClaudeProject) => {
+    const requestId = nextRequestId("selectProject");
     set({
       selectedProject: project,
       sessions: [],
       sessionsTotal: project.session_count,
       sessionsOffset: 0,
       hasMoreSessions: false,
-      selectedSession: null,
       isLoadingSessions: true,
       isLoadingMoreSessions: false,
     });
@@ -670,6 +692,16 @@ export const createProjectSlice: StateCreator<
         sessionsOffset: page.nextOffset,
         hasMoreSessions: page.hasMore,
       });
+
+      const held = get().selectedSession;
+      if (held) {
+        const refreshed = page.sessions.find(
+          (session) => session.file_path === held.file_path
+        );
+        if (refreshed) {
+          set({ selectedSession: refreshed });
+        }
+      }
 
       // Update project's session_count to match actual loaded sessions
       // (scan_projects counts files, but load_sessions filters invalid ones)

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -244,6 +244,7 @@ export interface AppStoreActions {
   scanProjects: () => Promise<void>;
   refreshAllConversations: () => Promise<void>;
   selectProject: (project: ClaudeProject) => Promise<void>;
+  reloadProjectSessions: (project: ClaudeProject) => Promise<void>;
   loadMoreSessions: () => Promise<void>;
   clearProjectSelection: (
     options?: import("@/utils/webuiDeepLink").WebUINavigationOptions,

--- a/src/store/slices/watcherSlice.ts
+++ b/src/store/slices/watcherSlice.ts
@@ -239,19 +239,23 @@ export const createWatcherSlice: StateCreator<
 
     triggerProjectRefresh: async (projectPath) => {
       try {
-        const { selectedProject, selectProject } = get();
+        const { selectedProject, reloadProjectSessions } = get();
 
         // A session file changed, so any Recent Edits result cached for this
-        // project describes the state before that write. `selectProject` below
-        // reloads the session list but never touches analytics, so without
+        // project describes the state before that write. The reload below
+        // refreshes the session list but never touches analytics, so without
         // this the cache — which only started actually hitting once its key
         // was fixed — would serve pre-edit rows for as long as the project
         // stays selected, with the header refresh button the only way out.
         get().invalidateRecentEdits(projectPath);
 
-        // If this is the currently selected project, reload its sessions
+        // Reload the selected project's sessions, keeping the open session
+        // open. This used to call `selectProject`, which nulls
+        // `selectedSession` because it is written for "the user picked a
+        // different project" — so every write to an open session's JSONL
+        // dropped the app to the empty state (#508).
         if (selectedProject && selectedProject.path === projectPath) {
-          await selectProject(selectedProject);
+          await reloadProjectSessions(selectedProject);
         }
       } catch (error) {
         get().setError({

--- a/src/test/watcherSelectionRetention.test.ts
+++ b/src/test/watcherSelectionRetention.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #508. While a session is open, any write to its `.jsonl` dropped the app back
+ * to the "select a session" empty state, so a session Claude Code was still
+ * writing to could not be watched at all.
+ *
+ * The two slices are wired together here rather than mocked, because the bug
+ * lives exactly in the seam: `watcherSlice` asks `projectSlice` to reload a
+ * project, and `selectProject` is written for "the user picked a different
+ * project" and clears the selection on the way. Mocking `selectProject`, as
+ * `watcherSlice.test.ts` does, makes the bug invisible.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import { api } from "../services/api";
+import { createWatcherSlice } from "../store/slices/watcherSlice";
+import { createProjectSlice } from "../store/slices/projectSlice";
+import type { FullAppStore } from "../store/slices/types";
+import type { ClaudeProject, ClaudeSession } from "../types";
+
+vi.mock("../services/api", () => ({ api: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+const PROJECT: ClaudeProject = {
+  name: "my-app",
+  path: "/Users/alex/.claude/projects/-Users-alex-my-app",
+  actual_path: "/Users/alex/my-app",
+  session_count: 1,
+  message_count: 2,
+  last_modified: "2026-08-19T00:00:00.000Z",
+};
+
+const SESSION: ClaudeSession = {
+  session_id: "s1",
+  actual_session_id: "s1",
+  file_path: "/Users/alex/.claude/projects/-Users-alex-my-app/s1.jsonl",
+  project_name: "my-app",
+  message_count: 2,
+  first_message_time: "2026-08-19T00:00:00.000Z",
+  last_message_time: "2026-08-19T00:00:01.000Z",
+  last_modified: "2026-08-19T00:00:01.000Z",
+  has_tool_use: false,
+  has_errors: false,
+};
+
+const mockedApi = vi.mocked(api);
+
+/**
+ * Only the two slices under test, plus the handful of members they reach for on
+ * the wider store. Building the whole app store would drag in every other
+ * slice's initialisation for no benefit here.
+ */
+const createStore = () =>
+  create<FullAppStore>()((set, get, store) => ({
+    ...createProjectSlice(set, get, store),
+    ...createWatcherSlice(set, get, store),
+    // Reached by the refresh path; irrelevant to what is asserted, but they
+    // have to be present or `scheduleSessionRefresh` throws on `messages`
+    // before the session half of the refresh ever runs, which would leave the
+    // 1500ms restore path untested while the assertions still passed.
+    messages: [],
+    activeSessionNearBottom: true,
+    analytics: { currentView: "messages", recentEdits: null, recentEditsGeneration: 0 },
+    selectSession: vi.fn().mockResolvedValue(undefined),
+    invalidateRecentEdits: vi.fn(),
+    clearSessionSearch: vi.fn(),
+    clearTokenStats: vi.fn(),
+    clearTargetMessage: vi.fn(),
+    exitSessionSelectionMode: vi.fn(),
+    setError: vi.fn(),
+  }) as unknown as FullAppStore);
+
+describe("#508 a file write must not clear the open session", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedApi.mockReset();
+    // Every backend call the reload path makes returns the same one-session page.
+    mockedApi.mockImplementation(async (command: string) => {
+      if (command === "load_provider_sessions_page") {
+        return { sessions: [SESSION], total: 1, nextOffset: 1, hasMore: false };
+      }
+      if (command === "load_session_messages_paginated") {
+        return { messages: [], total: 0, nextOffset: 0, hasMore: false };
+      }
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the session selected across a watcher-driven project reload", async () => {
+    const store = createStore();
+    store.setState({ selectedProject: PROJECT, selectedSession: SESSION });
+
+    void store.getState().triggerSessionRefresh(PROJECT.path, SESSION.file_path);
+
+    // The project reload fires at 250ms; the session refresh that would restore
+    // the selection is on a 1500ms quiet period, so the gap between them is
+    // where the empty state used to appear. Land inside it deliberately.
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(store.getState().selectedSession?.file_path).toBe(SESSION.file_path);
+  });
+
+  it("still has the session selected once everything settles", async () => {
+    const store = createStore();
+    store.setState({ selectedProject: PROJECT, selectedSession: SESSION });
+
+    void store.getState().triggerSessionRefresh(PROJECT.path, SESSION.file_path);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(store.getState().selectedSession?.file_path).toBe(SESSION.file_path);
+  });
+
+  it("still clears the selection when the user picks a different project", async () => {
+    // The nulling in `selectProject` is correct for its own case, and the fix
+    // must not take it away: switching projects has to drop a session that
+    // belongs to the project being left.
+    const store = createStore();
+    store.setState({ selectedProject: PROJECT, selectedSession: SESSION });
+
+    await store.getState().selectProject({ ...PROJECT, path: "/other", name: "other" });
+
+    expect(store.getState().selectedSession).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #508.

## The bug

Any write to an open session's `.jsonl` dropped the app back to the "select a session" empty state, and it never recovered. That makes the watcher's headline case — keeping a session open while Claude Code is still writing to it — impossible. Reported against v1.25.0 by @EvilCalf, whose root-cause trace was accurate line for line; this fix follows it.

```
session-file-changed
  → triggerSessionRefresh
  → scheduleProjectUpdated            (PROJECT_UPDATE_DEBOUNCE_MS, 250ms)
  → triggerProjectRefresh
  → selectProject(selectedProject)
  → set({ selectedSession: null })    ← the view collapses here
```

`selectProject` is written for "the user picked a different project", where clearing the selection is correct. The watcher was reusing it to refresh the *currently selected* project and inherited the clear.

Nothing put it back. `runSessionRefresh` would have, but it guards on `get().selectedSession` and runs on a 1500ms quiet period (`SESSION_REFRESH_QUIET_MS`) against the project reload's 250ms, so by the time it ran the selection it depends on was already gone. Not a race — a fixed ordering that always loses.

## The fix

Split the session-list load out of `selectProject` into `reloadProjectSessions`, which does not touch the selection, and point the watcher at that. `selectProject` keeps its clear and is now that clear plus a reload, so the "switched projects" behaviour is unchanged.

Two details in the new function:

- A session present in the reloaded page **replaces** the held one, so its message count and timestamps refresh in the sidebar instead of going stale.
- A session **absent** from the page is left selected, not cleared. This is only the first page, so absence means "not on page one", not "deleted". Clearing here would reintroduce the bug for any project whose open session has scrolled off page one.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no user-facing strings

## Tests

`src/test/watcherSelectionRetention.test.ts` wires `watcherSlice` and `projectSlice` together rather than mocking. The existing `watcherSlice.test.ts` mocks `selectProject`, which is exactly why it never caught this — the bug lives in the seam between the two slices.

Three cases: the selection survives the 250ms reload; it still survives once everything settles past 1500ms; and switching projects still clears it.

**Mutation check** — each mutation fails only the cases it should:

| mutation | result |
|---|---|
| watcher calls `selectProject` again (the original bug) | 2 failed, 1 passed |
| `reloadProjectSessions` nulls the selection | 2 failed, 1 passed |
| `selectProject` stops clearing | 1 failed, 2 passed |

One fixture note worth stating: the store fixture needs `messages` and `activeSessionNearBottom`, or `scheduleSessionRefresh` throws before the session half of the refresh runs — the assertions still passed while testing half of what they claimed. Caught by vitest's unhandled-rejection report, not by the assertions.

## End-to-end verification

Real `~/.claude` over `--serve`, session opened in a browser, then a line appended to its JSONL, probing the view on a timer. Same navigation both times; the two builds differ only in this diff.

| build | result |
|---|---|
| before | empty state within 400ms, still empty at 3.2s (8/8 probes) |
| after | session held at every probe |

On the fixed build the sidebar row updates to "0 minute ago" and the footer session count refreshes, so the reload still happens — it just no longer wipes the selection.

## Note on the second half of #508

The issue also observes that this ordering defeats the "don't refresh while the user has scrolled up" deferral, because the deferral at `watcherSlice.ts:122` guards only the session refresh and not the project reload that was doing the damage. With the reload no longer destructive, that concern loses its consequence — but the asymmetry is still there and the reload can still reorder the sidebar under a user who is reading. Leaving #508 open for that, or happy to close it and file the remainder separately, whichever you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the currently open session when project data refreshes automatically.
  * Kept session selection intact when the selected session remains available after refresh.
  * Continued clearing the session selection when manually switching projects.

* **Tests**
  * Added coverage for session retention during automatic project refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->