### PR TITLE
fix(viewer): order a windowed message set by time instead of hoisting

### DIFF
--- a/src/components/MessageViewer/helpers/flattenMessageTree.test.ts
+++ b/src/components/MessageViewer/helpers/flattenMessageTree.test.ts
@@ -1,0 +1,154 @@
+/**
+ * #535. Two defects in how a *partial* (windowed) message set is ordered.
+ *
+ * A session opens with only the newest `MESSAGE_PAGE_SIZE` messages loaded, so
+ * most messages' ancestor chains leave the window and are unreachable from any
+ * root. That case is handled: with no roots at all, the whole set is rendered
+ * chronologically.
+ *
+ * A `compact_boundary` breaks that. It carries no `parentUuid` (its real parent
+ * is in `logicalParentUuid`), so it *is* a root, `rootMessages` is not empty,
+ * and the chronological fallback is skipped. Whatever DFS reaches from the
+ * boundary is then pinned above everything older, because the recovery step
+ * appends rather than merges — and the recovery only runs below a 0.9 coverage
+ * threshold, so between 90% and 100% the unreachable messages are dropped with
+ * no placeholder and no warning outside DEV builds.
+ */
+import { describe, it, expect } from "vitest";
+import { flattenMessageTree } from "./flattenMessageTree";
+import type { ClaudeMessage } from "../../../types";
+
+const at = (minute: number) =>
+  new Date(Date.UTC(2026, 0, 1, 0, minute, 0)).toISOString();
+
+const msg = (
+  uuid: string,
+  minute: number,
+  parentUuid?: string
+): ClaudeMessage => ({
+  uuid,
+  ...(parentUuid === undefined ? {} : { parentUuid }),
+  timestamp: at(minute),
+  sessionId: "s1",
+  type: "user",
+  role: "user",
+  content: `content of ${uuid}`,
+});
+
+/**
+ * A compaction boundary. The point of the fixture is that it has no
+ * `parentUuid` — its parent link is logical — so the tree walk treats it as a
+ * root even though older messages precede it.
+ */
+const boundary = (uuid: string, minute: number): ClaudeMessage => ({
+  uuid,
+  timestamp: at(minute),
+  sessionId: "s1",
+  type: "system",
+  content: "compacted",
+});
+
+const renderedUuids = (messages: ClaudeMessage[]): string[] => {
+  const flattened = flattenMessageTree({
+    messages,
+    agentTaskGroups: new Map(),
+    agentTaskMemberUuids: new Set(),
+    agentProgressGroups: new Map(),
+    agentProgressMemberUuids: new Set(),
+    taskOperationGroups: new Map(),
+    taskOperationMemberUuids: new Set(),
+  });
+
+  const uuids: string[] = [];
+  for (const item of flattened) {
+    // Narrowed by the discriminant rather than cast: the union also carries
+    // date dividers and hidden-block placeholders, which have no message.
+    if (item.type === "message") {
+      uuids.push(item.message.uuid);
+    }
+  }
+  return uuids;
+};
+
+describe("flattenMessageTree on a windowed message set", () => {
+  /**
+   * The shape a user actually meets: older messages whose parents fell outside
+   * the window, then a compaction boundary and the exchange after it.
+   */
+  const windowed = (): ClaudeMessage[] => [
+    // Unreachable: their oldest ancestor is not in the window.
+    msg("old-1", 1, "outside-the-window"),
+    msg("old-2", 2, "old-1"),
+    msg("old-3", 3, "old-2"),
+    // A root, so the chronological fallback is skipped.
+    boundary("bnd", 4),
+    msg("new-1", 5, "bnd"),
+    msg("new-2", 6, "new-1"),
+  ];
+
+  it("renders in chronological order rather than hoisting the boundary", () => {
+    expect(renderedUuids(windowed())).toEqual([
+      "old-1",
+      "old-2",
+      "old-3",
+      "bnd",
+      "new-1",
+      "new-2",
+    ]);
+  });
+
+  it("never steps backwards in time", () => {
+    // The property, stated independently of the fixture. This is what a user
+    // sees as "the top of the conversation is dated after what follows it".
+    const all = windowed();
+    const times = renderedUuids(all).map((uuid) =>
+      new Date(all.find((m) => m.uuid === uuid)!.timestamp).getTime()
+    );
+
+    for (let i = 1; i < times.length; i++) {
+      expect(
+        times[i]! >= times[i - 1]!,
+        `render position ${i} goes backwards in time`
+      ).toBe(true);
+    }
+  });
+
+  it("drops nothing when coverage is just under 100%", () => {
+    // The 0.9 threshold is a cliff. One unreachable message out of twelve is
+    // ~92% coverage, so the recovery never ran and that message was silently
+    // discarded — no placeholder, and no warning outside DEV.
+    const all: ClaudeMessage[] = [
+      msg("orphan", 1, "outside-the-window"),
+      boundary("bnd", 2),
+    ];
+    for (let i = 3; i <= 12; i++) {
+      all.push(msg(`c-${i}`, i, i === 3 ? "bnd" : `c-${i - 1}`));
+    }
+
+    const order = renderedUuids(all);
+
+    expect(order).toHaveLength(all.length);
+    expect(order).toContain("orphan");
+  });
+
+  it("still walks the tree when the window holds a complete conversation", () => {
+    // Fully reachable, so DFS order is meaningful and must be kept: a branch
+    // whose reply arrives later than the next sibling still renders under its
+    // own parent rather than being re-sorted away from it.
+    const all: ClaudeMessage[] = [
+      msg("root", 1),
+      msg("a", 2, "root"),
+      msg("a-reply", 5, "a"),
+      msg("b", 3, "root"),
+      msg("b-reply", 4, "b"),
+    ];
+
+    expect(renderedUuids(all)).toEqual([
+      "root",
+      "a",
+      "a-reply",
+      "b",
+      "b-reply",
+    ]);
+  });
+});

