### PR TITLE
fix(a11y): gate skip links on their targets' real render conditions

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -385,14 +385,22 @@ export const AppLayout: React.FC<AppLayoutProps> = (props) => {
             defaultValue: "Skip navigation",
           })}
         >
-          <a
-            href="#project-explorer"
-            className="absolute left-2 top-[-40px] z-[700] rounded-md border border-border bg-card px-3 py-2 text-sm font-medium text-foreground transition-all focus:top-2"
-          >
-            {t("common.a11y.skipToProjects", {
-              defaultValue: "Skip to project explorer",
-            })}
-          </a>
+          {/*
+            Same rule, second instance. The desktop `ProjectTree` that owns
+            `#project-explorer` renders under `!isMobile`; on mobile the id
+            exists only inside the navigation drawer, and only while it is open.
+            So on mobile with the drawer shut this link resolved to nothing.
+          */}
+          {!isMobile && (
+            <a
+              href="#project-explorer"
+              className="absolute left-2 top-[-40px] z-[700] rounded-md border border-border bg-card px-3 py-2 text-sm font-medium text-foreground transition-all focus:top-2"
+            >
+              {t("common.a11y.skipToProjects", {
+                defaultValue: "Skip to project explorer",
+              })}
+            </a>
+          )}
           <a
             href="#main-content"
             className="absolute left-52 top-[-40px] z-[700] rounded-md border border-border bg-card px-3 py-2 text-sm font-medium text-foreground transition-all focus:top-2"
@@ -411,7 +419,15 @@ export const AppLayout: React.FC<AppLayoutProps> = (props) => {
               })}
             </a>
           )}
