### PR TITLE
fix(tests): the last four home sites — #551 sweep complete

### DIFF
--- a/src-tauri/src/commands/session/rename.rs
+++ b/src-tauri/src/commands/session/rename.rs
@@ -1937,10 +1937,12 @@ mod tests {
 
     #[test]
     fn test_validate_claude_path_filename_with_special_chars() {
-        let _home = crate::test_utils::SandboxHome::new();
+        // The guard's home, not `dirs::home_dir()` - the latter is the real one
+        // on Windows, so the fixture would sit outside the sandbox.
+        let home = crate::test_utils::SandboxHome::new();
         // Test filename validation with various invalid characters
-        if let Some(home) = dirs::home_dir() {
-            let claude_dir = home.join(".claude/projects");
+        {
+            let claude_dir = home.path().join(".claude").join("projects");
             // Filename with dot (besides extension) should fail
             let path_with_dot = claude_dir
                 .join("test.file.jsonl")

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -638,7 +638,7 @@ fn resolve_session_path(value: &str) -> Result<PathBuf, String> {
         ));
     }
 
-    let projects = dirs::home_dir()
+    let projects = crate::utils::home_dir()
         .ok_or("Could not determine home directory")?
         .join(".claude")
         .join("projects");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -905,7 +905,7 @@ fn resolve_auth_token(args: &[String]) -> Option<(String, AuthTokenSource)> {
 /// Persist auto-generated token to a local file instead of logging the full secret.
 #[cfg(feature = "webui-server")]
 fn write_generated_token_file(token: &str) -> Option<std::path::PathBuf> {
-    let home = dirs::home_dir()?;
+    let home = crate::utils::home_dir()?;
     let dir = home.join(".claude-history-viewer");
     std::fs::create_dir_all(&dir).ok()?;
     let path = dir.join("webui-token.txt");
@@ -986,7 +986,7 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
 
     let mut paths: Vec<PathBuf> = Vec::new();
 
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = crate::utils::home_dir() {
         let claude_projects = home.join(".claude").join("projects");
         if claude_projects.is_dir() {
             paths.push(claude_projects);


### PR DESCRIPTION
Closes #551. After this, `dirs::home_dir()` appears **exactly once** in the crate: inside `crate::utils::home_dir()` itself.

## Three production paths

| site | what it does |
|---|---|
| `export.rs` | resolves `~/.claude/projects` for the CLI export |
| `lib.rs::collect_watch_paths` | builds the watch list |
| `lib.rs::write_generated_token_file` | **writes** `~/.claude-history-viewer/webui-token.txt` |

The third is the one worth naming. It writes to the real home, so any test reaching it leaves a file behind on the developer's machine — the #536 shape, still live until now. Nothing currently reaches it, but nothing stopped it either; the sandbox panic does now.

## One fixture

`rename.rs`'s `test_validate_claude_path_filename_with_special_chars` built its path from `dirs::home_dir()` while holding a `SandboxHome`. Equivalent on Unix, where the guard sets `HOME` too — on Windows it is the real home, so the fixture would have sat outside the sandbox it thought it was in.

## Verification

No cascade at all: nothing was relying on these.

| path | result |
|---|---|
| nextest, default features | 998 passed |
| nextest, `webui-server` | 1043 passed |
| clippy, both feature sets | clean |
| `grep -rn 'dirs::home_dir()'` outside the helper | **0** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of session paths and home-directory locations across supported environments.
  * Fixed path resolution for Claude project sessions, generated authentication files, and provider directory monitoring.
  * Added safer validation for session paths containing special characters.
  * Prevented environment-specific path issues by consistently using the application’s configured home directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->