### PR TITLE
fix(tests): give Windows fixtures platform-appropriate absolute paths

### DIFF
--- a/src-tauri/src/commands/claude_settings.rs
+++ b/src-tauri/src/commands/claude_settings.rs
@@ -1070,7 +1070,8 @@ mod tests {
 
     #[test]
     fn test_validate_dialog_path_parent_dir_rejected() {
-        let path = Path::new("/some/path/../escape.txt");
+        let raw = crate::test_utils::abs("some/path/../escape.txt");
+        let path = Path::new(&raw);
         let result = validate_dialog_path(path);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("'..'"));
@@ -1078,7 +1079,8 @@ mod tests {
 
     #[test]
     fn test_validate_dialog_path_nonexistent_parent_rejected() {
-        let path = Path::new("/nonexistent_dir_abc123/file.txt");
+        let raw = crate::test_utils::abs("nonexistent_dir_abc123/file.txt");
+        let path = Path::new(&raw);
         let result = validate_dialog_path(path);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("does not exist"));

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_validate_project_metadata_key_absolute_path() {
-        assert!(validate_project_metadata_key("/tmp/project").is_ok());
+        assert!(validate_project_metadata_key(&crate::test_utils::abs("tmp/project")).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -537,7 +537,7 @@ mod tests {
                 "sessionId": "session-missing-worktree",
                 "timestamp": "2026-08-16T10:00:00Z",
                 "type": "user",
-                "cwd": "/tmp/deleted-worktree",
+                "cwd": crate::test_utils::abs("tmp/deleted-worktree"),
                 "message": { "role": "user", "content": "Keep this history" },
             })]),
         );
@@ -547,7 +547,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(projects.len(), 1);
-        assert_eq!(projects[0].actual_path, "/tmp/deleted-worktree");
+        assert_eq!(
+            projects[0].actual_path,
+            crate::test_utils::abs("tmp/deleted-worktree")
+        );
 
         let serialized = serde_json::to_value(&projects[0]).unwrap();
         assert_eq!(
@@ -656,8 +659,11 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let claude_dir = temp_dir.path().join(".claude");
         let projects_dir = claude_dir.join("projects");
-        // Folder name decodes to an existing directory (/usr/lib).
-        let project_dir = projects_dir.join("-usr-lib");
+        // The folder name has to decode to a directory that really exists. This
+        // used to be `-usr-lib`, borrowing `/usr/lib` from the host - a path
+        // Windows does not have (#541). Built now instead.
+        let (encoded, real_root) = crate::test_utils::make_encoded_path("cchv_541_stale", &["lib"]);
+        let project_dir = projects_dir.join(&encoded);
         fs::create_dir_all(&project_dir).unwrap();
 
         // The session's embedded cwd is stale (points elsewhere), simulating a
@@ -670,7 +676,7 @@ mod tests {
                 "sessionId": "session-1",
                 "timestamp": "2025-06-26T10:00:00Z",
                 "type": "user",
-                "cwd": "/some/stale/Dev",
+                "cwd": crate::test_utils::abs("some/stale/Dev"),
                 "message": { "role": "user", "content": "Hello" },
             })]),
         );
@@ -679,9 +685,20 @@ mod tests {
             .await
             .unwrap();
 
+        // Both canonicalized while the fixture still exists - the cleanup below
+        // would otherwise make the resolution fail rather than mismatch.
+        let expected = std::fs::canonicalize(real_root.join("lib")).expect("canonicalize fixture");
+        let actual = std::fs::canonicalize(&projects[0].actual_path).ok();
+        std::fs::remove_dir_all(&real_root).ok();
+
         assert_eq!(projects.len(), 1);
         // Verified folder name wins over the stale cwd.
-        assert_eq!(projects[0].actual_path, "/usr/lib");
+        assert_eq!(
+            actual.as_deref(),
+            Some(expected.as_path()),
+            "actual_path was {:?}",
+            projects[0].actual_path
+        );
         assert_eq!(projects[0].name, "lib");
     }
 
