### PR TITLE
fix(tests): isolate rename path validation

### DIFF
--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -301,7 +301,7 @@ fn configured_claude_dirs() -> Vec<String> {
 
 /// Expand a leading `~` to the home directory, mirroring `detect_claude_config_dir`.
 fn expand_home_prefix(raw: &str) -> String {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = crate::utils::home_dir() else {
         return raw.to_string();
     };
     if raw == "~" {
@@ -323,7 +323,7 @@ fn expand_home_prefix(raw: &str) -> String {
 fn resolve_claude_roots(configured: &[String]) -> Vec<PathBuf> {
     let mut roots = Vec::new();
 
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = crate::utils::home_dir() {
         push_root(&mut roots, home.join(".claude"));
     }
 
@@ -1017,7 +1017,7 @@ mod tests {
     /// `crate::utils::home_dir` made it say so (#540).
     fn isolated_home() -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().expect("temp home");
-        std::env::set_var("CCHV_TEST_HOME", dir.path());
+        std::env::set_var("CCHV_TEST_HOME", dir.path().canonicalize().unwrap());
         dir
     }
 
@@ -1642,15 +1642,12 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_valid_path() {
-        // Sandboxed only so `configured_claude_dirs` does not read the
-        // developer's registered custom paths. `resolve_claude_roots` still
-        // resolves the default root through `dirs::home_dir()`, which is why
-        // this still scans the real `~/.claude` — and why it asserts nothing on
-        // a machine without one. Left as-is deliberately; rename.rs is outside
-        // this change and the vacuity is filed separately.
-        let _home = isolated_home();
-        // This test requires a real .jsonl file in ~/.claude to exist
-        if let Some(home) = dirs::home_dir() {
+        let home_fixture = isolated_home();
+        let (_, expected_path) = make_claude_dir(
+            &real_temp_root(&home_fixture).join(".claude"),
+            "valid-session",
+        );
+        if let Some(home) = crate::utils::home_dir() {
             let claude_projects = home.join(".claude/projects");
             if claude_projects.exists() {
                 // Try to find any .jsonl file in projects subdirectories
@@ -1667,6 +1664,7 @@ mod tests {
                                             result.is_ok(),
                                             "Validation failed for valid path {test_path}: {result:?}"
                                         );
+                                        assert_eq!(test_path, expected_path);
                                         return; // Test passed
                                     }
                                 }
@@ -1676,7 +1674,7 @@ mod tests {
                 }
             }
         }
-        // Skip test if no suitable file found
+        panic!("sandboxed session fixture was not validated");
     }
 
     #[test]
@@ -1706,6 +1704,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_accepts_registered_custom_directory() {
+        let _home = isolated_home();
         let temp = tempfile::TempDir::new().unwrap();
         let custom_base = real_temp_root(&temp).join(".claude-holophonix");
         fs::create_dir_all(&custom_base).unwrap();
@@ -1720,6 +1719,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_directory_that_is_not_registered() {
+        let _home = isolated_home();
         let temp = tempfile::TempDir::new().unwrap();
         let unregistered = real_temp_root(&temp).join(".claude-other");
         fs::create_dir_all(&unregistered).unwrap();
@@ -1736,6 +1736,7 @@ mod tests {
 
     #[test]
     fn resolve_claude_roots_skips_directory_without_projects_subdir() {
+        let _home = isolated_home();
         let temp = tempfile::TempDir::new().unwrap();
         let bogus = real_temp_root(&temp).join(".claude-bogus");
         fs::create_dir_all(&bogus).unwrap(); // no projects/ inside
@@ -1750,6 +1751,7 @@ mod tests {
 
     #[test]
     fn resolve_claude_roots_skips_symlinked_custom_directory() {
+        let _home = isolated_home();
         let temp = tempfile::TempDir::new().unwrap();
         let real_base = real_temp_root(&temp).join("real-claude");
         fs::create_dir_all(real_base.join("projects")).unwrap();
@@ -1770,8 +1772,9 @@ mod tests {
 
     #[test]
     fn resolve_claude_roots_always_includes_default_claude_dir() {
+        let _home = isolated_home();
         let roots = resolve_claude_roots(&[]);
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = crate::utils::home_dir() {
             let default_root = home.join(".claude");
             // Roots are stored as-is (not canonicalized), unless ~/.claude is a
             // symlink (then push_root drops it).
@@ -1809,6 +1812,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_non_jsonl_extension() {
+        let _home = isolated_home();
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
         let project_dir = root.join("projects").join("-proj");
@@ -1846,6 +1850,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_accepts_symlinked_project_directory() {
+        let _home = isolated_home();
         // Mirrors the shared-sessions layout: a project directory under
         // <root>/projects is a symlink into a real directory elsewhere (e.g.
         // /Users/Shared/.claude/projects). The session file is a real file.
@@ -1876,6 +1881,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_symlink_below_project_directory() {
+        let _home = isolated_home();
         // A symlink deeper than the project directory is not allowed.
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
@@ -1903,6 +1909,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_symlinked_session_file() {
+        let _home = isolated_home();
         // The session file itself must be a real file, not a symlink.
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
@@ -1926,6 +1933,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_path_traversal_under_projects() {
+        let _home = isolated_home();
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
         fs::create_dir_all(root.join("projects")).unwrap();
@@ -1948,7 +1956,7 @@ mod tests {
     fn test_validate_claude_path_filename_with_special_chars() {
         let _home = isolated_home();
         // Test filename validation with various invalid characters
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = crate::utils::home_dir() {
             let claude_dir = home.join(".claude/projects");
             // Filename with dot (besides extension) should fail
             let path_with_dot = claude_dir


### PR DESCRIPTION
## What & why

Route `rename.rs` home-directory resolution through the test-aware helper so path validation cannot inspect a developer's real home during tests. The affected tests now create isolated homes, and the positive validation case creates and asserts against a real sandboxed `.jsonl` fixture instead of passing vacuously.

Closes #545

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
- [ ] `pnpm exec tsc --build .` and `pnpm lint` pass — N/A; this is an isolated Rust backend/test change with no frontend files.
- [x] **i18n**: N/A; no user-facing strings or translation keys changed.

Rust verification:

```text
cargo test commands::session::rename::tests
test result: ok. 54 passed; 0 failed

cargo fmt --all -- --check
cargo check
cargo clippy --lib -- -D warnings
all passed
```

`cargo nextest` was unavailable locally. All-target Clippy also reaches the pre-existing `items_after_test_module` error in `src/lib.rs`; the library-target Clippy check covering this change passes.

## If this adds a frontend-callable backend command

- [ ] Registered in **both** the Tauri `generate_handler!` (`src-tauri/src/lib.rs`) **and** the Axum WebUI router (`src-tauri/src/server/mod.rs`) — N/A; no command was added.

## If this adds a new provider

- [ ] Followed the existing provider pattern in `src-tauri/src/providers/` — N/A
- [ ] Session discovery verified on macOS / Linux / Windows (and WSL if applicable) — N/A
- [ ] No leftover identifiers copied from another provider (names, comments, fixtures) — N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude session path resolution for greater consistency across custom directories, symlinks, file extensions, and traversal scenarios.
  * Updated validation tests to use isolated sandbox data, avoiding reliance on files in the local home directory.
  * Added clearer failure handling when no valid session fixture is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->