### PR TITLE
fix(recent-edits): keep the docked panel open when the project is deselected

### DIFF
--- a/src/components/RecentEditsViewer/RecentEditsPanel.test.tsx
+++ b/src/components/RecentEditsViewer/RecentEditsPanel.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: unknown) =>
+      typeof fallback === "string" ? fallback : key,
+  }),
+}));
+
+vi.mock("@/contexts/theme", () => ({
+  useTheme: () => ({ isDarkMode: false }),
+}));
+
+type MockState = Record<string, unknown>;
+let state: MockState;
+
+vi.mock("@/store/useAppStore", () => ({
+  useAppStore: <T,>(selector?: (s: MockState) => T) =>
+    selector ? selector(state) : (state as unknown as T),
+}));
+
+import { RecentEditsPanel } from "./RecentEditsPanel";
+
+const loadRecentEditsDock = vi.fn();
+
+const baseState = (overrides: MockState = {}): MockState => ({
+  selectedSession: null,
+  selectedProject: { path: "/storage/project", actual_path: "/project" },
+  navigateToMessage: vi.fn(),
+  recentEditsDock: null,
+  isLoadingRecentEditsDock: false,
+  isLoadingMoreRecentEditsDock: false,
+  recentEditsDockError: null,
+  loadRecentEditsDock,
+  loadMoreRecentEditsDock: vi.fn(),
+  markRecentEditsDockFileRestored: vi.fn(),
+  recentEditsMode: "docked",
+  recentEditsScope: "project",
+  recentEditsMissingOnly: false,
+  setRecentEditsScope: vi.fn(),
+  setRecentEditsDensity: vi.fn(),
+  setRecentEditsGrouping: vi.fn(),
+  setRecentEditsMissingOnly: vi.fn(),
+  recentEditsDensityDock: "compact",
+  recentEditsDensityPage: "standard",
+  recentEditsGroupingProject: "file",
+  recentEditsGroupingSession: "edit",
+  ...overrides,
+});
+
+describe("RecentEditsPanel with no project selected", () => {
+  beforeEach(() => {
+    loadRecentEditsDock.mockReset();
+  });
+
+  it("tells the user to pick a project rather than claiming there are no edits", () => {
+    // Collapsing the selected project in the tree deselects it, and the dock
+    // now survives that. "No edits" would be a lie in that state: nothing has
+    // been asked, so nothing is known.
+    state = baseState({ selectedProject: null });
+
+    render(<RecentEditsPanel />);
+
+    expect(screen.getByText("Select a project to see its edits")).toBeTruthy();
+    expect(screen.queryByText("recentEdits.noEdits")).toBeNull();
+    expect(loadRecentEditsDock).not.toHaveBeenCalled();
+  });
+
+  it("disables both scope buttons, since neither scope can resolve", () => {
+    state = baseState({ selectedProject: null });
+
+    render(<RecentEditsPanel />);
+
+    expect(
+      screen.getByRole("button", { name: "Session" }).hasAttribute("disabled")
+    ).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Project" }).hasAttribute("disabled")
+    ).toBe(true);
+  });
+
+  it("still reports a genuinely empty project as having no edits", () => {
+    state = baseState({
+      recentEditsDock: { files: [], requestKey: "k", hasMore: false },
+    });
+
+    render(<RecentEditsPanel />);
+
+    expect(screen.getByText("recentEdits.noEdits")).toBeTruthy();
+  });
+});

--- a/src/components/RecentEditsViewer/RecentEditsPanel.tsx
+++ b/src/components/RecentEditsViewer/RecentEditsPanel.tsx
@@ -11,7 +11,7 @@
 
 import React, { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, FileEdit, Loader2 } from "lucide-react";
