### PR TITLE
fix(tests): sandbox the commands layer, and give is_safe_path a test seam

### DIFF
--- a/src-tauri/src/commands/claude_settings.rs
+++ b/src-tauri/src/commands/claude_settings.rs
@@ -41,12 +41,12 @@ pub struct AllMCPServers {
 
 /// The home directory these settings paths hang off.
 ///
-/// In a normal build this is exactly `dirs::home_dir()`.
+/// In a normal build this is exactly `crate::utils::home_dir()`.
 ///
 /// # Why this indirection exists
 ///
 /// The tests below intended to sandbox themselves with
-/// `env::set_var("HOME", temp_dir)`. That is inert on Windows: `dirs::home_dir()`
+/// `env::set_var("HOME", temp_dir)`. That is inert on Windows: `crate::utils::home_dir()`
 /// resolves through the known-folder API and consults neither `HOME` nor
 /// `USERPROFILE`. So `test_save_and_retrieve_user_settings` wrote
 /// `{"theme":"dark","fontSize":14}` straight over the developer's real
@@ -61,7 +61,7 @@ pub struct AllMCPServers {
 /// turns that mistake into a loud failure instead of silent data loss.
 #[cfg(not(test))]
 fn settings_home_dir() -> Option<PathBuf> {
-    dirs::home_dir()
+    crate::utils::home_dir()
 }
 
 #[cfg(test)]
@@ -633,6 +633,29 @@ pub(crate) fn validate_dialog_path(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// A user folder from the OS, or `None` under `cfg(test)`.
+///
+/// Production uses the known-folder APIs so Windows folder redirection - a
+/// Downloads moved into `OneDrive`, say - is honoured. Those APIs read the
+/// account's real profile and consult neither `HOME` nor `CCHV_TEST_HOME`,
+/// which is deliberate but leaves `is_safe_path` untestable: the allowlist
+/// would name the developer's own Downloads, and the only way to exercise the
+/// accept path would be to write there. That is exactly the mistake #536 and
+/// #540 were about.
+///
+/// Returning `None` under test collapses each entry to its home-relative
+/// fallback, so the whole allowlist derives from the sandboxed home and the
+/// accept path becomes testable. The redirection branch itself is an OS call
+/// with nothing to assert about (#541).
+#[cfg(feature = "webui-server")]
+fn known_folder(lookup: fn() -> Option<PathBuf>) -> Option<PathBuf> {
+    if cfg!(test) {
+        None
+    } else {
+        lookup()
+    }
+}
+
 /// Validate that a path is within allowed directories.
 ///
 /// Used by `WebUI` HTTP handlers to restrict file operations to safe directories.
@@ -645,17 +668,15 @@ pub(crate) fn validate_dialog_path(path: &Path) -> Result<(), String> {
 /// `Ok(())` if path is safe, error message if not
 #[cfg(feature = "webui-server")]
 pub(crate) fn is_safe_path(path: &Path) -> Result<(), String> {
-    let home_raw = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home_raw = crate::utils::home_dir().ok_or("Could not find home directory")?;
     // Canonicalize home to resolve symlinks (e.g. macOS /var → /private/var)
     let home = home_raw.canonicalize().unwrap_or_else(|_| home_raw.clone());
     let home = strip_windows_prefix(&home);
-    // Use known-folder APIs to support Windows folder redirection (e.g. OneDrive).
-    // Fall back to home-relative paths when the API returns None.
     let mut allowed_dirs = vec![home.join(".claude-history-viewer").join("exports")];
     for (api_dir, fallback_name) in [
-        (dirs::download_dir(), "Downloads"),
-        (dirs::document_dir(), "Documents"),
-        (dirs::desktop_dir(), "Desktop"),
+        (known_folder(dirs::download_dir), "Downloads"),
+        (known_folder(dirs::document_dir), "Documents"),
+        (known_folder(dirs::desktop_dir), "Desktop"),
     ] {
         let resolved = api_dir.unwrap_or_else(|| home.join(fallback_name));
         let resolved =

--- a/src-tauri/src/commands/mcp_presets.rs
+++ b/src-tauri/src/commands/mcp_presets.rs
@@ -56,7 +56,7 @@ pub struct MCPPresetInput {
 
 /// Get the MCP presets folder path (~/.claude-history-viewer/mcp-presets)
 fn get_mcp_presets_folder() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = crate::utils::home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude-history-viewer").join("mcp-presets"))
 }
 

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -64,8 +64,8 @@ pub async fn get_git_log(actual_path: String, limit: usize) -> Result<Vec<GitCom
 
 #[tauri::command]
 pub async fn get_claude_folder_path() -> Result<String, String> {
-    let home_dir =
-        dirs::home_dir().ok_or("HOME_DIRECTORY_NOT_FOUND:Could not determine home directory")?;
+    let home_dir = crate::utils::home_dir()
+        .ok_or("HOME_DIRECTORY_NOT_FOUND:Could not determine home directory")?;
     let claude_path = home_dir.join(".claude");
 
     if !claude_path.exists() {
@@ -133,12 +133,12 @@ pub async fn detect_claude_config_dir() -> Result<Option<String>, String> {
 
     // Expand ~ to home directory (only exact "~" or "~/..." patterns)
     let expanded = if raw == "~" {
-        match dirs::home_dir() {
+        match crate::utils::home_dir() {
             Some(home) => home.to_string_lossy().to_string(),
             None => raw,
         }
     } else if let Some(rest) = raw.strip_prefix("~/") {
-        match dirs::home_dir() {
+        match crate::utils::home_dir() {
             Some(home) => home.join(rest).to_string_lossy().to_string(),
             None => raw,
         }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -41,7 +41,7 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
             .unwrap_or_else(|| p.to_path_buf())
     }
 
-    let home_raw = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home_raw = crate::utils::home_dir().ok_or("Could not find home directory")?;
     let home = home_raw.canonicalize().unwrap_or_else(|_| home_raw.clone());
     let home = strip_windows_prefix(&home);
 
@@ -168,9 +168,11 @@ mod tests {
     #[test]
     #[serial]
     fn accepts_session_under_symlinked_claude_root() {
-        let _home = crate::test_utils::SandboxHome::new();
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let home = tmp.path();
+        // Built inside the guard's home. It used to create its own `TempDir`
+        // and point `HOME` at it via `with_home`, which leaves
+        // `CCHV_TEST_HOME` - the path actually resolved - somewhere else.
+        let sandbox = crate::test_utils::SandboxHome::new();
+        let home = sandbox.path();
         let store_projects = home.join(".claude-store").join("projects").join("proj");
         std::fs::create_dir_all(&store_projects).expect("mk store");
         symlink(home.join(".claude-store"), home.join(".claude")).expect("symlink .claude");
@@ -183,7 +185,7 @@ mod tests {
             .join("projects")
             .join("proj")
             .join("session.jsonl");
-        let res = with_home(home, || is_safe_session_path(&via_symlink));
+        let res = is_safe_session_path(&via_symlink);
         assert!(
             res.is_ok(),
             "session under a symlinked .claude root should be allowed: {res:?}"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -39,10 +39,10 @@ pub struct PresetInput {
 
 /// The home directory the presets folder hangs off.
 ///
-/// Normally just `dirs::home_dir()`. Under `cfg(test)` it reads
+/// Normally just `crate::utils::home_dir()`. Under `cfg(test)` it reads
 /// `CCHV_TEST_HOME` and panics if that is unset, for the same reason as the
 /// identical helper in `claude_settings.rs`: `env::set_var("HOME", temp_dir)`
-/// is inert on Windows, where `dirs::home_dir()` uses the known-folder API. The
+/// is inert on Windows, where `crate::utils::home_dir()` uses the known-folder API. The
 /// tests below therefore created and wrote to the real
 /// `~/.claude-history-viewer/presets` instead of a temp directory. Confirmed on
 /// this machine: that folder carries the timestamp of a `cargo test` run.
@@ -51,7 +51,7 @@ pub struct PresetInput {
 /// owns rather than overwriting Claude Code's config - but the same defect.
 #[cfg(not(test))]
 fn presets_home_dir() -> Option<PathBuf> {
-    dirs::home_dir()
+    crate::utils::home_dir()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/unified_presets.rs
+++ b/src-tauri/src/commands/unified_presets.rs
@@ -67,7 +67,7 @@ pub struct UnifiedPresetInput {
 
 /// Get the unified presets folder path
 fn get_presets_folder() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not find home directory")?;
+    let home = crate::utils::home_dir().ok_or("Could not find home directory")?;
     Ok(home.join(".claude-history-viewer").join("unified-presets"))
 }
 

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -771,6 +771,7 @@ mod tests {
     };
     use axum::body::to_bytes;
     use axum::body::Body;
+    use serial_test::serial;
     use tower::ServiceExt;
 
     /// Somewhere no export allowlist would ever cover.
@@ -784,7 +785,9 @@ mod tests {
     /// request could overwrite any reachable file while being refused
     /// permission to read that same path.
     #[test]
+    #[serial]
     fn test_restore_write_is_unrestricted_only_when_permitted() {
+        let _home = crate::test_utils::SandboxHome::new();
         use crate::server::handlers::restore_write_allowed;
 
         let outside = restore_gate_probe_path();
@@ -836,7 +839,9 @@ mod tests {
     /// handler leaves both tests above green, which is the failure mode a
     /// pure-function test cannot see.
     #[tokio::test]
+    #[serial]
     async fn test_restore_endpoint_refuses_a_path_outside_the_allowlist() {
+        let _home = crate::test_utils::SandboxHome::new();
         let state = state_with(false, None);
         let app = build_router(state, "127.0.0.1", 3727, None, "/");
 


### PR DESCRIPTION
Finishes the #551 sweep started in #555 (antigravity) and #556 (providers). Twelve more sites across `claude_settings`, `mcp_presets`, `unified_presets`, `project`, `settings` and `session`. **The provider layer is already at zero.**

## The one that matters: `is_safe_path`

This is the last of #541's Windows failures, and it needed a decision rather than a guard.

`is_safe_path` builds its allowlist from `dirs::download_dir()`, `document_dir()` and `desktop_dir()`. Those go through the Windows known-folder API **deliberately**, so a Downloads redirected into OneDrive is still honoured — and they consult neither `HOME` nor `CCHV_TEST_HOME`.

That left the function untestable there. The allowlist named the developer's real Downloads, so the only way to exercise the *accept* path would have been to write into it — which is precisely the mistake #536 and #540 were about.

```rust
fn known_folder(lookup: fn() -> Option<PathBuf>) -> Option<PathBuf> {
    if cfg!(test) { None } else { lookup() }
}
```

Under test each entry collapses to its home-relative fallback, so the whole allowlist derives from the sandboxed home. Production is untouched.

**What this gives up:** coverage of the redirection branch itself. That branch is a single OS call with nothing to assert about — the behaviour worth testing is whether a path inside or outside the allowlist is accepted, and that is now testable on every platform instead of none.

## Fixtures that were pointing at the wrong home

Three tests created their own temp and pointed `HOME` at it, leaving `CCHV_TEST_HOME` — the path actually resolved — somewhere else:

- `accepts_session_under_symlinked_claude_root`, via a `with_home` helper
- the two `server::tests` restore cases, which had no sandbox at all

## Verification

| path | result |
|---|---|
| nextest, default features | 998 passed |
| nextest, `webui-server` | 1043 passed |
| clippy, both feature sets | clean |

Mutation-checked the seam, since the whole claim is that the accept path is now real: emptying `allowed_dirs` after the loop **fails both accept tests**. Before this they could not run on Windows at all.

If Windows comes back at zero, #541 closes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when locating home directories and application folders across environments.
  * Enhanced safe-path validation for settings, projects, sessions, and presets, including symlinked locations.

* **Tests**
  * Improved test isolation and consistency for home-directory and restore-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->