### PR TITLE
perf(commands): run the heavy read commands on the blocking pool

### DIFF
--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -157,14 +157,33 @@ pub async fn detect_claude_config_dir() -> Result<Option<String>, String> {
     }
 }
 
+/// Scan the Claude storage directory for projects.
+///
+/// The body walks every project directory and reads their session files, all
+/// synchronously, so it runs on the blocking pool rather than holding the async
+/// runtime for the length of a scan. On a machine with many projects that was a
+/// visible stall, and under `--serve` a remote caller decided when it happened.
 #[tauri::command]
 pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, String> {
+    tauri::async_runtime::spawn_blocking(move || scan_projects_blocking(claude_path))
+        .await
+        .map(Ok)
+        .map_err(|e| format!("Task join error: {e}"))?
+}
+
+/// The scan itself. Separate from the command so the body stays at one indent
+/// level and the wrapper above is the only thing that had to change.
+///
+/// Infallible: an unreadable project directory is skipped rather than failing
+/// the scan. The command's `Result` is the IPC contract and stays; the
+/// `#[tauri::command]` attribute was hiding this from clippy.
+fn scan_projects_blocking(claude_path: String) -> Vec<ClaudeProject> {
     #[cfg(debug_assertions)]
     let start_time = std::time::Instant::now();
     let projects_path = PathBuf::from(&claude_path).join("projects");
 
     if !projects_path.exists() {
-        return Ok(vec![]);
+        return vec![];
     }
 
     let mut projects = Vec::new();
@@ -330,7 +349,7 @@ pub async fn scan_projects(claude_path: String) -> Result<Vec<ClaudeProject>, St
         );
     }
 
-    Ok(projects)
+    projects
 }
 
 fn extract_cwd_from_session_file(file_path: &Path) -> Option<String> {

--- a/src-tauri/src/commands/session/edits.rs
+++ b/src-tauri/src/commands/session/edits.rs
@@ -847,8 +847,30 @@ fn validate_session_file_in_project(
 ///
 /// `grouping` selects the reduction: "file" (default) for one row per file,
 /// "edit" for one row per edit event.
+///
+/// The work is entirely synchronous — a `WalkDir` over the project, then an
+/// mmap and line scan of every JSONL file — so it runs on the blocking pool
+/// rather than holding the async runtime for the duration of a project scan.
+/// Under `--serve` the caller chooses when that happens, which made it a remote
+/// stall vector as well as a local one.
 #[tauri::command]
 pub async fn get_recent_edits(
+    project_path: String,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    session_file_path: Option<String>,
+    grouping: Option<String>,
+) -> Result<PaginatedRecentEdits, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        get_recent_edits_blocking(project_path, offset, limit, session_file_path, grouping)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {e}"))?
+}
+
+/// The scan itself. Separate from the command so the whole body stays at one
+/// indent level and the wrapper above is the only thing that had to change.
+fn get_recent_edits_blocking(
     project_path: String,
     offset: Option<usize>,
     limit: Option<usize>,

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -1059,8 +1059,28 @@ fn clear_dropped_candidate(project_path: &str, path_str: &str) {
     }
 }
 
+/// Load one page of a project's sessions.
+///
+/// Reads and parses session files synchronously, so it runs on the blocking
+/// pool rather than holding the async runtime. This is on the path taken every
+/// time a project is selected, and again on every watcher-driven refresh.
 #[tauri::command]
 pub async fn load_project_sessions_page(
+    project_path: String,
+    exclude_sidechain: Option<bool>,
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> Result<SessionPage, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        load_project_sessions_page_blocking(project_path, exclude_sidechain, offset, limit)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {e}"))?
+}
+
+/// The load itself. Separate from the command so the body stays at one indent
+/// level and the wrapper above is the only thing that had to change.
+fn load_project_sessions_page_blocking(
     project_path: String,
     exclude_sidechain: Option<bool>,
     offset: Option<usize>,
@@ -1333,11 +1353,34 @@ pub async fn load_project_sessions_page(
     })
 }
 
+/// Load every session in a project.
+///
+/// Same shape as the paginated variant above and the same reasoning: the work
+/// is synchronous file reading and parsing, so it belongs on the blocking pool.
+/// Unpaginated, so on a large project it is the longer of the two.
 #[tauri::command]
 pub async fn load_project_sessions(
     project_path: String,
     exclude_sidechain: Option<bool>,
 ) -> Result<Vec<ClaudeSession>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        load_project_sessions_blocking(project_path, exclude_sidechain)
+    })
+    .await
+    .map(Ok)
+    .map_err(|e| format!("Task join error: {e}"))?
+}
+
+/// The load itself. Separate from the command so the body stays at one indent
+/// level and the wrapper above is the only thing that had to change.
+///
+/// Infallible: a session file that cannot be read is skipped rather than
+/// failing the load. The command's `Result` is the IPC contract and stays; the
+/// `#[tauri::command]` attribute was hiding this from clippy.
+fn load_project_sessions_blocking(
+    project_path: String,
+    exclude_sidechain: Option<bool>,
+) -> Vec<ClaudeSession> {
     #[cfg(debug_assertions)]
     let start_time = std::time::Instant::now();
 
@@ -1562,7 +1605,7 @@ pub async fn load_project_sessions(
         );
     }
 
