### PR TITLE
fix(webui): authorise restore from recorded edit history

### DIFF
--- a/src-tauri/src/commands/session/edits.rs
+++ b/src-tauri/src/commands/session/edits.rs
@@ -667,14 +667,11 @@ fn paginate_recent_edits(
     }
 }
 
-fn get_provider_recent_edits(
+fn collect_provider_edits(
     provider: EditsProvider,
     project_path: &str,
-    offset: usize,
-    limit: usize,
-    grouping: EditsGrouping,
     session_file_path: Option<&str>,
-) -> Result<PaginatedRecentEdits, String> {
+) -> Result<(Vec<RecentFileEdit>, Option<String>), String> {
     let project_cwd = resolve_provider_project_cwd(provider, project_path);
 
     let sessions = match provider {
@@ -711,13 +708,7 @@ fn get_provider_recent_edits(
         ));
     }
 
-    Ok(paginate_recent_edits(
-        all_edits,
-        project_cwd,
-        offset,
-        limit,
-        grouping,
-    ))
+    Ok((all_edits, project_cwd))
 }
 
 /// Paginated response for recent edits
@@ -894,23 +885,37 @@ fn get_recent_edits_blocking(
         None => DEFAULT_PAGE_LIMIT,
     };
     let grouping = EditsGrouping::from_param(grouping.as_deref());
-    let provider = detect_project_provider(&project_path);
+    let (all_edits, project_cwd) =
+        collect_all_recent_edits(&project_path, session_file_path.as_deref())?;
 