-          {!isMobile && isNavigatorOpen && selectedSession && (
+          {/*
+            `isTranscriptView` and not just a selected session: `MessageNavigator`
+            renders only in the transcript branch, while `selectedSession`
+            survives switching to analytics, token stats, board, settings or
+            archive. The link was keyed to the proxy, so on those views it stayed
+            in the tab order pointing at an id that was not in the document
+            (#518). Same treatment the recent-edits link above already has.
+          */}
+          {!isMobile && isTranscriptView && isNavigatorOpen && selectedSession && (
             <a
               href="#message-navigator"
               className="absolute left-[23rem] top-[-40px] z-[700] rounded-md border border-border bg-card px-3 py-2 text-sm font-medium text-foreground transition-all focus:top-2"

--- a/src/test/App.accessibility.test.tsx
+++ b/src/test/App.accessibility.test.tsx
@@ -184,20 +184,34 @@ vi.mock("@/hooks/useAnalytics", () => ({
       switchToAnalytics: vi.fn(),
       switchToSettings: vi.fn(),
     },
-    computed: {
-      isMessagesView: true,
-      isTokenStatsView: false,
-      isAnalyticsView: false,
-      isRecentEditsView: false,
-      isSettingsView: false,
-      isBoardView: false,
-      isAnyLoading: false,
-      isLoadingAnalytics: false,
-      isLoadingTokenStats: false,
-      isLoadingRecentEdits: false,
-    },
+    computed: computedMock,
   }),
 }));
+
+/**
+ * The view flags a test wants to vary. Hoisted and mutated in place rather than
+ * re-mocked per test, because `vi.mock` is hoisted above the test bodies.
+ */
+const { computedMock, resetComputedMock } = vi.hoisted(() => {
+  const defaults = {
+    isMessagesView: true,
+    isTokenStatsView: false,
+    isAnalyticsView: false,
+    isRecentEditsView: false,
+    isSettingsView: false,
+    isBoardView: false,
+    isArchiveView: false,
+    isAnyLoading: false,
+    isLoadingAnalytics: false,
+    isLoadingTokenStats: false,
+    isLoadingRecentEdits: false,
+  };
+  const mock = { ...defaults };
+  return {
+    computedMock: mock,
+    resetComputedMock: () => Object.assign(mock, defaults),
+  };
+});
 
 vi.mock("@/hooks/useUpdater", () => ({
   useUpdater: () => ({
@@ -273,6 +287,7 @@ describe("App accessibility smoke", () => {
   beforeEach(() => {
     window.history.replaceState({}, "", "/");
     vi.clearAllMocks();
+    resetComputedMock();
   });
 
   it("renders skip links and landmark targets", () => {
@@ -295,6 +310,65 @@ describe("App accessibility smoke", () => {
     expect(document.getElementById("main-content")).not.toBeNull();
     expect(document.getElementById("message-navigator")).not.toBeNull();
     expect(document.getElementById("app-settings-button")).not.toBeNull();
+  });
+
+  /**
+   * #518. A skip link whose target is not in the document is worse than an
+   * absent one: it takes a tab stop and then silently does nothing, which reads
+   * as the page being broken rather than the link being inapplicable.
+   *
+   * The rule these pin is that each link is gated on its target's real render
+   * condition, not on a proxy for it.
+   */
+  it.each([
+    ["settings", { isSettingsView: true }],
+    ["analytics", { isAnalyticsView: true }],
+    ["token stats", { isTokenStatsView: true }],
+    ["board", { isBoardView: true }],
+    // Archive is left out: its branch reads archive state this mock does not
+    // carry, so including it would test the fixture rather than the gating.
+    // It is covered by `isTranscriptView` all the same.
+    ["recent edits", { isRecentEditsView: true }],
+  ])(
+    "drops the message-navigator skip link in the %s view, where the navigator does not render",
+    (_label, flags) => {
+      // The navigator only renders in the transcript branch, but its link was
+      // keyed to `selectedSession` — which survives switching views.
+      Object.assign(computedMock, { isMessagesView: false }, flags);
+
+      render(<App />);
+
+      expect(document.getElementById("message-navigator")).toBeNull();
+      expect(
+        screen.queryByRole("link", { name: "Skip to message navigator" })
+      ).toBeNull();
+    }
+  );
+
+  it("keeps every rendered skip link pointing at a target that exists", () => {
+    // The general invariant, asserted across the view states rather than for
+    // one link: whatever the nav offers must resolve.
+    for (const flags of [
+      { isMessagesView: true },
+      { isMessagesView: false, isSettingsView: true },
+      { isMessagesView: false, isBoardView: true },
+    ]) {
+      resetComputedMock();
+      Object.assign(computedMock, flags);
+      const view = render(<App />);
+
+      const links = screen.getAllByRole("link");
+      for (const link of links) {
+        const href = link.getAttribute("href") ?? "";
+        if (!href.startsWith("#")) continue;
+        expect(
+          document.getElementById(href.slice(1)),
+          `${link.textContent} points at ${href}, which is not in the document`
+        ).not.toBeNull();
+      }
+
+      view.unmount();
+    }
   });
 
   it("replays a WebUI message link from browser history", async () => {


### PR DESCRIPTION
Closes #518.

## The bug

Two skip links pointed at ids that were not always in the document.

A skip link that resolves to nothing is worse than an absent one: it consumes a tab stop and then silently fails, which reads to a keyboard or screen-reader user as the page being broken rather than as the link being inapplicable.

### `#message-navigator`

Gated on `selectedSession`, which is a proxy. `MessageNavigator` renders only in the transcript branch, while the selection survives switching to analytics, token stats, board, settings or archive. Selecting a session and then switching views left the link in the tab order pointing at an id that had been unmounted.

Now gated on `isTranscriptView`, which `AppLayout` already derives — exactly the treatment the recent-edits link got when it was added in #515.

### `#project-explorer`

Ungated, and the issue did not mention this one — it turned up doing the audit the issue asked for. The desktop `ProjectTree` that owns the id renders under `!isMobile` (`AppLayout.tsx:488`); on mobile the id exists only inside the navigation drawer (`AppLayout.tsx:478`), and only while the drawer is open. So on mobile with the drawer shut, "Skip to project explorer" resolved to nothing.

Now gated on `!isMobile`, matching the tree's own condition.

### The other two

`#main-content` (`<main>`) and `#app-settings-button` (in the header dropdown) are unconditionally rendered. Checked rather than assumed.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no new strings; the links' existing keys are unchanged

## Tests

`src/test/App.accessibility.test.tsx` gains a mutable `computed` mock so a test can put the app in a non-transcript view, which it previously could not.

- five parameterised cases (settings, analytics, token stats, board, recent edits) asserting that when `#message-navigator` is not in the document, neither is its link
- a general invariant test that walks **every** rendered in-page link across three view states and asserts each `href` resolves. That is the test that would have caught either of these two without knowing to look for them, and it is the one that caught `#project-explorer`.

Archive is deliberately excluded from the parameterised list: its branch reads archive state this mock does not carry, so including it would test the fixture rather than the gating. `isTranscriptView` covers it regardless.

**Before the fix:** 7 of the 8 cases in the file fail. **After:** 8 pass.

**Gates.** `pnpm exec vitest run` 1132 passed (98 files), `pnpm exec tsc --build .` clean, `pnpm lint` clean.

## Note

The issue suggested pointing `scratch/recent-edits/verification/skiplink_target.py` at `#message-navigator`. Went with a vitest case instead, so the check lives with the code and runs in CI rather than being a script somebody has to remember to run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility skip links by showing them only when their destination is available.
  * Hidden the project explorer skip link on mobile devices.
  * Restricted the message navigator skip link to views where the navigator is open and a session is selected.
* **Tests**
  * Added coverage to verify skip links consistently point to existing content across supported views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->