### PR TITLE
fix(recent-edits): write the list and its cursor together

### DIFF
--- a/src/hooks/analytics/useAnalyticsNavigation.test.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.test.ts
@@ -946,3 +946,119 @@ describe("recent-edits cache invalidation on file change", () => {
     ).toBe(false);
   });
 });
+
+/**
+ * #517. The list and the cursor that describes it were two separate writes, and
+ * `refreshAllConversations` only made the first. Replacing 60 loaded rows with
+ * page 1 while leaving the cursor at 60 meant the next "Show More" fetched from
+ * 60 and stapled that page onto rows 1-20, losing everything between.
+ *
+ * #514 removed the symptom by deriving the load-more offset from the rows
+ * actually held, so the stale cursor no longer decides where the next page
+ * starts. What was left is the cursor's own `offset` and `hasMore` describing a
+ * list that no longer exists, which ends pagination early or late.
+ *
+ * These pin the invariant rather than any one call site: a wholesale write of
+ * the list carries its cursor with it, so the two cannot be written apart.
+ */
+describe("recent-edits list and cursor are written together", () => {
+  beforeEach(() => {
+    fetchRecentEdits.mockReset();
+    useAppStore.setState({ selectedProject: null, selectedSession: null });
+    useAppStore.getState().resetAnalytics();
+  });
+
+  const twoPagesLoaded = () =>
+    useAppStore.setState((state) => ({
+      analytics: {
+        ...state.analytics,
+        recentEditsPagination: {
+          totalEditsCount: 100,
+          uniqueFilesCount: 100,
+          offset: 60,
+          limit: 20,
+          hasMore: true,
+          isLoadingMore: false,
+        },
+      },
+    }));
+
+  it("resets the cursor when the list is replaced wholesale", () => {
+    const p = project("alpha");
+    twoPagesLoaded();
+
+    useAppStore.getState().setAnalyticsRecentEdits(
+      {
+        files: payload(p.actual_path).files,
+        total_edits_count: 42,
+        unique_files_count: 40,
+        project_cwd: p.actual_path,
+        offset: 0,
+        limit: 20,
+        has_more: true,
+      },
+      p.path
+    );
+
+    const pagination = useAppStore.getState().analytics.recentEditsPagination;
+    expect(pagination.offset).toBe(0);
+    expect(pagination.hasMore).toBe(true);
+    expect(pagination.totalEditsCount).toBe(42);
+    expect(pagination.uniqueFilesCount).toBe(40);
+    // A replacement is not a load-more, so it must never leave the flag raised.
+    expect(pagination.isLoadingMore).toBe(false);
+  });
+
+  it("carries has_more=false through, so pagination ends when the page says so", () => {
+    const p = project("alpha");
+    twoPagesLoaded();
+
+    useAppStore.getState().setAnalyticsRecentEdits(
+      {
+        files: payload(p.actual_path).files,
+        total_edits_count: 1,
+        unique_files_count: 1,
+        project_cwd: p.actual_path,
+        offset: 0,
+        limit: 20,
+        has_more: false,
+      },
+      p.path
+    );
+
+    expect(
+      useAppStore.getState().analytics.recentEditsPagination.hasMore
+    ).toBe(false);
+  });
+
+  it("resets the cursor when the list is cleared", () => {
+    // `refreshAnalytics` clears the list before refetching. A cursor left
+    // pointing into the old list is as wrong here as after a replacement.
+    twoPagesLoaded();
+
+    useAppStore.getState().setAnalyticsRecentEdits(null);
+
+    const pagination = useAppStore.getState().analytics.recentEditsPagination;
+    expect(useAppStore.getState().analytics.recentEdits).toBeNull();
+    expect(pagination.offset).toBe(0);
+    expect(pagination.hasMore).toBe(false);
+    expect(pagination.totalEditsCount).toBe(0);
+  });
+
+  it("leaves the switch-to-view path writing the cursor exactly once", async () => {
+    const p = project("alpha");
+    fetchRecentEdits.mockResolvedValue(payload(p.actual_path));
+    useAppStore.setState({ selectedProject: p });
+
+    const { result } = renderHook(() => useAnalyticsNavigation());
+    await act(async () => {
+      await result.current.switchToRecentEdits();
+    });
+
+    const pagination = useAppStore.getState().analytics.recentEditsPagination;
+    expect(pagination.offset).toBe(0);
+    expect(pagination.limit).toBe(20);
+    expect(pagination.hasMore).toBe(false);
+    expect(pagination.uniqueFilesCount).toBe(1);
+  });
+});