+    Ok(paginate_recent_edits(
+        all_edits,
+        project_cwd,
+        offset,
+        limit,
+        grouping,
+    ))
+}
+
+/// Every edit recorded for a project, before pagination, with the project's
+/// most common `cwd`.
+///
+/// Shared by the paginated command and by [`is_recorded_edit_target`], so the
+/// set the panel shows and the set restore will authorise are the same set by
+/// construction rather than by two implementations agreeing.
+fn collect_all_recent_edits(
+    project_path: &str,
+    session_file_path: Option<&str>,
+) -> Result<(Vec<RecentFileEdit>, Option<String>), String> {
+    let provider = detect_project_provider(project_path);
     if provider != EditsProvider::Claude {
-        return get_provider_recent_edits(
-            provider,
-            &project_path,
-            offset,
-            limit,
-            grouping,
-            session_file_path.as_deref(),
-        );
+        return collect_provider_edits(provider, project_path, session_file_path);
     }
 
     // Phase 1: Collect the session files to scan
-    let session_files: Vec<PathBuf> = match session_file_path.as_deref() {
-        Some(path) => vec![validate_session_file_in_project(path, &project_path)?],
-        None => WalkDir::new(&project_path)
+    let session_files: Vec<PathBuf> = match session_file_path {
+        Some(path) => vec![validate_session_file_in_project(path, project_path)?],
+        None => WalkDir::new(project_path)
             .into_iter()
             .filter_map(std::result::Result::ok)
             // Same symlink policy as the single-file path above. Without it the
@@ -945,13 +950,35 @@ fn get_recent_edits_blocking(
         .max_by_key(|(_, count)| *count)
         .map(|(cwd, _)| cwd);
 
-    Ok(paginate_recent_edits(
-        all_edits,
-        project_cwd,
-        offset,
-        limit,
-        grouping,
-    ))
+    Ok((all_edits, project_cwd))
+}
+
+/// Whether `file_path` is recorded as an edit target in this project's history.
+///
+/// This is the authorisation boundary for restore, replacing the question "is
+/// this path inside a directory we allow?" with "did this project actually
+/// edit this file?" (#525).
+///
+/// The distinction matters because containment is not a boundary here. The
+/// allowlist matches by prefix, and a project root is not a leaf: run `claude`
+/// once in your home directory and the recorded root is `~`, which would admit
+/// `~/.ssh/authorized_keys` and `~/.aws/credentials` along with it. Membership
+/// derived from recorded history admits neither, because Claude never wrote
+/// them.
+///
+/// Compared on `file_identity` rather than on the raw string, for the same
+/// separator and Windows-case reasons the grouping code already handles: under
+/// `--serve` the caller spells the path itself.
+pub(crate) fn is_recorded_edit_target(
+    project_path: &str,
+    session_file_path: Option<&str>,
+    file_path: &str,
+) -> Result<bool, String> {
+    let wanted = file_identity(file_path);
+    let (edits, _) = collect_all_recent_edits(project_path, session_file_path)?;
+    Ok(edits
+        .iter()
+        .any(|edit| file_identity(&edit.file_path) == wanted))
 }
 
 /// Restore a file by writing content to the specified path
@@ -959,9 +986,18 @@ fn get_recent_edits_blocking(
 /// Uses atomic write pattern: writes to a temporary file first, then renames.
 /// This prevents data loss if the write operation fails midway.
 ///
-/// Security: Validates path to prevent path traversal attacks
+/// Authorised against the project's recorded edit history, not against a
+/// directory allowlist: the only paths this will write are ones the project's
+/// session logs name as edit targets (#525). `project_path` is therefore
+/// required, and `session_file_path` narrows the scan the same way the panel's
+/// session scope does.
 #[tauri::command]
-pub async fn restore_file(file_path: String, content: String) -> Result<(), String> {
+pub async fn restore_file(
+    file_path: String,
+    content: String,
+    project_path: String,
+    session_file_path: Option<String>,
+) -> Result<(), String> {
     use std::fs;
     use std::path::Path;
 
@@ -981,6 +1017,24 @@ pub async fn restore_file(file_path: String, content: String) -> Result<(), Stri
         if let std::path::Component::ParentDir = component {
             return Err("Invalid file path: path traversal not allowed".to_string());
         }
+    }
+
+    // Authorisation. Runs before `create_dir_all` below, which is itself a
+    // write: an unauthorised path must not leave directories behind.
+    //
+    // Scoped to the session when the caller names one, so the common case
+    // reads one JSONL rather than walking the project. The scan costs what a
+    // panel refresh costs, and restores are rare and user-initiated.
+    let authorised = tauri::async_runtime::spawn_blocking({
+        let project_path = project_path.clone();
+        let file_path = file_path.clone();
+        move || is_recorded_edit_target(&project_path, session_file_path.as_deref(), &file_path)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {e}"))??;
+
+    if !authorised {
+        return Err("Refusing to restore a file this project has no recorded edit for".to_string());
     }
 
     // Create parent directories if they don't exist
@@ -1084,6 +1138,86 @@ mod tests {
         );
 
         (dir, session_a, session_b)
+    }
+
+    // ------------------------------------------------------------------
+    // #525: restore is authorised by recorded edit history, not containment
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn recorded_edit_target_admits_only_files_the_project_edited() {
+        let (dir, _a, _b) = project_with_two_sessions();
+        let root = dir.path();
+        let project = root.to_string_lossy().to_string();
+
+        for edited in ["alpha.txt", "beta.txt", "gamma.txt"] {
+            let target = root.join(edited).to_string_lossy().to_string();
+            assert!(
+                is_recorded_edit_target(&project, None, &target).unwrap(),
+                "{edited} is an edit target in this project"
+            );
+        }
+
+        // Containment is not the rule. A sibling inside the very same directory
+        // is refused because nothing ever edited it - which is the whole point:
+        // a project rooted at `~` must not thereby authorise `~/.ssh/...`.
+        let neighbour = root.join("never-edited.txt").to_string_lossy().to_string();
+        assert!(!is_recorded_edit_target(&project, None, &neighbour).unwrap());
+    }
+
+    #[test]
+    fn recorded_edit_target_respects_session_scope() {
+        let (dir, session_a, _b) = project_with_two_sessions();
+        let root = dir.path();
+        let project = root.to_string_lossy().to_string();
+        let scope = session_a.to_string_lossy().to_string();
+        let gamma = root.join("gamma.txt").to_string_lossy().to_string();
+        let alpha = root.join("alpha.txt").to_string_lossy().to_string();
+
+        // `gamma.txt` belongs to session B, so scoping to A excludes it.
+        assert!(is_recorded_edit_target(&project, None, &gamma).unwrap());
+        assert!(!is_recorded_edit_target(&project, Some(&scope), &gamma).unwrap());
+        assert!(is_recorded_edit_target(&project, Some(&scope), &alpha).unwrap());
+    }
+
+    #[tokio::test]
+    async fn restore_refuses_a_file_the_project_never_edited() {
+        let (dir, _a, _b) = project_with_two_sessions();
+        let root = dir.path();
+        let project = root.to_string_lossy().to_string();
+        let target = root.join("never-edited.txt");
+
+        let result = restore_file(
+            target.to_string_lossy().to_string(),
+            "should never be written".to_string(),
+            project,
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "unauthorised restore must be refused");
+        assert!(
+            !target.exists(),
+            "the refusal must land before anything reaches the disk"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_writes_a_recorded_edit_target() {
+        let (dir, _a, _b) = project_with_two_sessions();
+        let root = dir.path();
+        let target = root.join("alpha.txt");
+
+        restore_file(
+            target.to_string_lossy().to_string(),
+            "restored".to_string(),
+            root.to_string_lossy().to_string(),
+            None,
+        )
+        .await
+        .expect("a recorded edit target must be restorable");
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "restored");
     }
 
     #[tokio::test]
@@ -1712,18 +1846,44 @@ mod tests {
         );
     }
 
+    /// A project whose session log records one edit to `name`, so restore is
+    /// authorised for it. Tests below that only care about the write mechanics
+    /// still have to satisfy the #525 authorisation gate to reach it.
+    fn project_recording_edit_to(name: &str) -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().to_path_buf();
+        let target = root.join(name);
+        create_test_jsonl_file(
+            &dir,
+            "session.jsonl",
+            &write_record("u1", "s1", "2026-08-21T10:00:00Z", &root, &target),
+        );
+        (dir, target)
+    }
+
     // Test restore_file security validations
     #[tokio::test]
     async fn test_restore_file_rejects_null_bytes() {
-        let result = restore_file("/tmp/test\0file.txt".to_string(), "content".to_string()).await;
+        let result = restore_file(
+            "/tmp/test\0file.txt".to_string(),
+            "content".to_string(),
+            "/tmp".to_string(),
+            None,
+        )
+        .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("null bytes"));
     }
 
     #[tokio::test]
     async fn test_restore_file_rejects_relative_path() {
-        let result =
-            restore_file("relative/path/file.txt".to_string(), "content".to_string()).await;
+        let result = restore_file(
+            "relative/path/file.txt".to_string(),
+            "content".to_string(),
+            "/tmp".to_string(),
+            None,
+        )
+        .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("absolute path"));
     }
@@ -1733,6 +1893,8 @@ mod tests {
         let result = restore_file(
             crate::test_utils::abs("tmp/../etc/passwd"),
             "content".to_string(),
+            crate::test_utils::abs("tmp"),
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -1741,12 +1903,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_file_success() {
-        let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("test_restore.txt");
+        let (temp_dir, file_path) = project_recording_edit_to("test_restore.txt");
 
         let result = restore_file(
             file_path.to_string_lossy().to_string(),
             "restored content".to_string(),
+            temp_dir.path().to_string_lossy().to_string(),
+            None,
         )
         .await;
 
@@ -1759,13 +1922,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_file_atomic_write_no_temp_file_left() {
-        let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("atomic_test.txt");
+        let (temp_dir, file_path) = project_recording_edit_to("atomic_test.txt");
         let temp_path = temp_dir.path().join("atomic_test.tmp.restore");
 
         let result = restore_file(
             file_path.to_string_lossy().to_string(),
             "atomic content".to_string(),
+            temp_dir.path().to_string_lossy().to_string(),
+            None,
         )
         .await;
 
@@ -1779,8 +1943,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_file_overwrites_existing() {
-        let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("existing.txt");
+        let (temp_dir, file_path) = project_recording_edit_to("existing.txt");
 
         // Create existing file
         fs::write(&file_path, "old content").unwrap();
@@ -1788,6 +1951,8 @@ mod tests {
         let result = restore_file(
             file_path.to_string_lossy().to_string(),
             "new content".to_string(),
+            temp_dir.path().to_string_lossy().to_string(),
+            None,
         )
         .await;
 
@@ -1798,16 +1963,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_file_creates_parent_dirs() {
-        let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("nested/dir/file.txt");
+        let (temp_dir, file_path) = project_recording_edit_to("nested/dir/file.txt");
 
         let result = restore_file(
             file_path.to_string_lossy().to_string(),
             "content".to_string(),
+            temp_dir.path().to_string_lossy().to_string(),
+            None,
         )
         .await;
 
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "{result:?}");
         assert!(file_path.exists());
     }
 

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -7,7 +7,7 @@ use axum::extract::State;
 use axum::Json;
 use serde::Deserialize;
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::state::AppState;
@@ -163,6 +163,12 @@ pub struct RecentEditsParams {
 pub struct RestoreFileParams {
     pub file_path: String,
     pub content: String,
+    /// The project whose recorded edits authorise this write (#525).
+    pub project_path: String,
+    /// Narrows the authorising scan to one session, matching the panel's
+    /// session scope.
+    #[serde(default)]
+    pub session_file_path: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -573,81 +579,28 @@ handler_json!(
     }
 );
 
-/// Where a `WebUI` restore may write, given how this server is bound.
-///
-/// Named rather than inlined so the decision can be tested without standing up
-/// a router, the same reason `is_read_only_allowed_path` is its own function.
-///
-/// `unrestricted` is deliberately a decided boolean rather than the raw bind
-/// flag, so the one place that decides is the call site and this stays a pure
-/// predicate.
-pub(crate) fn restore_write_allowed(unrestricted: bool, path: &Path) -> Result<(), String> {
-    if unrestricted {
-        return Ok(());
+// Write a file back to disk from a recorded edit.
+//
+// A plain `handler_json!` now: the decision no longer depends on how this
+// server is bound.
+//
+// This used to gate on the bind address plus authentication, because the
+// export allowlist does not cover a user's project directory and applying it
+// unconditionally would have broken the feature. The command authorises
+// against the project's recorded edit history instead (#525), which is both
+// tighter and independent of the socket: the only writable paths are ones the
+// session logs name as edit targets, on loopback and off it alike.
+//
+// Command-level validation (absolute path, no null bytes, no `..`, atomic
+// write) still runs underneath.
+handler_json!(
+    restore_file,
+    RestoreFileParams,
+    |p: RestoreFileParams| async move {
+        commands::session::restore_file(p.file_path, p.content, p.project_path, p.session_file_path)
+            .await
     }
-    commands::claude_settings::is_safe_path(path)
-}
-
-/// Whether this server may write outside the export allowlist.
-///
-/// Loopback alone is not enough. "The caller is this machine" is only the same
-/// statement as "the caller is the person at the keyboard" while something
-/// proves the request came from this app: with `--no-auth` the router installs
-/// `allow_origin(Any)` (see `build_router`), so any page the user has open can
-/// preflight and then `POST /api/restore_file` at `127.0.0.1` with a path and a
-/// body of its choosing. `~/.zshrc`, or a hook in `~/.claude/settings.json`,
-/// makes that code execution.
-///
-/// `--no-auth` is also permitted on a loopback host without
-/// `--allow-unsafe-no-auth`, so that combination is not exotic — it is the one
-/// in the project's own `--serve` instructions.
-///
-/// Requiring both keeps the case the carve-out exists for (the desktop-like
-/// local session, authenticated, restoring a file in your own project) and
-/// drops the one it never meant to cover.
-pub(crate) fn restore_write_is_unrestricted(state: &AppState) -> bool {
-    state.loopback_bind && state.auth.is_enabled()
-}
-
-/// Write a file back to disk from a recorded edit.
-///
-/// Stateful rather than a `handler_json!` because the allowlist decision depends
-/// on how this server is bound.
-///
-/// `read_text_file` above enforces the export allowlist unconditionally, and for
-/// a long while this, its write-side counterpart, enforced nothing: over
-/// `--serve` a request could overwrite any file the process could reach while
-/// being refused permission to *read* that same path. Writing is strictly the
-/// more dangerous of the two, so the guard belonged here first.
-///
-/// The gate is the bind address plus authentication rather than a blanket
-/// allowlist. On an authenticated loopback server the caller is this app on
-/// this machine, so restoring a file anywhere is exactly what the desktop app
-/// already does through the OS dialog, and forcing the allowlist there would
-/// break restoring a file in your own project for no safety gained. Bound to a
-/// routable address, or with auth off, the caller is someone else — possibly a
-/// web page — and the same allowlist the read path uses applies. See
-/// `restore_write_is_unrestricted`.
-///
-/// Command-level validation (absolute path, no null bytes, no `..`, atomic
-/// write) still runs underneath in both cases; this only decides *where*.
-pub async fn restore_file(
-    State(state): State<Arc<AppState>>,
-    Json(p): Json<RestoreFileParams>,
-) -> Result<Json<Value>, ApiError> {
-    restore_write_allowed(
-        restore_write_is_unrestricted(&state),
-        Path::new(&p.file_path),
-    )?;
-
-    commands::session::restore_file(p.file_path, p.content)
-        .await
-        .map_err(ApiError::from)?;
-    // The command yields `()`, which is the `null` the macro-generated handlers
-    // serialize for the other mutating endpoints. Written out rather than bound
-    // to a variable first, which would be a unit-valued binding.
-    Ok(Json(Value::Null))
-}
+);
 
 handler_json!(get_preset, IdParam, |p: IdParam| async move {
     commands::settings::get_preset(p.id).await

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -780,59 +780,44 @@ mod tests {
         std::env::temp_dir().join("ccv-restore-gate-probe.txt")
     }
 
-    /// The write side of the allowlist, which for a long while had no guard at
-    /// all while `read_text_file` beside it enforced one. Over `--serve` a
-    /// request could overwrite any reachable file while being refused
-    /// permission to read that same path.
-    #[test]
+    /// #525. The bind-address carve-out is gone: an authenticated loopback
+    /// server - the case the old gate existed to permit - must now be refused
+    /// just the same when the project has no recorded edit for the path. The
+    /// socket is no longer an input to a filesystem decision.
+    #[tokio::test]
     #[serial]
-    fn test_restore_write_is_unrestricted_only_when_permitted() {
+    async fn test_restore_refuses_unrecorded_path_even_on_authenticated_loopback() {
         let _home = crate::test_utils::SandboxHome::new();
-        use crate::server::handlers::restore_write_allowed;
+        let project = tempfile::tempdir().expect("project dir");
+        let state = state_with(true, Some("a-token"));
+        let app = build_router(state, "127.0.0.1", 3728, None, "/");
 
-        let outside = restore_gate_probe_path();
+        let body = serde_json::json!({
+            "filePath": restore_gate_probe_path().to_string_lossy(),
+            "content": "should never be written",
+            "projectPath": project.path().to_string_lossy(),
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/restore_file")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
 
-        assert!(
-            restore_write_allowed(true, &outside).is_ok(),
-            "an authenticated loopback server is this app on this machine, so \
-             restoring anywhere is what the desktop app already does"
+        assert_ne!(
+            response.status(),
+            StatusCode::OK,
+            "loopback plus auth no longer authorises a path the project never edited"
         );
-
-        let refused = restore_write_allowed(false, &outside);
         assert!(
-            refused.is_err(),
-            "otherwise the caller is someone else, so the same allowlist the \
-             read path uses must apply"
+            !restore_gate_probe_path().exists(),
+            "the refusal must happen before anything reaches the disk"
         );
-    }
-
-    /// Loopback alone must not open the gate. With `--no-auth` the router
-    /// installs `allow_origin(Any)`, so any page the user has open can POST to
-    /// `127.0.0.1`; and `--no-auth` needs no extra flag on a loopback host.
-    #[test]
-    fn test_restore_write_needs_auth_as_well_as_loopback() {
-        use crate::server::handlers::restore_write_is_unrestricted;
-
-        let authenticated_loopback = state_with(true, Some("a-token"));
-        assert!(
-            restore_write_is_unrestricted(&authenticated_loopback),
-            "the case the carve-out exists for must keep working"
-        );
-
-        let open_loopback = state_with(true, None);
-        assert!(
-            !restore_write_is_unrestricted(&open_loopback),
-            "--no-auth on loopback is reachable by any web page the user has \
-             open, so it is not the person at the keyboard"
-        );
-
-        let authenticated_routable = state_with(false, Some("a-token"));
-        assert!(
-            !restore_write_is_unrestricted(&authenticated_routable),
-            "an authenticated remote caller is still a remote caller"
-        );
-
-        assert!(!restore_write_is_unrestricted(&state_with(false, None)));
     }
 
     /// Pins the wiring, not just the predicate. Deleting the guard from the
@@ -845,9 +830,11 @@ mod tests {
         let state = state_with(false, None);
         let app = build_router(state, "127.0.0.1", 3727, None, "/");
 
+        let project = tempfile::tempdir().expect("project dir");
         let body = serde_json::json!({
             "filePath": restore_gate_probe_path().to_string_lossy(),
             "content": "should never be written",
+            "projectPath": project.path().to_string_lossy(),
         });
         let response = app
             .oneshot(

--- a/src/components/RecentEditsViewer/FileEditItem.tsx
+++ b/src/components/RecentEditsViewer/FileEditItem.tsx
@@ -50,6 +50,7 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
   dense = false,
   projectCwd,
   onRestored,
+  restoreScope,
 }) => {
   const { t } = useTranslation();
   const { t: tCommon } = useTranslation();
@@ -72,7 +73,7 @@ export const FileEditItem: React.FC<FileEditItemProps> = ({
     requestRestore,
     confirmRestore,
     cancelRestore,
-  } = useFileEditActions(edit, { onRestored });
+  } = useFileEditActions(edit, { onRestored, restoreScope });
 
   const language = getLanguageFromPath(edit.file_path);
   const fileName = getPathLeaf(edit.file_path);

--- a/src/components/RecentEditsViewer/FileEditRowCompact.test.tsx
+++ b/src/components/RecentEditsViewer/FileEditRowCompact.test.tsx
@@ -244,3 +244,50 @@ describe("FileEditRowCompact", () => {
     expect(onJumpToMessage).toHaveBeenCalledWith("msg-1");
   });
 });
+
+describe("FileEditRowCompact restore authorisation (#525)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const confirmRestore = () => {
+    fireEvent.click(screen.getAllByLabelText("recentEdits.restoreFile")[0]!);
+    fireEvent.click(screen.getByRole("button", { name: "recentEdits.confirmRestore" }));
+  };
+
+  it("sends the project that recorded the edit, and the session it was scoped to", async () => {
+    const { api } = await import("@/services/api");
+    render(
+      <FileEditRowCompact
+        edit={makeEdit()}
+        isDarkMode={false}
+        projectCwd={PROJECT}
+        restoreScope={{
+          projectPath: "/encoded/project/path",
+          sessionFilePath: "/encoded/project/path/session-a.jsonl",
+        }}
+      />
+    );
+
+    confirmRestore();
+
+    expect(api).toHaveBeenCalledWith(
+      "restore_file",
+      expect.objectContaining({
+        projectPath: "/encoded/project/path",
+        sessionFilePath: "/encoded/project/path/session-a.jsonl",
+      })
+    );
+  });
+
+  /// Without a project there is nothing to authorise against, so the call must
+  /// not be made at all rather than be sent and refused by the backend.
+  it("does not call the backend when the originating project is unknown", async () => {
+    const { api } = await import("@/services/api");
+    render(<FileEditRowCompact edit={makeEdit()} isDarkMode={false} projectCwd={PROJECT} />);
+
+    confirmRestore();
+
+    expect(api).not.toHaveBeenCalledWith("restore_file", expect.anything());
+  });
+});

--- a/src/components/RecentEditsViewer/FileEditRowCompact.tsx
+++ b/src/components/RecentEditsViewer/FileEditRowCompact.tsx
@@ -56,6 +56,13 @@ export interface FileEditRowCompactProps {
   onJumpToMessage?: (messageUuid: string) => void;
   /** Called after a successful restore, so the list can clear the missing flag. */
   onRestored?: (filePath: string) => void;
+  /**
+   * The project these rows came from, and the session they were scoped to.
+   * Restore is authorised against that project's recorded edits (#525), so the
+   * caller has to name it - and it must be the request that produced the row,
+   * not the live selection, which can have moved on.
+   */
+  restoreScope?: { projectPath: string; sessionFilePath?: string };
 }
 
 export const FileEditRowCompact: React.FC<FileEditRowCompactProps> = ({
@@ -65,11 +72,12 @@ export const FileEditRowCompact: React.FC<FileEditRowCompactProps> = ({
   grouping = "file",
   onJumpToMessage,
   onRestored,
+  restoreScope,
 }) => {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const [viewMode, setViewMode] = useState<EditViewMode>("content");
-  const actions = useFileEditActions(edit, { onRestored });
+  const actions = useFileEditActions(edit, { onRestored, restoreScope });
 
   const fileName = getPathLeaf(edit.file_path);
   const directory = elideProjectRoot(

--- a/src/components/RecentEditsViewer/RecentEditsPanel.test.tsx
+++ b/src/components/RecentEditsViewer/RecentEditsPanel.test.tsx
@@ -82,7 +82,16 @@ describe("RecentEditsPanel with no project selected", () => {
 
   it("still reports a genuinely empty project as having no edits", () => {
     state = baseState({
-      recentEditsDock: { files: [], requestKey: "k", hasMore: false },
+      recentEditsDock: {
+        files: [],
+        requestKey: "k",
+        hasMore: false,
+        request: {
+          projectPath: "/tmp/project",
+          scope: "project" as const,
+          grouping: "file" as const,
+        },
+      },
     });
 
     render(<RecentEditsPanel />);

--- a/src/components/RecentEditsViewer/RecentEditsPanel.tsx
+++ b/src/components/RecentEditsViewer/RecentEditsPanel.tsx
@@ -85,6 +85,21 @@ export const RecentEditsPanel: React.FC = () => {
   // exactly when the question being asked changes.
   const requestKey = request ? recentEditsDockRequestKey(request) : null;
 
+  // Taken from the request the rows on screen answer, not from `request` above.
+  // The two differ whenever the dock outlives the selection - deselecting a
+  // project keeps the panel open on the previous one (#533) - and restore is
+  // authorised against the project that recorded the edit (#525), so
+  // authorising against the live selection would be authorising against a
+  // project these rows did not come from.
+  const answered = recentEdits?.request;
+  const restoreScope = answered
+    ? {
+        projectPath: answered.projectPath,
+        sessionFilePath:
+          answered.scope === "session" ? answered.sessionFilePath : undefined,
+      }
+    : undefined;
+
   useEffect(() => {
     if (!request) return;
     void loadRecentEditsDock(request);
@@ -196,6 +211,7 @@ export const RecentEditsPanel: React.FC = () => {
                   grouping={grouping}
                   onJumpToMessage={navigateToMessage}
                   onRestored={handleRestored}
+                  restoreScope={restoreScope}
                 />
               ) : (
                 <div key={`${edit.file_path}-${index}`} className="p-2">
@@ -210,6 +226,7 @@ export const RecentEditsPanel: React.FC = () => {
                     dense
                     projectCwd={recentEdits?.projectCwd}
                     onRestored={handleRestored}
+                    restoreScope={restoreScope}
                   />
                 </div>
               )

--- a/src/components/RecentEditsViewer/RecentEditsViewer.tsx
+++ b/src/components/RecentEditsViewer/RecentEditsViewer.tsx
@@ -39,6 +39,14 @@ export const RecentEditsViewer: React.FC<RecentEditsViewerProps> = ({
   // Entry into docked mode. The same toggle renders in the docked panel's
   // header for the return trip, so both directions read as one control.
   const selectedProject = useAppStore((s) => s.selectedProject);
+
+  // The project the rows were fetched for, not the current selection: restore
+  // is authorised against the project that recorded the edit (#525), and the
+  // cache is keyed on the requested path for the same reason (#514). This view
+  // has no session scope, so the whole project authorises.
+  const restoreScope = recentEdits?.requestedProjectPath
+    ? { projectPath: recentEdits.requestedProjectPath }
+    : undefined;
   const setRecentEditsMode = useAppStore((s) => s.setRecentEditsMode);
   const setRecentEditsDockOpen = useAppStore((s) => s.setRecentEditsDockOpen);
   const switchToMessages = useAppStore(
@@ -208,7 +216,12 @@ export const RecentEditsViewer: React.FC<RecentEditsViewerProps> = ({
         ) : (
           <>
             {displayedFiles.map((edit, index) => (
-              <FileEditItem key={`${edit.file_path}-${index}`} edit={edit} isDarkMode={isDarkMode} />
+              <FileEditItem
+                key={`${edit.file_path}-${index}`}
+                edit={edit}
+                isDarkMode={isDarkMode}
+                restoreScope={restoreScope}
+              />
             ))}
 
             {/* Show More Button */}

--- a/src/components/RecentEditsViewer/types.ts
+++ b/src/components/RecentEditsViewer/types.ts
@@ -41,6 +41,13 @@ export interface FileEditItemProps {
    * the same restore behaved differently depending on the density.
    */
   onRestored?: (filePath: string) => void;
+  /**
+   * The project these rows came from, and the session they were scoped to.
+   * Restore is authorised against that project's recorded edits (#525), so the
+   * caller has to name it - and it must be the request that produced the row,
+   * not the live selection, which can have moved on.
+   */
+  restoreScope?: { projectPath: string; sessionFilePath?: string };
 }
 
 export type RestoreStatus = "idle" | "loading" | "success" | "error";

--- a/src/components/RecentEditsViewer/useFileEditActions.ts
+++ b/src/components/RecentEditsViewer/useFileEditActions.ts
@@ -43,7 +43,11 @@ export interface FileEditActions {
 
 export function useFileEditActions(
   edit: RecentFileEdit,
-  options: { onRestored?: (filePath: string) => void } = {}
+  options: {
+    onRestored?: (filePath: string) => void;
+    /** See `restoreScope` on the row props - required for restore to be offered. */
+    restoreScope?: { projectPath: string; sessionFilePath?: string };
+  } = {}
 ): FileEditActions {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
@@ -113,7 +117,18 @@ export function useFileEditActions(
     setRestoreError(null);
     try {
       setRestoreStatus("loading");
-      await api("restore_file", { filePath, content });
+      // The project is what authorises the write, so a row without one cannot
+      // restore. Guarded here rather than only in the UI so the call is never
+      // made without it.
+      if (!options.restoreScope) {
+        throw new Error("Cannot restore without the originating project");
+      }
+      await api("restore_file", {
+        filePath,
+        content,
+        projectPath: options.restoreScope.projectPath,
+        sessionFilePath: options.restoreScope.sessionFilePath,
+      });
       setRestoreStatus("success");
       // The row's `exists_on_disk` was resolved when the page was fetched, so
       // without telling anyone the row keeps reporting itself missing.

--- a/src/store/slices/recentEditsPanelSlice.ts
+++ b/src/store/slices/recentEditsPanelSlice.ts
@@ -94,6 +94,15 @@ export interface RecentEditsDockResult {
    * the response, which is the mistake the page view's cache guard made.
    */
   requestKey: string;
+  /**
+   * The request itself, so a row can name the project that produced it.
+   *
+   * Restore is authorised against the project's recorded edits (#525), and the
+   * rows on screen may outlive the current selection - deselecting a project
+   * leaves the dock showing the previous one (#533). Reading the live selection
+   * would authorise against a project these rows did not come from.
+   */
+  request: RecentEditsDockRequest;
 }
 
 export interface RecentEditsDockRequest {
@@ -249,7 +258,7 @@ const initialRecentEditsPanelState = (): RecentEditsPanelSliceState => ({
 });
 
 const toDockResult = (
-  requestKey: string,
+  request: RecentEditsDockRequest,
   result: {
     files: RecentFileEdit[];
     total_edits_count: number;
@@ -268,7 +277,8 @@ const toDockResult = (
   offset: result.offset,
   limit: result.limit,
   hasMore: result.has_more,
-  requestKey,
+  requestKey: recentEditsDockRequestKey(request),
+  request,
 });
 
 export const createRecentEditsPanelSlice: StateCreator<
@@ -370,7 +380,7 @@ export const createRecentEditsPanelSlice: StateCreator<
           request.scope === "session" ? request.sessionFilePath : undefined,
       });
       if (!stillOwns()) return;
-      set({ recentEditsDock: toDockResult(key, result) });
+      set({ recentEditsDock: toDockResult(request, result) });
     } catch (error) {
       if (!stillOwns()) return;
       set({
@@ -445,7 +455,7 @@ export const createRecentEditsPanelSlice: StateCreator<
       // sets, so a scope change mid-flight discards this page.
       if (recentEditsDockGeneration !== generation) return;
       if (!latest || latest.requestKey !== key) return;
-      set({ recentEditsDock: toDockResult(key, result, latest.files) });
+      set({ recentEditsDock: toDockResult(request, result, latest.files) });
     } catch (error) {
       // Same ownership rule as the success path. A late failure from a request
       // the user has already moved on from must not paint an error over rows


### PR DESCRIPTION
Closes #525 — implementing the **corrected** design in that issue, not the one it was filed with.

## Why not the obvious fix

`restore_file` was gated on bind address plus authentication (#520), because the export allowlist does not cover a user's project directory and applying it unconditionally would break the feature. That put the socket in charge of a filesystem decision.

The obvious alternative — add the scanned project roots to the allowlist — is **worse**, and the issue's own follow-up says why: `is_safe_path` matches by prefix, and a project root is not a leaf.

Run `claude` once in your home directory and the recorded root is `~`. The allowlist then contains the home directory, so restore will happily write `~/.ssh/authorized_keys`, `~/.aws/credentials`, or hooks in `~/.claude/settings.json`.

## Membership, not containment

The only paths restore will write are ones the project's session logs **name as edit targets**. Strictly tighter than the allowlist it replaces, and independent of how the server is bound — so `restore_write_allowed`, `restore_write_is_unrestricted` and the bind-address branch are all gone.

A project rooted at `~` now grants nothing extra: only the files Claude actually edited.

## One collection path

`collect_all_recent_edits` backs both the paginated panel and the authorisation check, so **the set the user sees and the set restore accepts are the same set by construction** rather than by two implementations agreeing.

That mattered concretely: testing membership against the paginated result would have capped authorisation at `MAX_PAGE_LIMIT` and quietly refused the 201st file.

## The frontend subtlety

The scope comes from the request **the rows on screen answer**, not the live selection. Those differ — deselecting a project leaves the dock showing the previous one (#533) — and authorising against the current selection would authorise against a project the rows did not come from.

`RecentEditsDockResult` carries its request for that reason. The full-page view uses the `requestedProjectPath` its cache is already keyed on (#514). A row with no known project cannot restore, and the hook refuses before calling rather than letting the backend do it.

## Verification

| | |
|---|---|
| Rust, both feature sets | 1003 / 1049 passed |
| frontend | 1156 passed |
| clippy, both sets | clean |

Mutation-checked: removing the gate fails the refusal tests. Tests cover the containment case directly — a sibling file in the very same directory is refused, because nothing edited it.

## Not covered

The session-scope narrowing is tested at the unit level but I have not clicked through the dock's session toggle against a real store. The backend rule is the security boundary and that is tested; the UI path to it is inferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * File restoration is now restricted to paths recorded as edits for the selected project and, when applicable, session.
  * Unauthorized restore attempts are rejected before any files or directories are changed.
* **Improvements**
  * Recent edit results retain their project and session context, ensuring restores use the context that produced them.
  * Restore actions now require the associated project scope.
* **Tests**
  * Added coverage for authorized and unauthorized restore scenarios, including authenticated local requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->