### PR TITLE
fix(tests): sandbox the antigravity home, and share one guard

### DIFF
--- a/src-tauri/src/commands/antigravity.rs
+++ b/src-tauri/src/commands/antigravity.rs
@@ -35,7 +35,10 @@ static MODEL_ALIAS_MAP: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(||
 
 /// 定位 antigravity 根目录：`~/.gemini/antigravity`
 pub fn get_antigravity_root() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".gemini").join("antigravity"))
+    // Sandboxed helper, not `dirs::home_dir()`: on Windows the latter goes to
+    // the known-folder API and ignores `HOME`, so a test pointing `HOME` at a
+    // fixture was silently scanning the developer's real one (#551).
+    crate::utils::home_dir().map(|h| h.join(".gemini").join("antigravity"))
 }
 
 /// Resolves the antigravity root directory, with fallback discovery logic.
@@ -110,7 +113,7 @@ pub fn get_antigravity_rpc_cache_root(root: &Path) -> PathBuf {
 fn discover_external_state_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     let bases = if cfg!(target_os = "macos") {
-        dirs::home_dir()
+        crate::utils::home_dir()
             .map(|home| vec![home.join("Library").join("Application Support")])
             .unwrap_or_default()
     } else if cfg!(target_os = "windows") {
@@ -120,7 +123,7 @@ fn discover_external_state_dirs() -> Vec<PathBuf> {
         if let Some(config_dir) = dirs::config_dir() {
             candidates.push(config_dir);
         }
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = crate::utils::home_dir() {
             let fallback = home.join(".config");
             if !candidates.iter().any(|candidate| candidate == &fallback) {
                 candidates.push(fallback);
@@ -986,6 +989,7 @@ mod tests {
     use crate::models::{
         PersistedSessionState, SessionLifecycle, SessionLifecycleStatus, SessionTotals,
     };
+    use serial_test::serial;
     use tempfile::TempDir;
 
     fn make_session(
@@ -1183,7 +1187,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_load_antigravity_state_impl_missing_dir() {
+        let _home = crate::test_utils::SandboxHome::new();
         let state = load_antigravity_state_impl(Path::new("/nonexistent/path/xyz")).unwrap();
         assert!(state.sessions.is_empty());
     }
@@ -1231,7 +1237,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_antigravity_root_from_path_returns_none_when_marker_absent() {
+        let _home = crate::test_utils::SandboxHome::new();
         // A temp directory that has none of the antigravity layout
         // (no `.token-monitor/rpc-cache/v1`) and is outside the default
         // root must NOT resolve to anything — the function used to fall
@@ -1249,7 +1257,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_antigravity_root_from_path_finds_marker_in_parent() {
+        let _home = crate::test_utils::SandboxHome::new();
         // Sanity check that the happy path (the supplied path lives
         // under a directory that has the `.token-monitor/rpc-cache/v1`
         // marker) still resolves to that root.
@@ -1345,7 +1355,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_get_antigravity_project_summary_uses_explicit_root_path() {
+        let _home = crate::test_utils::SandboxHome::new();
         let dir = TempDir::new().unwrap();
         let root = dir.path();
         let rpc_dir = root

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -6645,7 +6645,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_antigravity_conversation_breakdown_uses_chat_message_tokens() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         // resolve_usage_jsonl_path validates the canonical session_path is
         // under a marker-rooted antigravity root before reading. Create the
@@ -7390,7 +7392,9 @@ mod tests {
     /// `providers::antigravity::load_messages` so a brain/-only session whose
     /// `usage.jsonl` lives in the rpc-cache contributes records (and therefore
     /// tokens) to per-session / project / global stats.
+    #[serial]
     fn test_load_antigravity_usage_records_falls_back_to_rpc_cache() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let root = temp_dir.path();
         let rpc_v1 = root
@@ -7444,7 +7448,9 @@ mod tests {
     #[test]
     /// When neither in-session nor rpc-cache `usage.jsonl` exists, the helper
     /// returns `Ok(vec![])` (legacy behaviour preserved).
+    #[serial]
     fn test_load_antigravity_usage_records_returns_empty_when_missing() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let root = temp_dir.path();
         fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1"))

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -830,20 +830,26 @@ mod tests {
         // CLI layout next to it.
         write_cli_fixture(home.path());
 
+        // Derived from the same value the fixture writes. Hardcoding
+        // `/tmp/cli-proj` here left the expectation Unix-shaped while the
+        // fixture had already moved to a host-appropriate absolute path, so
+        // this looked like a missing project on Windows (#541).
+        let cli_workspace = format!(
+            "antigravity-cli://{}",
+            crate::test_utils::abs("tmp/cli-proj")
+        );
+
         let projects = scan_projects().expect("scan projects");
         assert!(
             projects.iter().any(|p| p.name == "Antigravity"),
             "desktop project missing from {projects:?}"
         );
         assert!(
-            projects
-                .iter()
-                .any(|p| p.path == "antigravity-cli:///tmp/cli-proj"),
+            projects.iter().any(|p| p.path == cli_workspace),
             "cli project missing from {projects:?}"
         );
 
-        let cli_sessions =
-            load_sessions("antigravity-cli:///tmp/cli-proj", false).expect("cli sessions");
+        let cli_sessions = load_sessions(&cli_workspace, false).expect("cli sessions");
         assert_eq!(cli_sessions.len(), 1);
         assert_eq!(cli_sessions[0].session_id, "conv-cli");
         assert_eq!(cli_sessions[0].provider.as_deref(), Some("antigravity"));

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -768,34 +768,6 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
-    /// Saves/restores `HOME` around a test so both the desktop root and the
-    /// CLI root resolve under a fresh `TempDir` rather than the real user
-    /// home. `HOME` is process-global; combined with `#[serial]` so these
-    /// tests don't race other HOME-touching tests.
-    struct HomeGuard {
-        original: Option<String>,
-    }
-    impl HomeGuard {
-        fn set(path: &std::path::Path) -> Self {
-            let original = std::env::var("HOME").ok();
-            std::env::set_var("HOME", path);
-            // `HOME` alone is inert on Windows, where `dirs::home_dir()` uses
-            // the known-folder API. `crate::utils::home_dir()` reads this
-            // instead under `cfg(test)`, and panics without it (#540).
-            std::env::set_var("CCHV_TEST_HOME", path);
-            Self { original }
-        }
-    }
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            std::env::remove_var("CCHV_TEST_HOME");
-            match self.original.as_ref() {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-    }
-
     /// Writes a minimal antigravity-cli fixture (index + one transcript)
     /// under `<home>/.gemini/antigravity-cli` and returns the session dir.
     fn write_cli_fixture(home: &std::path::Path) -> std::path::PathBuf {
@@ -839,11 +811,12 @@ mod tests {
     /// store: `scan_projects` must surface both layouts, without id
     /// collisions between their sessions.
     fn scan_projects_merges_desktop_and_cli_layouts() {
-        let temp = TempDir::new().expect("temp dir");
-        let _guard = HomeGuard::set(temp.path());
+        // Fixtures go inside the sandbox root, not a second temp dir - the
+        // code under test resolves them through the home the guard exports.
+        let home = crate::test_utils::SandboxHome::new();
 
         // Desktop layout: one rpc-cache session with a usage record.
-        let desktop_session = temp
+        let desktop_session = home
             .path()
             .join(".gemini")
             .join("antigravity")
@@ -855,7 +828,7 @@ mod tests {
         make_usage_file(&desktop_session, "session-desktop", "claude-opus-4-5");
 
         // CLI layout next to it.
-        write_cli_fixture(temp.path());
+        write_cli_fixture(home.path());
 
         let projects = scan_projects().expect("scan projects");
         assert!(
@@ -882,9 +855,8 @@ mod tests {
     /// `~/.gemini/antigravity-cli/brain/`) to the transcript parser instead
     /// of the desktop usage.jsonl reader.
     fn load_messages_routes_cli_session_paths() {
-        let temp = TempDir::new().expect("temp dir");
-        let _guard = HomeGuard::set(temp.path());
-        let session_dir = write_cli_fixture(temp.path());
+        let home = crate::test_utils::SandboxHome::new();
+        let session_dir = write_cli_fixture(home.path());
 
         let messages = load_messages(&session_dir.to_string_lossy()).expect("load cli messages");
 
@@ -900,9 +872,8 @@ mod tests {
     /// Content search must cover CLI transcripts too — the desktop layout
     /// only matches session metadata.
     fn search_covers_cli_transcript_content() {
-        let temp = TempDir::new().expect("temp dir");
-        let _guard = HomeGuard::set(temp.path());
-        write_cli_fixture(temp.path());
+        let home = crate::test_utils::SandboxHome::new();
+        write_cli_fixture(home.path());
 
         let results = search("wire the cli", 10).expect("search");
         assert_eq!(results.len(), 1);
@@ -1189,7 +1160,9 @@ mod tests {
 
     #[test]
     /// Direct `<session_path>/usage.jsonl` is returned when it exists.
+    #[serial]
     fn test_resolve_usage_jsonl_path_prefers_in_session_file() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path();
         std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();
@@ -1216,7 +1189,9 @@ mod tests {
     /// antigravity root must NOT resolve to a readable `usage.jsonl`. Pre-fix
     /// behaviour: `dir.join("usage.jsonl")` would follow the symlink and read
     /// the attacker-controlled target.
+    #[serial]
     fn test_resolve_usage_jsonl_path_rejects_symlink_escaping_root() {
+        let _home = crate::test_utils::SandboxHome::new();
         // "Inside" tree — a legitimate antigravity root.
         let inside = TempDir::new().unwrap();
         std::fs::create_dir_all(
@@ -1258,7 +1233,9 @@ mod tests {
     /// A symlinked `usage.jsonl` (file-level, not directory-level) inside a
     /// legitimate session directory must be rejected. `Path::exists()` would
     /// follow the symlink — `admit_usage_jsonl` does not.
+    #[serial]
     fn test_resolve_usage_jsonl_path_rejects_symlinked_usage_jsonl() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path();
         std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();
@@ -1285,7 +1262,9 @@ mod tests {
     /// The same symlink-file defense must apply to the rpc-cache fallback so
     /// a symlinked `usage.jsonl` dropped into `<root>/.token-monitor/...`
     /// cannot redirect the read.
+    #[serial]
     fn test_resolve_usage_jsonl_path_rejects_symlinked_usage_jsonl_in_rpc_cache() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path();
         let rpc_session = root
@@ -1314,7 +1293,9 @@ mod tests {
     /// When `<session_path>/usage.jsonl` is absent, fall back to the rpc-cache
     /// location — matching what `load_messages` already does for brain/-only
     /// sessions.
+    #[serial]
     fn test_resolve_usage_jsonl_path_falls_back_to_rpc_cache() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path();
         let rpc_v1 = root.join(".token-monitor").join("rpc-cache").join("v1");
@@ -1338,7 +1319,9 @@ mod tests {
     #[test]
     /// Returns `None` when neither the in-session nor the rpc-cache file
     /// exists — callers should treat this as "no records".
+    #[serial]
     fn test_resolve_usage_jsonl_path_returns_none_when_missing_everywhere() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path();
         std::fs::create_dir_all(root.join(".token-monitor").join("rpc-cache").join("v1")).unwrap();

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -9,7 +9,7 @@ use crate::models::*;
 use serde_json::json;
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 // Re-export commonly used test utilities
@@ -399,6 +399,75 @@ pub fn strip_verbatim_prefix(path: &std::path::Path) -> String {
     raw.strip_prefix(r"\\?\UNC\")
         .map(|rest| format!(r"\\{rest}"))
         .unwrap_or_else(|| raw.strip_prefix(r"\\?\").unwrap_or(&raw).to_string())
+}
+
+/// A temporary home directory, exported to the process for the lifetime of the
+/// value and restored on drop.
+///
+/// Sets both `HOME` and `CCHV_TEST_HOME`: the first is what `dirs::home_dir()`
+/// reads on Unix, the second is what `crate::utils::home_dir()` reads under
+/// `cfg(test)` and what works on Windows, where the known-folder API ignores
+/// `HOME` entirely.
+///
+/// Two things this does that the per-module guards it replaces did not:
+///
+/// - the path is canonicalised, because on macOS the temp dir is handed back as
+///   `/var/...` while anything resolving it sees `/private/var/...`
+/// - the previous values are *restored*, not dropped. Leaving `CCHV_TEST_HOME`
+///   set leaks the sandbox into every later test in the same process, which is
+///   precisely what hid nine unsandboxed tests until CI ran them under nextest
+///   with a process each (#544).
+///
+/// Both env vars are process-global, so tests holding one need `#[serial]`.
+pub struct SandboxHome {
+    dir: TempDir,
+    canonical: PathBuf,
+    previous_home: Option<std::ffi::OsString>,
+    previous_test_home: Option<std::ffi::OsString>,
+}
+
+impl SandboxHome {
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("temp home");
+        let canonical = dir.path().canonicalize().expect("canonicalize temp home");
+        let previous_home = std::env::var_os("HOME");
+        let previous_test_home = std::env::var_os("CCHV_TEST_HOME");
+        std::env::set_var("HOME", &canonical);
+        std::env::set_var("CCHV_TEST_HOME", &canonical);
+        Self {
+            dir,
+            canonical,
+            previous_home,
+            previous_test_home,
+        }
+    }
+
+    /// The sandbox root, canonicalised — compare fixtures against this, not
+    /// against a `TempDir::path()` captured elsewhere.
+    pub fn path(&self) -> &Path {
+        &self.canonical
+    }
+}
+
+impl Default for SandboxHome {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for SandboxHome {
+    fn drop(&mut self) {
+        let _ = &self.dir;
+        for (key, previous) in [
+            ("HOME", &self.previous_home),
+            ("CCHV_TEST_HOME", &self.previous_test_home),
+        ] {
+            match previous {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -429,7 +429,14 @@ pub struct SandboxHome {
 impl SandboxHome {
     pub fn new() -> Self {
         let dir = TempDir::new().expect("temp home");
-        let canonical = dir.path().canonicalize().expect("canonicalize temp home");
+        // Canonicalised so macOS `/var/...` resolves to `/private/var/...`, then
+        // stripped of the Windows extended-length prefix that canonicalising
+        // adds there. Leaving the `\\?\` form in place exports a home that
+        // code comparing plain paths cannot match - the antigravity CLI root
+        // went missing on Windows for exactly that reason.
+        let canonical = PathBuf::from(strip_verbatim_prefix(
+            &dir.path().canonicalize().expect("canonicalize temp home"),
+        ));
         let previous_home = std::env::var_os("HOME");
         let previous_test_home = std::env::var_os("CCHV_TEST_HOME");
         std::env::set_var("HOME", &canonical);


### PR DESCRIPTION
First module of #551. Picked first because two of #541's four remaining Windows failures are here.

## The gap

`commands::antigravity` resolved `dirs::home_dir()` at three sites. On Windows that goes to the known-folder API and consults neither `HOME` nor `CCHV_TEST_HOME`, so every test pointing `HOME` at a fixture was quietly scanning the developer's real home and asserting against an empty scan.

Converting it cascades into **thirteen** tests that reach the root with no sandbox of their own — which is why I reverted this out of #550 rather than riding it along.

## One guard instead of a seventh copy

There were already six guard definitions across the repo (`pi`, `openinterpreter`, `ompi`, `antigravity`, `stats`, `rename`), all slightly different. This adds `test_utils::SandboxHome` and migrates `providers::antigravity` onto it, deleting the local `HomeGuard`.

Two things the per-module guards did not do:

- **canonicalises** the path — on macOS the temp dir comes back as `/var/…` while anything resolving it sees `/private/var/…`. That is @nightcityblade's observation from #546, now applied at the source rather than patched per guard.
- **restores** the previous values rather than dropping them. Leaving `CCHV_TEST_HOME` set leaks the sandbox forward into every later test in the same process — which is precisely what hid nine unsandboxed tests until CI ran them under nextest with a process each (#544).

Five definitions remain; they migrate as their modules are converted.

## Verification

| path | result |
|---|---|
| `cargo test -- --test-threads=1` (release checklist) | 1043 / 0 failed |
| `cargo nextest run --profile ci` | 998 passed |
| `… --features webui-server` | 1043 passed |
| clippy, both feature sets | clean |

## One thing not fixed, stated plainly

Plain `cargo test` with **default parallelism** is not green — and I made it worse.

```
develop:    1010 passed, 15 failed
this branch: 1002 passed, 23 failed
```

`#[serial]` only orders serial tests against each other; untagged tests still run alongside them, so adding thirteen more HOME mutators widens the window. develop is already broken there for the same reason.

That configuration is neither the CI path (nextest, process per test) nor the release path (`--test-threads=1`), and it only closes properly when every HOME-toucher is tagged — which is the end state #551 describes. Flagging it rather than leaving it to be discovered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home-directory detection so configured `HOME` locations are honored consistently across platforms.
  * Prevented usage and statistics data from being read from unintended local directories.
  * Improved reliability when loading usage records and conversation statistics from configured locations.

* **Tests**
  * Improved test isolation by using temporary home directories.
  * Reduced test interference when running home-directory and usage-related tests in parallel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->