### PR TITLE
fix(tests): route the provider layer through the sandboxed home

### DIFF
--- a/src-tauri/src/commands/session/delete.rs
+++ b/src-tauri/src/commands/session/delete.rs
@@ -97,6 +97,7 @@ pub async fn delete_session(file_path: String) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;
@@ -162,7 +163,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn trash_valid_jsonl_file() {
+        let _home = crate::test_utils::SandboxHome::new();
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("abc-123.jsonl");
         fs::write(&file, "{}\n").unwrap();
@@ -172,7 +175,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn trash_jsonl_and_associated_directory() {
+        let _home = crate::test_utils::SandboxHome::new();
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("session-1.jsonl");
         let assoc_dir = dir.path().join("session-1");

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -168,6 +168,7 @@ mod tests {
     #[test]
     #[serial]
     fn accepts_session_under_symlinked_claude_root() {
+        let _home = crate::test_utils::SandboxHome::new();
         let tmp = tempfile::tempdir().expect("tempdir");
         let home = tmp.path();
         let store_projects = home.join(".claude-store").join("projects").join("proj");
@@ -192,6 +193,7 @@ mod tests {
     #[test]
     #[serial]
     fn rejects_session_outside_allowlist() {
+        let _home = crate::test_utils::SandboxHome::new();
         let tmp = tempfile::tempdir().expect("tempdir");
         let home = tmp.path();
         std::fs::create_dir_all(home.join(".claude").join("projects")).expect("mk claude");
@@ -211,11 +213,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_safe_session_path_allows_kimi_sessions() {
-        let temp = TempDir::new().unwrap();
-        let old_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", temp.path());
+        // The guard owns `HOME`; the fixture goes inside it. This used to
+        // save/restore `HOME` around its own `TempDir`, which leaves
+        // `CCHV_TEST_HOME` pointing somewhere else entirely - the path the
+        // code under test actually resolves.
+        let home = crate::test_utils::SandboxHome::new();
 
-        let session_dir = temp
+        let session_dir = home
             .path()
             .join(".kimi")
             .join("sessions")
@@ -227,18 +231,13 @@ mod tests {
 
         let result = is_safe_session_path(&session_file);
 
-        if let Some(home) = old_home {
-            std::env::set_var("HOME", home);
-        } else {
-            std::env::remove_var("HOME");
-        }
-
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "kimi session rejected: {result:?}");
     }
 
     #[test]
     #[serial]
     fn test_safe_session_path_allows_custom_kimi_home() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = TempDir::new().unwrap();
         let old_kimi_home = std::env::var_os("KIMI_HOME");
         std::env::set_var("KIMI_HOME", temp.path());
@@ -288,6 +287,7 @@ mod tests {
     #[test]
     #[serial]
     fn safe_session_path_allows_codex_home_sessions() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::tempdir().unwrap();
         let codex_home = temp.path().join("custom-codex");
         let sessions = codex_home.join("sessions");
@@ -303,6 +303,7 @@ mod tests {
     #[test]
     #[serial]
     fn safe_session_path_allows_codex_home_archived_sessions() {
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::tempdir().unwrap();
         let codex_home = temp.path().join("custom-codex");
         let archived_sessions = codex_home.join("archived_sessions");

--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -1007,25 +1007,6 @@ mod tests {
     use super::*;
 
     /// Points home resolution at an empty temp directory for the duration of a
-    /// test.
-    ///
-    /// These tests assert on rejection paths and want nothing from the home
-    /// directory, but the code under test reaches it — `configured_claude_dirs`
-    /// reads `~/.claude-history-viewer/user-data.json` and honours the custom
-    /// Claude paths registered there. That made the allowlist depend on the
-    /// developer's own machine, silently, until the sandbox in
-    /// `crate::utils::home_dir` made it say so (#540).
-    fn isolated_home() -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("temp home");
-        // Canonicalised: on macOS the temp dir is handed back as `/var/...`
-        // while anything that canonicalises sees `/private/var/...`, so an
-        // uncanonicalised sandbox root silently fails to match.
-        // Spotted by @nightcityblade in #546.
-        let canonical = dir.path().canonicalize().expect("canonicalize temp home");
-        std::env::set_var("CCHV_TEST_HOME", canonical);
-        dir
-    }
-
     fn sample_rename_test_user(session_id: &str, uuid: &str, content: &str) -> String {
         serde_json::json!({
             "parentUuid": Value::Null,
@@ -1621,7 +1602,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_rejects_relative_path() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let result = validate_claude_path("relative/path/file.jsonl");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be absolute"));
@@ -1629,7 +1610,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_rejects_invalid_filename() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         // Filename with dots should be rejected by regex
         let result = validate_claude_path("/etc/passwd");
         assert!(result.is_err());
@@ -1638,7 +1619,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_rejects_non_claude_directory() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         // Use a path with valid filename but wrong directory
         let result = validate_claude_path("/tmp/validfilename.jsonl");
         assert!(result.is_err());
@@ -1655,11 +1636,8 @@ mod tests {
     /// run, it asserted against whichever file happened to be enumerated first.
     #[test]
     fn test_validate_claude_path_valid_path() {
-        let home = isolated_home();
-        // `real_temp_root` because the sandbox root is canonicalised - see
-        // `isolated_home`.
-        let (_base, session_path) =
-            make_claude_dir(&real_temp_root(&home).join(".claude"), "session-1");
+        let home = crate::test_utils::SandboxHome::new();
+        let (_base, session_path) = make_claude_dir(&home.path().join(".claude"), "session-1");
 
         let result = validate_claude_path(&session_path);
 
@@ -1671,7 +1649,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_nonexistent_file() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         // Nonexistent file should fail at canonicalize
         let result = validate_claude_path("/nonexistent/path/to/file.jsonl");
         assert!(result.is_err());
@@ -1696,7 +1674,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_accepts_registered_custom_directory() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::TempDir::new().unwrap();
         let custom_base = real_temp_root(&temp).join(".claude-holophonix");
         fs::create_dir_all(&custom_base).unwrap();
@@ -1711,7 +1689,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_directory_that_is_not_registered() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::TempDir::new().unwrap();
         let unregistered = real_temp_root(&temp).join(".claude-other");
         fs::create_dir_all(&unregistered).unwrap();
@@ -1728,7 +1706,7 @@ mod tests {
 
     #[test]
     fn resolve_claude_roots_skips_directory_without_projects_subdir() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::TempDir::new().unwrap();
         let bogus = real_temp_root(&temp).join(".claude-bogus");
         fs::create_dir_all(&bogus).unwrap(); // no projects/ inside
@@ -1743,7 +1721,7 @@ mod tests {
 
     #[test]
     fn resolve_claude_roots_skips_symlinked_custom_directory() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::TempDir::new().unwrap();
         let real_base = real_temp_root(&temp).join("real-claude");
         fs::create_dir_all(real_base.join("projects")).unwrap();
@@ -1768,8 +1746,8 @@ mod tests {
         // resolve the developer's real home and skip the assertion entirely
         // when that home had no `.claude`, or had one behind a symlink - two
         // ways to report `ok` without checking anything (#545).
-        let home = isolated_home();
-        let default_root = real_temp_root(&home).join(".claude");
+        let home = crate::test_utils::SandboxHome::new();
+        let default_root = home.path().join(".claude");
 
         let roots = resolve_claude_roots(&[]);
 
@@ -1801,7 +1779,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_non_jsonl_extension() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
         let project_dir = root.join("projects").join("-proj");
@@ -1855,7 +1833,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_accepts_symlinked_project_directory() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         // Mirrors the shared-sessions layout: a project directory under
         // <root>/projects is a symlink into a real directory elsewhere (e.g.
         // /Users/Shared/.claude/projects). The session file is a real file.
@@ -1886,7 +1864,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_symlink_below_project_directory() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         // A symlink deeper than the project directory is not allowed.
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
@@ -1914,7 +1892,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_symlinked_session_file() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         // The session file itself must be a real file, not a symlink.
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
@@ -1938,7 +1916,7 @@ mod tests {
 
     #[test]
     fn validate_claude_path_rejects_path_traversal_under_projects() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let temp = tempfile::TempDir::new().unwrap();
         let root = real_temp_root(&temp).join(".claude");
         fs::create_dir_all(root.join("projects")).unwrap();
@@ -1959,7 +1937,7 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_filename_with_special_chars() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         // Test filename validation with various invalid characters
         if let Some(home) = dirs::home_dir() {
             let claude_dir = home.join(".claude/projects");

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -6621,7 +6621,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_kimi_project_name_resolves_from_session_parent_directory() {
+        let _home = crate::test_utils::SandboxHome::new();
         let session_path = "/tmp/kimi/sessions/project-hash/session-1";
 
         assert_eq!(
@@ -6631,7 +6633,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_kimi_code_project_name_falls_back_to_workspace_directory() {
+        let _home = crate::test_utils::SandboxHome::new();
         // When the store is not scannable (no ~/.kimi-code on this machine,
         // or the workspace was removed), the name falls back to the last
         // path segment — which requires stripping the kimi-code scheme.

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -5410,16 +5410,6 @@ mod tests {
     /// while classifying a path, so the result depended on the developer's own
     /// machine until the sandbox in `crate::utils::home_dir` made it say so
     /// (#540).
-    fn isolated_home() -> tempfile::TempDir {
-        let dir = tempfile::TempDir::new().expect("temp home");
-        // Canonicalised: on macOS the temp dir is handed back as `/var/...`
-        // while anything that canonicalises sees `/private/var/...`, so an
-        // uncanonicalised sandbox root silently fails to match.
-        // Spotted by @nightcityblade in #546.
-        let canonical = dir.path().canonicalize().expect("canonicalize temp home");
-        std::env::set_var("CCHV_TEST_HOME", canonical);
-        dir
-    }
     use serde_json::json;
     use serial_test::serial;
     use std::ffi::OsString;
@@ -6050,7 +6040,7 @@ mod tests {
     #[test]
     /// Verify detect project provider from virtual prefix.
     fn test_detect_project_provider_from_virtual_prefix() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         assert_eq!(
             detect_project_provider("codex:///Users/jack/workspace"),
             StatsProvider::Codex
@@ -6120,7 +6110,7 @@ mod tests {
     #[test]
     /// Verify detect session provider from path pattern.
     fn test_detect_session_provider_from_path_pattern() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         assert_eq!(
             detect_session_provider("forgecode://workspace/ws-1/conversation/conv-1"),
             StatsProvider::ForgeCode
@@ -6195,7 +6185,7 @@ mod tests {
     #[test]
     #[serial]
     fn detect_session_provider_uses_copilot_cli_home_env() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let tmp = TempDir::new().unwrap();
         let events_path = tmp
             .path()
@@ -7304,7 +7294,7 @@ mod tests {
 
     #[test]
     fn test_antigravity_provider_project_summary_uses_mode_adjusted_daily_tokens() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let root = temp_dir.path();
         let session_dir = root
@@ -7740,7 +7730,7 @@ mod tests {
     #[serial]
     /// Verify forgecode stats commands use provider paths.
     async fn test_forgecode_stats_commands_use_provider_paths() {
-        let _home = isolated_home();
+        let _home = crate::test_utils::SandboxHome::new();
         let forge_dir = TempDir::new().expect("failed to create forge temp dir");
         write_forgecode_test_db(forge_dir.path());
 

--- a/src-tauri/src/providers/aider.rs
+++ b/src-tauri/src/providers/aider.rs
@@ -236,7 +236,7 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
 
 fn get_search_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = crate::utils::home_dir() {
         for subdir in ["client", "projects", "code", "src", "dev", "work", "repos"] {
             let d = home.join(subdir);
             if d.is_dir() {

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -2,7 +2,7 @@ use super::ProviderInfo;
 
 /// Detect Claude Code installation
 pub fn detect() -> Option<ProviderInfo> {
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let claude_path = home.join(".claude");
     let projects_path = claude_path.join("projects");
 
@@ -16,7 +16,7 @@ pub fn detect() -> Option<ProviderInfo> {
 
 /// Get the Claude base path (~/.claude)
 pub fn get_base_path() -> Option<String> {
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let claude_path = home.join(".claude");
     if claude_path.exists() {
         Some(claude_path.to_string_lossy().to_string())

--- a/src-tauri/src/providers/cline.rs
+++ b/src-tauri/src/providers/cline.rs
@@ -264,7 +264,7 @@ fn get_all_base_paths() -> Vec<(PathBuf, String)> {
         ("Codium", "VSCodium"),
     ];
 
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = crate::utils::home_dir() {
         let app_support = home.join("Library/Application Support");
 
         for (editor_dir, editor_label) in editors {

--- a/src-tauri/src/providers/codebuddy.rs
+++ b/src-tauri/src/providers/codebuddy.rs
@@ -29,7 +29,7 @@ pub fn detect() -> Option<ProviderInfo> {
 
 /// Get the `CodeBuddy` projects base path (`~/.codebuddy/projects`)
 pub fn get_base_path() -> Option<String> {
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let projects_path = home.join(".codebuddy").join("projects");
     if projects_path.exists() && projects_path.is_dir() {
         Some(projects_path.to_string_lossy().to_string())
@@ -41,7 +41,7 @@ pub fn get_base_path() -> Option<String> {
 /// Scan `CodeBuddy` projects under the user's `~/.codebuddy/projects` root.
 ///
 /// Thin wrapper over [`scan_projects_in`] that resolves the production root
-/// from `dirs::home_dir()`. Tests should call `scan_projects_in` directly with
+/// from `crate::utils::home_dir()`. Tests should call `scan_projects_in` directly with
 /// a tempdir so the assertion runs against the real production code path
 /// instead of a copy of the loop logic.
 pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
@@ -371,7 +371,7 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
 
 /// Validate that a session path is within `~/.codebuddy/projects`
 fn validate_session_path(path: &Path) -> Result<(), String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = crate::utils::home_dir().ok_or("Could not find home directory")?;
     let allowed = home.join(".codebuddy").join("projects");
 
     let canonical = if path.exists() {
@@ -810,6 +810,7 @@ fn extract_session_info(file_path: &Path) -> Option<ClaudeSession> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use serial_test::serial;
     use std::fmt::Write as _;
 
     /// Serialize a slice of JSON values into a newline-delimited body for
@@ -992,7 +993,9 @@ mod tests {
     /// `load_sessions` must reject paths outside `~/.codebuddy/projects` to
     /// prevent path-traversal-style reads of arbitrary directories on disk.
     #[test]
+    #[serial]
     fn load_sessions_rejects_path_outside_codebuddy_root() {
+        let _home = crate::test_utils::SandboxHome::new();
         // The function checks existence first, so this needs a directory that
         // really is on disk and really is outside the codebuddy root. It used
         // to reach for `/tmp`; Windows has no such path, and a nonexistent one

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -46,7 +46,7 @@ pub fn get_base_path() -> Option<String> {
     }
 
     // Default: ~/.codex
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let codex_path = home.join(".codex");
     if codex_path.exists() {
         Some(codex_path.to_string_lossy().to_string())

--- a/src-tauri/src/providers/continue_dev.rs
+++ b/src-tauri/src/providers/continue_dev.rs
@@ -140,7 +140,7 @@ fn global_dir_for(f: &Family) -> Option<PathBuf> {
             }
         }
     }
-    Some(dirs::home_dir()?.join(f.home_subdir))
+    Some(crate::utils::home_dir()?.join(f.home_subdir))
 }
 
 /// Base path (`<global-dir>/sessions`); `None` unless the directory exists.

--- a/src-tauri/src/providers/copilot_cli.rs
+++ b/src-tauri/src/providers/copilot_cli.rs
@@ -119,7 +119,7 @@ pub fn get_base_path() -> Option<String> {
             return Some(env);
         }
     }
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let candidate = home.join(".copilot");
     if candidate.is_dir() {
         Some(candidate.to_string_lossy().to_string())

--- a/src-tauri/src/providers/crush.rs
+++ b/src-tauri/src/providers/crush.rs
@@ -282,7 +282,7 @@ fn search_one_db(
 /// Common code roots to scan (mirrors the Aider provider).
 fn search_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = crate::utils::home_dir() {
         for subdir in ["client", "projects", "code", "src", "dev", "work", "repos"] {
             let d = home.join(subdir);
             if d.is_dir() {

--- a/src-tauri/src/providers/cursor.rs
+++ b/src-tauri/src/providers/cursor.rs
@@ -29,7 +29,7 @@ pub fn get_base_path() -> Option<PathBuf> {
         }
     }
 
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
 
     #[cfg(target_os = "macos")]
     let base = home.join("Library/Application Support/Cursor/User");

--- a/src-tauri/src/providers/cursor_agent.rs
+++ b/src-tauri/src/providers/cursor_agent.rs
@@ -57,7 +57,7 @@ pub fn detect() -> Option<ProviderInfo> {
 
 /// Base path for Cursor Agent transcripts: `~/.cursor/projects`.
 pub fn get_base_path() -> Option<String> {
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let projects = home.join(".cursor").join("projects");
     if projects.is_dir() {
         Some(projects.to_string_lossy().to_string())

--- a/src-tauri/src/providers/forgecode.rs
+++ b/src-tauri/src/providers/forgecode.rs
@@ -74,7 +74,7 @@ pub fn get_base_path() -> Option<String> {
         }
     }
 
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let default_path = home.join(".forge");
     if default_path.exists() {
         Some(default_path.to_string_lossy().to_string())
@@ -1476,7 +1476,7 @@ fn extract_workspace_display_name_from_context_json(context_json: &str) -> Optio
 
 /// Extract a workspace display name from a JSON value.
 fn extract_workspace_display_name_from_value(value: &Value) -> Option<String> {
-    let home_dir = dirs::home_dir();
+    let home_dir = crate::utils::home_dir();
     let home_dir = home_dir.as_deref();
     let mut cwd_votes: BTreeMap<String, usize> = BTreeMap::new();
     collect_workspace_display_name_votes(value, home_dir, &mut cwd_votes);
@@ -1575,7 +1575,7 @@ fn collect_cwd_votes(value: &Value, cwd_votes: &mut BTreeMap<String, usize>) {
 
 /// Picks the most-voted cwd, filtering out home directories.
 fn choose_best_cwd(cwd_votes: &BTreeMap<String, usize>) -> Option<String> {
-    let home_dir = dirs::home_dir();
+    let home_dir = crate::utils::home_dir();
     cwd_votes
         .iter()
         .filter(|(path, _)| {
@@ -1802,6 +1802,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use rusqlite::params;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     /// RAII guard that restores a process-wide env var when dropped.
@@ -2046,7 +2047,9 @@ mod tests {
 
     #[test]
     /// Verify `SQLite` scan projects groups rows by workspace.
+    #[serial]
     fn sqlite_scan_projects_groups_rows_by_workspace() {
+        let _home = crate::test_utils::SandboxHome::new();
         let tmp = tempfile::tempdir().unwrap();
         let conn = create_test_db(&tmp);
         seed_test_data(&conn);
@@ -2075,7 +2078,9 @@ mod tests {
 
     #[test]
     /// Verify `SQLite` load sessions filters null context and preserves virtual ids.
+    #[serial]
     fn sqlite_load_sessions_filters_null_context_and_preserves_virtual_ids() {
+        let _home = crate::test_utils::SandboxHome::new();
         let tmp = tempfile::tempdir().unwrap();
         let conn = create_test_db(&tmp);
         seed_test_data(&conn);
@@ -2233,7 +2238,9 @@ mod tests {
 
     #[test]
     /// Extract workspace display name prefers cwd basename and ignores home dir.
+    #[serial]
     fn extract_workspace_display_name_prefers_cwd_basename_and_ignores_home_dir() {
+        let _home = crate::test_utils::SandboxHome::new();
         let context = json!({
             "messages": [
                 {

--- a/src-tauri/src/providers/forgecode.rs
+++ b/src-tauri/src/providers/forgecode.rs
@@ -2240,14 +2240,17 @@ mod tests {
     /// Extract workspace display name prefers cwd basename and ignores home dir.
     #[serial]
     fn extract_workspace_display_name_prefers_cwd_basename_and_ignores_home_dir() {
-        let _home = crate::test_utils::SandboxHome::new();
+        // The "home" entry has to be the home the code under test resolves, so
+        // it comes from the guard. `dirs::home_dir()` was the real one on
+        // Windows, which is not the home being ignored (#551).
+        let home = crate::test_utils::SandboxHome::new();
         let context = json!({
             "messages": [
                 {
                     "message": {
                         "tool": {
                             "arguments": {
-                                "cwd": dirs::home_dir().unwrap().to_string_lossy().to_string()
+                                "cwd": home.path().to_string_lossy().to_string()
                             }
                         }
                     }
@@ -2256,7 +2259,7 @@ mod tests {
                     "message": {
                         "tool": {
                             "arguments": {
-                                "cwd": "/Users/christian/projects/banana-prompting-service"
+                                "cwd": crate::test_utils::abs("Users/christian/projects/banana-prompting-service")
                             }
                         }
                     }

--- a/src-tauri/src/providers/gemini.rs
+++ b/src-tauri/src/providers/gemini.rs
@@ -26,7 +26,7 @@ pub fn get_base_path() -> Option<String> {
             return Some(val);
         }
     }
-    dirs::home_dir().map(|h| h.join(".gemini").to_string_lossy().to_string())
+    crate::utils::home_dir().map(|h| h.join(".gemini").to_string_lossy().to_string())
 }
 
 /// Scan for all Gemini CLI projects from a specific base path.

--- a/src-tauri/src/providers/goose.rs
+++ b/src-tauri/src/providers/goose.rs
@@ -42,7 +42,7 @@ fn candidate_db_paths() -> Vec<PathBuf> {
             paths.push(PathBuf::from(xdg).join("goose/sessions/sessions.db"));
         }
     }
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = crate::utils::home_dir() {
         // XDG default (Linux, and macOS under Goose's etcetera strategy).
         paths.push(home.join(".local/share/goose/sessions/sessions.db"));
         // macOS Apple-strategy fallback.

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -944,13 +944,12 @@ mod tests {
     #[test]
     #[serial]
     fn get_base_path_returns_none_when_default_dir_absent() {
+        // The sandbox guarantees the default dir is absent, so the assertion
+        // always runs. This used to bail out when the developer happened to
+        // have `~/.grok`, which made it pass by doing nothing on their machine
+        // and reach the real home on CI (#551).
+        let _home = crate::test_utils::SandboxHome::new();
         let _env = EnvVarGuard::remove("GROK_HOME");
-        if dirs::home_dir()
-            .map(|h| h.join(".grok").exists())
-            .unwrap_or(false)
-        {
-            return;
-        }
         assert!(get_base_path().is_none());
     }
 

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -40,7 +40,7 @@ pub fn get_base_path() -> Option<String> {
         }
     }
 
-    let default = dirs::home_dir()?.join(".grok");
+    let default = crate::utils::home_dir()?.join(".grok");
     if default.exists() {
         let normalized = default.canonicalize().unwrap_or(default);
         Some(normalized.to_string_lossy().to_string())

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -70,7 +70,7 @@ pub fn get_base_path() -> Option<String> {
         }
     }
 
-    let default = dirs::home_dir()?.join(".kimi");
+    let default = crate::utils::home_dir()?.join(".kimi");
     if default.exists() {
         let normalized = default.canonicalize().unwrap_or(default);
         Some(normalized.to_string_lossy().to_string())
@@ -816,6 +816,7 @@ mod tests {
     #[test]
     #[serial]
     fn get_base_path_returns_none_when_default_dir_absent() {
+        let _home = crate::test_utils::SandboxHome::new();
         let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
         let _home_env = EnvVarGuard::remove("KIMI_HOME");
         if dirs::home_dir()

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -816,15 +816,12 @@ mod tests {
     #[test]
     #[serial]
     fn get_base_path_returns_none_when_default_dir_absent() {
+        // The sandbox guarantees the default dir is absent, so the assertion
+        // always runs - the old bail-out when `~/.kimi` existed made this pass
+        // by doing nothing on a machine that had it (#551).
         let _home = crate::test_utils::SandboxHome::new();
         let _share = EnvVarGuard::remove("KIMI_SHARE_DIR");
         let _home_env = EnvVarGuard::remove("KIMI_HOME");
-        if dirs::home_dir()
-            .map(|h| h.join(".kimi").exists())
-            .unwrap_or(false)
-        {
-            return;
-        }
         assert!(get_base_path().is_none());
     }
 

--- a/src-tauri/src/providers/kimi_code.rs
+++ b/src-tauri/src/providers/kimi_code.rs
@@ -91,7 +91,7 @@ pub(crate) fn default_root() -> Option<PathBuf> {
         }
         return None;
     }
-    let default = dirs::home_dir()?.join(".kimi-code");
+    let default = crate::utils::home_dir()?.join(".kimi-code");
     default
         .exists()
         .then(|| default.canonicalize().unwrap_or(default))

--- a/src-tauri/src/providers/ompi.rs
+++ b/src-tauri/src/providers/ompi.rs
@@ -58,7 +58,6 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::fs;
-    use std::path::Path;
 
     const SESSION: &str = concat!(
         r#"{"type":"session","version":3,"id":"omp-1","timestamp":"2026-06-03T14:57:13.623Z","cwd":"/Users/ac/dev/omp-fixture"}"#,
@@ -71,38 +70,13 @@ mod tests {
         "\n",
     );
 
-    struct HomeGuard {
-        original: Option<String>,
-    }
-    impl HomeGuard {
-        fn set(path: &Path) -> Self {
-            let original = std::env::var("HOME").ok();
-            std::env::set_var("HOME", path);
-            // `HOME` alone is inert on Windows, where `dirs::home_dir()` uses
-            // the known-folder API. `crate::utils::home_dir()` reads this
-            // instead under `cfg(test)`, and panics without it (#540).
-            std::env::set_var("CCHV_TEST_HOME", path);
-            Self { original }
-        }
-    }
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            std::env::remove_var("CCHV_TEST_HOME");
-            match self.original.as_ref() {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-    }
-
     /// The full pipeline resolves against `~/.omp/agent/sessions` and stamps
     /// the `ompi` provider id — the only two things this thin module adds
     /// over the shared Pi core.
     #[test]
     #[serial]
     fn ompi_reads_omp_store_and_stamps_provider_id() {
-        let home = tempfile::tempdir().expect("tempdir");
-        let _guard = HomeGuard::set(home.path());
+        let home = crate::test_utils::SandboxHome::new();
         let dir = home
             .path()
             .join(".omp")

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -169,7 +169,7 @@ pub fn get_base_path() -> Option<String> {
     }
 
     // Default: ~/.local/share/opencode
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let opencode_path = home.join(".local").join("share").join("opencode");
     if opencode_path.exists() {
         Some(opencode_path.to_string_lossy().to_string())

--- a/src-tauri/src/providers/openhands.rs
+++ b/src-tauri/src/providers/openhands.rs
@@ -33,7 +33,9 @@ const SUMMARY_MAX_CHARS: usize = 80;
 
 /// `~/.openhands/sessions` (the classic `file_store_path` default).
 fn sessions_dir() -> Option<PathBuf> {
-    let dir = dirs::home_dir()?.join(".openhands").join("sessions");
+    let dir = crate::utils::home_dir()?
+        .join(".openhands")
+        .join("sessions");
     if dir.is_dir() {
         Some(dir)
     } else {

--- a/src-tauri/src/providers/openinterpreter.rs
+++ b/src-tauri/src/providers/openinterpreter.rs
@@ -30,7 +30,7 @@ fn home_dir() -> Option<PathBuf> {
             return if p.exists() { Some(p) } else { None };
         }
     }
-    let p = dirs::home_dir()?.join(".openinterpreter");
+    let p = crate::utils::home_dir()?.join(".openinterpreter");
     if p.exists() {
         Some(p)
     } else {

--- a/src-tauri/src/providers/pi.rs
+++ b/src-tauri/src/providers/pi.rs
@@ -853,42 +853,13 @@ mod tests {
         assert_eq!(projects[0].provider.as_deref(), Some("pi"));
     }
 
-    /// Saves/restores `HOME` around a test so `sessions_root()` resolves to a
-    /// fixture store under a fresh `TempDir` rather than the real user home.
-    /// `HOME` is process-global; combined with `#[serial]` so these tests
-    /// don't race each other.
-    struct HomeGuard {
-        original: Option<String>,
-    }
-    impl HomeGuard {
-        fn set(path: &Path) -> Self {
-            let original = std::env::var("HOME").ok();
-            std::env::set_var("HOME", path);
-            // `HOME` alone is inert on Windows, where `dirs::home_dir()` uses
-            // the known-folder API. `crate::utils::home_dir()` reads this
-            // instead under `cfg(test)`, and panics without it (#540).
-            std::env::set_var("CCHV_TEST_HOME", path);
-            Self { original }
-        }
-    }
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            std::env::remove_var("CCHV_TEST_HOME");
-            match self.original.as_ref() {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-    }
-
     /// `load_messages` must work against a literal session path under the
     /// fixture store that `$HOME` is pointed at, proving the store resolution
     /// works without requiring the real `~/.pi/agent/sessions`.
     #[test]
     #[serial]
     fn load_messages_succeeds_for_fixture_path_under_home_override() {
-        let home = tempfile::tempdir().expect("tempdir");
-        let _guard = HomeGuard::set(home.path());
+        let home = crate::test_utils::SandboxHome::new();
         let dir = home
             .path()
             .join(".pi")
@@ -909,8 +880,7 @@ mod tests {
     #[test]
     #[serial]
     fn load_sessions_succeeds_for_fixture_dir_under_home_override() {
-        let home = tempfile::tempdir().expect("tempdir");
-        let _guard = HomeGuard::set(home.path());
+        let home = crate::test_utils::SandboxHome::new();
         let dir = home
             .path()
             .join(".pi")
@@ -937,7 +907,7 @@ mod tests {
         let home = tempfile::tempdir().expect("tempdir");
         fs::create_dir_all(home.path().join(".pi").join("agent").join("sessions"))
             .expect("create sessions root");
-        let _guard = HomeGuard::set(home.path());
+        let _home = crate::test_utils::SandboxHome::new();
 
         let outside = tempfile::tempdir().expect("outside tempdir");
         let dir = outside.path().join("--Users-ac-dev-fixture--");

--- a/src-tauri/src/providers/qwen.rs
+++ b/src-tauri/src/providers/qwen.rs
@@ -41,7 +41,7 @@ fn runtime_base() -> Option<PathBuf> {
             }
         }
     }
-    Some(dirs::home_dir()?.join(".qwen"))
+    Some(crate::utils::home_dir()?.join(".qwen"))
 }
 
 fn projects_dir() -> Option<PathBuf> {

--- a/src-tauri/src/providers/vibe.rs
+++ b/src-tauri/src/providers/vibe.rs
@@ -39,7 +39,7 @@ pub fn get_base_path() -> Option<String> {
         }
     }
 
-    let default = dirs::home_dir()?.join(".vibe");
+    let default = crate::utils::home_dir()?.join(".vibe");
     if default.exists() {
         let normalized = default.canonicalize().unwrap_or(default);
         Some(normalized.to_string_lossy().to_string())

--- a/src-tauri/src/providers/vscode.rs
+++ b/src-tauri/src/providers/vscode.rs
@@ -69,7 +69,7 @@ pub fn get_base_paths() -> Vec<PathBuf> {
 }
 
 fn get_user_data_roots() -> Vec<UserDataRoot> {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = crate::utils::home_dir() else {
         return Vec::new();
     };
 


### PR DESCRIPTION
Second and largest part of #551, after #555 did antigravity.

**28 `dirs::home_dir()` call sites across 23 provider modules** now go through `crate::utils::home_dir()`.

## Why it matters only on Windows

On Unix the two are equivalent — `dirs::home_dir()` reads `$HOME` and the tests set it, so the sandbox worked by coincidence. On Windows `dirs::home_dir()` goes through the known-folder API and consults neither `HOME` nor `CCHV_TEST_HOME`, deliberately, to support OneDrive redirection.

So every provider test pointing `HOME` at a fixture was resolving the **developer's real home** there, and the `cfg(test)` panic that makes an unsandboxed read loud never fired for any of these modules.

## The tail

Fifteen tests were reaching home with no sandbox of their own — far fewer than the 28 sites suggested. All now hold `SandboxHome`.

One was worse than merely unguarded. `test_safe_session_path_allows_kimi_sessions` saved and restored `HOME` around its own `TempDir`:

```rust
let temp = TempDir::new().unwrap();
std::env::set_var("HOME", temp.path());
// … fixture written under temp …
```

which leaves `CCHV_TEST_HOME` pointing somewhere else entirely — the path the code under test actually resolves. It passed because on Unix `HOME` was enough. The guard owns the home now and the fixture lives inside it.

## Not included

Five guard definitions remain (`pi`, `openinterpreter`, `ompi`, `stats`, `rename`). Migrating them onto `SandboxHome` means retargeting each fixture at the guard's own directory rather than a separately-created temp — a per-call-site rewrite with real room to get wrong quietly. Following separately.

## Verification

| path | result |
|---|---|
| nextest, default features | 998 passed |
| nextest, `webui-server` | 1043 passed |
| clippy, both feature sets | clean |

Windows count reported when the job finishes — that is what this is for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of session and project data across supported AI tools, including customized home-directory locations.
  * Increased reliability when locating provider-specific folders and validating session paths.
  * Reduced environment-dependent behavior that could cause incorrect results.

* **Tests**
  * Strengthened isolation and coverage for session deletion, path validation, provider detection, and project discovery.
  * Improved consistency across platforms and home-directory configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->