-    Ok(sessions)
+    sessions
 }
 
 /// Parse a single line into `ClaudeMessage` (with line number)

--- a/src-tauri/src/commands/session/search.rs
+++ b/src-tauri/src/commands/session/search.rs
@@ -454,8 +454,29 @@ pub fn apply_search_filters(
         .collect()
 }
 
+/// Search messages across a Claude storage directory.
+///
+/// Walks and scans every session file synchronously, so it runs on the blocking
+/// pool. Search is the one command a user is most likely to fire repeatedly,
+/// and holding the runtime meant each keystroke-triggered search froze
+/// everything else until it finished.
 #[tauri::command]
 pub async fn search_messages(
+    claude_path: String,
+    query: String,
+    filters: serde_json::Value,
+    limit: Option<usize>,
+) -> Result<Vec<ClaudeMessage>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        search_messages_blocking(claude_path, query, filters, limit)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {e}"))?
+}
+
+/// The search itself. Separate from the command so the body stays at one indent
+/// level and the wrapper above is the only thing that had to change.
+fn search_messages_blocking(
     claude_path: String,
     query: String,
     filters: serde_json::Value,

--- a/src-tauri/tests/blocking_offload_test.rs
+++ b/src-tauri/tests/blocking_offload_test.rs
@@ -1,0 +1,127 @@
+//! #516. The heavy read commands were declared `async` while doing entirely
+//! synchronous work — `WalkDir`, then mmap and a line scan of every JSONL file
+//! — so the async runtime was held for the length of a scan. On a large project
+//! that was a visible stall, and under `--serve` a remote caller chose when it
+//! happened.
+//!
+//! These pin the offload rather than the timing. On a current-thread runtime a
+//! future that never yields cannot let another task run: an `async fn` whose
+//! body contains no `.await` is polled once, returns `Ready`, and awaiting it
+//! never reaches the scheduler. Awaiting a `spawn_blocking` join handle is
+//! `Pending` on the first poll, so it does.
+//!
+//! So "did an already-queued task get to run?" is a decisive, timing-free test
+//! of whether the work left the runtime thread. It fails on every one of these
+//! commands before the fix and passes after, and it needs no large fixture:
+//! what is being observed is the yield, not the work.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use claude_code_history_viewer_lib::commands;
+
+/// Queue a task, run `f`, and report whether the task got to run.
+///
+/// `tokio::spawn` only makes the task runnable; on a current-thread runtime it
+/// cannot make progress until something yields.
+async fn yielded_during<F, T>(f: F) -> bool
+where
+    F: Future<Output = T>,
+{
+    let ran = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&ran);
+    tokio::spawn(async move {
+        flag.store(true, Ordering::SeqCst);
+    });
+
+    let _ = f.await;
+    ran.load(Ordering::SeqCst)
+}
+
+/// A path that exists but holds nothing. The commands still take their full
+/// path through `spawn_blocking`; the assertion is about where the work runs,
+/// not how much of it there is.
+fn empty_root() -> tempfile::TempDir {
+    tempfile::TempDir::new().expect("temp dir")
+}
+
+#[tokio::test]
+async fn get_recent_edits_leaves_the_runtime_free() {
+    let root = empty_root();
+    let path = root.path().to_string_lossy().to_string();
+
+    assert!(
+        yielded_during(commands::session::get_recent_edits(
+            path, None, None, None, None
+        ))
+        .await,
+        "get_recent_edits held the runtime thread for the whole scan"
+    );
+}
+
+#[tokio::test]
+async fn scan_projects_leaves_the_runtime_free() {
+    let root = empty_root();
+    let path = root.path().to_string_lossy().to_string();
+
+    assert!(
+        yielded_during(commands::project::scan_projects(path)).await,
+        "scan_projects held the runtime thread for the whole scan"
+    );
+}
+
+#[tokio::test]
+async fn load_project_sessions_page_leaves_the_runtime_free() {
+    let root = empty_root();
+    let path = root.path().to_string_lossy().to_string();
+
+    assert!(
+        yielded_during(commands::session::load_project_sessions_page(
+            path, None, None, None
+        ))
+        .await,
+        "load_project_sessions_page held the runtime thread for the whole load"
+    );
+}
+
+#[tokio::test]
+async fn load_project_sessions_leaves_the_runtime_free() {
+    let root = empty_root();
+    let path = root.path().to_string_lossy().to_string();
+
+    assert!(
+        yielded_during(commands::session::load_project_sessions(path, None)).await,
+        "load_project_sessions held the runtime thread for the whole load"
+    );
+}
+
+#[tokio::test]
+async fn search_messages_leaves_the_runtime_free() {
+    let root = empty_root();
+    let path = root.path().to_string_lossy().to_string();
+
+    assert!(
+        yielded_during(commands::session::search_messages(
+            path,
+            "needle".to_string(),
+            serde_json::json!({}),
+            None,
+        ))
+        .await,
+        "search_messages held the runtime thread for the whole search"
+    );
+}
+
+/// The control. `get_claude_folder_path` is deliberately *not* offloaded — two
+/// stat calls on the home directory, where a task spawn would cost more than it
+/// saves. If someone later wraps it, this test says so rather than letting the
+/// pattern spread by habit.
+#[tokio::test]
+async fn trivial_commands_are_deliberately_not_offloaded() {
+    assert!(
+        !yielded_during(commands::project::get_claude_folder_path()).await,
+        "get_claude_folder_path is now offloading; either that is deliberate \
+         (update this test and say why) or the pattern was applied by habit"
+    );
+}


