### PR TITLE
fix(tests): stop cargo test overwriting the real ~/.claude/settings.json

### DIFF
--- a/src-tauri/src/commands/claude_settings.rs
+++ b/src-tauri/src/commands/claude_settings.rs
@@ -39,21 +39,61 @@ pub struct AllMCPServers {
     pub local_claude_json: Option<serde_json::Value>,
 }
 
+/// The home directory these settings paths hang off.
+///
+/// In a normal build this is exactly `dirs::home_dir()`.
+///
+/// # Why this indirection exists
+///
+/// The tests below intended to sandbox themselves with
+/// `env::set_var("HOME", temp_dir)`. That is inert on Windows: `dirs::home_dir()`
+/// resolves through the known-folder API and consults neither `HOME` nor
+/// `USERPROFILE`. So `test_save_and_retrieve_user_settings` wrote
+/// `{"theme":"dark","fontSize":14}` straight over the developer's real
+/// `~/.claude/settings.json`, and because `save_settings` replaces rather than
+/// merges, every other key went with it. It destroyed a 22-key config twice
+/// before anyone connected it to `cargo test`, and the test reported `ok` each
+/// time.
+///
+/// Under `cfg(test)` this reads `CCHV_TEST_HOME` instead, and **panics if that
+/// variable is unset**. Falling back to the real home would leave the same
+/// landmine armed for the next test that forgets to sandbox itself; a panic
+/// turns that mistake into a loud failure instead of silent data loss.
+#[cfg(not(test))]
+fn settings_home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+#[cfg(test)]
+// Always Some or a panic under cfg(test); the Option matches the real
+// signature above so callers stay identical in both builds.
+#[allow(clippy::unnecessary_wraps)]
+fn settings_home_dir() -> Option<PathBuf> {
+    match std::env::var_os("CCHV_TEST_HOME") {
+        Some(value) => Some(PathBuf::from(value)),
+        None => panic!(
+            "a test resolved a real ~/.claude path without a sandbox. \
+             Call `setup_test_env()` first: writing here would overwrite the \
+             developer's own settings.json."
+        ),
+    }
+}
+
 /// Get the user settings path (~/.claude/settings.json)
 fn get_user_settings_path() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = settings_home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude").join("settings.json"))
 }
 
 /// Get the user MCP settings path (~/.claude/.mcp.json)
 fn get_user_mcp_path() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = settings_home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude").join(".mcp.json"))
 }
 
 /// Get the main Claude config path (~/.claude.json) - the official config file
 fn get_claude_json_path() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = settings_home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude.json"))
 }
 
