### PR TITLE
fix(recent-edits): distinguish two dock requests that carry the same key

### DIFF
--- a/src/store/slices/recentEditsPanelSlice.test.ts
+++ b/src/store/slices/recentEditsPanelSlice.test.ts
@@ -550,3 +550,110 @@ describe("recentEditsPanelSlice dock reset", () => {
     expect(store.getState().recentEditsDock).toBeNull();
   });
 });
+
+/**
+ * #538. The in-flight guard compares request keys for equality, so a key that
+ * is cleared and then set back to the *same* value looks unchanged — an ABA.
+ *
+ * `clearRecentEditsDock` (added in #533) nulls the key on deselect, and the
+ * gesture that PR is about — clicking the selected project to collapse it —
+ * deselects and re-selects. So a quick double click restarts the request with
+ * an identical key while the first fetch is still in flight, and the stale
+ * response satisfies `key === key` and lands.
+ *
+ * Deferred promises use the executor form rather than `Promise.withResolvers`,
+ * which the jsdom realm on CI does not provide — measured, not assumed.
+ */
+describe("recentEditsPanelSlice request identity across a restart", () => {
+  const request = {
+    projectPath: "/storage/project",
+    scope: "project" as const,
+    grouping: "file" as const,
+    sessionFilePath: "/storage/project/session-a.jsonl",
+  };
+
+  const pageOf = (paths: string[]) => ({
+    files: paths.map((file_path) => ({
+      file_path,
+      timestamp: "2026-08-01T00:00:00.000Z",
+      session_id: "s1",
+      operation_type: "edit" as const,
+      content_after_change: "after",
+      lines_added: 1,
+      lines_removed: 0,
+    })),
+    total_edits_count: paths.length,
+    unique_files_count: paths.length,
+    project_cwd: "/project",
+    offset: 0,
+    limit: 20,
+    has_more: false,
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchRecentEdits.mockReset();
+  });
+
+  it("drops a stale response when the request restarts with the same key", async () => {
+    const store = makeStore();
+
+    let releaseStale: ((value: unknown) => void) | undefined;
+    fetchRecentEdits
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (releaseStale = resolve))
+      )
+      .mockResolvedValueOnce(pageOf(["/project/fresh.ts"]));
+
+    const stale = store.getState().loadRecentEditsDock(request);
+
+    // Deselect, then re-select the same project: same key, second fetch.
+    store.getState().clearRecentEditsDock();
+    await store.getState().loadRecentEditsDock(request);
+
+    expect(store.getState().recentEditsDock?.files[0]?.file_path).toBe(
+      "/project/fresh.ts"
+    );
+
+    releaseStale?.(pageOf(["/project/stale.ts"]));
+    await stale;
+
+    // The first fetch answers a question that was asked again and already
+    // answered. Its page must not replace the newer one.
+    expect(store.getState().recentEditsDock?.files[0]?.file_path).toBe(
+      "/project/fresh.ts"
+    );
+  });
+
+  it("does not let a stale failure clear the spinner or paint an error", async () => {
+    const store = makeStore();
+
+    let rejectStale: ((reason: unknown) => void) | undefined;
+    let releaseFresh: ((value: unknown) => void) | undefined;
+    fetchRecentEdits
+      .mockImplementationOnce(
+        () => new Promise((_resolve, reject) => (rejectStale = reject))
+      )
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (releaseFresh = resolve))
+      );
+
+    const stale = store.getState().loadRecentEditsDock(request);
+    store.getState().clearRecentEditsDock();
+    const fresh = store.getState().loadRecentEditsDock(request);
+
+    expect(store.getState().isLoadingRecentEditsDock).toBe(true);
+
+    rejectStale?.(new Error("the abandoned request failed"));
+    await stale;
+
+    // The second fetch is still running, so the panel is still loading and
+    // has nothing to apologise for.
+    expect(store.getState().isLoadingRecentEditsDock).toBe(true);
+    expect(store.getState().recentEditsDockError).toBeNull();
+
+    releaseFresh?.(pageOf(["/project/fresh.ts"]));
+    await fresh;
+    expect(store.getState().isLoadingRecentEditsDock).toBe(false);
+  });
+});

