### PR TITLE
fix(sessions): hide redundant Claude predecessors

### DIFF
--- a/src-tauri/src/commands/session/chain.rs
+++ b/src-tauri/src/commands/session/chain.rs
@@ -251,13 +251,13 @@ pub fn resolve_session_chain(session_path: &Path) -> Vec<PathBuf> {
     chain
 }
 
-/// Every file in `project_root` that is unambiguously replaced by one direct
-/// continuation. A predecessor remains visible when multiple files branch
-/// from the same boundary, or when it keeps receiving conversation turns
-/// after the referenced UUID. Those shapes are forks, not linear automatic
-/// continuation chains.
+/// Every file in `project_root` whose direct continuations already cover its
+/// conversation history. Multiple children can share the same predecessor
+/// without making that predecessor useful as a separate session-list entry.
+/// It remains visible only when it kept receiving main-conversation turns
+/// after at least one referenced branch point.
 pub fn superseded_chain_paths(project_root: &Path) -> HashSet<PathBuf> {
-    let mut direct_successors: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    let mut referenced_branch_points: HashMap<PathBuf, HashSet<String>> = HashMap::new();
     let Ok(entries) = fs::read_dir(project_root) else {
         return HashSet::new();
     };
@@ -275,18 +275,18 @@ pub fn superseded_chain_paths(project_root: &Path) -> HashSet<PathBuf> {
         let Some(predecessor) = find_file_containing_uuid(project_root, &parent_uuid, &skip) else {
             continue;
         };
-        direct_successors
+        referenced_branch_points
             .entry(predecessor)
             .or_default()
-            .push(parent_uuid);
+            .insert(parent_uuid);
     }
 
-    direct_successors
+    referenced_branch_points
         .into_iter()
         .filter_map(|(predecessor, parent_uuids)| {
-            let parent_uuid = parent_uuids.first()?;
-            (parent_uuids.len() == 1
-                && !has_main_conversation_after_uuid(&predecessor, parent_uuid))
+            (!parent_uuids
+                .iter()
+                .any(|parent_uuid| has_main_conversation_after_uuid(&predecessor, parent_uuid)))
             .then_some(predecessor)
         })
         .collect()
@@ -486,12 +486,49 @@ mod tests {
     }
 
     #[test]
-    fn superseded_paths_keeps_a_parent_with_multiple_direct_children() {
+    fn superseded_paths_hides_an_inactive_parent_with_multiple_direct_children() {
         let dir = TempDir::new().unwrap();
         let parent = write_file(
             &dir,
             "parent.jsonl",
             "{\"uuid\":\"tail-uuid\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[]}}\n",
+        );
+        let first_child = write_file(
+            &dir,
+            "first-child.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-1\",",
+                "\"logicalParentUuid\":\"tail-uuid\"}\n",
+                "{\"uuid\":\"u1\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"first\"}}\n",
+            ),
+        );
+        let second_child = write_file(
+            &dir,
+            "second-child.jsonl",
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"compact_boundary\",\"uuid\":\"boundary-2\",",
+                "\"logicalParentUuid\":\"tail-uuid\"}\n",
+                "{\"uuid\":\"u2\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"second\"}}\n",
+            ),
+        );
+
+        let superseded = superseded_chain_paths(dir.path());
+        assert!(superseded.contains(&parent));
+        assert!(!superseded.contains(&first_child));
+        assert!(!superseded.contains(&second_child));
+    }
+
+    #[test]
+    fn superseded_paths_keeps_an_active_parent_with_multiple_direct_children() {
+        let dir = TempDir::new().unwrap();
+        let parent = write_file(
+            &dir,
+            "parent.jsonl",
+            concat!(
+                "{\"uuid\":\"tail-uuid\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[]}}\n",
+                "{\"uuid\":\"later-user\",\"type\":\"user\",\"isSidechain\":false,",
+                "\"message\":{\"role\":\"user\",\"content\":\"still active\"}}\n",
+            ),
         );
         let first_child = write_file(
             &dir,


### PR DESCRIPTION
## What & why

Thank you for reviewing and merging #568 so quickly.

After the merge, I noticed an edge case I had overlooked: multiple direct continuations alone should not keep an otherwise inactive predecessor visible. Sorry for missing this in the original change.

When a predecessor has no messages after the referenced branch points, each child session already includes the shared predecessor history. Showing the predecessor separately therefore creates a redundant session-list entry.

This follow-up:

- hides a predecessor when it has no main-conversation messages after any referenced branch point, regardless of the number of direct children
- continues to show the predecessor when it has user or assistant messages after at least one referenced branch point
- deduplicates repeated branch-point UUIDs before inspecting the predecessor
- remains scoped to Claude Code cross-file continuation handling

## Type

- [x] Bug fix
- [ ] New feature
- [ ] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / ...)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **develop**, not main
- [x] Added/updated **tests** for the changed behavior
- [x] pnpm exec tsc --build . and pnpm lint pass
- [x] **i18n**: N/A - no new user-facing strings

## Testing

- cargo test --manifest-path src-tauri/Cargo.toml commands::session::chain::tests --lib - 11 passed
- cargo test --manifest-path src-tauri/Cargo.toml commands::session:: --lib -- --test-threads=1 - 186 passed
- pnpm exec vitest run - 1200 passed
- pnpm exec tsc --build .
- pnpm lint
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session history handling for branched conversations.
  * Inactive parent sessions are now hidden when none of their branches contain subsequent main-conversation activity.
  * Active parent sessions with multiple branches remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->