### PR TITLE
fix(watcher): stop the session list blanking on every watcher reload

### DIFF
--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -641,7 +641,15 @@ export const createProjectSlice: StateCreator<
     // projects abandons any in-progress multi-selection and any session that
     // belonged to the project being left.
     get().exitSessionSelectionMode();
-    set({ selectedSession: null });
+    // Clearing the list belongs here, not in the reload. The outgoing
+    // project's rows must not linger under the incoming project's name.
+    set({
+      selectedSession: null,
+      sessions: [],
+      sessionsTotal: project.session_count,
+      sessionsOffset: 0,
+      hasMoreSessions: false,
+    });
     await get().reloadProjectSessions(project);
   },
 
@@ -663,15 +671,22 @@ export const createProjectSlice: StateCreator<
    */
   reloadProjectSessions: async (project: ClaudeProject) => {
     const requestId = nextRequestId("selectProject");
-    set({
+    set((state) => ({
       selectedProject: project,
-      sessions: [],
-      sessionsTotal: project.session_count,
-      sessionsOffset: 0,
-      hasMoreSessions: false,
-      isLoadingSessions: true,
+      // The rows already on screen stay until the new page arrives. Blanking
+      // here made the sidebar flash on every watcher tick: measured at 18 rows
+      // -> 1 -> 18 within 29ms for a single write, and a session Claude Code is
+      // actively writing produces a tick at least every 250ms.
+      //
+      // Only a caller that is changing projects clears the list, and
+      // `selectProject` does that itself before calling this.
+      //
+      // Likewise the spinner: it means "there is nothing to look at yet", so it
+      // is only raised when the list is in fact empty. Raising it over rows the
+      // user is already reading is the same flash by another name.
+      isLoadingSessions: state.sessions.length === 0,
       isLoadingMoreSessions: false,
-    });
+    }));
     try {
       const provider = project.provider ?? "claude";
       const page = await api<SessionPage>("load_provider_sessions_page", {

--- a/src/test/watcherSelectionRetention.test.ts
+++ b/src/test/watcherSelectionRetention.test.ts
@@ -127,3 +127,103 @@ describe("#508 a file write must not clear the open session", () => {
     expect(store.getState().selectedSession).toBeNull();
   });
 });
+
+/**
+ * #508, second half. The watcher's project reload blanked the session list
+ * before refetching it, so the sidebar emptied and refilled on every tick.
+ * Measured against the running app: a single write took the list from 18 rows
+ * to 1 and back within 29ms, and a session Claude Code is actively writing
+ * produces a tick at least every 250ms.
+ *
+ * That is also what defeated the "don't refresh while the user has scrolled up"
+ * deferral: the deferral guards the session refresh, but the project reload
+ * fired regardless and churned the sidebar underneath the reader. Rather than
+ * plumb the deferral through — which would hide genuinely new sessions from
+ * someone mid-read — the reload is simply no longer disruptive.
+ */
+describe("#508 a watcher reload must not blank the session list", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedApi.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Holds the session page open so mid-flight state can be observed. */
+  const deferredPage = () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mockedApi.mockImplementation(async (command: string) => {
+      if (command === "load_provider_sessions_page") {
+        await gate;
+        return { sessions: [SESSION], total: 1, nextOffset: 1, hasMore: false };
+      }
+      return null;
+    });
+    return { release: () => release() };
+  };
+
+  it("keeps the rows on screen while the new page is in flight", async () => {
+    const store = createStore();
+    store.setState({
+      selectedProject: PROJECT,
+      selectedSession: SESSION,
+      sessions: [SESSION],
+    });
+
+    const { release } = deferredPage();
+    const pending = store.getState().reloadProjectSessions(PROJECT);
+
+    // Mid-flight: this is the window the sidebar used to render empty in.
+    expect(store.getState().sessions).toHaveLength(1);
+    expect(store.getState().isLoadingSessions).toBe(false);
+
+    release();
+    await pending;
+    expect(store.getState().sessions).toHaveLength(1);
+  });
+
+  it("still raises the spinner when there is genuinely nothing to show", async () => {
+    // The flag means "the user has nothing to look at yet", so an empty list
+    // must still get one. Suppressing it unconditionally would trade a flash
+    // for a dead-looking sidebar on first load.
+    const store = createStore();
+    store.setState({ selectedProject: PROJECT, sessions: [] });
+
+    const { release } = deferredPage();
+    const pending = store.getState().reloadProjectSessions(PROJECT);
+
+    expect(store.getState().isLoadingSessions).toBe(true);
+
+    release();
+    await pending;
+    expect(store.getState().isLoadingSessions).toBe(false);
+  });
+
+  it("still clears the outgoing project's rows when switching projects", async () => {
+    // The clear moved into `selectProject`; it must not have been lost. The
+    // previous project's sessions must never render under the new project's
+    // name.
+    const store = createStore();
+    store.setState({
+      selectedProject: PROJECT,
+      selectedSession: SESSION,
+      sessions: [SESSION],
+    });
+
+    const { release } = deferredPage();
+    const pending = store
+      .getState()
+      .selectProject({ ...PROJECT, path: "/other", name: "other" });
+
+    expect(store.getState().sessions).toHaveLength(0);
+    expect(store.getState().selectedSession).toBeNull();
+
+    release();
+    await pending;
+  });
+});