### PR DESCRIPTION
Closes #516.

## The problem

`get_recent_edits` is declared `async` while doing entirely synchronous work — a `WalkDir` over the project, then mmap and a line scan of every JSONL file, in parallel via rayon. Nothing yields, so the async runtime is held for the length of a scan. Under `--serve` a remote caller decides when that happens.

## The survey the issue asked for

> Worth checking whether sibling commands in the same module share the shape before fixing just this one.

They do, and they are the heavy ones. Of the twenty async commands that touch the filesystem, **fourteen already use `tauri::async_runtime::spawn_blocking`** and six did not:

| command | lines of sync body | offloaded here |
|---|---|---|
| `load_project_sessions_page` | 266 | yes |
| `load_project_sessions` | 226 | yes |
| `scan_projects` | 174 | yes |
| `search_messages` | 122 | yes |
| `get_recent_edits` | 77 | yes |
| `get_claude_folder_path` | 19 | **no — see below** |

Fixing only `get_recent_edits` would have left the stall exactly where a user meets it: selecting a project goes through `load_project_sessions_page`, and every watcher-driven refresh does it again.

All six have **zero internal awaits** and take owned parameters, so the transformation is uniform and mechanical.

## Why `get_claude_folder_path` is excluded

Two stat calls on the home directory. A task spawn costs more than it saves, and wrapping it would be applying the pattern rather than fixing the defect — the defect is *unbounded* work on the runtime thread. `trivial_commands_are_deliberately_not_offloaded` pins the exclusion, so if someone later wraps it that is a decision with a test to update rather than habit.

## Shape

Each command becomes a four-line wrapper over a `_blocking` function holding the original body, **unmoved and at the same indent level**. The diff is the wrapper, not a reindent of 266 lines: **+108 / −3** across four files.

The convention followed is the repo's existing one, `tauri::async_runtime::spawn_blocking(...).await.map_err(|e| format!("Task join error: {e}"))?`, as used in `claude_settings.rs`, `archive.rs`, `mcp_presets.rs` and elsewhere — not `tokio::task::spawn_blocking` as the issue suggested.

## A thing the extraction exposed

Clippy immediately flagged `scan_projects_blocking` and `load_project_sessions_blocking` as `unnecessary_wraps`: **both are infallible.** That was invisible while they were `#[tauri::command]`, because clippy exempts command signatures — the `Result` there is the IPC contract. Now that the body is an ordinary function, the lint can see it. Both return their value directly and the wrapper supplies the `Ok`; the commands' signatures are unchanged.

## Type

- [x] Refactor / perf

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` clean
- [x] i18n: no user-facing strings
- [x] No command signature changed, so no Tauri/Axum parity work

## Tests

`src-tauri/tests/blocking_offload_test.rs`, six cases, **and they are not timing-based**.

On a current-thread runtime, a future that never yields cannot let another task run: an `async fn` whose body contains no `.await` is polled once, returns `Ready`, and awaiting it never reaches the scheduler. Awaiting a `spawn_blocking` join handle is `Pending` on the first poll, so it does.

So the test queues a task with `tokio::spawn`, awaits the command, and asserts the task got to run. That is decisive about *where the work ran* with no sleeps, no thresholds and no large fixture — what is being observed is the yield, not the work. An empty tempdir is enough.

**Mutation check.** Reverting `get_recent_edits` to run inline fails `get_recent_edits_leaves_the_runtime_free` and only that one (5 passed, 1 failed).

**Gates.** `cargo test --all-features -- --test-threads=1`: 1021 + 6 + 5 + 4 + 3 passed, 0 failed. Clippy and fmt clean. Frontend untouched, 1126 passing.

## What this does not change

Total work per request is the same. The page size clamp (200) and resolving `exists_on_disk` only for returned rows already bound the cost; this is about which thread pays it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved app responsiveness while scanning projects, loading sessions, and searching messages.
  - These operations now run without blocking other app activity, helping the interface remain responsive during larger or slower searches and data loads.
- **Reliability**
  - Improved handling of background task failures, with clearer error reporting when an operation cannot complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->