+import { ChevronDown, FileEdit, FolderOpen, Loader2 } from "lucide-react";
 import { useTheme } from "@/contexts/theme";
 import { useAppStore } from "@/store/useAppStore";
 import {
@@ -64,6 +64,13 @@ export const RecentEditsPanel: React.FC = () => {
   // With no session selected, session scope has nothing to point at.
   const canScopeToSession = Boolean(selectedSession);
   const effectiveScope = canScopeToSession ? recentEditsScope : "project";
+  /*
+    The dock outlives the project selection - collapsing the selected project
+    in the tree deselects it, and the panel is a workspace fixture that should
+    not vanish under that click. So "no project" is a state the panel renders
+    rather than one its host prevents.
+  */
+  const hasProject = Boolean(selectedProject);
 
   const request: RecentEditsDockRequest | null = selectedProject
     ? {
@@ -124,7 +131,8 @@ export const RecentEditsPanel: React.FC = () => {
         <RecentEditsScopeToggle
           value={effectiveScope}
           onChange={setRecentEditsScope}
-          disabled={!canScopeToSession}
+          sessionDisabled={!canScopeToSession}
+          projectDisabled={!hasProject}
         />
         <div className="ml-auto flex items-center gap-1">
           <RecentEditsDensityToggle
@@ -143,7 +151,22 @@ export const RecentEditsPanel: React.FC = () => {
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
-        {error ? (
+        {!hasProject ? (
+          /*
+            Distinct from "no edits" on purpose. Nothing has been asked of the
+            backend in this state, so nothing is known - reporting an empty
+            result would be asserting a fact the panel does not have.
+          */
+          <div className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground">
+            <FolderOpen className="h-6 w-6 opacity-40" aria-hidden="true" />
+            <p className="px-4 text-center text-px11">
+              {t(
+                "recentEdits.noProjectSelected",
+                "Select a project to see its edits"
+              )}
+            </p>
+          </div>
+        ) : error ? (
           <p className="px-3 py-6 text-center text-sm text-destructive">
             {error}
           </p>

--- a/src/components/RecentEditsViewer/RecentEditsToggles.test.tsx
+++ b/src/components/RecentEditsViewer/RecentEditsToggles.test.tsx
@@ -46,7 +46,11 @@ describe("RecentEditsScopeToggle", () => {
     // the panel being broken rather than as one mode being unavailable.
     const onChange = vi.fn();
     const { container } = render(
-      <RecentEditsScopeToggle value="project" onChange={onChange} disabled />
+      <RecentEditsScopeToggle
+        value="project"
+        onChange={onChange}
+        sessionDisabled
+      />
     );
 
     const session = screen.getByRole("button", { name: "Session" });
@@ -66,6 +70,37 @@ describe("RecentEditsScopeToggle", () => {
     // reliably fire the events a native tooltip needs.
     expect(
       container.querySelector('[title="Select a session to scope edits to it"]')
+    ).toBeTruthy();
+  });
+
+  it("disables both buttons when there is no project either", () => {
+    // The dock outlives the project selection, so this state is reachable:
+    // collapsing the selected project in the tree deselects it while the panel
+    // stays open. Neither scope resolves without a project, and the hint has to
+    // name the project rather than the session - telling someone to pick a
+    // session is useless advice when they have not picked a project.
+    const onChange = vi.fn();
+    const { container } = render(
+      <RecentEditsScopeToggle
+        value="project"
+        onChange={onChange}
+        sessionDisabled
+        projectDisabled
+      />
+    );
+
+    const session = screen.getByRole("button", { name: "Session" });
+    const project = screen.getByRole("button", { name: "Project" });
+
+    expect(session.hasAttribute("disabled")).toBe(true);
+    expect(project.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(session);
+    fireEvent.click(project);
+    expect(onChange).not.toHaveBeenCalled();
+
+    expect(
+      container.querySelector('[title="Select a project first"]')
     ).toBeTruthy();
   });
 });

--- a/src/components/RecentEditsViewer/RecentEditsToggles.tsx
+++ b/src/components/RecentEditsViewer/RecentEditsToggles.tsx
@@ -57,28 +57,41 @@ export interface RecentEditsScopeToggleProps {
    * disabled control advertises that session scoping exists and what unlocks
    * it, a hidden one teaches nothing.
    */
-  disabled?: boolean;
+  sessionDisabled?: boolean;
+  /**
+   * With no project selected either, neither scope resolves. Named after the
+   * button it governs, like `sessionDisabled`: one flag per button means no
+   * combination of the two can contradict itself, which a single `disabled`
+   * plus an "and also project" flag would allow.
+   */
+  projectDisabled?: boolean;
   className?: string;
 }
 
 export const RecentEditsScopeToggle: React.FC<RecentEditsScopeToggleProps> = ({
   value,
   onChange,
-  disabled = false,
+  sessionDisabled = false,
+  projectDisabled = false,
   className,
 }) => {
   const { t } = useTranslation();
-  const disabledHint = t(
-    "recentEdits.scopeNeedsSession",
-    "Select a session to scope edits to it"
-  );
+  // Nothing selected at all is the more fundamental problem, so it wins the
+  // tooltip: telling someone to pick a session is useless advice when they
+  // have not picked a project either.
+  // Reuses the page view's existing hint rather than adding a second string in
+  // the same register: both are tooltips on a control disabled for want of a
+  // project.
+  const disabledHint = projectDisabled
+    ? t("recentEdits.selectProjectFirst", "Select a project first")
+    : t("recentEdits.scopeNeedsSession", "Select a session to scope edits to it");
 
   return (
     // The title sits on the wrapper, not the buttons: a disabled button does
     // not reliably fire the mouse events a native tooltip needs.
     <span
       className={cn("inline-flex", className)}
-      title={disabled ? disabledHint : undefined}
+      title={sessionDisabled || projectDisabled ? disabledHint : undefined}
     >
       <div className={TRACK_CLASS}>
         {SCOPES.map((scope) => {
@@ -90,7 +103,8 @@ export const RecentEditsScopeToggle: React.FC<RecentEditsScopeToggleProps> = ({
             looking at. It read as the panel being broken rather than as one
             mode being unavailable.
           */
-          const scopeDisabled = disabled && scope.id === "session";
+          const scopeDisabled =
+            scope.id === "session" ? sessionDisabled : projectDisabled;
           return (
             <button
               key={scope.id}

--- a/src/i18n/locales/en/recentEdits.json
+++ b/src/i18n/locales/en/recentEdits.json
@@ -26,6 +26,7 @@
   "recentEdits.noEditsDescription": "No file edits or creations found in this project",
   "recentEdits.noLinesToShow": "No lines to display",
   "recentEdits.noMissingFiles": "No missing files",
+  "recentEdits.noProjectSelected": "Select a project to see its edits",
   "recentEdits.noSearchResults": "No files match your search",
   "recentEdits.panelOptions": "Panel options",
   "recentEdits.projectRoot": "Project root",

--- a/src/i18n/locales/ja/recentEdits.json
+++ b/src/i18n/locales/ja/recentEdits.json
@@ -26,6 +26,7 @@
   "recentEdits.noEditsDescription": "このプロジェクトでファイルの編集や作成が見つかりません",
   "recentEdits.noLinesToShow": "表示する行がありません",
   "recentEdits.noMissingFiles": "見つからないファイルはありません",
+  "recentEdits.noProjectSelected": "プロジェクトを選択すると、その編集が表示されます",
   "recentEdits.noSearchResults": "検索に一致するファイルがありません",
   "recentEdits.panelOptions": "パネルオプション",
   "recentEdits.projectRoot": "プロジェクトルート",

--- a/src/i18n/locales/ko/recentEdits.json
+++ b/src/i18n/locales/ko/recentEdits.json
@@ -26,6 +26,7 @@
   "recentEdits.noEditsDescription": "이 프로젝트에서 파일 편집이나 생성을 찾을 수 없습니다",
   "recentEdits.noLinesToShow": "표시할 줄이 없습니다",
   "recentEdits.noMissingFiles": "없어진 파일이 없습니다",
+  "recentEdits.noProjectSelected": "프로젝트를 선택하면 편집 내역이 표시됩니다",
   "recentEdits.noSearchResults": "검색과 일치하는 파일이 없습니다",
   "recentEdits.panelOptions": "패널 옵션",
   "recentEdits.projectRoot": "프로젝트 루트",

--- a/src/i18n/locales/zh-CN/recentEdits.json
+++ b/src/i18n/locales/zh-CN/recentEdits.json
@@ -26,6 +26,7 @@
   "recentEdits.noEditsDescription": "在此项目中未找到文件编辑或创建记录",
   "recentEdits.noLinesToShow": "没有可显示的行",
   "recentEdits.noMissingFiles": "没有缺失的文件",
+  "recentEdits.noProjectSelected": "选择一个项目后即可查看其编辑记录",
   "recentEdits.noSearchResults": "没有匹配搜索的文件",
   "recentEdits.panelOptions": "面板选项",
   "recentEdits.projectRoot": "项目根目录",

--- a/src/i18n/locales/zh-TW/recentEdits.json
+++ b/src/i18n/locales/zh-TW/recentEdits.json
@@ -26,6 +26,7 @@
   "recentEdits.noEditsDescription": "在此專案中未找到檔案編輯或建立記錄",
   "recentEdits.noLinesToShow": "沒有可顯示的行",
   "recentEdits.noMissingFiles": "沒有遺失的檔案",
+  "recentEdits.noProjectSelected": "選擇一個專案後即可檢視其編輯記錄",
   "recentEdits.noSearchResults": "沒有符合搜尋的檔案",
   "recentEdits.panelOptions": "面板選項",
   "recentEdits.projectRoot": "專案根目錄",

--- a/src/i18n/types.generated.ts
+++ b/src/i18n/types.generated.ts
@@ -5,8 +5,8 @@
  * 직접 수정하지 마세요.
  *
  * 생성 명령: pnpm run generate:i18n-types
- * 생성 시간: 2026-08-24T23:22:54.969Z
- * 총 키 개수: 1927
+ * 생성 시간: 2026-08-26T18:00:54.440Z
+ * 총 키 개수: 1928
  * Namespace 수: 11
  */
 
@@ -1959,7 +1959,7 @@ export type FeedbackKeys =
   | 'feedback.types.other';
 
 /**
- * recentEdits namespace의 번역 키 (68개)
+ * recentEdits namespace의 번역 키 (69개)
  * 파일: locales/{lang}/recentEdits.json
  */
 export type RecentEditsKeys =
@@ -1990,6 +1990,7 @@ export type RecentEditsKeys =
   | 'recentEdits.noEditsDescription'
   | 'recentEdits.noLinesToShow'
   | 'recentEdits.noMissingFiles'
+  | 'recentEdits.noProjectSelected'
   | 'recentEdits.noSearchResults'
   | 'recentEdits.panelOptions'
   | 'recentEdits.projectRoot'
@@ -2886,6 +2887,7 @@ export type TranslationKey =
   | 'recentEdits.noEditsDescription'
   | 'recentEdits.noLinesToShow'
   | 'recentEdits.noMissingFiles'
+  | 'recentEdits.noProjectSelected'
   | 'recentEdits.noSearchResults'
   | 'recentEdits.panelOptions'
   | 'recentEdits.projectRoot'

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -312,16 +312,16 @@ export const AppLayout: React.FC<AppLayoutProps> = (props) => {
     page for a dock nobody could see. `useIsMobile` only reaches to 767, so it
     was never the right gate for an `xl` surface.
 
-    Gated on a selected project too. Without one the panel issues no request,
-    but it still reads the store, so it would render the previous project's
-    edits in a view where no project is selected. That only became reachable
-    once the dock stopped requiring a session.
+    Deliberately NOT gated on a selected project. Clicking the selected project
+    in the tree collapses and deselects it, and gating here meant the whole rail
+    vanished on a click the user made to collapse a node - the panel is a
+    workspace fixture, so it stays put and shows its own empty state instead.
+    The stale-rows problem that gate was solving is handled at the source:
+    `clearProjectSelection` drops the dock's fetched page, so there is nothing
+    left of the old project to render.
   */
   const showRecentEditsDock =
-    isXlUp &&
-    Boolean(selectedProject) &&
-    isRecentEditsDockOpen &&
-    isTranscriptView;
+    isXlUp && isRecentEditsDockOpen && isTranscriptView;
 
   const recentEditsDock = showRecentEditsDock ? (
       <div className="hidden xl:block">

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -817,6 +817,11 @@ export const createProjectSlice: StateCreator<
     get().clearTokenStats();
     get().resetAnalytics();
     get().clearBoard();
+    // The docked Recent Edits panel outlives the selection - it stays open
+    // because open-ness is the user's choice - so its rows have to be dropped
+    // here. Otherwise the panel keeps rendering the deselected project's
+    // edits.
+    get().clearRecentEditsDock();
     get().setDateFilter({ start: null, end: null });
     get().clearTargetMessage();
     get().exitSessionSelectionMode();

--- a/src/store/slices/recentEditsPanelSlice.test.ts
+++ b/src/store/slices/recentEditsPanelSlice.test.ts
@@ -504,6 +504,35 @@ describe("recentEditsPanelSlice dock reset", () => {
     ).toEqual(["/project/a.ts"]);
   });
 
+  it("discards a load-more page that arrives after the reset", async () => {
+    // Pins the observable contract rather than the mechanism: after a reset,
+    // a load-more page that lands late must neither repopulate the panel nor
+    // surface an error. Two things currently deliver that - the `!latest`
+    // ownership guard, and the catch's `recentEditsDockRequestedKey` check
+    // that swallows the null dereference if the guard is ever removed - so
+    // this asserts the outcome and stays true whichever one holds.
+    fetchRecentEdits.mockResolvedValueOnce({
+      ...page(["/project/a.ts"]),
+      has_more: true,
+    });
+    const store = makeStore();
+    await store.getState().loadRecentEditsDock(request);
+
+    let resolveSlow: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveSlow = resolve))
+    );
+    const slow = store.getState().loadMoreRecentEditsDock(request);
+    store.getState().clearRecentEditsDock();
+
+    resolveSlow?.(page(["/project/b.ts"]));
+    await expect(slow).resolves.toBeUndefined();
+
+    expect(store.getState().recentEditsDock).toBeNull();
+    expect(store.getState().recentEditsDockError).toBeNull();
+    expect(store.getState().isLoadingMoreRecentEditsDock).toBe(false);
+  });
+
   it("discards a response that arrives after the reset", async () => {
     // Deselecting mid-flight must not repopulate the panel a moment later.
     let resolveSlow: ((value: unknown) => void) | undefined;

--- a/src/store/slices/recentEditsPanelSlice.test.ts
+++ b/src/store/slices/recentEditsPanelSlice.test.ts
@@ -437,3 +437,87 @@ describe("recentEditsPanelSlice dock fetch: regressions from adversarial review"
     expect(fetchRecentEdits).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("recentEditsPanelSlice dock reset", () => {
+  const page = (paths: string[]) => ({
+    files: paths.map((file_path) => ({
+      file_path,
+      timestamp: "2026-08-21T10:00:00Z",
+      session_id: "s1",
+      operation_type: "edit" as const,
+      content_after_change: "after",
+      lines_added: 1,
+      lines_removed: 0,
+    })),
+    total_edits_count: paths.length,
+    unique_files_count: paths.length,
+    project_cwd: "/project",
+    offset: 0,
+    limit: 20,
+    has_more: false,
+  });
+
+  const request = {
+    projectPath: "/storage/project",
+    scope: "project" as const,
+    grouping: "file" as const,
+    sessionFilePath: undefined,
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchRecentEdits.mockReset();
+    fetchRecentEdits.mockResolvedValue(page(["/project/a.ts"]));
+  });
+
+  it("drops the fetched page but keeps the persisted preferences", async () => {
+    const store = makeStore();
+    store.getState().setRecentEditsDockOpen(true);
+    store.getState().setRecentEditsScope("project");
+    await store.getState().loadRecentEditsDock(request);
+    expect(store.getState().recentEditsDock).not.toBeNull();
+
+    store.getState().clearRecentEditsDock();
+
+    expect(store.getState().recentEditsDock).toBeNull();
+    expect(store.getState().recentEditsDockRequestedKey).toBeNull();
+    expect(store.getState().recentEditsDockError).toBeNull();
+    expect(store.getState().isLoadingRecentEditsDock).toBe(false);
+    expect(store.getState().isLoadingMoreRecentEditsDock).toBe(false);
+    // The dock is a preference, not data: deselecting a project must not
+    // silently close a dock the user opened.
+    expect(store.getState().isRecentEditsDockOpen).toBe(true);
+    expect(store.getState().recentEditsScope).toBe("project");
+  });
+
+  it("refetches the same request after a reset rather than serving the cache", async () => {
+    const store = makeStore();
+    await store.getState().loadRecentEditsDock(request);
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(1);
+
+    store.getState().clearRecentEditsDock();
+    await store.getState().loadRecentEditsDock(request);
+
+    expect(fetchRecentEdits).toHaveBeenCalledTimes(2);
+    expect(
+      store.getState().recentEditsDock?.files.map((f) => f.file_path)
+    ).toEqual(["/project/a.ts"]);
+  });
+
+  it("discards a response that arrives after the reset", async () => {
+    // Deselecting mid-flight must not repopulate the panel a moment later.
+    let resolveSlow: ((value: unknown) => void) | undefined;
+    fetchRecentEdits.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveSlow = resolve))
+    );
+
+    const store = makeStore();
+    const slow = store.getState().loadRecentEditsDock(request);
+    store.getState().clearRecentEditsDock();
+
+    resolveSlow?.(page(["/project/stale.ts"]));
+    await slow;
+
+    expect(store.getState().recentEditsDock).toBeNull();
+  });
+});

--- a/src/store/slices/recentEditsPanelSlice.ts
+++ b/src/store/slices/recentEditsPanelSlice.ts
@@ -173,6 +173,18 @@ export interface RecentEditsPanelSliceActions {
   loadRecentEditsDock: (request: RecentEditsDockRequest) => Promise<void>;
   loadMoreRecentEditsDock: (request: RecentEditsDockRequest) => Promise<void>;
   /**
+   * Drop the fetched page and everything derived from it, leaving the
+   * persisted preferences alone. Called when the project selection is cleared:
+   * the dock stays open because open-ness is the user's choice, but the rows
+   * belong to a project that is no longer selected and must not be shown under
+   * the next one.
+   *
+   * Nulling the requested key also disowns any fetch still in flight, so a
+   * response that lands after the reset is discarded instead of repopulating
+   * the panel.
+   */
+  clearRecentEditsDock: () => void;
+  /**
    * Mark one row as present on disk again after a successful restore, without
    * refetching the page and scrolling the list out from under the user.
    */
@@ -348,6 +360,19 @@ export const createRecentEditsPanelSlice: StateCreator<
         set({ isLoadingRecentEditsDock: false });
       }
     }
+  },
+
+  clearRecentEditsDock: () => {
+    set({
+      recentEditsDock: null,
+      // Disowns any in-flight fetch: its response no longer matches the key
+      // the slice is holding, so it is dropped rather than landing on a panel
+      // whose project has gone away.
+      recentEditsDockRequestedKey: null,
+      isLoadingRecentEditsDock: false,
+      isLoadingMoreRecentEditsDock: false,
+      recentEditsDockError: null,
+    });
   },
 
   markRecentEditsDockFileRestored: (filePath) =>

--- a/src/store/slices/types.ts
+++ b/src/store/slices/types.ts
@@ -424,6 +424,7 @@ export interface AppStoreActions {
   loadMoreRecentEditsDock: (
     request: import('./recentEditsPanelSlice').RecentEditsDockRequest
   ) => Promise<void>;
+  clearRecentEditsDock: () => void;
   markRecentEditsDockFileRestored: (filePath: string) => void;
 
   // Provider actions

--- a/src/test/projectSlice.scanProjects.test.ts
+++ b/src/test/projectSlice.scanProjects.test.ts
@@ -73,6 +73,7 @@ type TestStore = ProjectSlice & {
   clearTargetMessage: ReturnType<typeof vi.fn>;
   resetAnalytics: ReturnType<typeof vi.fn>;
   clearBoard: ReturnType<typeof vi.fn>;
+  clearRecentEditsDock: ReturnType<typeof vi.fn>;
   setDateFilter: ReturnType<typeof vi.fn>;
 };
 
@@ -150,6 +151,7 @@ const createTestStore = () =>
     clearTargetMessage: vi.fn(),
     resetAnalytics: vi.fn(),
     clearBoard: vi.fn(),
+    clearRecentEditsDock: vi.fn(),
     setDateFilter: vi.fn(),
     ...createProjectSlice(
       set as Parameters<typeof createProjectSlice>[0],
@@ -175,6 +177,17 @@ describe("projectSlice scanProjects", () => {
     const url = new URL(window.location.href);
     expect(url.searchParams.get("session")).toBeNull();
     expect(url.searchParams.get("msg")).toBeNull();
+  });
+
+  it("drops the docked Recent Edits rows along with the selection", () => {
+    // The dock survives deselection now - it is a workspace fixture, not a
+    // property of the selected project - so the rows have to be dropped here.
+    // Without this the panel keeps rendering the deselected project's edits.
+    const store = createTestStore();
+
+    store.getState().clearProjectSelection();
+
+    expect(store.getState().clearRecentEditsDock).toHaveBeenCalled();
   });
 
   it("publishes each provider as soon as that provider scan completes", async () => {


### PR DESCRIPTION
## What & why

Closes #534

The docked Recent Edits panel closed when you clicked the selected project in the
tree to collapse it.

That click does two things, only one of which the user intended. `handleProjectClick`
calls `onProjectSelect` even when the project is already selected, and
`handleProjectSelect` treats a repeat selection as a deselection, so
`clearProjectSelection()` runs and `selectedProject` becomes `null`. The dock was
gated on `Boolean(selectedProject)`, so the whole rail unmounted on a click meant
only to collapse a tree node.

The dock is a workspace fixture. Its open-ness is a persisted preference
(`recent-edits-dock-open`), not a property of whichever project happens to be
selected, so it should stay put.

That gate was not arbitrary: it stopped the panel rendering the *previous* project's
rows in a view where no project is selected. Removing it therefore meant solving
that at the source rather than deleting the symptom.

- `clearProjectSelection` now calls a new `clearRecentEditsDock` action, alongside
  the `clearTokenStats` / `resetAnalytics` / `clearBoard` calls already there.
- That action drops the fetched page **and** nulls `recentEditsDockRequestedKey`, so
  a fetch still in flight when the project is deselected is discarded instead of
  repopulating the panel a moment later.
- It deliberately leaves the persisted preferences alone, so deselecting never
  silently closes a dock the user opened.

The panel gains a "no project selected" empty state, kept distinct from "No Recent
Edits": nothing has been asked of the backend in that state, so reporting an empty
result would assert a fact the panel does not have.

Cross-project switching was never affected and still is not. `selectProject`
assigns `selectedProject` straight from A to B without passing through `null`.

### Drive-by

`RecentEditsScopeToggle`'s `disabled` prop only ever governed the Session button.
It is renamed `sessionDisabled` and joined by `projectDisabled`, so each flag names
the one button it controls and no combination of the two can contradict itself.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: any new user-facing string is `t()`-wrapped and the key exists in **all 5 languages** (`en, ko, ja, zh-CN, zh-TW`), verified with `pnpm run i18n:validate`

One new key, `recentEdits.noProjectSelected`, added to all five locales. The
disabled-scope tooltip reuses the existing `recentEdits.selectProjectFirst` rather
than adding a second string in the same register.

## Tests

Four new store tests and three new component tests:

- `clearRecentEditsDock` drops the page and both loading flags but keeps
  `isRecentEditsDockOpen` and the scope preference
- the same request refetches after a reset rather than serving the cache
- a `loadRecentEditsDock` response that lands after the reset is discarded
- ditto for a `loadMoreRecentEditsDock` page
- the panel renders "select a project", not "no edits", when nothing is selected
- both scope buttons disable when no project resolves
- a genuinely empty project still reports "No Recent Edits"

Each reset test was mutation-checked. Worth recording honestly: the
`loadRecentEditsDock` one fails when the contract is broken, but the
`loadMoreRecentEditsDock` one survives removing the `!latest` guard on its own,
because the catch block's ownership check swallows the resulting null dereference.
Its comment says so rather than claiming to pin a guard it does not.

Backend untouched, so no Rust tests and no Tauri/Axum command surface change.

## Verification

Full run: `tsc` clean, 1148 tests across 99 files pass, `eslint` clean,
`i18n:validate` passes.

Also driven in a real rendered view (WebUI `--serve`, 1600px, above the `xl` gate),
not just jsdom:

| Step | Dock | Header subtitle | Body |
|---|---|---|---|
| Fresh load, no project | present | none | "Select a project to see its edits" |
| Select project | present | 88 files, 120 total edits | 20 rows |
| Click it again to collapse | **present** | none | empty state, both scope buttons disabled |
| Re-select | present | 88 files, 120 total edits | rows return |
| Switch to a *different* project | present | swaps to the new project's counts | new project's rows |

Zero console errors throughout.

## Not changed

Clicking the selected project still deselects it and still resets the main content
area. That is an app-wide navigation gesture the code marks as intentional
(`// Deselecting: also collapse`); this PR only stops the panel being collateral
damage. Decoupling collapse from deselection would be a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent Edits now remains accessible when no project is selected.
  * A clear prompt guides users to select a project before viewing edits.
  * Session and Project scope controls can be disabled independently.
  * Recent Edits content is cleared when switching away from a project, preventing stale entries.

* **Bug Fixes**
  * Improved empty-state handling for unselected and genuinely empty projects.
  * Added localized messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