@@ -754,11 +794,23 @@ mod tests {
     use std::env;
     use tempfile::TempDir;
 
-    /// Sets up a test environment with a temporary HOME directory.
+    /// Sets up a test environment with a temporary home directory.
+    ///
+    /// Sets `CCHV_TEST_HOME`, which `settings_home_dir()` reads under
+    /// `cfg(test)`. It also still sets `HOME`, because other helpers reached
+    /// from these tests resolve through `dirs::home_dir()` directly and behave
+    /// correctly with it on Unix.
+    ///
+    /// `HOME` alone was the previous mechanism and is not enough: on Windows
+    /// `dirs::home_dir()` uses the known-folder API and ignores it, so the
+    /// sandbox silently did nothing and writes landed on the real
+    /// `~/.claude/settings.json`.
+    ///
     /// NOTE: Tests using this MUST run with --test-threads=1 because
-    /// `env::set_var("HOME")` is process-global and not thread-safe.
+    /// `env::set_var` is process-global and not thread-safe.
     fn setup_test_env() -> TempDir {
         let temp_dir = TempDir::new().unwrap();
+        env::set_var("CCHV_TEST_HOME", temp_dir.path());
         env::set_var("HOME", temp_dir.path());
         temp_dir
     }
@@ -769,6 +821,34 @@ mod tests {
         let path = get_user_settings_path().unwrap();
         assert!(path.to_string_lossy().contains(".claude"));
         assert!(path.to_string_lossy().ends_with("settings.json"));
+        drop(temp);
+    }
+
+    /// The assertion the test above was missing.
+    ///
+    /// "contains `.claude`" and "ends with settings.json" were both true of the
+    /// developer's REAL settings file, so that test passed happily while the
+    /// sandbox did nothing on Windows and `test_save_and_retrieve_user_settings`
+    /// overwrote a 22-key config with `{"theme":"dark","fontSize":14}`.
+    ///
+    /// Anchoring the resolved path inside the temp directory is what actually
+    /// proves the sandbox holds. This fails on Windows without the
+    /// `CCHV_TEST_HOME` indirection, which is the point.
+    #[test]
+    fn settings_paths_stay_inside_the_sandbox() {
+        let temp = setup_test_env();
+        for path in [
+            get_user_settings_path().unwrap(),
+            get_user_mcp_path().unwrap(),
+            get_claude_json_path().unwrap(),
+        ] {
+            assert!(
+                path.starts_with(temp.path()),
+                "path escaped the test sandbox: {} is not under {}",
+                path.display(),
+                temp.path().display()
+            );
+        }
         drop(temp);
     }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -37,9 +37,40 @@ pub struct PresetInput {
     pub settings: String, // JSON string of UserSettings
 }
 
+/// The home directory the presets folder hangs off.
+///
+/// Normally just `dirs::home_dir()`. Under `cfg(test)` it reads
+/// `CCHV_TEST_HOME` and panics if that is unset, for the same reason as the
+/// identical helper in `claude_settings.rs`: `env::set_var("HOME", temp_dir)`
+/// is inert on Windows, where `dirs::home_dir()` uses the known-folder API. The
+/// tests below therefore created and wrote to the real
+/// `~/.claude-history-viewer/presets` instead of a temp directory. Confirmed on
+/// this machine: that folder carries the timestamp of a `cargo test` run.
+///
+/// Less destructive than the `~/.claude` case - it pollutes a folder this app
+/// owns rather than overwriting Claude Code's config - but the same defect.
+#[cfg(not(test))]
+fn presets_home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+#[cfg(test)]
+// Always Some or a panic under cfg(test); the Option matches the real
+// signature above so callers stay identical in both builds.
+#[allow(clippy::unnecessary_wraps)]
+fn presets_home_dir() -> Option<PathBuf> {
+    match std::env::var_os("CCHV_TEST_HOME") {
+        Some(value) => Some(PathBuf::from(value)),
+        None => panic!(
+            "a test resolved a real ~/.claude-history-viewer path without a \
+             sandbox. Call `setup_test_env()` first."
+        ),
+    }
+}
+
 /// Get the presets folder path (~/.claude-history-viewer/presets)
 fn get_presets_folder() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = presets_home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude-history-viewer").join("presets"))
 }
 