--- a/src/components/MessageViewer/helpers/flattenMessageTree.ts
+++ b/src/components/MessageViewer/helpers/flattenMessageTree.ts
@@ -168,10 +168,13 @@ export function flattenMessageTree({
     taskOperationMemberUuids,
   };
 
-  // If no root messages exist, treat all messages as flat list
+  // A window with no roots at all cannot be walked as a tree, so it is
+  // rendered chronologically. Sorted explicitly rather than trusting the
+  // loader's order: the guarantee this path exists to make should not depend
+  // on how the caller happened to assemble the array.
   if (rootMessages.length === 0) {
     return flattenWithPlaceholders(
-      processedMessages,
+      [...processedMessages].sort(sortByTimestamp),
       hiddenSet,
       groups
     );
@@ -212,23 +215,37 @@ export function flattenMessageTree({
     traverse(root);
   }
 
-  // Fallback: If tree traversal resulted in significantly fewer messages,
-  // add remaining unvisited messages (sorted by timestamp)
-  if (orderedMessages.length < processedMessages.length * 0.9) {
+  // The same situation, reached a different way. A `compact_boundary` carries
+  // no `parentUuid` - its parent link is `logicalParentUuid` - so it counts as
+  // a root and the check above passes even though most of the window is
+  // unreachable. What the walk found from the boundary is then a fragment, and
+  // rendering that fragment first pins it above everything older (#535).
+  //
+  // Two things were wrong here before. The recovery appended the orphans after
+  // the walked fragment instead of ordering the whole set, which is what
+  // hoisted the boundary and its neighbours above earlier messages. And it only
+  // ran below a 0.9 coverage threshold, so a window that was 90-99% reachable
+  // skipped recovery altogether and the remainder was dropped - no placeholder,
+  // no warning outside DEV.
+  //
+  // Both go away by treating any incomplete walk as what it is: a partial
+  // window, ordered by time. `visited` rather than `orderedMessages.length` is
+  // the right measure, because the walk deliberately omits messages hidden by a
+  // hidden parent, and those are not orphans.
+  //
+  // The complete-walk case keeps DFS order, which is meaningful there: a branch
+  // whose reply is slower than its sibling still belongs under its own parent.
+  if (visited.size < processedMessages.length) {
     if (import.meta.env.DEV) {
       console.warn(
-        `[flattenMessageTree] Tree traversal found ${orderedMessages.length}/${processedMessages.length} messages. Adding orphaned messages.`
+        `[flattenMessageTree] Tree walk reached ${visited.size}/${processedMessages.length} messages; rendering the window chronologically.`
       );
     }
-    // Collect and sort orphaned messages by timestamp
-    const orphanedMessages = processedMessages
-      .filter((msg) => !visited.has(msg.uuid))
-      .sort(sortByTimestamp);
-
-    for (const msg of orphanedMessages) {
-      orderedMessages.push(msg);
-      visited.add(msg.uuid);
-    }
+    return flattenWithPlaceholders(
+      [...processedMessages].sort(sortByTimestamp),
+      hiddenSet,
+      groups
+    );
   }
 
   // Now flatten with placeholders


### PR DESCRIPTION
Closes #535. Thanks @k-wolfe99 — the analysis was precise enough that the fix followed directly from it, and the measurement discipline (visible rows only, stating what this is *not*) made it possible to judge severity honestly.

## Verified the mechanism before changing anything

All three claims hold, checked in code and against a real store:

- **`compact_boundary` really is a root.** From my own `~/.claude`: `parentUuid=None, logicalParentUuid='553afd0f-…'`. So `rootMessages` is non-empty and the `rootMessages.length === 0` chronological fallback at L172 is skipped.
- **Orphans were appended, not ordered** — `orderedMessages.push(msg)` after the walked fragment.
- **The 0.9 threshold is a cliff** — between 90% and 100% coverage the recovery never runs and the unreachable messages never enter `orderedMessages` at all.

One thing worth adding to the analysis: **the tree walk contributes ordering only.** `flattenWithPlaceholders` calls `createFlattenedMessage(message, 0, index, groups)` — depth is hardcoded 0. No nesting or structure survives the flatten, so ordering a partial window chronologically costs nothing structurally. That is what makes the fix a few lines rather than a merge algorithm.

## The change

Treat an incomplete walk as what it is: a partial window, ordered by time.

- `visited.size < processedMessages.length` is the measure, not `orderedMessages.length`. The walk deliberately omits messages hidden by a hidden parent, and those are not orphans — using the ordered length would misfire whenever anything is collapsed.
- A complete walk keeps DFS order, which is meaningful there: a branch whose reply arrives after the next sibling still belongs under its own parent.
- The no-roots path now sorts explicitly instead of trusting the loader's array order, so the guarantee that path exists to make no longer depends on how the caller assembled it.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no user-facing strings

## Tests

`flattenMessageTree.test.ts` is new — the helper had none. Four cases built from the exact mechanism, not from the symptom:

1. a windowed set with a boundary renders in chronological order rather than hoisting
2. the render order never steps backwards in time — the property, stated independently of the fixture
3. nothing is dropped at ~92% coverage, the case the cliff skipped
4. a fully-reachable window still uses DFS order, so the fix does not flatten real tree structure away

Before the fix, 1–3 fail and 4 passes:

```
× renders in chronological order …   expected ['bnd','new-1','new-2',…] to equal ['old-1','old-2','old-3',…]
× never steps backwards in time      render position 3 goes backwards in time
× drops nothing when coverage …      expected length 12 but got 11
✓ still walks the tree …
```

**Mutation check.** Restoring the 0.9 cliff fails case 3 only. Going back to appending orphans fails cases 1 and 2 only. Neither regression is silent.

**Gates.** `pnpm exec vitest run` 1152 passed (100 files), `tsc --build` clean, `pnpm lint` clean.

## What I could not verify

My local corpus has exactly one compacted session, and its initial window spans a single minute, so there is no visible time spread to show the hoisting in a running app. I confirmed the session renders correctly after the fix, but the ordering evidence here is the unit reproduction plus your 25/25 measurement, not a screenshot. Saying so rather than implying otherwise.

## Not included

The "jump to start of session" affordance from the issue. It is a good idea and it addresses a real complaint — seven "Load more" clicks returning nothing from the earliest day reads as lost history — but it is a feature, and it should not ride along with an ordering fix. Worth its own issue if you want to open one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message ordering when viewing partial or windowed conversation history.
  * Prevented older unreachable messages from appearing before compaction boundaries.
  * Ensured no messages are omitted when conversation history is incomplete.
  * Preserved chronological ordering for incomplete message windows while maintaining tree order for fully connected history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->