### PR DESCRIPTION
The second half of #508, which was left open when #527 merged.

## What the reporter noticed

> The same ordering also defeats the "don't refresh while the user is scrolled up" logic: the deferral at `watcherSlice.ts:122` only guards the session refresh, not the project reload.

#527 stopped that reload destroying the selection. This stops it churning the sidebar.

## The measurement

Before writing anything I checked what the reload actually costs a user, because "the deferral is asymmetric" is a description of the code, not of a symptom.

Drove the running app over `--serve` against a real `~/.claude`, sampled the sidebar's session-row count every 40ms, then appended one line to the open session's JSONL:

| | transitions | range |
|---|---|---|
| before | `18 → 1 → 18` within 29ms | 1–18 |
| after | none, across 545 samples | 18–18 |

A session Claude Code is actively writing produces a watcher tick at least every 250ms, so that is not a one-off blink — it is continuous flicker for as long as you watch a live session.

I also checked the thing I *expected* to find and did not: replacing `selectedSession` with the refreshed object does not disturb the transcript. `MessageViewer`'s effects key on `selectedSession?.session_id`, which is unchanged, so there is no remount and no scroll jump. The harm was confined to the sidebar.

## The change

`reloadProjectSessions` no longer blanks the list. The rows stay until the new page arrives.

The spinner follows the same rule: `isLoadingSessions` means "there is nothing to look at yet", so it is raised only when the list is in fact empty. Raising it over rows the user is reading is the same flash by another name.

Clearing moved into `selectProject`, which is the caller that genuinely needs it — the outgoing project's rows must not linger under the incoming project's name.

## Why not plumb the deferral through

That is the literal reading of the issue, and I think it is the wrong fix. The project reload also exists to surface *new* session files — a Claude Code auto-continuation, for instance. Deferring it while someone is scrolled up would hide genuinely new sessions from a reader for as long as they keep reading.

A reload that is not disruptive is a better answer than a reload that is postponed, and it helps every tick rather than only the scrolled-up ones.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no user-facing strings

## Tests

Three cases added to `watcherSelectionRetention.test.ts`, which already wires `watcherSlice` and `projectSlice` together rather than mocking the seam between them. They hold the session page open on a gate so mid-flight state is observable, which is the window the flash lived in:

- rows stay on screen while the new page is in flight, and the spinner stays down
- the spinner *is* raised when the list is genuinely empty, so this does not trade a flash for a dead-looking sidebar on first load
- switching projects still clears the outgoing rows immediately

**Mutation check.** Restoring the blanking fails the first case only; removing the clear from `selectProject` fails the third only. Neither regression is silent.

**Gates.** `pnpm exec vitest run` 1139 passed (98 files), `pnpm exec tsc --build .` clean, `pnpm lint` clean.

Closes the remainder of #508.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Switching projects now clears the previous session selection and list before loading the new project.
  - Session lists remain visible during refreshes instead of being replaced by a loading state.
  - Existing session selections are preserved when data reloads.
  - Loading indicators continue to appear when no sessions are available.

- **Tests**
  - Added coverage for project switching, session retention, refresh behavior, and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->