### PR TITLE
fix(tests): sandbox the remaining modules that resolved the real home

### DIFF
--- a/src-tauri/src/commands/archive.rs
+++ b/src-tauri/src/commands/archive.rs
@@ -133,7 +133,7 @@ pub struct ExportResult {
 
 /// Returns the archives base directory path: `~/.claude-history-viewer/archives/`
 fn get_archives_dir() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = crate::utils::home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude-history-viewer").join("archives"))
 }
 
@@ -1313,7 +1313,7 @@ pub async fn get_expiring_sessions(
 
         // Read cleanupPeriodDays from ~/.claude/settings.json
         let cleanup_period_days: i64 = {
-            let home = dirs::home_dir().ok_or("Could not find home directory")?;
+            let home = crate::utils::home_dir().ok_or("Could not find home directory")?;
             let settings_path = home.join(".claude").join("settings.json");
             if settings_path.exists() {
                 fs::read_to_string(&settings_path)
@@ -1500,6 +1500,10 @@ mod tests {
     fn setup_test_env() -> TempDir {
         let dir = TempDir::new().unwrap();
         env::set_var("HOME", dir.path());
+        // The one that actually holds on Windows. Without it these tests ran
+        // create/delete/rename/migrate against the real
+        // `~/.claude-history-viewer/archives` (#540).
+        env::set_var("CCHV_TEST_HOME", dir.path());
         dir
     }
 

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -57,7 +57,7 @@ impl Default for MetadataState {
 
 /// Get the metadata folder path (~/.claude-history-viewer)
 fn get_metadata_folder() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = crate::utils::home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude-history-viewer"))
 }
 
@@ -324,6 +324,9 @@ mod tests {
         let guard = TEST_ENV_MUTEX.lock().unwrap();
         let temp_dir = TempDir::new().unwrap();
         env::set_var("HOME", temp_dir.path());
+        // `HOME` is inert on Windows; this is what `crate::utils::home_dir()`
+        // reads under `cfg(test)` (#540).
+        env::set_var("CCHV_TEST_HOME", temp_dir.path());
         (guard, temp_dir)
     }
 

--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -1006,6 +1006,21 @@ pub async fn rename_opencode_session_title(
 mod tests {
     use super::*;
 
+    /// Points home resolution at an empty temp directory for the duration of a
+    /// test.
+    ///
+    /// These tests assert on rejection paths and want nothing from the home
+    /// directory, but the code under test reaches it — `configured_claude_dirs`
+    /// reads `~/.claude-history-viewer/user-data.json` and honours the custom
+    /// Claude paths registered there. That made the allowlist depend on the
+    /// developer's own machine, silently, until the sandbox in
+    /// `crate::utils::home_dir` made it say so (#540).
+    fn isolated_home() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().expect("temp home");
+        std::env::set_var("CCHV_TEST_HOME", dir.path());
+        dir
+    }
+
     fn sample_rename_test_user(session_id: &str, uuid: &str, content: &str) -> String {
         serde_json::json!({
             "parentUuid": Value::Null,
@@ -1601,6 +1616,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_rejects_relative_path() {
+        let _home = isolated_home();
         let result = validate_claude_path("relative/path/file.jsonl");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be absolute"));
@@ -1608,6 +1624,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_rejects_invalid_filename() {
+        let _home = isolated_home();
         // Filename with dots should be rejected by regex
         let result = validate_claude_path("/etc/passwd");
         assert!(result.is_err());
@@ -1616,6 +1633,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_rejects_non_claude_directory() {
+        let _home = isolated_home();
         // Use a path with valid filename but wrong directory
         let result = validate_claude_path("/tmp/validfilename.jsonl");
         assert!(result.is_err());
@@ -1624,6 +1642,13 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_valid_path() {
+        // Sandboxed only so `configured_claude_dirs` does not read the
+        // developer's registered custom paths. `resolve_claude_roots` still
+        // resolves the default root through `dirs::home_dir()`, which is why
+        // this still scans the real `~/.claude` — and why it asserts nothing on
+        // a machine without one. Left as-is deliberately; rename.rs is outside
+        // this change and the vacuity is filed separately.
+        let _home = isolated_home();
         // This test requires a real .jsonl file in ~/.claude to exist
         if let Some(home) = dirs::home_dir() {
             let claude_projects = home.join(".claude/projects");
@@ -1656,6 +1681,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_nonexistent_file() {
+        let _home = isolated_home();
         // Nonexistent file should fail at canonicalize
         let result = validate_claude_path("/nonexistent/path/to/file.jsonl");
         assert!(result.is_err());
@@ -1920,6 +1946,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_filename_with_special_chars() {
+        let _home = isolated_home();
         // Test filename validation with various invalid characters
         if let Some(home) = dirs::home_dir() {
             let claude_dir = home.join(".claude/projects");

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -5401,6 +5401,20 @@ pub async fn get_global_stats_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Points home resolution at an empty temp directory for the duration of a
+    /// test.
+    ///
+    /// These tests assert on rejection paths and want nothing from the home
+    /// directory, but the code under test reaches it — provider detection resolves it
+    /// while classifying a path, so the result depended on the developer's own
+    /// machine until the sandbox in `crate::utils::home_dir` made it say so
+    /// (#540).
+    fn isolated_home() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().expect("temp home");
+        std::env::set_var("CCHV_TEST_HOME", dir.path());
+        dir
+    }
     use serde_json::json;
     use serial_test::serial;
     use std::ffi::OsString;
@@ -6031,6 +6045,7 @@ mod tests {
     #[test]
     /// Verify detect project provider from virtual prefix.
     fn test_detect_project_provider_from_virtual_prefix() {
+        let _home = isolated_home();
         assert_eq!(
             detect_project_provider("codex:///Users/jack/workspace"),
             StatsProvider::Codex
@@ -6100,6 +6115,7 @@ mod tests {
     #[test]
     /// Verify detect session provider from path pattern.
     fn test_detect_session_provider_from_path_pattern() {
+        let _home = isolated_home();
         assert_eq!(
             detect_session_provider("forgecode://workspace/ws-1/conversation/conv-1"),
             StatsProvider::ForgeCode
@@ -6174,6 +6190,7 @@ mod tests {
     #[test]
     #[serial]
     fn detect_session_provider_uses_copilot_cli_home_env() {
+        let _home = isolated_home();
         let tmp = TempDir::new().unwrap();
         let events_path = tmp
             .path()
@@ -7707,6 +7724,7 @@ mod tests {
     #[serial]
     /// Verify forgecode stats commands use provider paths.
     async fn test_forgecode_stats_commands_use_provider_paths() {
+        let _home = isolated_home();
         let forge_dir = TempDir::new().expect("failed to create forge temp dir");
         write_forgecode_test_db(forge_dir.path());
 

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -620,7 +620,7 @@ fn is_antigravity_path(path: &str) -> bool {
 /// Whether `path` lies under `~/.codebuddy/projects/`. Anchored detection avoids
 /// false positives from arbitrary substrings (e.g. `/work/foo.codebuddy-test`).
 fn is_codebuddy_path(path: &str) -> bool {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = crate::utils::home_dir() else {
         return false;
     };
     is_codebuddy_path_under(path, &home)
@@ -649,7 +649,7 @@ fn is_kimi_path(path: &str) -> bool {
 /// (`~/.omp/agent/sessions/`). Anchored detection avoids false positives
 /// from arbitrary substrings (e.g. `/work/foo.omp-agent-test`).
 fn is_ompi_path(path: &str) -> bool {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = crate::utils::home_dir() else {
         return false;
     };
     is_ompi_path_under(path, &home)
@@ -665,7 +665,7 @@ fn is_ompi_path_under(path: &str, home: &Path) -> bool {
 /// Whether `path` lies under the Pi sessions store root
 /// (`~/.pi/agent/sessions/`).
 fn is_pi_path(path: &str) -> bool {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = crate::utils::home_dir() else {
         return false;
     };
     is_pi_path_under(path, &home)
@@ -6896,6 +6896,10 @@ mod tests {
     /// Verify project summary session count matches token list in conversation mode.
     async fn test_project_summary_session_count_matches_token_list_in_conversation_mode() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
+        // Nothing here wants the home directory, but the code under test
+        // resolves it while detecting providers. Point it at this test's own
+        // temp dir so it cannot reach the developer's (#540).
+        let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp_dir.path());
         let claude_path = temp_dir.path();
         let project_dir = claude_path.join("projects").join("demo-project");
         fs::create_dir_all(&project_dir).expect("failed to create project dir");
@@ -6947,6 +6951,10 @@ mod tests {
     /// Verify stats mode reconciles global project and session totals.
     async fn test_stats_mode_reconciles_global_project_and_session_totals() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
+        // Nothing here wants the home directory, but the code under test
+        // resolves it while detecting providers. Point it at this test's own
+        // temp dir so it cannot reach the developer's (#540).
+        let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp_dir.path());
         let claude_path = temp_dir.path();
         let project_dir = claude_path.join("projects").join("demo-project");
         fs::create_dir_all(&project_dir).expect("failed to create project dir");
@@ -7074,6 +7082,10 @@ mod tests {
     /// Verify session token stats respects date filter.
     async fn test_session_token_stats_respects_date_filter() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
+        // Nothing here wants the home directory, but the code under test
+        // resolves it while detecting providers. Point it at this test's own
+        // temp dir so it cannot reach the developer's (#540).
+        let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp_dir.path());
         let project_dir = temp_dir.path().join("projects").join("demo-project");
         fs::create_dir_all(&project_dir).expect("failed to create project dir");
         let session_path = project_dir.join("session-date-filter.jsonl");
@@ -7129,6 +7141,10 @@ mod tests {
     /// Verify session comparison respects date filter.
     async fn test_session_comparison_respects_date_filter() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
+        // Nothing here wants the home directory, but the code under test
+        // resolves it while detecting providers. Point it at this test's own
+        // temp dir so it cannot reach the developer's (#540).
+        let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp_dir.path());
         let project_dir = temp_dir.path().join("projects").join("demo-project");
         fs::create_dir_all(&project_dir).expect("failed to create project dir");
 
@@ -7172,6 +7188,10 @@ mod tests {
     /// Verify project summary daily session count tracks multiple sessions on same day.
     async fn test_project_summary_daily_session_count_tracks_multiple_sessions_on_same_day() {
         let temp_dir = TempDir::new().expect("failed to create temp dir");
+        // Nothing here wants the home directory, but the code under test
+        // resolves it while detecting providers. Point it at this test's own
+        // temp dir so it cannot reach the developer's (#540).
+        let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp_dir.path());
         let project_dir = temp_dir.path().join("projects").join("demo-project");
         fs::create_dir_all(&project_dir).expect("failed to create project dir");
 
@@ -7553,6 +7573,9 @@ mod tests {
         // it cannot race with other HOME-touching tests.
         let original_home = std::env::var("HOME").ok();
         std::env::set_var("HOME", home);
+        // `HOME` is inert on Windows; this is what `crate::utils::home_dir()`
+        // reads under `cfg(test)` (#540).
+        std::env::set_var("CCHV_TEST_HOME", home);
 
         let antigravity_root = home.join(".gemini").join("antigravity");
         let rpc_session = antigravity_root
@@ -7603,6 +7626,7 @@ mod tests {
         assert_eq!(summary.token_distribution.input, 100);
         assert_eq!(summary.token_distribution.output, 50);
 
+        std::env::remove_var("CCHV_TEST_HOME");
         if let Some(value) = original_home {
             std::env::set_var("HOME", value);
         } else {
@@ -8250,6 +8274,9 @@ mod tests {
     fn detect_project_provider_routes_new_providers() {
         let temp = TempDir::new().expect("tempdir");
         let _guard = EnvVarGuard::set("HOME", temp.path());
+        // `HOME` is inert on Windows, and a value left over from an
+        // earlier test would otherwise win here. Both, always (#540).
+        let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp.path());
         let home = temp.path().to_string_lossy().to_string();
 
         let ompi_proj = format!("{home}/.omp/agent/sessions/-tmp");
@@ -8274,6 +8301,9 @@ mod tests {
     fn detect_session_provider_routes_new_providers() {
         let temp = TempDir::new().expect("tempdir");
         let _guard = EnvVarGuard::set("HOME", temp.path());
+        // `HOME` is inert on Windows, and a value left over from an
+        // earlier test would otherwise win here. Both, always (#540).
+        let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp.path());
         let gemini_home = TempDir::new_in(".").expect("relative Gemini home");
         let _gemini_guard = EnvVarGuard::set("GEMINI_HOME", gemini_home.path());
         let gemini_home_absolute = fs::canonicalize(gemini_home.path()).expect("Gemini home");

--- a/src-tauri/src/commands/watcher.rs
+++ b/src-tauri/src/commands/watcher.rs
@@ -710,6 +710,10 @@ mod tests {
     #[test]
     fn test_to_file_watch_event_ignores_unchanged_content_signature() {
         let temp = TempDir::new().unwrap();
+        // Nothing here wants the home directory, but `to_file_watch_event`
+        // resolves it while classifying the path. Point it at this test's own
+        // temp dir so it cannot reach the developer's (#540).
+        std::env::set_var("CCHV_TEST_HOME", temp.path());
         let project_dir = temp
             .path()
             .join(".claude")

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -779,11 +779,16 @@ mod tests {
         fn set(path: &std::path::Path) -> Self {
             let original = std::env::var("HOME").ok();
             std::env::set_var("HOME", path);
+            // `HOME` alone is inert on Windows, where `dirs::home_dir()` uses
+            // the known-folder API. `crate::utils::home_dir()` reads this
+            // instead under `cfg(test)`, and panics without it (#540).
+            std::env::set_var("CCHV_TEST_HOME", path);
             Self { original }
         }
     }
     impl Drop for HomeGuard {
         fn drop(&mut self) {
+            std::env::remove_var("CCHV_TEST_HOME");
             match self.original.as_ref() {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),

--- a/src-tauri/src/providers/ompi.rs
+++ b/src-tauri/src/providers/ompi.rs
@@ -78,11 +78,16 @@ mod tests {
         fn set(path: &Path) -> Self {
             let original = std::env::var("HOME").ok();
             std::env::set_var("HOME", path);
+            // `HOME` alone is inert on Windows, where `dirs::home_dir()` uses
+            // the known-folder API. `crate::utils::home_dir()` reads this
+            // instead under `cfg(test)`, and panics without it (#540).
+            std::env::set_var("CCHV_TEST_HOME", path);
             Self { original }
         }
     }
     impl Drop for HomeGuard {
         fn drop(&mut self) {
+            std::env::remove_var("CCHV_TEST_HOME");
             match self.original.as_ref() {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),

--- a/src-tauri/src/providers/pi.rs
+++ b/src-tauri/src/providers/pi.rs
@@ -70,7 +70,7 @@ impl PiStore {
     /// Store root: `~/<dot_dir>/agent/sessions`.
     fn sessions_root(&self) -> Option<PathBuf> {
         Some(
-            dirs::home_dir()?
+            crate::utils::home_dir()?
                 .join(self.dot_dir)
                 .join("agent")
                 .join("sessions"),
@@ -864,11 +864,16 @@ mod tests {
         fn set(path: &Path) -> Self {
             let original = std::env::var("HOME").ok();
             std::env::set_var("HOME", path);
+            // `HOME` alone is inert on Windows, where `dirs::home_dir()` uses
+            // the known-folder API. `crate::utils::home_dir()` reads this
+            // instead under `cfg(test)`, and panics without it (#540).
+            std::env::set_var("CCHV_TEST_HOME", path);
             Self { original }
         }
     }
     impl Drop for HomeGuard {
         fn drop(&mut self) {
+            std::env::remove_var("CCHV_TEST_HOME");
             match self.original.as_ref() {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -3,7 +3,53 @@ use chrono::{DateTime, Utc};
 use memchr::memchr_iter;
 use serde_json::Value;
 use std::fs;
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
+
+/// The user's home directory, sandboxed under `cfg(test)`.
+///
+/// In a normal build this is exactly `dirs::home_dir()`.
+///
+/// # Why this indirection exists
+///
+/// Test modules across this crate sandbox themselves with
+/// `env::set_var("HOME", temp_dir)`. That is inert on Windows, where
+/// `dirs::home_dir()` resolves through the known-folder API and consults
+/// neither `HOME` nor `USERPROFILE`. The sandbox silently does nothing and the
+/// writes land on the developer's real home.
+///
+/// That is not hypothetical. It overwrote a real `~/.claude/settings.json`
+/// twice (#536) and, worse, `archive.rs`'s nine mutating tests — create,
+/// delete, rename, migrate — were running against the real
+/// `~/.claude-history-viewer/archives`, which is where a user's saved session
+/// backups live (#540). The suite reported `ok` throughout.
+///
+/// Under `cfg(test)` this reads `CCHV_TEST_HOME` and **panics when it is
+/// unset**. Falling back to the real home would leave the landmine armed for
+/// the next test that forgets to sandbox itself; a panic turns that mistake
+/// into a loud failure instead of silent data loss.
+///
+/// Shared rather than duplicated per module: `cfg(test)` is per-crate, so one
+/// definition covers every caller, and eight copies of a security-relevant
+/// branch is eight chances for one of them to drift.
+#[cfg(not(test))]
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+#[cfg(test)]
+// Always `Some` or a panic; the `Option` matches the real signature above so
+// callers read identically in both builds.
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    match std::env::var_os("CCHV_TEST_HOME") {
+        Some(value) => Some(PathBuf::from(value)),
+        None => panic!(
+            "a test resolved a real home directory without a sandbox. Set \
+             CCHV_TEST_HOME (see `setup_test_env`) before touching any path \
+             under it: writing there would hit the developer's own files."
+        ),
+    }
+}
 
 /// Estimated average bytes per JSONL line (used for capacity pre-allocation)
 /// Based on typical Claude message sizes (800-1200 bytes average)


### PR DESCRIPTION
Closes #540. Extends #537, which fixed two of eight modules.

## The remaining six

`env::set_var("HOME", temp)` is inert on Windows — `dirs::home_dir()` resolves through the known-folder API and consults neither `HOME` nor `USERPROFILE`. Every test module sandboxing that way wrote to the developer's real home.

| module | before |
|---|---|
| `commands/archive.rs` | **unfixed, and mutating** |
| `commands/stats.rs` | unfixed |
| `commands/metadata.rs` | unfixed |
| `providers/pi.rs` | unfixed |
| `providers/antigravity.rs` | unfixed (reaches home via callees) |
| `providers/ompi.rs` | unfixed (reaches home via callees) |

`archive.rs` is the serious one. `get_archives_dir()` resolves `~/.claude-history-viewer/archives` and its test module has **nine mutating tests** — create, delete, rename, and a UUID-to-name migration. On a real machine that directory holds saved session backups. #536 overwrote a config file, which is re-creatable; this class can delete the archives someone made precisely so they would not lose those sessions.

## Shape

One shared `crate::utils::home_dir()` rather than a helper per module. `cfg(test)` is per-crate, so a single definition covers every caller, and eight copies of a security-relevant branch is eight chances for one to drift. It keeps #537's design otherwise: `dirs::home_dir()` normally, `CCHV_TEST_HOME` under `cfg(test)`, **panic when that is unset**.

## What the panic found immediately

**Six tests were reaching the real home with no sandbox at all** — five in `stats.rs`, one in `watcher.rs`. None of them wants a home directory; each builds its own `TempDir`, and the code under test resolves home while detecting providers. They were reading whatever happened to be in the developer's `~`. Each now points the sandbox at its own temp dir.

**`CCHV_TEST_HOME` leaks between tests** under `cargo test -- --test-threads=1`, because a `TempDir` going out of scope does not unset an environment variable. Two tests sandboxing via `EnvVarGuard::set("HOME", …)` were inheriting a stale value from an earlier test and asserting against the wrong root. They now set both, and the three provider `HomeGuard`s remove the variable on drop.

Neither of those was in the issue. Both were invisible before the panic existed.

## Type

- [x] Bug fix

## Checklist

- [x] PR targets `develop`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` clean
- [x] Frontend untouched
- [x] i18n: no user-facing strings

## Verification

`cargo test --all-features -- --test-threads=1`: **1022 + 6 + 5 + 4 + 3 passed, 0 failed.**

**Mutation check.** Removing archive's `CCHV_TEST_HOME` line fails 18 tests, every one of them with the actionable message rather than silently proceeding:

```
a test resolved a real home directory without a sandbox. Set CCHV_TEST_HOME
(see `setup_test_env`) before touching any path under it: writing there would
hit the developer's own files.
```

That is the guarantee: an unsandboxed archive test now cannot run.

**One mutation I deliberately did not run.** The pair that would dramatise the bug — remove the sandbox *and* make the helper fall back to the real home — would have executed nine create/delete/rename/migrate tests against my actual `~/.claude-history-viewer/archives`. That is the issue, not a demonstration of it. I confirmed my archives are intact instead (manifest still 1 entry, directory timestamps unchanged).

## Windows

The failure mode is Windows-only and I cannot run Windows locally. The informational Windows job added in #539 is the signal — the six `archive.rs` failures there were contamination from the real store (`assertion failed: manifest.archives.is_empty()`), so they should disappear with this. That job does not gate, so if some remain it reports rather than blocks.

This should also shrink #541: `stats`, `metadata`, `pi`, `antigravity` and `ompi` all appear in that list, and a share of their failures were contamination rather than path assumptions. Worth re-reading that issue against a fresh Windows run once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of archive, metadata, statistics, session, and provider path handling across platforms.
  * Prevented test operations from accessing or modifying the developer’s actual home directory.
  * Strengthened test isolation, particularly on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->