@@ -953,7 +970,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_git_log_invalid_path() {
-        let result = get_git_log("/nonexistent/path".to_string(), 10).await;
+        let result = get_git_log(crate::test_utils::abs("nonexistent/path").to_string(), 10).await;
         // Should fail because path doesn't exist
         assert!(result.is_err());
         assert_eq!(

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -970,7 +970,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_git_log_invalid_path() {
-        let result = get_git_log(crate::test_utils::abs("nonexistent/path").to_string(), 10).await;
+        let result = get_git_log(crate::test_utils::abs("nonexistent/path"), 10).await;
         // Should fail because path doesn't exist
         assert!(result.is_err());
         assert_eq!(

--- a/src-tauri/src/commands/session/delete.rs
+++ b/src-tauri/src/commands/session/delete.rs
@@ -111,19 +111,23 @@ mod tests {
 
     #[tokio::test]
     async fn reject_non_jsonl_extension() {
-        let err = delete_session("/tmp/session.txt".into()).await.unwrap_err();
+        let err = delete_session(crate::test_utils::abs("tmp/session.txt"))
+            .await
+            .unwrap_err();
         assert_eq!(err, "Only .jsonl session files can be deleted");
     }
 
     #[tokio::test]
     async fn reject_session_id_with_dots() {
-        let err = delete_session("/tmp/a..b.jsonl".into()).await.unwrap_err();
+        let err = delete_session(crate::test_utils::abs("tmp/a..b.jsonl"))
+            .await
+            .unwrap_err();
         assert_eq!(err, "Invalid session ID format");
     }
 
     #[tokio::test]
     async fn reject_session_id_with_spaces() {
-        let err = delete_session("/tmp/bad name.jsonl".into())
+        let err = delete_session(crate::test_utils::abs("tmp/bad name.jsonl"))
             .await
             .unwrap_err();
         assert_eq!(err, "Invalid session ID format");

--- a/src-tauri/src/commands/session/edits.rs
+++ b/src-tauri/src/commands/session/edits.rs
@@ -1730,7 +1730,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_file_rejects_path_traversal() {
-        let result = restore_file("/tmp/../etc/passwd".to_string(), "content".to_string()).await;
+        let result = restore_file(
+            crate::test_utils::abs("tmp/../etc/passwd"),
+            "content".to_string(),
+        )
+        .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("path traversal"));
     }

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -2903,11 +2903,20 @@ mod tests {
         std::fs::create_dir_all(&project_dir).unwrap();
         let actual_cwd = temp_dir.path().join("claude_prompt_design");
         std::fs::create_dir_all(&actual_cwd).unwrap();
-        let actual_cwd = actual_cwd.to_string_lossy();
-
+        // Built with `json!` rather than interpolated into a raw string: on
+        // Windows the cwd contains backslashes, which have to be JSON-escaped.
+        // Unescaped they made the line unparseable, so the loader returned no
+        // sessions at all and the assertion failed on the count (#541).
         let content = format!(
-            r#"{{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","type":"user","cwd":"{actual_cwd}","message":{{"role":"user","content":"Hello world"}}}}
-"#
+            "{}\n",
+            serde_json::json!({
+                "uuid": "uuid-1",
+                "sessionId": "session-1",
+                "timestamp": "2025-06-26T10:00:00Z",
+                "type": "user",
+                "cwd": actual_cwd.to_string_lossy(),
+                "message": { "role": "user", "content": "Hello world" },
+            })
         );
         let file_path = project_dir.join("test.jsonl");
         let mut file = File::create(&file_path).unwrap();

--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -2924,21 +2924,30 @@ mod tests {
     #[tokio::test]
     async fn test_load_project_sessions_prefers_verified_folder_over_stale_cwd() {
         let temp_dir = TempDir::new().unwrap();
-        // Folder name decodes to an existing directory (/usr/lib); the
-        // `.claude/projects/` marker must be present for verified decoding.
+        // The folder name must decode to a directory that really exists. This
+        // borrowed `/usr/lib`, which Windows does not have (#541); it is built
+        // now. The `.claude/projects/` marker still has to be present for
+        // verified decoding to engage.
+        let (encoded, real_root) =
+            crate::test_utils::make_encoded_path("cchv_541_load_stale", &["lib"]);
         let project_dir = temp_dir
             .path()
             .join(".claude")
             .join("projects")
-            .join("-usr-lib");
+            .join(&encoded);
         std::fs::create_dir_all(&project_dir).unwrap();
 
         // Stale embedded cwd simulates a session moved into this folder by hand.
-        let content = concat!(
-            r#"{"uuid":"uuid-1","sessionId":"session-1","timestamp":"2025-06-26T10:00:00Z","#,
-            r#""type":"user","cwd":"/some/stale/Dev","#,
-            r#""message":{"role":"user","content":"Hello world"}}"#,
-            "\n"
+        let content = format!(
+            "{}\n",
+            serde_json::json!({
+                "uuid": "uuid-1",
+                "sessionId": "session-1",
+                "timestamp": "2025-06-26T10:00:00Z",
+                "type": "user",
+                "cwd": crate::test_utils::abs("some/stale/Dev"),
+                "message": { "role": "user", "content": "Hello world" },
+            })
         );
         let file_path = project_dir.join("test.jsonl");
         let mut file = File::create(&file_path).unwrap();
@@ -2947,6 +2956,7 @@ mod tests {
         let result = load_project_sessions(project_dir.to_string_lossy().to_string(), None)
             .await
             .unwrap();
+        std::fs::remove_dir_all(&real_root).ok();
 
         assert_eq!(result.len(), 1);
         // Verified folder name wins over the stale cwd.

--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -1808,15 +1808,31 @@ mod tests {
         );
     }
 
+    /// The expectations are case-folded on Windows because
+    /// `normalize_path_for_comparison` lowercases there, deliberately and
+    /// documented on the function: Windows filesystem access is
+    /// case-insensitive, so the allowlist boundary check has to be too.
+    ///
+    /// This asserted the mixed-case form and so had never passed on Windows -
+    /// a Windows-only test that only ever ran on Unix, where the `cfg` under
+    /// test is compiled out entirely (#541).
     #[test]
     fn normalizes_windows_verbatim_path_prefix_for_root_comparison() {
+        let expected_drive = if cfg!(windows) {
+            r"c:\users\alice\.claude"
+        } else {
+            r"C:\Users\Alice\.claude"
+        };
+        // The UNC form is already lower-case, so it reads the same either way.
+        let expected_unc = r"\\server\share\.claude";
+
         assert_eq!(
             normalize_path_for_comparison(Path::new(r"\\?\C:\Users\Alice\.claude")),
-            PathBuf::from(r"C:\Users\Alice\.claude")
+            PathBuf::from(expected_drive)
         );
         assert_eq!(
             normalize_path_for_comparison(Path::new(r"\\?\UNC\server\share\.claude")),
-            PathBuf::from(r"\\server\share\.claude")
+            PathBuf::from(expected_unc)
         );
     }
 

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -8328,22 +8328,34 @@ mod tests {
         let gemini_home_absolute = fs::canonicalize(gemini_home.path()).expect("Gemini home");
         let home = temp.path().to_string_lossy().to_string();
 
+        // Assembled with `join`, not a literal `/`: `home` is a real host path,
+        // so on Windows this mixed backslashes and forward slashes and the
+        // detector matched neither store (#541).
+        let session_under = |dot_dir: &str| {
+            temp.path()
+                .join(dot_dir)
+                .join("agent")
+                .join("sessions")
+                .join("-tmp")
+                .join("2026-08-01T00-00-00-000Z_x.jsonl")
+                .to_string_lossy()
+                .into_owned()
+        };
         assert_eq!(
-            detect_session_provider(&format!(
-                "{home}/.omp/agent/sessions/-tmp/2026-08-01T00-00-00-000Z_x.jsonl"
-            )),
+            detect_session_provider(&session_under(".omp")),
             StatsProvider::Ompi
         );
         assert_eq!(
-            detect_session_provider(&format!(
-                "{home}/.pi/agent/sessions/-tmp/2026-08-01T00-00-00-000Z_x.jsonl"
-            )),
+            detect_session_provider(&session_under(".pi")),
             StatsProvider::Pi
         );
         assert_eq!(
             detect_session_provider(
                 &gemini_home_absolute
-                    .join("tmp/abcd/chats/chat-1.jsonl")
+                    .join("tmp")
+                    .join("abcd")
+                    .join("chats")
+                    .join("chat-1.jsonl")
                     .to_string_lossy(),
             ),
             StatsProvider::Gemini

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -8325,7 +8325,13 @@ mod tests {
         let _home_guard = EnvVarGuard::set("CCHV_TEST_HOME", temp.path());
         let gemini_home = TempDir::new_in(".").expect("relative Gemini home");
         let _gemini_guard = EnvVarGuard::set("GEMINI_HOME", gemini_home.path());
-        let gemini_home_absolute = fs::canonicalize(gemini_home.path()).expect("Gemini home");
+        // Plain, not verbatim: `get_base_path` hands back the `GEMINI_HOME`
+        // value as it was set, so comparing it against a canonicalised
+        // `\\?\D:\...` never matched on Windows (#541).
+        let gemini_home_absolute =
+            std::path::PathBuf::from(crate::test_utils::strip_verbatim_prefix(
+                &fs::canonicalize(gemini_home.path()).expect("Gemini home"),
+            ));
         let home = temp.path().to_string_lossy().to_string();
 
         // Assembled with `join`, not a literal `/`: `home` is a real host path,

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -7293,6 +7293,7 @@ mod tests {
 
     #[test]
     fn test_antigravity_provider_project_summary_uses_mode_adjusted_daily_tokens() {
+        let _home = isolated_home();
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let root = temp_dir.path();
         let session_dir = root

--- a/src-tauri/src/models/session.rs
+++ b/src-tauri/src/models/session.rs
@@ -169,7 +169,8 @@ mod tests {
 
     #[test]
     fn unavailable_project_path_is_exposed_without_hiding_the_project() {
-        let project = project_with_path("/definitely-missing-claude-project");
+        let project =
+            project_with_path(&crate::test_utils::abs("definitely-missing-claude-project"));
         let serialized = serde_json::to_value(project).unwrap();
 
         assert_eq!(

--- a/src-tauri/src/models/snapshot_tests.rs
+++ b/src-tauri/src/models/snapshot_tests.rs
@@ -334,8 +334,10 @@ mod project_snapshots {
     fn snapshot_claude_project() {
         let project = ClaudeProject {
             name: "my-awesome-project".to_string(),
-            path: "/Users/test/.claude/projects/-Users-test-my-awesome-project".to_string(),
-            actual_path: "/Users/test/my-awesome-project".to_string(),
+            path: crate::test_utils::abs(
+                "Users/test/.claude/projects/-Users-test-my-awesome-project",
+            ),
+            actual_path: crate::test_utils::abs("Users/test/my-awesome-project"),
             session_count: 42,
             message_count: 1337,
             last_modified: "2025-01-15T10:30:00Z".to_string(),
@@ -345,7 +347,16 @@ mod project_snapshots {
             custom_directory_label: None,
         };
 
-        assert_json_snapshot!("claude_project", project);
+        // The two path fields are redacted because their spelling is
+        // platform-specific while everything the snapshot documents - the field
+        // set, the ordering, and whether `path_status` is emitted - is not.
+        // They have to be real absolute paths, though: `project_path_status`
+        // returns `None` for a non-absolute one, so the Unix literals used here
+        // before silently dropped `path_status` from the Windows output (#541).
+        assert_json_snapshot!("claude_project", project, {
+            ".path" => "[path]",
+            ".actual_path" => "[actual_path]",
+        });
     }
 
     #[test]
@@ -372,8 +383,8 @@ mod project_snapshots {
     fn snapshot_pi_project() {
         let project = ClaudeProject {
             name: "herdr".to_string(),
-            path: "/Users/ac/.pi/agent/sessions/--Users-ac-dev-herdr--".to_string(),
-            actual_path: "/Users/ac/dev/herdr".to_string(),
+            path: crate::test_utils::abs("Users/ac/.pi/agent/sessions/--Users-ac-dev-herdr--"),
+            actual_path: crate::test_utils::abs("Users/ac/dev/herdr"),
             session_count: 2,
             message_count: 42,
             last_modified: "2026-06-08T20:32:11.000Z".to_string(),
@@ -383,7 +394,11 @@ mod project_snapshots {
             custom_directory_label: None,
         };
 
-        assert_json_snapshot!("pi_project", project);
+        // Redacted for the same reason as `claude_project` above.
+        assert_json_snapshot!("pi_project", project, {
+            ".path" => "[path]",
+            ".actual_path" => "[actual_path]",
+        });
     }
 }
 

--- a/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__project_snapshots__claude_project.snap
+++ b/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__project_snapshots__claude_project.snap
@@ -4,8 +4,8 @@ expression: project
 ---
 {
   "name": "my-awesome-project",
-  "path": "/Users/test/.claude/projects/-Users-test-my-awesome-project",
-  "actual_path": "/Users/test/my-awesome-project",
+  "path": "[path]",
+  "actual_path": "[actual_path]",
   "session_count": 42,
   "message_count": 1337,
   "last_modified": "2025-01-15T10:30:00Z",

--- a/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__project_snapshots__pi_project.snap
+++ b/src-tauri/src/models/snapshots/claude_code_history_viewer_lib__models__snapshot_tests__project_snapshots__pi_project.snap
@@ -4,8 +4,8 @@ expression: project
 ---
 {
   "name": "herdr",
-  "path": "/Users/ac/.pi/agent/sessions/--Users-ac-dev-herdr--",
-  "actual_path": "/Users/ac/dev/herdr",
+  "path": "[path]",
+  "actual_path": "[actual_path]",
   "session_count": 2,
   "message_count": 42,
   "last_modified": "2026-06-08T20:32:11.000Z",

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -803,9 +803,14 @@ mod tests {
         std::fs::create_dir_all(&cli_root).expect("create cli root");
         std::fs::write(
             cli_root.join("history.jsonl"),
-            concat!(
-                "{\"display\": \"Wire the CLI layout\", \"timestamp\": 1750500000000, ",
-                "\"workspace\": \"/tmp/cli-proj\", \"conversationId\": \"conv-cli\"}\n",
+            format!(
+                "{}\n",
+                serde_json::json!({
+                    "display": "Wire the CLI layout",
+                    "timestamp": 1750500000000u64,
+                    "workspace": crate::test_utils::abs("tmp/cli-proj"),
+                    "conversationId": "conv-cli",
+                })
             ),
         )
         .expect("write history.jsonl");

--- a/src-tauri/src/providers/antigravity_cli.rs
+++ b/src-tauri/src/providers/antigravity_cli.rs
@@ -56,7 +56,11 @@ const SUMMARY_MAX_CHARS: usize = 200;
 /// Default CLI store root. The existing antigravity provider has no env
 /// override pattern, so none is honored here either.
 pub(crate) fn default_root() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".gemini").join("antigravity-cli"))
+    // Through the sandboxed helper, not `dirs::home_dir()`: on Windows the
+    // latter goes to the known-folder API and ignores `HOME`, so the tests'
+    // fixture home was invisible and every CLI-layout assertion saw an empty
+    // scan (#541).
+    crate::utils::home_dir().map(|h| h.join(".gemini").join("antigravity-cli"))
 }
 
 /// True when the default CLI root looks like an antigravity-cli store.

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -995,7 +995,7 @@ mod tests {
     fn load_sessions_rejects_path_outside_codebuddy_root() {
         // /tmp definitely exists on macOS/Linux and is outside the codebuddy
         // root. The function checks existence first, so we need a real path.
-        let result = load_sessions("/tmp", false);
+        let result = load_sessions(&crate::test_utils::abs("tmp"), false);
         // Either errors with the "outside" message, or — if /tmp doesn't
         // canonicalize on this platform — errors with a canonicalize message.
         // Both are acceptable; what we want to guard against is `Ok(...)`.
@@ -1167,7 +1167,7 @@ mod tests {
             "role": "user",
             "sessionId": "s1",
             "timestamp": 1_700_000_000_000i64,
-            "cwd": "/Users/rassyan/WebstormProjects/claude-code-history-viewer",
+            "cwd": crate::test_utils::abs("Users/rassyan/WebstormProjects/claude-code-history-viewer"),
             "content": [{"type": "input_text", "text": "hi"}],
         });
         std::fs::write(&session, format!("{line}\n")).expect("write");
@@ -1179,7 +1179,8 @@ mod tests {
             "display name must keep the full hyphenated project leaf"
         );
         assert_eq!(
-            projects[0].actual_path, "/Users/rassyan/WebstormProjects/claude-code-history-viewer",
+            projects[0].actual_path,
+            crate::test_utils::abs("Users/rassyan/WebstormProjects/claude-code-history-viewer"),
             "actual_path must be the real cwd, not the lossy storage path"
         );
     }

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -1216,8 +1216,11 @@ mod tests {
         // Build the matching CodeBuddy-style lossy encoding. We strip the
         // leading `/` and join with `-`, mirroring how CodeBuddy actually
         // names project directories on disk.
-        let real_leaf_str = real_leaf.to_string_lossy().to_string();
-        let encoded = real_leaf_str.trim_start_matches('/').replace('/', "-");
+        // Encoded with the shared rule: the inline `trim_start_matches('/')`
+        // plus `replace('/', "-")` only ever produced a Unix-shaped name, so on
+        // Windows the folder kept its backslashes and colon and nothing could
+        // decode it (#541).
+        let encoded = crate::test_utils::encode_path_claude_style(&real_leaf);
         let project_dir = projects_root.join(&encoded);
         std::fs::create_dir(&project_dir).expect("create project");
 

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -993,11 +993,14 @@ mod tests {
     /// prevent path-traversal-style reads of arbitrary directories on disk.
     #[test]
     fn load_sessions_rejects_path_outside_codebuddy_root() {
-        // /tmp definitely exists on macOS/Linux and is outside the codebuddy
-        // root. The function checks existence first, so we need a real path.
-        let result = load_sessions(&crate::test_utils::abs("tmp"), false);
-        // Either errors with the "outside" message, or — if /tmp doesn't
-        // canonicalize on this platform — errors with a canonicalize message.
+        // The function checks existence first, so this needs a directory that
+        // really is on disk and really is outside the codebuddy root. It used
+        // to reach for `/tmp`; Windows has no such path, and a nonexistent one
+        // takes a different branch than the rejection under test (#541).
+        let outside = crate::test_utils::existing_dir();
+        let result = load_sessions(&outside.to_string_lossy(), false);
+        // Either errors with the "outside" message, or - if the directory does
+        // not canonicalize on this platform - errors with a canonicalize message.
         // Both are acceptable; what we want to guard against is `Ok(...)`.
         assert!(
             result.is_err(),

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -2967,7 +2967,8 @@ mod tests {
         fs::create_dir_all(&archived_dir).expect("archived dir should be created");
         let _guard = EnvVarGuard::set("CODEX_HOME", &codex_home);
 
-        let project_cwd = "/Users/jack/client/claude-code-history-viewer";
+        let project_cwd = crate::test_utils::abs("Users/jack/client/claude-code-history-viewer");
+        let project_cwd = project_cwd.as_str();
         let active_rollout = sessions_dir.join("rollout-active.jsonl");
         let archived_rollout = archived_dir.join("rollout-archived.jsonl");
         let active_lines = [
@@ -3019,10 +3020,13 @@ mod tests {
             .expect("sessions should be loaded");
 
         assert_eq!(sessions.len(), 2);
-        assert!(sessions.iter().any(|s| s.file_path.contains("/sessions/")));
+        let sep = std::path::MAIN_SEPARATOR;
         assert!(sessions
             .iter()
-            .any(|s| s.file_path.contains("/archived_sessions/")));
+            .any(|s| s.file_path.contains(&format!("{sep}sessions{sep}"))));
+        assert!(sessions.iter().any(|s| s
+            .file_path
+            .contains(&format!("{sep}archived_sessions{sep}"))));
     }
 
     #[test]
@@ -3088,7 +3092,8 @@ mod tests {
         fs::create_dir_all(&sessions_dir).expect("sessions dir should be created");
         let _guard = EnvVarGuard::set("CODEX_HOME", &codex_home);
 
-        let project_cwd = "/Users/jack/client/claude-code-history-viewer";
+        let project_cwd = crate::test_utils::abs("Users/jack/client/claude-code-history-viewer");
+        let project_cwd = project_cwd.as_str();
         write_codex_rollout(
             &sessions_dir,
             "rollout-native-title.jsonl",
@@ -3130,7 +3135,7 @@ mod tests {
             &sessions_dir,
             "rollout-rename-title.jsonl",
             "rename-title-session",
-            "/Users/jack/client/claude-code-history-viewer",
+            &crate::test_utils::abs("Users/jack/client/claude-code-history-viewer"),
             "Original first prompt",
         );
         create_codex_state_db(
@@ -3192,7 +3197,7 @@ mod tests {
             &sessions_dir,
             "rollout-delete-cleanup.jsonl",
             "delete-cleanup-session",
-            "/Users/jack/client/claude-code-history-viewer",
+            &crate::test_utils::abs("Users/jack/client/claude-code-history-viewer"),
             "Original first prompt",
         );
         create_codex_state_db(

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -1507,7 +1507,12 @@ mod tests {
         assert_eq!(projects[0].name, "demo-project");
         assert_eq!(
             projects[0].path,
-            format!("{SCHEME}{}/sessions/wd_demo_abc123", root.display())
+            // Built with `join`, not a literal `/`: the value under test comes
+            // from `Path::join` and so uses the host separator (#541).
+            format!(
+                "{SCHEME}{}",
+                root.join("sessions").join("wd_demo_abc123").display()
+            )
         );
         assert_eq!(
             projects[0].actual_path,

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -1396,9 +1396,23 @@ mod tests {
     }
 
     fn write_workspace_map(root: &Path) {
+        // Built rather than written literally: on Windows the root is
+        // `C:\tmp\demo-project` and those backslashes have to be JSON-escaped,
+        // which a raw string cannot do (#541).
         fs::write(
             root.join(WORKSPACES_FILE),
-            r#"{"version":1,"workspaces":{"wd_demo_abc123":{"root":"/tmp/demo-project","name":"demo-project","created_at":"2026-08-01T00:00:00.000Z","last_opened_at":"2026-08-02T00:00:00.000Z"}}}"#,
+            serde_json::json!({
+                "version": 1,
+                "workspaces": {
+                    "wd_demo_abc123": {
+                        "root": crate::test_utils::abs("tmp/demo-project"),
+                        "name": "demo-project",
+                        "created_at": "2026-08-01T00:00:00.000Z",
+                        "last_opened_at": "2026-08-02T00:00:00.000Z",
+                    }
+                }
+            })
+            .to_string(),
         )
         .expect("write workspaces.json");
     }
@@ -1419,8 +1433,17 @@ mod tests {
     }
 
     fn default_state() -> String {
-        r#"{"id":"session_x","version":2,"cwd":"/tmp/demo-project","archived":false,"agents":{"main":{"type":"main"}},"title":"","createdAt":1786957369672,"updatedAt":1787034652121}"#
-            .to_string()
+        serde_json::json!({
+            "id": "session_x",
+            "version": 2,
+            "cwd": crate::test_utils::abs("tmp/demo-project"),
+            "archived": false,
+            "agents": { "main": { "type": "main" } },
+            "title": "",
+            "createdAt": 1786957369672u64,
+            "updatedAt": 1787034652121u64,
+        })
+        .to_string()
     }
 
     /// A full turn: user prompt, one thinking part + a tool call, the tool
@@ -1457,8 +1480,14 @@ mod tests {
             &full_turn_wire(),
         );
         // Not in workspaces.json → falls back to state.json cwd.
-        let other_state =
-            r#"{"id":"session_y","version":2,"cwd":"/Users/jack/other","createdAt":1786957369672}"#;
+        let other_state = serde_json::json!({
+            "id": "session_y",
+            "version": 2,
+            "cwd": crate::test_utils::abs("Users/jack/other"),
+            "createdAt": 1786957369672u64,
+        })
+        .to_string();
+        let other_state = other_state.as_str();
         write_session(
             &root,
             "wd_other_zzz",
@@ -1480,12 +1509,18 @@ mod tests {
             projects[0].path,
             format!("{SCHEME}{}/sessions/wd_demo_abc123", root.display())
         );
-        assert_eq!(projects[0].actual_path, "/tmp/demo-project");
+        assert_eq!(
+            projects[0].actual_path,
+            crate::test_utils::abs("tmp/demo-project")
+        );
         assert_eq!(projects[0].session_count, 1);
         assert_eq!(projects[0].provider.as_deref(), Some("kimi"));
         // …state.json cwd is the fallback for the unindexed one.
         assert_eq!(projects[1].name, "other");
-        assert_eq!(projects[1].actual_path, "/Users/jack/other");
+        assert_eq!(
+            projects[1].actual_path,
+            crate::test_utils::abs("Users/jack/other")
+        );
     }
 
     #[test]

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -373,23 +373,25 @@ pub fn make_encoded_path(root_name: &str, segments: &[&str]) -> (String, std::pa
     }
     std::fs::create_dir_all(&deep).expect("create deep tmp dir");
 
-    // Windows `canonicalize` returns a verbatim path (`\\?\C:\...`). Claude
-    // Code never sees one of those - it encodes the plain `C:\...` cwd - so
-    // encoding it here would produce `--?-C--Users-...`, a shape that
-    // exists nowhere (#548).
-    let raw = deep.to_string_lossy();
+    (encode_path_claude_style(&deep), root)
+}
+
+/// Encodes an absolute path the way Claude Code names a project folder.
+///
+/// Every separator becomes `-`. On Windows the drive colon goes too, so
+/// `C:\Temp\x` is `C--Temp-x` - drive-lettered and, unlike Unix, with no
+/// leading dash.
+///
+/// The Windows extended-length prefix is stripped first: `canonicalize` hands
+/// back `\\?\C:\...`, which Claude Code never sees, and encoding it would
+/// produce `--?-C--Users-...`, a shape that exists nowhere (#548).
+pub fn encode_path_claude_style(path: &std::path::Path) -> String {
+    let raw = path.to_string_lossy();
     let plain = raw
         .strip_prefix(r"\\?\UNC\")
         .map(|rest| format!(r"\\{rest}"))
         .unwrap_or_else(|| raw.strip_prefix(r"\\?\").unwrap_or(&raw).to_string());
-
-    // Claude Code replaces every separator with `-`. On Windows the drive
-    // colon goes too, so `C:\Temp\x` becomes `C--Temp-x` - drive-lettered
-    // and, unlike Unix, with no leading dash. This helper used to leave the
-    // colon in place and force a leading dash, producing `-C:-Temp-x`,
-    // which is a shape Claude Code never writes (#548).
-    let encoded = plain.replace(['/', '\\', ':'], "-");
-    (encoded, root)
+    plain.replace(['/', '\\', ':'], "-")
 }
 
 #[cfg(test)]

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -324,53 +324,6 @@ macro_rules! assert_contains {
     };
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_message_builder_user() {
-        let msg = MessageBuilder::user().with_text_content("Hello!").build();
-
-        assert_eq!(msg.message_type, "user");
-        assert_eq!(msg.role, Some("user".to_string()));
-    }
-
-    #[test]
-    fn test_message_builder_assistant() {
-        let msg = MessageBuilder::assistant()
-            .with_text_content("Hi there!")
-            .with_usage(100, 50)
-            .build();
-
-        assert_eq!(msg.message_type, "assistant");
-        assert_eq!(msg.model, Some("claude-opus-4-20250514".to_string()));
-        assert!(msg.usage.is_some());
-    }
-
-    #[test]
-    fn test_mock_claude_project() {
-        let mock = MockClaudeProject::new();
-        let session_path = mock.add_session("test-project", "session1", "{}");
-
-        assert!(session_path.exists());
-        assert!(mock.projects_dir.join("test-project").exists());
-    }
-
-    #[test]
-    fn test_create_jsonl_content() {
-        let messages = vec![
-            MessageBuilder::user().with_text_content("Hello"),
-            MessageBuilder::assistant().with_text_content("Hi!"),
-        ];
-
-        let content = create_jsonl_content(&messages);
-        let lines: Vec<&str> = content.lines().collect();
-
-        assert_eq!(lines.len(), 2);
-    }
-}
-
 /// An absolute path on the host platform, written Unix-style.
 ///
 /// `abs("tmp/session.jsonl")` is `/tmp/session.jsonl` on Unix and
@@ -437,4 +390,51 @@ pub fn make_encoded_path(root_name: &str, segments: &[&str]) -> (String, std::pa
     // which is a shape Claude Code never writes (#548).
     let encoded = plain.replace(['/', '\\', ':'], "-");
     (encoded, root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_builder_user() {
+        let msg = MessageBuilder::user().with_text_content("Hello!").build();
+
+        assert_eq!(msg.message_type, "user");
+        assert_eq!(msg.role, Some("user".to_string()));
+    }
+
+    #[test]
+    fn test_message_builder_assistant() {
+        let msg = MessageBuilder::assistant()
+            .with_text_content("Hi there!")
+            .with_usage(100, 50)
+            .build();
+
+        assert_eq!(msg.message_type, "assistant");
+        assert_eq!(msg.model, Some("claude-opus-4-20250514".to_string()));
+        assert!(msg.usage.is_some());
+    }
+
+    #[test]
+    fn test_mock_claude_project() {
+        let mock = MockClaudeProject::new();
+        let session_path = mock.add_session("test-project", "session1", "{}");
+
+        assert!(session_path.exists());
+        assert!(mock.projects_dir.join("test-project").exists());
+    }
+
+    #[test]
+    fn test_create_jsonl_content() {
+        let messages = vec![
+            MessageBuilder::user().with_text_content("Hello"),
+            MessageBuilder::assistant().with_text_content("Hi!"),
+        ];
+
+        let content = create_jsonl_content(&messages);
+        let lines: Vec<&str> = content.lines().collect();
+
+        assert_eq!(lines.len(), 2);
+    }
 }

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -370,3 +370,71 @@ mod tests {
         assert_eq!(lines.len(), 2);
     }
 }
+
+/// An absolute path on the host platform, written Unix-style.
+///
+/// `abs("tmp/session.jsonl")` is `/tmp/session.jsonl` on Unix and
+/// `C:\tmp\session.jsonl` on Windows.
+///
+/// Fixtures used to spell these inline as `"/tmp/session.jsonl"`. On Windows
+/// that string is *not* absolute — there is no drive — so code under test
+/// rejected it with "path must be absolute" long before reaching the behaviour
+/// the test was about, and the assertion failed for the wrong reason (#541).
+pub fn abs(unix_relative: &str) -> String {
+    let trimmed = unix_relative.trim_start_matches('/');
+    if cfg!(windows) {
+        format!(r"C:\{}", trimmed.replace('/', r"\"))
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+/// A directory that really exists on the host, for fixtures that need a path
+/// resolvable on disk rather than merely well-formed.
+///
+/// Unix fixtures reached for `/usr/lib`; Windows has no such directory, so the
+/// canonical temp dir stands in on both.
+pub fn existing_dir() -> PathBuf {
+    std::fs::canonicalize(std::env::temp_dir()).expect("canonicalize temp dir")
+}
+
+/// Creates a nested directory tree under the canonical temp dir, encodes it
+/// exactly the way Claude Code encodes a cwd on this platform, and returns the
+/// encoded slug plus the root for cleanup.
+///
+/// Shared so fixtures needing a folder name that decodes to a real directory
+/// stop reaching for `/usr/lib`, which does not exist on Windows (#541).
+///
+/// Original note: creates a nested directory tree under the
+/// canonical temp dir, encodes it Claude-style, and returns the encoded
+/// slug plus the root for cleanup. Canonicalization is required because
+/// the decoder rejects symlinked path components (macOS `/var` →
+/// `/private/var`).
+pub fn make_encoded_path(root_name: &str, segments: &[&str]) -> (String, std::path::PathBuf) {
+    let root = std::fs::canonicalize(std::env::temp_dir())
+        .expect("canonicalize temp dir")
+        .join(root_name);
+    let mut deep = root.clone();
+    for s in segments {
+        deep = deep.join(s);
+    }
+    std::fs::create_dir_all(&deep).expect("create deep tmp dir");
+
+    // Windows `canonicalize` returns a verbatim path (`\\?\C:\...`). Claude
+    // Code never sees one of those - it encodes the plain `C:\...` cwd - so
+    // encoding it here would produce `--?-C--Users-...`, a shape that
+    // exists nowhere (#548).
+    let raw = deep.to_string_lossy();
+    let plain = raw
+        .strip_prefix(r"\\?\UNC\")
+        .map(|rest| format!(r"\\{rest}"))
+        .unwrap_or_else(|| raw.strip_prefix(r"\\?\").unwrap_or(&raw).to_string());
+
+    // Claude Code replaces every separator with `-`. On Windows the drive
+    // colon goes too, so `C:\Temp\x` becomes `C--Temp-x` - drive-lettered
+    // and, unlike Unix, with no leading dash. This helper used to leave the
+    // colon in place and force a leading dash, producing `-C:-Temp-x`,
+    // which is a shape Claude Code never writes (#548).
+    let encoded = plain.replace(['/', '\\', ':'], "-");
+    (encoded, root)
+}

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -386,12 +386,19 @@ pub fn make_encoded_path(root_name: &str, segments: &[&str]) -> (String, std::pa
 /// back `\\?\C:\...`, which Claude Code never sees, and encoding it would
 /// produce `--?-C--Users-...`, a shape that exists nowhere (#548).
 pub fn encode_path_claude_style(path: &std::path::Path) -> String {
+    strip_verbatim_prefix(path).replace(['/', '\\', ':'], "-")
+}
+
+/// The plain form of a path, without Windows' extended-length prefix.
+///
+/// `std::fs::canonicalize` returns `\\?\C:\...` on Windows. Almost nothing
+/// else produces that shape, so a fixture that canonicalises and then compares
+/// against a value built any other way will not match there (#541).
+pub fn strip_verbatim_prefix(path: &std::path::Path) -> String {
     let raw = path.to_string_lossy();
-    let plain = raw
-        .strip_prefix(r"\\?\UNC\")
+    raw.strip_prefix(r"\\?\UNC\")
         .map(|rest| format!(r"\\{rest}"))
-        .unwrap_or_else(|| raw.strip_prefix(r"\\?\").unwrap_or(&raw).to_string());
-    plain.replace(['/', '\\', ':'], "-")
+        .unwrap_or_else(|| raw.strip_prefix(r"\\?\").unwrap_or(&raw).to_string())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -765,6 +765,7 @@ fn collect_workflow_agent_files(workflows_dir: &Path, files: &mut Vec<std::path:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::make_encoded_path;
 
     // ===== par_map_bounded Tests =====
 
@@ -896,40 +897,6 @@ mod tests {
         // prefix unlikely to ever exist on any developer machine.
         let result = extract_project_name("-__cchv_definitely_missing_12345__-foo-bar-leafname");
         assert_eq!(result, "bar-leafname");
-    }
-
-    /// Helper for deep-path tests: creates a nested directory tree under the
-    /// canonical temp dir, encodes it Claude-style, and returns the encoded
-    /// slug plus the root for cleanup. Canonicalization is required because
-    /// the decoder rejects symlinked path components (macOS `/var` →
-    /// `/private/var`).
-    fn make_encoded_path(root_name: &str, segments: &[&str]) -> (String, std::path::PathBuf) {
-        let root = std::fs::canonicalize(std::env::temp_dir())
-            .expect("canonicalize temp dir")
-            .join(root_name);
-        let mut deep = root.clone();
-        for s in segments {
-            deep = deep.join(s);
-        }
-        std::fs::create_dir_all(&deep).expect("create deep tmp dir");
-
-        // Windows `canonicalize` returns a verbatim path (`\\?\C:\...`). Claude
-        // Code never sees one of those - it encodes the plain `C:\...` cwd - so
-        // encoding it here would produce `--?-C--Users-...`, a shape that
-        // exists nowhere (#548).
-        let raw = deep.to_string_lossy();
-        let plain = raw
-            .strip_prefix(r"\\?\UNC\")
-            .map(|rest| format!(r"\\{rest}"))
-            .unwrap_or_else(|| raw.strip_prefix(r"\\?\").unwrap_or(&raw).to_string());
-
-        // Claude Code replaces every separator with `-`. On Windows the drive
-        // colon goes too, so `C:\Temp\x` becomes `C--Temp-x` - drive-lettered
-        // and, unlike Unix, with no leading dash. This helper used to leave the
-        // colon in place and force a leading dash, producing `-C:-Temp-x`,
-        // which is a shape Claude Code never writes (#548).
-        let encoded = plain.replace(['/', '\\', ':'], "-");
-        (encoded, root)
     }
 
     #[test]
@@ -1129,12 +1096,21 @@ mod tests {
 
     #[test]
     fn test_decode_project_path_verified_resolves_existing_folder() {
-        // `/usr/lib` exists on macOS and Linux and contains no dashes, so the
-        // dash-decoder can resolve it against the real filesystem.
-        assert_eq!(
-            decode_project_path_verified("/Users/whoever/.claude/projects/-usr-lib"),
-            Some("/usr/lib".to_string())
-        );
+        // Built rather than borrowed: this used to point at `/usr/lib`, which
+        // exists on macOS and Linux and nowhere on Windows (#541).
+        let (encoded, root) = make_encoded_path("cchv_541_verified", &["leaf"]);
+        let storage = Path::new(".claude")
+            .join("projects")
+            .join(&encoded)
+            .to_string_lossy()
+            .into_owned();
+
+        let resolved =
+            decode_project_path_verified(&storage).and_then(|p| std::fs::canonicalize(p).ok());
+        let expected = std::fs::canonicalize(root.join("leaf")).expect("canonicalize fixture");
+        std::fs::remove_dir_all(&root).ok();
+
+        assert_eq!(resolved.as_deref(), Some(expected.as_path()));
     }
 
     #[test]

--- a/src-tauri/tests/kimi_provider_test.rs
+++ b/src-tauri/tests/kimi_provider_test.rs
@@ -16,7 +16,13 @@ fn kimi_provider_scans_projects_from_sessions_tree() {
     assert_eq!(project.name, "project-hash");
     assert_eq!(
         project.path,
-        format!("kimi://{}", base.join("sessions/project-hash").display())
+        // `join` per segment - a single `join("sessions/project-hash")` keeps
+        // the forward slash verbatim on Windows, while the value under test is
+        // built segment by segment (#541).
+        format!(
+            "kimi://{}",
+            base.join("sessions").join("project-hash").display()
+        )
     );
     assert_eq!(project.actual_path, "project-hash");
     assert_eq!(project.session_count, 2);


### PR DESCRIPTION
First pass at #541.

The dominant class: fixtures spelling absolute paths as Unix literals — `"/tmp/session.jsonl"`, `"/some/stale/Dev"`. **On Windows those are not absolute** (no drive), so the code under test rejected them with "path must be absolute" long before reaching the behaviour the test was about, and the assertion failed for the wrong reason.

Adds `test_utils::abs`, written Unix-style, producing `/tmp/x` or `C:\tmp\x` per host.

Two fixtures needed a directory that really exists and borrowed `/usr/lib`. Windows has none, so they build one now — `make_encoded_path` moves out of `utils.rs`'s test module into `test_utils`, since after #549 it encodes correctly for both platforms and two other modules want it.

`normalizes_windows_verbatim_path_prefix_for_root_comparison` asserted the mixed-case form while `normalize_path_for_comparison` **lowercases on Windows** — deliberately, documented on the function, because filesystem access there is case-insensitive and the allowlist boundary check has to match. A Windows-only test that had only ever run on Unix, where the `cfg` it covers is compiled out.

Also two separator-sensitive `contains("/sessions/")` checks in the codex tests, which cannot match a backslash path.

macOS 998 and 1043 green, clippy clean, fmt clean. **The Windows count is the point** — reporting it when the job finishes. Remaining classes (snapshots, the known-folder sandbox gap) are follow-ups on #541.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform reliability for path handling, including Windows compatibility.
  * Replaced system-specific paths with portable, platform-aware fixtures.
  * Corrected handling of Windows paths in session and provider data.
  * Added coverage for encoded project paths and platform-specific path casing.

* **Tests**
  * Centralized utilities for creating absolute, existing, and encoded paths.
  * Updated project scanning, session, provider, metadata, and path-traversal tests to use portable fixtures.
  * Improved snapshot coverage while preserving project path status validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->