--- a/src/store/slices/recentEditsPanelSlice.ts
+++ b/src/store/slices/recentEditsPanelSlice.ts
@@ -153,6 +153,23 @@ export interface RecentEditsPanelSliceState {
   recentEditsDockError: string | null;
 }
 
+/**
+ * Distinguishes two requests that carry the *same* key.
+ *
+ * The key answers "which question is being asked". It cannot answer "which
+ * asking of it", and equality reads the same across a clear-and-restart: null
+ * the key, set it back to the identical value, and an in-flight response from
+ * before the reset satisfies `key === key` and lands (#538). Deselecting a
+ * project and re-selecting it is exactly that sequence, and it is one click in
+ * the project tree.
+ *
+ * Bumped when a request starts and when the dock is cleared, so a captured
+ * value identifies one attempt rather than one question. Module state, not
+ * store state: nothing renders it, matching `recentEditsLoadMoreSeq` in the
+ * analytics slice.
+ */
+let recentEditsDockGeneration = 0;
+
 export interface RecentEditsPanelSliceActions {
   setRecentEditsMode: (mode: RecentEditsMode) => void;
   /** Explicitly targets one mode's density so the other cannot be clobbered. */
@@ -332,11 +349,18 @@ export const createRecentEditsPanelSlice: StateCreator<
       return;
     }
 
+    const generation = ++recentEditsDockGeneration;
     set({
       isLoadingRecentEditsDock: true,
       recentEditsDockError: null,
       recentEditsDockRequestedKey: key,
     });