--- a/src/hooks/analytics/useAnalyticsNavigation.ts
+++ b/src/hooks/analytics/useAnalyticsNavigation.ts
@@ -212,27 +212,10 @@ export function useAnalyticsNavigation() {
         return;
       }
 
-      setAnalyticsRecentEdits({
-        files: result.files,
-        total_edits_count: result.total_edits_count,
-        unique_files_count: result.unique_files_count,
-        project_cwd: result.project_cwd,
-        requestedProjectPath: project.path,
-      });
-
-      useAppStore.setState((state) => ({
-        analytics: {
-          ...state.analytics,
-          recentEditsPagination: {
-            totalEditsCount: result.total_edits_count,
-            uniqueFilesCount: result.unique_files_count,
-            offset: result.offset,
-            limit: result.limit,
-            hasMore: result.has_more,
-            isLoadingMore: false,
-          },
-        },
-      }));
+      // One write. The cursor used to be a second `setState` right here, which
+      // is the shape that let `refreshAllConversations` replace the list and
+      // forget the cursor (#517).
+      setAnalyticsRecentEdits(result, project.path);
     } catch (error) {
       const errorMessage =
         error instanceof Error

--- a/src/store/slices/analyticsSlice.ts
+++ b/src/store/slices/analyticsSlice.ts
@@ -7,13 +7,12 @@
 import type {
   ProjectStatsSummary,
   SessionComparison,
-  RecentEditsResult,
   PaginatedRecentEdits,
   MetricMode,
   StatsMode,
 } from "../../types";
 import type { AnalyticsState, AnalyticsViewType } from "../../types/analytics";
-import { initialAnalyticsState } from "../../types/analytics";
+import { initialAnalyticsState, initialRecentEditsPagination } from "../../types/analytics";
 import type { StateCreator } from "zustand";
 import { toast } from "sonner";
 import type { FullAppStore } from "./types";
@@ -48,7 +47,10 @@ export interface AnalyticsSliceActions {
   setAnalyticsLoadingSessionComparison: (loading: boolean) => void;
   setAnalyticsProjectSummaryError: (error: string | null) => void;
   setAnalyticsSessionComparisonError: (error: string | null) => void;
-  setAnalyticsRecentEdits: (edits: RecentEditsResult | null) => void;
+  setAnalyticsRecentEdits: (
+    page: PaginatedRecentEdits | null,
+    requestedProjectPath?: string
+  ) => void;
   setAnalyticsRecentEditsSearchQuery: (query: string) => void;
   setAnalyticsLoadingRecentEdits: (loading: boolean) => void;
   setAnalyticsRecentEditsError: (error: string | null) => void;
@@ -171,11 +173,49 @@ export const createAnalyticsSlice: StateCreator<
     }));
   },
 
