### PR TITLE
fix(release): do not gate publishing on the Homebrew tap sync

### DIFF
--- a/.github/workflows/updater-release.yml
+++ b/.github/workflows/updater-release.yml
@@ -433,7 +433,14 @@ jobs:
               data: JSON.stringify(latestJson, null, 2)
             });
 
+      # Never blocks the release. The tap lives in another repository and this
+      # step is a plain API round-trip, so a transient 5xx there skipped
+      # "Publish release" below and left a fully built, fully signed release
+      # sitting as a draft - which is exactly what happened on v1.26.1. The
+      # cask can be re-synced by re-running the job; the release should not
+      # be held hostage to it.
       - name: Sync Homebrew tap cask
+        continue-on-error: true
         uses: actions/github-script@v7
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
Found by shipping v1.26.1 an hour after fixing #532.

## What happened

All three platforms built and signed, all 18 assets uploaded, `latest.json` generated — and the release stayed a **draft**.

```
success  Generate and upload latest.json
failure  Sync Homebrew tap cask     <- HttpError 500 from api.github.com
skipped  Publish release
```

A transient 5xx on a `getRelease` call, in a step that updates a cask in a *different* repository, skipped the step that publishes the release. Re-running the failed job fixed it, but until someone noticed, a complete signed release was invisible to users and to the updater.

## The change

`continue-on-error: true` on the tap sync. It is a courtesy to one install path; it should not decide whether the release exists. A flaky round-trip now leaves the cask stale — recoverable by re-running the job, and the verify step already checks the published cask version — instead of leaving the release unpublished.

## Why this is the same bug as #532

Both are a single transient failure with no recovery except manual intervention:

| | trigger | old recovery |
|---|---|---|
| #532 | tag event dropped during an Actions outage | delete and re-push a published tag |
| this | 5xx from the GitHub API | notice the draft, re-run the job |

The v1.26.0 release hit the first. The v1.26.1 release hit the second, one hour after the first was fixed. The release path had two single points of failure and no one had run into them close enough together to see the pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release publication can now continue when Homebrew tap synchronization encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->