+    // Both, because they answer different questions. The key rejects an answer
+    // to a question no longer being asked; the generation rejects an answer to
+    // an earlier asking of the same one.
+    const stillOwns = () =>
+      recentEditsDockGeneration === generation &&
+      get().recentEditsDockRequestedKey === key;
     try {
       const result = await fetchRecentEdits(request.projectPath, {
         offset: 0,
@@ -345,29 +369,31 @@ export const createRecentEditsPanelSlice: StateCreator<
         sessionFilePath:
           request.scope === "session" ? request.sessionFilePath : undefined,
       });
-      // Scope or grouping may have changed while this was in flight. Only the
-      // answer to the question still being asked is allowed to land.
-      if (get().recentEditsDockRequestedKey !== key) return;
+      if (!stillOwns()) return;
       set({ recentEditsDock: toDockResult(key, result) });
     } catch (error) {
-      if (get().recentEditsDockRequestedKey !== key) return;
+      if (!stillOwns()) return;
       set({
         recentEditsDockError:
           error instanceof Error ? error.message : String(error),
       });
     } finally {
-      if (get().recentEditsDockRequestedKey === key) {
+      // Only the newest attempt may lower the spinner. A superseded one doing
+      // it would report a request that is still running as finished.
+      if (recentEditsDockGeneration === generation) {
         set({ isLoadingRecentEditsDock: false });
       }
     }
   },
 
   clearRecentEditsDock: () => {
+    // No generation bump here, deliberately. Two cases and both are already
+    // covered: if a request follows, it bumps on its way in and disowns
+    // anything older; if none follows, the null key rejects the stale response
+    // on its own. A bump here would be unfalsifiable — removing it fails no
+    // test, which is how it was noticed.
     set({
       recentEditsDock: null,
-      // Disowns any in-flight fetch: its response no longer matches the key
-      // the slice is holding, so it is dropped rather than landing on a panel
-      // whose project has gone away.
       recentEditsDockRequestedKey: null,
       isLoadingRecentEditsDock: false,
       isLoadingMoreRecentEditsDock: false,
@@ -397,6 +423,11 @@ export const createRecentEditsPanelSlice: StateCreator<
     if (!current || current.requestKey !== key || !current.hasMore) return;
     if (get().isLoadingMoreRecentEditsDock) return;
 
+    // Captured, not bumped. A page continues the request that is already in
+    // the slot rather than starting a new one, so it must be discarded by the
+    // same reset that discards that request — including a clear-and-restart
+    // where the key comes back identical (#538).
+    const generation = recentEditsDockGeneration;
     set({ isLoadingMoreRecentEditsDock: true });
     try {
       const result = await fetchRecentEdits(request.projectPath, {
@@ -412,19 +443,24 @@ export const createRecentEditsPanelSlice: StateCreator<
       const latest = get().recentEditsDock;
       // Appending onto a different request's rows would interleave two result
       // sets, so a scope change mid-flight discards this page.
+      if (recentEditsDockGeneration !== generation) return;
       if (!latest || latest.requestKey !== key) return;
       set({ recentEditsDock: toDockResult(key, result, latest.files) });
     } catch (error) {
       // Same ownership rule as the success path. A late failure from a request
       // the user has already moved on from must not paint an error over rows
       // that loaded fine.
+      if (recentEditsDockGeneration !== generation) return;
       if (get().recentEditsDockRequestedKey !== key) return;
       set({
         recentEditsDockError:
           error instanceof Error ? error.message : String(error),
       });
     } finally {
-      set({ isLoadingMoreRecentEditsDock: false });
+      // A superseded page must not lower a flag the current request owns.
+      if (recentEditsDockGeneration === generation) {
+        set({ isLoadingMoreRecentEditsDock: false });
+      }
     }
   },
 });


### PR DESCRIPTION
Closes #538.

## The bug

The in-flight guard compared request keys for equality:

```ts
if (get().recentEditsDockRequestedKey !== key) return;
```

A key that is cleared and then set back to the **same** value looks unchanged, so a response from before the reset satisfies `key === key` and lands.

`clearRecentEditsDock` nulls the key on deselect, and the gesture #533 is about — clicking the selected project collapses *and* deselects it — makes this a one-click sequence. Deselect and re-select the same project and the restart carries an identical key.

## The fix

A generation counter, bumped when a request starts. The key answers *which question is being asked*; it cannot answer *which asking of it*. Both are checked, on the success, failure and `finally` paths of both loaders.

`loadMoreRecentEditsDock` **captures** the generation rather than bumping it: a page continues the request already in the slot rather than starting a new one, so it should be discarded by the same reset that discards that request.

## One thing deliberately not done

There is no generation bump in `clearRecentEditsDock`, even though that reads like the obvious place for one.

Both cases are already covered: a request that follows bumps on its way in and disowns anything older, and if no request follows, the null key rejects the stale response by itself.

I had written that bump first. The mutation check is what caught it — **removing it failed no test**, while removing the loader's generation check failed two. Unfalsifiable code left in on the strength of sounding right is exactly what I would flag in someone else's PR, so it came out and the reason is recorded at the call site so it does not get re-added.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] Tests added for the changed behaviour
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] i18n: no user-facing strings

## Tests

Two cases reproducing the ABA sequence directly — start a request, clear, restart with the identical key, then release the first fetch:

1. the stale page does not replace the fresh one
2. a stale *failure* neither lowers the spinner while the second request is still running nor paints an error over it

Both fail before the fix (`expected '/project/stale.ts' to be '/project/fresh.ts'`, `expected false to be true`).

**Mutation check.** Reducing the guard back to key-only fails both. Removing the bump from `clearRecentEditsDock` fails none — which is why that bump is not in the diff.

**Gates.** `pnpm exec vitest run` 1154 passed (100 files), `tsc --build` clean, `pnpm lint` clean.

## On how this got in

I reviewed and approved #533, and explicitly checked this guard — but only that it re-reads the key *after* the await, not that key equality fails to survive a clear-and-restart. The same lesson had already been paid for in #514 and #522, where the fix was a generation counter for exactly this reason, with a commit message saying ownership cannot substitute for a version. Thanks to CodeRabbit for catching it and to @jprisant for filing it separately rather than folding it into a scoped UI fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recent edits loading to safely handle restarted requests.
  * Prevented outdated responses from replacing newer results.
  * Fixed stale failures from clearing loading indicators or displaying incorrect errors.
  * Improved consistency when clearing and restarting recent edits requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->