### PR TITLE
fix(webui): accept provider URIs, and read OpenCode subagents from the DB

### DIFF
--- a/src-tauri/src/commands/session/load.rs
+++ b/src-tauri/src/commands/session/load.rs
@@ -2009,10 +2009,53 @@ fn workflow_run_id_for(sa_path: &Path) -> Option<String> {
     run_dir.file_name().map(|n| n.to_string_lossy().to_string())
 }
 
+/// Subagent rows for an `opencode://<project_id>/<session_id>` parent.
+///
+/// Each child becomes a `SubagentSession` addressed by its own
+/// `opencode://` id, so clicking one in the panel opens it through the same
+/// path the project list already uses. `file_size` is 0 - there is no file -
+/// and `tool_use_id` is `None`, which the frontend already handles by falling
+/// back to progress messages.
+fn opencode_subagents(session_path: &str) -> Vec<SubagentSession> {
+    let Some(rest) = session_path.strip_prefix("opencode://") else {
+        return Vec::new();
+    };
+    let Some((project_id, session_id)) = rest.split_once('/') else {
+        return Vec::new();
+    };
+    if !crate::utils::is_safe_storage_id(project_id)
+        || !crate::utils::is_safe_storage_id(session_id)
+    {
+        return Vec::new();
+    }
+
+    crate::providers::opencode::load_child_sessions(project_id, session_id)
+        .into_iter()
+        .map(|child| SubagentSession {
+            file_path: format!("opencode://{project_id}/{}", child.id),
+            agent_id: child.id,
+            message_count: child.message_count,
+            file_size: 0,
+            first_message_time: Some(child.created_at),
+            last_message_time: Some(child.updated_at),
+            summary: (!child.title.trim().is_empty()).then_some(child.title),
+            tool_use_id: None,
+            workflow_run_id: None,
+        })
+        .collect()
+}
+
 /// Returns subagent sessions for a given parent session file.
 #[tauri::command]
 pub async fn get_session_subagents(session_path: String) -> Result<Vec<SubagentSession>, String> {
     use crate::utils::find_subagent_files;
+
+    // OpenCode keeps subagent runs as child rows in SQLite rather than as
+    // sidechain files beside the parent, so the file scan below has nothing to
+    // find and the absolute-path check would reject the URI outright (#560).
+    if session_path.starts_with("opencode://") {
+        return Ok(opencode_subagents(&session_path));
+    }
 
     let path = PathBuf::from(&session_path);
     if !path.is_absolute() {

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -24,6 +24,25 @@ pub use rename::*;
 pub use resume::*;
 pub use search::*;
 
+/// Split a provider URI into its scheme and remainder, or `None` if the value
+/// is an ordinary path.
+///
+/// Deliberately structural rather than a list of known schemes: those live as
+/// per-module constants across seventeen providers, and a copy kept here would
+/// silently fall behind the next one added — the failure mode being a provider
+/// that works on desktop and is rejected over `--serve`.
+#[cfg(feature = "webui-server")]
+fn uri_parts(path: &std::path::Path) -> Option<(String, String)> {
+    let raw = path.to_string_lossy();
+    let (scheme, rest) = raw.split_once("://")?;
+    let valid = !scheme.is_empty()
+        && scheme.starts_with(|c: char| c.is_ascii_lowercase())
+        && scheme
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '+');
+    valid.then(|| (scheme.to_string(), rest.to_string()))
+}
+
 /// Reject session file paths that fall outside the on-disk roots used by
 /// the supported providers. Defends `WebUI` handlers (which accept untrusted
 /// HTTP input) against being pointed at arbitrary `.jsonl` files on the host.
@@ -33,6 +52,28 @@ pub use search::*;
 #[cfg(feature = "webui-server")]
 pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String> {
     use std::path::PathBuf;
+
+    // A provider URI is not a filesystem path. Several providers keep their
+    // sessions in a database rather than in files - OpenCode's SQLite store,
+    // Zed, Trae, ForgeCode and a dozen others - and mint identifiers of the
+    // form `scheme://…` for them. There is no file for an allowlist to
+    // confine, and the command that receives one resolves it against its own
+    // provider root, exactly as it does on desktop where this guard does not
+    // run at all.
+    //
+    // Treating them as paths meant canonicalising a parent that does not
+    // exist, so every guarded WebUI endpoint rejected them as "Invalid path"
+    // under `--serve` (#560).
+    //
+    // Traversal is still refused: a URI is waved past the filesystem check, so
+    // it must not be able to smuggle one through.
+    if let Some((scheme, rest)) = uri_parts(path) {
+        return if rest.split(['/', '\\']).any(|seg| seg == "..") {
+            Err(format!("Invalid {scheme} session id"))
+        } else {
+            Ok(())
+        };
+    }
 
     fn strip_windows_prefix(p: &std::path::Path) -> PathBuf {
         let s = p.to_string_lossy();
@@ -209,6 +250,43 @@ mod tests {
             res.is_err(),
             "a path outside every provider root must be rejected"
         );
+    }
+
+    /// #560. Several providers mint session paths that are provider URIs, not
+    /// filesystem paths - `OpenCode`'s `SQLite` store is one, and a dozen others do
+    /// the same. The guard treated them as paths, failed to canonicalise a
+    /// parent that does not exist, and rejected them as "Invalid path", which
+    /// broke every guarded `WebUI` endpoint for those providers under `--serve`.
+    #[test]
+    #[serial]
+    fn accepts_provider_uri_session_paths() {
+        let _home = crate::test_utils::SandboxHome::new();
+
+        for uri in [
+            "opencode://proj-1/ses_abc123",
+            "kimi-code://wd_demo/session_1",
+            "forgecode-db://workspace/conv-1",
+            "zed://thread-7",
+        ] {
+            let res = is_safe_session_path(&std::path::PathBuf::from(uri));
+            assert!(res.is_ok(), "provider URI {uri} was rejected: {res:?}");
+        }
+    }
+
+    /// A URI is waved past the filesystem allowlist, so it must not be able to
+    /// smuggle a traversal through it.
+    #[test]
+    #[serial]
+    fn rejects_traversal_inside_a_provider_uri() {
+        let _home = crate::test_utils::SandboxHome::new();
+
+        for uri in [
+            "opencode://../../etc/passwd",
+            "zed://thread/../../../root/.ssh/id_rsa",
+        ] {
+            let res = is_safe_session_path(&std::path::PathBuf::from(uri));
+            assert!(res.is_err(), "traversal inside {uri} was accepted");
+        }
     }
 
     // Kimi sessions live under ~/.kimi/sessions (or $KIMI_HOME) — #349.

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -444,6 +444,64 @@ pub fn load_sessions(
     Ok(sessions)
 }
 
+/// Child sessions of `session_id`, i.e. the subagent runs it spawned.
+///
+/// `OpenCode` has no sidechain files. A Task run is a row in `session` whose
+/// `parent_id` points at its parent, so the parent→child link the `SubAgent`
+/// panel draws has to come from the database (#560).
+///
+/// Newest first. Empty when the store is file-backed or the session has no
+/// children.
+pub struct ChildSession {
+    pub id: String,
+    pub title: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub message_count: usize,
+}
+
+pub fn load_child_sessions(project_id: &str, session_id: &str) -> Vec<ChildSession> {
+    let Some(base_path) = get_base_path() else {
+        return Vec::new();
+    };
+    load_child_sessions_from_db(&base_path, project_id, session_id)
+}
+
+/// [`load_child_sessions`] against an explicit store root, matching
+/// `scan_projects_from_db` and friends so it can be exercised on a fixture.
+pub fn load_child_sessions_from_db(
+    base_path: &str,
+    project_id: &str,
+    session_id: &str,
+) -> Vec<ChildSession> {
+    let Some(conn) = open_db(base_path) else {
+        return Vec::new();
+    };
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT s.id, s.title, s.time_created, s.time_updated,
+                (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) AS message_count
+         FROM session s
+         WHERE s.parent_id = ?1 AND s.project_id = ?2
+         ORDER BY s.time_created DESC",
+    ) else {
+        return Vec::new();
+    };
+
+    let Ok(rows) = stmt.query_map(rusqlite::params![session_id, project_id], |row| {
+        Ok(ChildSession {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            created_at: epoch_ms_to_rfc3339(row.get::<_, u64>(2)?),
+            updated_at: epoch_ms_to_rfc3339(row.get::<_, u64>(3)?),
+            message_count: row.get(4)?,
+        })
+    }) else {
+        return Vec::new();
+    };
+
+    rows.filter_map(std::result::Result::ok).collect()
+}
+
 /// Load messages for an `OpenCode` session
 pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
     let base_path = get_base_path().ok_or_else(|| "OpenCode not found".to_string())?;
@@ -1850,6 +1908,42 @@ mod tests {
 
     fn project_ref(project_id: &str) -> OpenCodeProjectRef {
         OpenCodeProjectRef::parse(&format!("opencode://{project_id}")).unwrap()
+    }
+
+    /// #560. A subagent run is a `session` row whose `parent_id` points at its
+    /// parent, not a sidechain file, so the panel's parent→child link can only
+    /// come from here.
+    #[test]
+    fn sqlite_load_child_sessions_reads_subagent_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let conn = create_test_db(tmp.path());
+        seed_test_data(&conn);
+        for (id, title, created) in [
+            ("ses_child_a", "Search the codebase", 1_700_000_200_000_i64),
+            ("ses_child_b", "Write the migration", 1_700_000_300_000_i64),
+        ] {
+            conn.execute(
+                "INSERT INTO session (id, project_id, title, time_created, time_updated, parent_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![id, "proj1", title, created, created, "ses_001"],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        let base = tmp.path().to_string_lossy().to_string();
+        let children = load_child_sessions_from_db(&base, "proj1", "ses_001");
+
+        // Newest first.
+        assert_eq!(
+            children.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+            vec!["ses_child_b", "ses_child_a"]
+        );
+        assert_eq!(children[0].title, "Write the migration");
+
+        // A session with no children yields nothing rather than erroring, and
+        // children are not claimed by a sibling parent.
+        assert!(load_child_sessions_from_db(&base, "proj1", "ses_child_a").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #560. @GoldenStain's analysis was correct on every point — I verified each claim against the source rather than taking it on trust, and doing so turned up a **wider blast radius than the reported symptom**.

## The guard rejects every provider URI, not just OpenCode's

`is_safe_session_path` had no notion of a provider URI. Seventeen providers mint session ids of the form `scheme://…` for stores that are not files — OpenCode's SQLite database, plus Zed, Trae, ForgeCode, Crush, Goose, Amazon Q, OpenHands, Qwen, Vibe, LLM, Kimi Code, Antigravity CLI and others. The guard treated them as filesystem paths, could not canonicalise a parent that does not exist, and fell through to `Err("Invalid path")`.

That is **five endpoints**, not one:

| endpoint | broken for |
|---|---|
| `get_session_subagents` | the reported symptom |
| `delete_session` | every DB-backed provider |
| `rename_session_native` | ” |
| `reset_session_native_name` | ” |
| `rename_opencode_session_title` | …the endpoint that exists to rename exactly the sessions being rejected |

All under `--serve` only; desktop does not run this guard, which is why it went unnoticed.

## Why structural rather than a scheme list

Schemes live as per-module constants across seventeen files, several private. A copy kept beside the guard would fall behind the next provider added, and the failure mode is quiet: a provider that works on desktop and 404s over HTTP.

So the rule is on shape. A URI is not a filesystem path — there is no file for an allowlist to confine, and the receiving command resolves it against its own provider root, which is already exactly what happens on desktop. Traversal inside the URI is still refused, since it is being waved past the filesystem check:

```
opencode://../../etc/passwd   -> rejected
opencode://proj-1/ses_abc123  -> accepted, provider validates
```

## Second half: subagents from SQLite

OpenCode has no sidechain files. A Task run is a `session` row whose `parent_id` points at the parent, so `get_session_subagents` now routes `opencode://` to a `parent_id` lookup instead of scanning a directory for `agent-*.jsonl` that will never be there. Children are addressed by their own `opencode://` id, so clicking one opens it through the path the project list already uses.

## Verification

**Reproduced first.** The guard test failed with the reporter's exact error before any fix:

```
provider URI opencode://proj-1/ses_abc123 was rejected: Err("Invalid path")
```

**Mutation-checked both halves**, since "the panel now works" is easy to claim:

| mutation | result |
|---|---|
| query `s.id` instead of `s.parent_id` | child-session test **fails** ✓ |
| disable the traversal check | URI test **fails** ✓ |

999 and 1046 tests, both feature sets, clippy clean on both, fmt clean.

## Not covered

The DB fixture proves the query and the wiring. I have no OpenCode SQLite store with real subagent rows to click through, so the panel rendering itself is unverified end to end — @GoldenStain, if you are able to try a build from this branch, that is the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying child sessions from OpenCode projects.
  * Provider-backed session links can now be opened through the web interface.
  * Child sessions show titles, timestamps, and message counts, ordered from newest to oldest.

* **Bug Fixes**
  * Improved session link validation while continuing to block unsafe path traversal attempts.
  * Fixed provider session links being incorrectly rejected as invalid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->