-  setAnalyticsRecentEdits: (edits: RecentEditsResult | null) => {
+  /**
+   * Replace the Recent Edits list, and the cursor that describes it, together.
+   *
+   * Takes the whole page rather than just its rows so the two cannot be written
+   * apart. They used to be two writes at each call site, and
+   * `refreshAllConversations` made only the first: 60 loaded rows were replaced
+   * with page 1 while the cursor stayed at 60, so the next page was fetched
+   * from 60 and stapled onto rows 1-20 (#517). Deriving the load-more offset
+   * from the rows actually held removed that symptom, but left `offset` and
+   * `hasMore` describing a list that no longer existed, which ends pagination
+   * early or late.
+   *
+   * `null` clears both. A cursor pointing into a list that has been cleared is
+   * as wrong as one pointing into a list that has been replaced.
+   */
+  setAnalyticsRecentEdits: (
+    page: PaginatedRecentEdits | null,
+    requestedProjectPath?: string
+  ) => {
     set((state) => ({
       analytics: {
         ...state.analytics,
-        recentEdits: edits,
+        recentEdits: page
+          ? {
+              files: page.files,
+              total_edits_count: page.total_edits_count,
+              unique_files_count: page.unique_files_count,
+              project_cwd: page.project_cwd,
+              requestedProjectPath,
+            }
+          : null,
+        recentEditsPagination: page
+          ? {
+              totalEditsCount: page.total_edits_count,
+              uniqueFilesCount: page.unique_files_count,
+              offset: page.offset,
+              limit: page.limit,
+              hasMore: page.has_more,
+              // A replacement is not a load-more, so it never leaves the flag
+              // raised — a stranded flag blocks every future page.
+              isLoadingMore: false,
+            }
+          : initialRecentEditsPagination,
         // Bumping here, rather than at each call site, is what makes the
         // generation true for all three writers of the cache without any of
         // them having to remember.

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -609,13 +609,13 @@ export const createProjectSlice: StateCreator<
         // while this was in flight, writing would show one project's edits
         // under another's identity.
         if (get().selectedProject?.path === refreshedProject.path) {
-          refreshedState.setAnalyticsRecentEdits({
-            files: recentEdits.files,
-            total_edits_count: recentEdits.total_edits_count,
-            unique_files_count: recentEdits.unique_files_count,
-            project_cwd: recentEdits.project_cwd,
-            requestedProjectPath: refreshedProject.path,
-          });
+          // The whole page, so the cursor is replaced along with the rows.
+          // Passing only the rows is what left the cursor at 60 while the list
+          // went back to page 1 (#517).
+          refreshedState.setAnalyticsRecentEdits(
+            recentEdits,
+            refreshedProject.path
+          );
         }
       } else if (refreshedState.analytics.currentView === "board") {
         refreshedState.clearBoard();

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -15,7 +15,7 @@ import type {
   SessionComparison,
   GlobalStatsSummary,
   SearchFilters,
-  RecentEditsResult,
+  PaginatedRecentEdits,
   UserMetadata,
   SessionMetadata,
   ProjectMetadata,
@@ -297,7 +297,10 @@ export interface AppStoreActions {
   setAnalyticsLoadingSessionComparison: (loading: boolean) => void;
   setAnalyticsProjectSummaryError: (error: string | null) => void;
   setAnalyticsSessionComparisonError: (error: string | null) => void;
-  setAnalyticsRecentEdits: (edits: RecentEditsResult | null) => void;
+  setAnalyticsRecentEdits: (
+    page: PaginatedRecentEdits | null,
+    requestedProjectPath?: string
+  ) => void;
   setAnalyticsRecentEditsSearchQuery: (query: string) => void;
   setAnalyticsLoadingRecentEdits: (loading: boolean) => void;
   setAnalyticsRecentEditsError: (error: string | null) => void;


### PR DESCRIPTION
Closes #517.

## The bug

Refreshing all conversations while Recent Edits was open replaced the rows with page 1 but left the pagination cursor where it was. With two pages loaded, the cursor sat at 60; the next "Show More" fetched from 60 and appended that page straight onto rows 1–20, losing everything between.

## The cause was shape, not an oversight

The list and the cursor that describes it were **two separate writes at every call site**:

```ts
setAnalyticsRecentEdits({ files, ... });      // the list
useAppStore.setState(... recentEditsPagination ...);  // the cursor
```

The navigation hook happened to do both. `refreshAllConversations` did only the first. Nothing made that a mistake the type system or the API could catch, so it was one call site away from happening again.

## The fix

`setAnalyticsRecentEdits` now takes the whole `PaginatedRecentEdits` — which already carries `offset`, `limit` and `has_more` — and writes the list and the cursor in one `set`. The two can no longer be written apart.

Its `null` case resets the cursor as well. A cursor pointing into a cleared list is as wrong as one pointing into a replaced list, and `refreshAnalytics` clears before refetching.

Call sites: the hook loses its second `setState`; `refreshAllConversations` passes the page it already had in hand.

`loadMoreRecentEdits` keeps writing both itself, because appending is not a wholesale replacement — it has to preserve the accumulated rows.

## On severity

#514 had already removed the visible symptom, by deriving the load-more offset from the rows actually held rather than from the stored cursor. So a desynced cursor no longer decided where the next page started. What remained is `offset` and `hasMore` describing a list that no longer exists, which ends pagination early or late. Worth fixing as a correctness and shape problem, not as a live user-facing break.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no user-facing strings

## Tests

Four cases in `useAnalyticsNavigation.test.ts`, pinning the invariant rather than any one call site:

- a wholesale replacement resets `offset`, carries the new counts, and never leaves `isLoadingMore` raised
- `has_more: false` is carried through, so pagination ends when the page says it should
- clearing the list resets the cursor
- the switch-to-view path still writes the cursor exactly once, with the values from the response

**Mutation check.** Removing the pagination write from the setter fails 14 of 28 cases in that file — the invariant is now load-bearing for the load-more and invalidation tests too, which is the point of moving ownership rather than adding a second write.

**Gates.** `pnpm exec vitest run` 1136 passed (98 files), `pnpm exec tsc --build .` clean, `pnpm lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Recent Edits pagination updates when loading or switching views.
  * Ensured pagination cursors and “more results” indicators reset correctly when results are replaced or cleared.
  * Kept Recent Edits data and pagination metadata synchronized during refreshes.

* **Tests**
  * Added regression coverage for Recent Edits replacement, clearing, pagination resets, and view switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->