### PR TITLE
fix(ci): lint the default feature set too, and canonicalise the sandbox home

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -54,7 +54,15 @@ jobs:
         working-directory: src-tauri
         run: cargo fmt --all -- --check
 
-      - name: Run Clippy
+      # Both feature sets. `--all-features` alone missed an
+      # `items_after_test_module` error that only the default set reported,
+      # because the feature-gated items around it change what follows the test
+      # module. Reported by @nightcityblade on #546.
+      - name: Run Clippy (default features)
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run Clippy (all features)
         working-directory: src-tauri
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -1017,7 +1017,12 @@ mod tests {
     /// `crate::utils::home_dir` made it say so (#540).
     fn isolated_home() -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().expect("temp home");
-        std::env::set_var("CCHV_TEST_HOME", dir.path());
+        // Canonicalised: on macOS the temp dir is handed back as `/var/...`
+        // while anything that canonicalises sees `/private/var/...`, so an
+        // uncanonicalised sandbox root silently fails to match.
+        // Spotted by @nightcityblade in #546.
+        let canonical = dir.path().canonicalize().expect("canonicalize temp home");
+        std::env::set_var("CCHV_TEST_HOME", canonical);
         dir
     }
 
@@ -1651,7 +1656,10 @@ mod tests {
     #[test]
     fn test_validate_claude_path_valid_path() {
         let home = isolated_home();
-        let (_base, session_path) = make_claude_dir(&home.path().join(".claude"), "session-1");
+        // `real_temp_root` because the sandbox root is canonicalised - see
+        // `isolated_home`.
+        let (_base, session_path) =
+            make_claude_dir(&real_temp_root(&home).join(".claude"), "session-1");
 
         let result = validate_claude_path(&session_path);
 
@@ -1761,7 +1769,7 @@ mod tests {
         // when that home had no `.claude`, or had one behind a symlink - two
         // ways to report `ok` without checking anything (#545).
         let home = isolated_home();
-        let default_root = home.path().join(".claude");
+        let default_root = real_temp_root(&home).join(".claude");
 
         let roots = resolve_claude_roots(&[]);
 

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -5412,7 +5412,12 @@ mod tests {
     /// (#540).
     fn isolated_home() -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().expect("temp home");
-        std::env::set_var("CCHV_TEST_HOME", dir.path());
+        // Canonicalised: on macOS the temp dir is handed back as `/var/...`
+        // while anything that canonicalises sees `/private/var/...`, so an
+        // uncanonicalised sandbox root silently fails to match.
+        // Spotted by @nightcityblade in #546.
+        let canonical = dir.path().canonicalize().expect("canonicalize temp home");
+        std::env::set_var("CCHV_TEST_HOME", canonical);
         dir
     }
     use serde_json::json;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -314,43 +314,6 @@ fn run_tauri() {
         });
 }
 
-#[cfg(test)]
-mod ime_environment_tests {
-    use super::linux_ime_environment_updates;
-
-    #[test]
-    fn linux_ime_environment_sets_missing_ibus_variables_when_ibus_is_available() {
-        let updates = linux_ime_environment_updates(None, None, Some("unix:path=/tmp/ibus"));
-
-        assert_eq!(
-            updates,
-            vec![("GTK_IM_MODULE", "ibus"), ("XMODIFIERS", "@im=ibus"),]
-        );
-    }
-
-    #[test]
-    fn linux_ime_environment_preserves_existing_values() {
-        let updates =
-            linux_ime_environment_updates(Some("custom-gtk"), Some("@im=custom"), Some("ibus"));
-
-        assert!(updates.is_empty());
-    }
-
-    #[test]
-    fn linux_ime_environment_uses_existing_ibus_values_as_signal() {
-        let updates = linux_ime_environment_updates(Some("ibus"), None, None);
-
-        assert_eq!(updates, vec![("XMODIFIERS", "@im=ibus")]);
-    }
-
-    #[test]
-    fn linux_ime_environment_does_nothing_without_ibus_signal() {
-        let updates = linux_ime_environment_updates(None, None, None);
-
-        assert!(updates.is_empty());
-    }
-}
-
 #[cfg(target_os = "linux")]
 fn configure_linux_ime_environment() {
     // configure_linux_ime_environment runs during process startup before Tauri
@@ -401,6 +364,43 @@ fn linux_ime_environment_updates(
     }
 
     updates
+}
+
+#[cfg(test)]
+mod ime_environment_tests {
+    use super::linux_ime_environment_updates;
+
+    #[test]
+    fn linux_ime_environment_sets_missing_ibus_variables_when_ibus_is_available() {
+        let updates = linux_ime_environment_updates(None, None, Some("unix:path=/tmp/ibus"));
+
+        assert_eq!(
+            updates,
+            vec![("GTK_IM_MODULE", "ibus"), ("XMODIFIERS", "@im=ibus"),]
+        );
+    }
+
+    #[test]
+    fn linux_ime_environment_preserves_existing_values() {
+        let updates =
+            linux_ime_environment_updates(Some("custom-gtk"), Some("@im=custom"), Some("ibus"));
+
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn linux_ime_environment_uses_existing_ibus_values_as_signal() {
+        let updates = linux_ime_environment_updates(Some("ibus"), None, None);
+
+        assert_eq!(updates, vec![("XMODIFIERS", "@im=ibus")]);
+    }
+
+    #[test]
+    fn linux_ime_environment_does_nothing_without_ibus_signal() {
+        let updates = linux_ime_environment_updates(None, None, None);
+
+        assert!(updates.is_empty());
+    }
 }
 
 /// Run the Axum-based `WebUI` server (headless mode).


### PR DESCRIPTION
Both findings are @nightcityblade's, from the notes on #546. Credited in the code and the commit.

## CI only ever linted one feature set

The lint job runs `cargo clippy --all-targets --all-features`, and nothing else. With the **default** feature set, `src/lib.rs` reports `items_after_test_module`: `mod ime_environment_tests` sits above the items it tests, and which items follow it depends on the `cfg(feature)` gates around them — so the all-features build happened not to trip it.

I dismissed the report initially because my own `--all-features` run was clean. Measuring the default set:

```
plain:    2 errors
all-feat: 0 errors
```

The test module moves below `linux_ime_environment_updates`, and the lint job now runs **both** sets. Same lesson as installing nextest for #544 — if CI exercises one configuration, that is the only one anyone is checking.

## The sandbox root was not canonicalised

`isolated_home` exported `CCHV_TEST_HOME` as `TempDir::path()`. On macOS that is `/var/folders/…` while anything that canonicalises sees `/private/var/folders/…`:

```
raw      : /var/folders/w8/…/tmp51t0ssyz
canonical: /private/var/folders/w8/…/tmp51t0ssyz
diverges : True
```

So the sandbox root silently failed to match wherever a comparison ran through `canonicalize`. It happened not to bite in the tests as written, but it is a trap waiting for the next one.

Canonicalised now in both `isolated_home` definitions. Two rename tests compared against the raw path and needed `real_temp_root`, which already existed for exactly this reason.

Both feature sets: 998 and 1043 green, clippy clean, fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for environments where temporary directories use alternate or symlinked paths.
  - Expanded lint validation to check both standard and optional feature configurations.
  - Strengthened path-related checks across session and statistics functionality.

- **Refactor**
  - Reorganized internal test placement without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->