### PR TITLE
ci(rust): add a Windows build gate, and an informational Windows test run

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -59,24 +59,18 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   # Main test job - runs in parallel with lint
+  # PR: Ubuntu only, Main: Ubuntu + macOS
   #
-  # Windows is in the matrix because it was absent, and its absence was not
-  # theoretical: two `use std::os::unix` imports landed in a test module and the
-  # entire lib test binary stopped compiling on Windows for days (#536). Nothing
-  # noticed, because nothing built it. The same blind spot let a test overwrite
-  # the developer's real `~/.claude/settings.json`, since the `HOME` sandbox those
-  # tests rely on is inert there.
-  #
-  # PR: Ubuntu + Windows. Windows is the platform no contributor runs locally, so
-  # it has to be a pre-merge gate rather than a post-merge discovery.
-  # Push: adds macOS for full coverage.
+  # Windows is NOT here. It gets its own job below, because the Windows suite
+  # does not pass yet (#540, #541) and putting it in this matrix would make
+  # every PR red for reasons unrelated to the PR.
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "macos-latest"]') }}
         rust: [stable]
 
     steps:
@@ -131,6 +125,58 @@ jobs:
           name: test-results-${{ matrix.os }}
           path: src-tauri/target/nextest/ci/junit.xml
           retention-days: 7
+
+  # Windows.
+  #
+  # Split into a blocking half and an informational half, because the two things
+  # we need from this platform have very different readiness.
+  #
+  # BLOCKING - does the test binary build? That is the failure that hid
+  # everything else: two `use std::os::unix` imports without a `cfg(unix)` gate
+  # meant the whole lib test binary stopped compiling, so Windows had no test
+  # coverage at all and nobody was told (#536). Compiling is cheap, it passes
+  # today, and it is the gate that keeps this platform from going dark again.
+  #
+  # INFORMATIONAL - does the suite pass? Not yet: 928 of 968, with 41 failures
+  # tracked in #540 (tests writing to the real home, one set of them mutating
+  # archives) and #541 (Unix path assumptions in assertions). Making that
+  # blocking today would redden every unrelated PR, so it reports and does not
+  # gate. Flip `continue-on-error` off once #540 and #541 are closed, and fold
+  # this job back into the matrix above.
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          cache-on-failure: true
+
+      # `shell: bash` because the runner defaults to PowerShell, which has no
+      # `touch` and rejects `mkdir -p`. Git Bash ships on the image.
+      - name: Create dist placeholder for rust-embed
+        shell: bash
+        run: mkdir -p dist && touch dist/index.html
+
+      - name: Build test binaries (blocking)
+        working-directory: src-tauri
+        run: |
+          cargo nextest run --profile ci --no-run
+          cargo nextest run --profile ci --no-run --features webui-server
+
+      - name: Run tests (informational until #540 and #541 are closed)
+        working-directory: src-tauri
+        continue-on-error: true
+        run: cargo nextest run --profile ci --retries 2 --features webui-server
 
   # Code coverage - main branch only
   coverage:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -59,14 +59,24 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   # Main test job - runs in parallel with lint
-  # PR: Ubuntu only, Main: Ubuntu + macOS
+  #
+  # Windows is in the matrix because it was absent, and its absence was not
+  # theoretical: two `use std::os::unix` imports landed in a test module and the
+  # entire lib test binary stopped compiling on Windows for days (#536). Nothing
+  # noticed, because nothing built it. The same blind spot let a test overwrite
+  # the developer's real `~/.claude/settings.json`, since the `HOME` sandbox those
+  # tests rely on is inert there.
+  #
+  # PR: Ubuntu + Windows. Windows is the platform no contributor runs locally, so
+  # it has to be a pre-merge gate rather than a post-merge discovery.
+  # Push: adds macOS for full coverage.
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "macos-latest"]') }}
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
         rust: [stable]
 
     steps:
@@ -97,8 +107,10 @@ jobs:
           workspaces: src-tauri
           cache-on-failure: true
 
-
+      # `shell: bash` because the Windows runner defaults to PowerShell, which
+      # has no `touch` and rejects `mkdir -p`. Git Bash ships on the image.
       - name: Create dist placeholder for rust-embed
+        shell: bash
         run: mkdir -p dist && touch dist/index.html
 
       - name: Run tests with nextest


### PR DESCRIPTION
Closes the systemic half of #536. #537 fixed the data loss; this closes the reason nobody saw it for days.

## The gap

`rust-tests.yml` ran `ubuntu-latest` on pull requests and `ubuntu-latest, macos-latest` on push. **Windows was never built.** Two consequences, both of which actually happened:

1. Two `use std::os::unix` imports landed in a `kimi_code.rs` test module without a `cfg(unix)` gate. An unresolved path in any test module fails the *whole* lib test binary, so the Rust suite had not compiled on Windows since that merged. Nothing reported it, because nothing built it.
2. The settings tests sandbox with `env::set_var("HOME", temp)`, which is inert on Windows — `dirs::home_dir()` there resolves through the known-folder API. Writes landed on the developer's real `~/.claude/settings.json`, and the suite reported `ok` while doing it.

The second was found by a human losing their config twice, not by CI.

## Why #537's own test does not cover this

`settings_paths_stay_inside_the_sandbox` cannot fail on any platform CI currently runs. On Unix `dirs::home_dir()` reads `$HOME`, so the assertion holds with or without the `CCHV_TEST_HOME` indirection. The test is correct and worth having — the matrix was the gap, and no test written in that file can close it.

## The change

```yaml
os: ${{ github.event_name == 'pull_request'
        && fromJSON('["ubuntu-latest", "windows-latest"]')
        || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
```

**Windows is on the pull-request matrix, not only on push.** That is the deliberate part. It is the platform no contributor here runs locally, so it has to be a pre-merge gate rather than a post-merge discovery — post-merge is exactly what we had, and it took a lost config to surface. macOS stays push-only, because contributors do run it and it is the least likely to hold a surprise.

One supporting fix: the dist placeholder step gains `shell: bash`. The Windows runner defaults to PowerShell, which has no `touch` and rejects `mkdir -p`.

## Type

- [x] Refactor / perf (CI)

## Checklist

- [x] PR targets `develop`
- [x] No product code touched; frontend and Rust sources unchanged
- [x] i18n: not applicable

## What this PR is also for

I cannot run Windows locally, so **this PR's own CI run is the experiment.** It is the first time the Rust suite will have been built and run on Windows since #513.

If it comes back green, the matrix change stands as written. If it comes back red, that is not a reason to revert it — it is the backlog it was added to find, and I will triage what it turns up before merging rather than after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated testing across Ubuntu, macOS, and Windows environments.
  * Pull request checks now run on Ubuntu, while push validation includes Ubuntu and macOS.
  * Added dedicated Windows build validation, with test results reported informationally.
  * Improved cross-platform reliability for workflow steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->