### PR TITLE
fix(webui): carry provider into synthetic subagent session

### DIFF
--- a/src/store/slices/messageSlice.ts
+++ b/src/store/slices/messageSlice.ts
@@ -1168,6 +1168,11 @@ export const createMessageSlice: StateCreator<
       has_tool_use: false,
       has_errors: false,
       summary: subagent.summary ?? subagent.agent_id,
+      // Subagent files live under the parent session's provider storage, so
+      // they inherit its provider; leaving this unset would make selectSession
+      // fall back to "claude" and load an empty message list for other
+      // providers (codex, opencode, gemini, ...).
+      provider: currentSession.provider ?? "claude",
     };
 
     isSubagentNav = true;

--- a/src/test/messageSlice.subagent.test.ts
+++ b/src/test/messageSlice.subagent.test.ts
@@ -228,6 +228,7 @@ const asPage = (
 
 type PaginatedArgs = {
   sessionPath: string;
+  provider?: string;
   offset?: number;
   limit?: number;
   excludeSidechain?: boolean;
@@ -636,6 +637,60 @@ describe("messageSlice — navigate guards & error branches", () => {
     expect(store.getState().parentSessionStack[0]?.file_path).toBe(
       "/tmp/parent.jsonl",
     );
+  });
+
+  it("navigateToSubagent carries the parent session's provider into the synthetic session", async () => {
+    const store = createTestStore();
+    const parent = makeSession({
+      file_path: "/tmp/parent.jsonl",
+      provider: "codex",
+    });
+    store.setState({ selectedSession: parent });
+
+    const seenProviders: (string | undefined)[] = [];
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated") {
+        seenProviders.push(args.provider);
+        return Promise.resolve(asPage([makeUserMessage("sub-1", true)], args));
+      }
+      if (cmd === "get_session_subagents") return Promise.resolve([]);
+      return Promise.reject(new Error(`unexpected: ${cmd}`));
+    });
+
+    await store
+      .getState()
+      .navigateToSubagent(makeSubagent("agent-1", "/tmp/sub.jsonl"));
+
+    // The synthetic session must keep the parent's provider, both in state
+    // and in the API call that loads the subagent's messages.
+    expect(store.getState().selectedSession?.file_path).toBe("/tmp/sub.jsonl");
+    expect(store.getState().selectedSession?.provider).toBe("codex");
+    expect(seenProviders).toEqual(["codex"]);
+    expect(store.getState().messages.map((m) => m.uuid)).toEqual(["sub-1"]);
+  });
+
+  it("navigateToSubagent falls back to claude provider when the parent has none", async () => {
+    const store = createTestStore();
+    // Legacy data shape: parent session without a provider field
+    const parent = makeSession({ file_path: "/tmp/parent.jsonl" });
+    store.setState({ selectedSession: parent });
+
+    const seenProviders: (string | undefined)[] = [];
+    mockApi.mockImplementation((cmd: string, args: PaginatedArgs) => {
+      if (cmd === "load_provider_messages_paginated") {
+        seenProviders.push(args.provider);
+        return Promise.resolve(asPage([], args));
+      }
+      if (cmd === "get_session_subagents") return Promise.resolve([]);
+      return Promise.reject(new Error(`unexpected: ${cmd}`));
+    });
+
+    await store
+      .getState()
+      .navigateToSubagent(makeSubagent("agent-1", "/tmp/sub.jsonl"));
+
+    expect(store.getState().selectedSession?.provider).toBe("claude");
+    expect(seenProviders).toEqual(["claude"]);
   });
 
   it("selectSession suppresses stale failure when user navigated away mid-flight", async () => {


### PR DESCRIPTION
## Description

### Problem

Clicking a subagent chip (or a parallel-task chip) while viewing a session from a **non-Claude provider** (codex, opencode, gemini, cursor, ...) opens an **empty** subagent view.

### Root cause

`navigateToSubagent` in `src/store/slices/messageSlice.ts` builds a synthetic `ClaudeSession` for the subagent file but never copies the `provider` field:

```ts
const syntheticSession: ClaudeSession = {
  session_id: subagent.file_path,
  ...
  summary: subagent.summary ?? subagent.agent_id,
  // ❌ no provider
};
await get().selectSession(syntheticSession);
```

`selectSession` then resolves the storage backend with `const provider = session.provider ?? "claude"` and calls `load_provider_messages_paginated` with the wrong provider. The backend looks for the subagent JSONL under the Claude base directory, finds nothing, and returns an empty list.

### Fix

Subagent files always live under the parent session's provider storage, so the synthetic session inherits `currentSession.provider` (falling back to `"claude"` for legacy data without a provider field):

```ts
provider: currentSession.provider ?? "claude",
```

### Reproduction

1. Open the WebUI with at least one non-Claude provider project (e.g. codex/opencode) that has a session containing subagent records
2. Select a session, click a subagent chip
3. Expected: subagent messages render. Actual (before this fix): empty view, since the request went out as `provider=claude` for a non-Claude session path

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## Related Issue

No existing issue found for this bug; repro and root-cause analysis are included above.

## Testing

- [x] Added regression tests: `navigateToSubagent` now asserts that the parent's `provider` reaches both the synthetic session state and the `load_provider_messages_paginated` call (`src/test/messageSlice.subagent.test.ts`), plus a legacy-data fallback case (parent without `provider` → `"claude"`)
- [x] `pnpm vitest run` — 100 files / 1158 tests passed
- [x] `pnpm exec tsc --build .` — no errors
- [x] `pnpm lint` — no errors (one pre-existing warning in `RecentEditsViewer/useFileEditActions.ts`, untouched by this PR)

## Self-Review Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for non-obvious logic
- [x] No new user-visible strings added (no i18n changes needed)
- [x] No debug logs or console statements added
- [x] No secrets or API keys in the code
- [x] TypeScript compiles without errors
- [x] ESLint passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subagent conversations for non-Claude providers so their messages load correctly.
  * Ensured subagent sessions inherit the active provider, with Claude used as a fallback when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->