@@ -262,11 +293,20 @@ mod tests {
     use std::env;
     use tempfile::TempDir;
 
-    /// Sets up a test environment with a temporary HOME directory.
+    /// Sets up a test environment with a temporary home directory.
+    ///
+    /// Sets `CCHV_TEST_HOME`, which `presets_home_dir()` reads under
+    /// `cfg(test)`. `HOME` is still set because it is what works on Unix for
+    /// anything resolving through `dirs::home_dir()` directly.
+    ///
+    /// `HOME` alone was the previous mechanism and does nothing on Windows, so
+    /// these tests wrote into the real `~/.claude-history-viewer`.
+    ///
     /// NOTE: Tests using this MUST run with --test-threads=1 because
-    /// `env::set_var("HOME")` is process-global and not thread-safe.
+    /// `env::set_var` is process-global and not thread-safe.
     fn setup_test_env() -> TempDir {
         let temp_dir = TempDir::new().unwrap();
+        env::set_var("CCHV_TEST_HOME", temp_dir.path());
         env::set_var("HOME", temp_dir.path());
         temp_dir
     }
@@ -275,9 +315,16 @@ mod tests {
     fn test_get_presets_folder() {
         let _temp = setup_test_env();
         let folder = get_presets_folder().unwrap();
+        // Compared by path components, not as a substring. The original
+        // assertion looked for the literal ".claude-history-viewer/presets",
+        // which a Windows path never contains because it separates with
+        // backslashes, so this test failed on Windows regardless of where the
+        // folder actually resolved.
+        assert!(folder.ends_with("presets"));
         assert!(folder
-            .to_string_lossy()
-            .contains(".claude-history-viewer/presets"));
+            .parent()
+            .expect("presets folder has a parent")
+            .ends_with(".claude-history-viewer"));
     }
 
     #[test]

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -2182,6 +2182,10 @@ mod tests {
     /// Rejecting only the `wire.jsonl` leaf is not enough: a symlinked
     /// `agents` or `main` directory redirects the read outside the store
     /// while the journal itself is a perfectly ordinary file.
+    // Unix-only: `std::os::unix::fs` does not exist on Windows, and without this
+    // gate the import failed to resolve, which broke compilation of the whole lib
+    // test binary rather than just skipping this one case.
+    #[cfg(unix)]
     #[test]
     fn symlinked_journal_directories_are_rejected() {
         use std::os::unix::fs as unix_fs;
@@ -2230,6 +2234,7 @@ mod tests {
 
     /// Same for the blob store: the leaf check misses a symlinked `blobs`
     /// directory pointing at arbitrary files.
+    #[cfg(unix)]
     #[test]
     fn symlinked_blob_directory_is_not_followed() {
         use std::os::unix::fs as unix_fs;


### PR DESCRIPTION
## What & why

Closes #536

`cargo test` overwrites the developer's real `~/.claude/settings.json` with
`{"theme":"dark","fontSize":14}`, taking every other key with it. On the machine
this was found on, that included `cleanupPeriodDays: 36500`, the setting that
governs how long Claude Code keeps session transcripts. It destroyed that config
twice, and the test reported `ok` both times.

`setup_test_env()` sandboxes with `env::set_var("HOME", temp_dir)`. `HOME` is a
Unix convention: on Windows `dirs::home_dir()` resolves through the known-folder
API and consults neither `HOME` nor `USERPROFILE`, so the sandbox silently does
nothing and `save_settings` writes to the real path. It replaces rather than
merges, so the whole file goes at once.

Reproduced before fixing: **7273 bytes / 22 keys became 30 bytes.**

## The fix

Both files resolve their home through a small helper. In a normal build it is
exactly `dirs::home_dir()`. Under `cfg(test)` it reads `CCHV_TEST_HOME` and
**panics when that is unset**.

The panic is the deliberate part. Falling back to the real home would leave the
same landmine armed for the next test that forgets to sandbox itself. A panic
turns that mistake into a loud failure instead of silent data loss.

`settings.rs` had the identical defect against `~/.claude-history-viewer/presets`.
Less destructive, since that folder belongs to this app rather than to Claude
Code, but the same mechanism, and on the affected machine that folder carries the
timestamp of the same `cargo test` run.

## Two supporting fixes, both needed to see any of this on Windows

- **`kimi_code.rs` did not compile on Windows.** Two symlink tests import
  `std::os::unix::fs` with no `#[cfg(unix)]` gate, so `std::os::unix` fails to
  resolve and the **entire lib test binary** fails to build. The Rust suite could
  not run on Windows at all, which is why the config wipe went unattributed for
  days. Gated both, matching the convention already used in six other modules.
  Note this re-arms the wipe, which is why it belongs in the same PR.
- **`test_get_presets_folder` asserted a substring with a forward slash**
  (`".claude-history-viewer/presets"`), which a Windows path never contains.
  Compared by path components instead.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass (frontend untouched)
- [x] **i18n**: no user-facing strings changed

## Tests

Adds `settings_paths_stay_inside_the_sandbox`, which anchors every resolved path
inside the temp directory.

The existing `test_get_user_settings_path` asserted only that the path contains
`.claude` and ends with `settings.json`. Both were true of the developer's real
file, which is precisely why it passed while the sandbox did nothing. Checking
containment is the assertion that actually proves the sandbox holds.

## Verification

On Windows, watching the real file by hash throughout:

| | Before this PR | After |
|---|---|---|
| Lib test binary | does not compile | compiles |
| `commands::settings::` | could not run | 8 passed, 0 failed |
| `claude_settings::` (isolated) | 6 failed | 2 failed, both pre-existing and order-dependent |
| Full lib suite | could not run | 910 passed, 40 failed |
| Real `settings.json` after a full run | wiped to 30 bytes | **byte-identical, 22 keys** |

`cargo clippy --all-targets --all-features -- -D warnings` and
`cargo fmt --all -- --check` both clean.

The 40 remaining failures are pre-existing Windows environment issues, newly
visible now that the suite compiles at all. None are in the files this PR
touches, and none were introduced here.

## Note for reviewers on other platforms

On Unix `env::set_var("HOME")` already worked, so none of this was reachable
there. `HOME` is still set by `setup_test_env()` alongside the new variable,
because other helpers reached from these tests resolve through
`dirs::home_dir()` directly and behave correctly with it on Unix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings and preset path handling across supported platforms.
  * Fixed test path validation for Windows compatibility.
  * Prevented platform-specific tests from breaking builds on non-Unix systems.
  * Ensured test data remains contained within its temporary sandbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->