### PR TITLE
feat(provider): add Z Code (Z.ai) session source

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -70,7 +70,7 @@ Docker、VPS、systemdのセットアップは[サーバーモード](#サーバ
 
 AIコーディングアシスタントは数千もの会話メッセージを生成しますが、ツール間で履歴を振り返る方法を提供していません。CCHVがこの課題を解決します。
 
-**29のアシスタント。1つのビューア。** Claude Code、GitHub Copilot、Gemini CLI、Antigravity、Codex CLI、Cline（Roo Code・Kilo Code含む）、Cursor、Cursor Agent、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Traeのセッションをシームレスに切り替え — トークン使用量を比較し、プロバイダー間で検索し、ワークフローを1つのインターフェースで分析。
+**30のアシスタント。1つのビューア。** Claude Code、GitHub Copilot、Gemini CLI、Antigravity、Codex CLI、Cline（Roo Code・Kilo Code含む）、Cursor、Cursor Agent、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Trae、Z Codeのセッションをシームレスに切り替え — トークン使用量を比較し、プロバイダー間で検索し、ワークフローを1つのインターフェースで分析。
 
 | プロバイダー | データの場所 | 取得できる情報 |
 |----------|--------------|--------------|
@@ -101,6 +101,7 @@ AIコーディングアシスタントは数千もの会話メッセージを生
 | **Mistral Vibe** | `~/.vibe/logs/session/` | reasoningとツール呼び出しを含むOpenAIスタイルのチャットトランスクリプト（`VIBE_HOME`で上書き可） |
 | **Qwen Code** | `~/.qwen/projects/.../chats/` | セッション単位のJSONLトランスクリプト（ツール呼び出し、思考プロセス、トークン使用量） |
 | **Zed** | `…/Zed/threads/threads.db` | Agent Panelスレッド — SQLite + Zstd圧縮JSON |
+| **Z Code** | `~/.zcode/cli/db/db.sqlite` | Z.ai の GLM コーディングエージェント — session/message/part 型 SQLite ストア（タイトル、ツール呼び出し、思考、トークン使用量） |
 | **OpenHands** | `~/.openhands/sessions/` | クラシックなイベントストア形式の会話 |
 | **Trae** | `…/Trae/User/workspaceStorage/.../state.vscdb` | ワークスペース単位のチャット（icubeストア；実験的、リバースエンジニアリングによる対応） |
 
@@ -128,7 +129,7 @@ Antigravityに関する注記：ビューアはAntigravityルートを`~/.gemini
 
 | 機能 | 説明 |
 |---------|-------------|
-| **マルチプロバイダー対応** | **29のAIコーディングアシスタント**を統合ビューアで閲覧 — Claude Code、GitHub Copilot、Gemini CLI、Codex CLI、Cursor / Cursor Agent、Cline（Roo Code・Kilo Code含む）、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Antigravity、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Trae — プロバイダー別フィルタリング、ツール間比較 |
+| **マルチプロバイダー対応** | **30のAIコーディングアシスタント**を統合ビューアで閲覧 — Claude Code、GitHub Copilot、Gemini CLI、Codex CLI、Cursor / Cursor Agent、Cline（Roo Code・Kilo Code含む）、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Antigravity、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Trae、Z Code — プロバイダー別フィルタリング、ツール間比較 |
 | **会話ブラウザ** | プロジェクト/セッション別に会話を閲覧（ワークツリーグループ化対応） |
 | **グローバル検索** | 全プロバイダーの会話を瞬時に検索 |
 | **分析ダッシュボード** | デュアルモードトークン統計（課金 vs 会話）、コスト内訳、プロバイダー分布チャート |
@@ -398,7 +399,7 @@ GET /health
 ## 使い方
 
 1. アプリを起動
-2. 対応する全29プロバイダー（Claude Code、Codex CLI、Gemini CLI、Cursor、Cline、Continue.dev、Goose、Zed、Qwen Code、Amazon Q CLIなど — 上記のプロバイダー表を参照）から会話データを自動スキャン
+2. 対応する全30プロバイダー（Claude Code、Codex CLI、Gemini CLI、Cursor、Cline、Continue.dev、Goose、Zed、Qwen Code、Amazon Q CLIなど — 上記のプロバイダー表を参照）から会話データを自動スキャン
 3. 左サイドバーでプロジェクトを閲覧 — タブバーでプロバイダー別フィルタリング
 4. セッションをクリックしてメッセージを確認
 5. タブでメッセージ、分析、トークン統計、最近の編集、セッションボードを切り替え

--- a/README.ko.md
+++ b/README.ko.md
@@ -70,7 +70,7 @@ Docker, VPS, systemd 설정은 [서버 모드](#서버-모드-webui)를 참고�
 
 AI 코딩 어시스턴트는 수천 개의 대화 메시지를 생성하지만, 도구 간에 히스토리를 돌아볼 방법을 제공하지 않습니다. CCHV가 이를 해결합니다.
 
-**스물아홉 가지 어시스턴트. 하나의 뷰어.** Claude Code, GitHub Copilot, Gemini CLI, Antigravity, Codex CLI, Cline (Roo Code & Kilo Code 포함), Cursor, Cursor Agent, Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, Trae 세션을 자유롭게 전환하고 — 토큰 사용량을 비교하고, 프로바이더 간 검색하고, 워크플로를 하나의 인터페이스에서 분석하세요.
+**서른 가지 어시스턴트. 하나의 뷰어.** Claude Code, GitHub Copilot, Gemini CLI, Antigravity, Codex CLI, Cline (Roo Code & Kilo Code 포함), Cursor, Cursor Agent, Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, Trae, Z Code 세션을 자유롭게 전환하고 — 토큰 사용량을 비교하고, 프로바이더 간 검색하고, 워크플로를 하나의 인터페이스에서 분석하세요.
 
 | 프로바이더 | 데이터 위치 | 제공 내용 |
 |----------|--------------|--------------|
@@ -101,6 +101,7 @@ AI 코딩 어시스턴트는 수천 개의 대화 메시지를 생성하지만, 
 | **Mistral Vibe** | `~/.vibe/logs/session/` | reasoning과 도구 호출을 포함한 OpenAI 스타일 대화 기록 (`VIBE_HOME` 오버라이드 지원) |
 | **Qwen Code** | `~/.qwen/projects/.../chats/` | 세션별 JSONL 트랜스크립트 (도구 호출, 사고 과정, 토큰 사용량) |
 | **Zed** | `…/Zed/threads/threads.db` | Agent Panel 스레드 — SQLite + Zstd 압축 JSON |
+| **Z Code** | `~/.zcode/cli/db/db.sqlite` | Z.ai의 GLM 코딩 에이전트 — session/message/part 구조 SQLite 스토어 (제목, 도구 호출, 추론, 토큰 사용량) |
 | **OpenHands** | `~/.openhands/sessions/` | 클래식 이벤트 스토어 대화 |
 | **Trae** | `…/Trae/User/workspaceStorage/.../state.vscdb` | 워크스페이스별 채팅 (icube 스토어; 실험적, 리버스 엔지니어링 기반) |
 
@@ -128,7 +129,7 @@ Antigravity 참고: 뷰어는 Antigravity 루트를 `~/.gemini/antigravity`로 �
 
 | 기능 | 설명 |
 |---------|-------------|
-| **멀티 프로바이더** | **29개 AI 코딩 어시스턴트**를 위한 통합 뷰어 — Claude Code, GitHub Copilot, Gemini CLI, Codex CLI, Cursor / Cursor Agent, Cline (Roo Code & Kilo Code 포함), Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Antigravity, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, Trae — 프로바이더별 필터링, 도구 간 비교 |
+| **멀티 프로바이더** | **30개 AI 코딩 어시스턴트**를 위한 통합 뷰어 — Claude Code, GitHub Copilot, Gemini CLI, Codex CLI, Cursor / Cursor Agent, Cline (Roo Code & Kilo Code 포함), Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Antigravity, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, Trae, Z Code — 프로바이더별 필터링, 도구 간 비교 |
 | **대화 브라우저** | 프로젝트/세션별 대화 탐색 (워크트리 그룹핑 지원) |
 | **글로벌 검색** | 모든 프로바이더의 대화에서 즉시 검색 |
 | **분석 대시보드** | 듀얼 모드 토큰 통계 (빌링 vs 대화), 비용 브레이크다운, 프로바이더 분포 차트 |
@@ -398,7 +399,7 @@ GET /health
 ## 사용법
 
 1. 앱 실행
-2. 지원하는 29개 프로바이더 (Claude Code, Codex CLI, Gemini CLI, Cursor, Cline, Continue.dev, Goose, Zed, Qwen Code, Amazon Q CLI 등 — 위 프로바이더 표 참조)에서 대화 데이터 자동 스캔
+2. 지원하는 30개 프로바이더 (Claude Code, Codex CLI, Gemini CLI, Cursor, Cline, Continue.dev, Goose, Zed, Qwen Code, Amazon Q CLI 등 — 위 프로바이더 표 참조)에서 대화 데이터 자동 스캔
 3. 좌측 사이드바에서 프로젝트 탐색 — 탭 바로 프로바이더별 필터링
 4. 세션 클릭하여 메시지 확인
 5. 탭으로 메시지, 분석, 토큰 통계, 최근 편집, 세션 보드 전환

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [Server Mode](#server-mode-webui) for Docker, VPS, and systemd setup.
 
 AI coding assistants generate thousands of conversation messages, but none of them provide a way to look back at your history across tools. CCHV solves this.
 
-**Twenty-nine assistants. One viewer.** Switch between Claude Code, GitHub Copilot, Gemini CLI, Antigravity, Codex CLI, Cline (incl. Roo Code & Kilo Code), Cursor, Cursor Agent, Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, and Trae sessions seamlessly — compare token usage, search across providers, and analyze your workflow in a single interface.
+**Thirty assistants. One viewer.** Switch between Claude Code, GitHub Copilot, Gemini CLI, Antigravity, Codex CLI, Cline (incl. Roo Code & Kilo Code), Cursor, Cursor Agent, Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, Trae, and Z Code sessions seamlessly — compare token usage, search across providers, and analyze your workflow in a single interface.
 
 | Provider | Data Location | What You Get |
 |----------|--------------|--------------|
@@ -101,6 +101,7 @@ AI coding assistants generate thousands of conversation messages, but none of th
 | **Mistral Vibe** | `~/.vibe/logs/session/` | OpenAI-style chat transcripts with reasoning and tool calls (`VIBE_HOME` override) |
 | **Qwen Code** | `~/.qwen/projects/.../chats/` | Per-session JSONL transcripts (tool calls, thinking, token usage) |
 | **Zed** | `…/Zed/threads/threads.db` | Agent Panel threads — SQLite + Zstd-compressed JSON |
+| **Z Code** | `~/.zcode/cli/db/db.sqlite` | Z.ai's GLM coding agent — session/message/part SQLite store (titles, tool calls, thinking, token usage) |
 | **OpenHands** | `~/.openhands/sessions/` | Classic event-store conversations |
 | **Trae** | `…/Trae/User/workspaceStorage/.../state.vscdb` | Per-workspace chat (icube store; experimental, reverse-engineered) |
 
@@ -128,7 +129,7 @@ Antigravity note: the viewer resolves the Antigravity root as `~/.gemini/antigra
 
 | Feature | Description |
 |---------|-------------|
-| **Multi-Provider Support** | Unified viewer for **29 AI coding assistants** — Claude Code, GitHub Copilot, Gemini CLI, Codex CLI, Cursor / Cursor Agent, Cline (incl. Roo Code & Kilo Code), Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Antigravity, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, and Trae — filter by provider, compare across tools |
+| **Multi-Provider Support** | Unified viewer for **30 AI coding assistants** — Claude Code, GitHub Copilot, Gemini CLI, Codex CLI, Cursor / Cursor Agent, Cline (incl. Roo Code & Kilo Code), Aider, OpenCode, ForgeCode, CodeBuddy Code, Grok CLI, Kimi, Kiro, Antigravity, Amazon Q CLI, Continue.dev, PearAI, Goose, Crush, llm, Open Interpreter, Pi, oh-my-pi, Mistral Vibe, Qwen Code, Zed, OpenHands, Trae, and Z Code — filter by provider, compare across tools |
 | **Conversation Browser** | Navigate conversations by project/session with worktree grouping |
 | **Global Search** | Search across all conversations from all providers instantly |
 | **Analytics Dashboard** | Dual-mode token stats (billing vs conversation), cost breakdown, and provider distribution charts |
@@ -398,7 +399,7 @@ GET /health
 ## Usage
 
 1. Launch the app
-2. It automatically scans for conversation data from all 29 supported providers (Claude Code, Codex CLI, Gemini CLI, Cursor, Cline, Continue.dev, Goose, Zed, Qwen Code, Amazon Q CLI, and more — see the provider table above)
+2. It automatically scans for conversation data from all 30 supported providers (Claude Code, Codex CLI, Gemini CLI, Cursor, Cline, Continue.dev, Goose, Zed, Qwen Code, Amazon Q CLI, and more — see the provider table above)
 3. Browse projects in the left sidebar — filter by provider using the tab bar
 4. Click a session to view messages
 5. Use tabs to switch between Messages, Analytics, Token Stats, Recent Edits, and Session Board

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,7 +70,7 @@ Docker、VPS、systemd 设置请参阅[服务器模式](#服务器模式-webui)�
 
 AI 编程助手生成了数千条对话消息，但它们都不提供跨工具回顾历史的方式。CCHV 解决了这个问题。
 
-**二十九个助手。一个查看器。** 在 Claude Code、GitHub Copilot、Gemini CLI、Antigravity、Codex CLI、Cline（含 Roo Code 和 Kilo Code）、Cursor、Cursor Agent、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands 和 Trae 会话之间无缝切换 — 比较 Token 用量、跨提供商搜索、在一个界面中分析你的工作流。
+**三十个助手。一个查看器。** 在 Claude Code、GitHub Copilot、Gemini CLI、Antigravity、Codex CLI、Cline（含 Roo Code 和 Kilo Code）、Cursor、Cursor Agent、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Trae 和 Z Code 会话之间无缝切换 — 比较 Token 用量、跨提供商搜索、在一个界面中分析你的工作流。
 
 | 提供商 | 数据位置 | 获取内容 |
 |----------|--------------|--------------|
@@ -101,6 +101,7 @@ AI 编程助手生成了数千条对话消息，但它们都不提供跨工具�
 | **Mistral Vibe** | `~/.vibe/logs/session/` | 含 reasoning 与工具调用的 OpenAI 风格聊天转录（支持 `VIBE_HOME` 覆盖） |
 | **Qwen Code** | `~/.qwen/projects/.../chats/` | 每会话 JSONL 记录（工具调用、思维过程、Token 用量） |
 | **Zed** | `…/Zed/threads/threads.db` | Agent Panel 线程 — SQLite + Zstd 压缩 JSON |
+| **Z Code** | `~/.zcode/cli/db/db.sqlite` | Z.ai 的 GLM 编程智能体 — session/message/part 三表 SQLite 存储（标题、工具调用、思考过程、Token 用量） |
 | **OpenHands** | `~/.openhands/sessions/` | 经典事件存储对话 |
 | **Trae** | `…/Trae/User/workspaceStorage/.../state.vscdb` | 按工作区的聊天记录（icube 存储；实验性，逆向工程） |
 
@@ -128,7 +129,7 @@ Antigravity 说明：查看器将 Antigravity 根目录解析为 `~/.gemini/anti
 
 | 功能 | 描述 |
 |---------|-------------|
-| **多提供商支持** | 统一查看 **29 个 AI 编程助手** — Claude Code、GitHub Copilot、Gemini CLI、Codex CLI、Cursor / Cursor Agent、Cline（含 Roo Code 和 Kilo Code）、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Antigravity、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands 和 Trae — 按提供商筛选、跨工具比较 |
+| **多提供商支持** | 统一查看 **30 个 AI 编程助手** — Claude Code、GitHub Copilot、Gemini CLI、Codex CLI、Cursor / Cursor Agent、Cline（含 Roo Code 和 Kilo Code）、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Antigravity、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Trae 和 Z Code — 按提供商筛选、跨工具比较 |
 | **对话浏览器** | 按项目/会话导航对话,支持工作树分组 |
 | **全局搜索** | 即时搜索所有提供商的对话内容 |
 | **分析仪表板** | 双模式 Token 统计（计费 vs 对话）、成本明细、提供商分布图表 |
@@ -398,7 +399,7 @@ GET /health
 ## 使用方法
 
 1. 启动应用
-2. 自动扫描全部 29 个支持的提供商（Claude Code、Codex CLI、Gemini CLI、Cursor、Cline、Continue.dev、Goose、Zed、Qwen Code、Amazon Q CLI 等 — 参见上方提供商表格）的对话数据
+2. 自动扫描全部 30 个支持的提供商（Claude Code、Codex CLI、Gemini CLI、Cursor、Cline、Continue.dev、Goose、Zed、Qwen Code、Amazon Q CLI 等 — 参见上方提供商表格）的对话数据
 3. 在左侧边栏浏览项目 — 使用标签栏按提供商筛选
 4. 点击会话查看消息
 5. 使用标签页在消息、分析、Token 统计、最近编辑和会话面板之间切换

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -70,7 +70,7 @@ Docker、VPS、systemd 設定請參閱[伺服器模式](#伺服器模式-webui)�
 
 AI 程式設計助手產生了數千條對話訊息，但它們都沒有提供跨工具回顧歷史的方式。CCHV 解決了這個問題。
 
-**二十九個助手。一個檢視器。** 在 Claude Code、GitHub Copilot、Gemini CLI、Antigravity、Codex CLI、Cline（含 Roo Code 和 Kilo Code）、Cursor、Cursor Agent、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands 和 Trae 工作階段之間無縫切換 — 比較 Token 用量、跨提供者搜尋、在一個介面中分析您的工作流程。
+**三十個助手。一個檢視器。** 在 Claude Code、GitHub Copilot、Gemini CLI、Antigravity、Codex CLI、Cline（含 Roo Code 和 Kilo Code）、Cursor、Cursor Agent、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Trae 和 Z Code 工作階段之間無縫切換 — 比較 Token 用量、跨提供者搜尋、在一個介面中分析您的工作流程。
 
 | 提供者 | 資料位置 | 取得內容 |
 |----------|--------------|--------------|
@@ -101,6 +101,7 @@ AI 程式設計助手產生了數千條對話訊息，但它們都沒有提供�
 | **Mistral Vibe** | `~/.vibe/logs/session/` | 含 reasoning 與工具呼叫的 OpenAI 風格聊天轉錄（支援 `VIBE_HOME` 覆寫） |
 | **Qwen Code** | `~/.qwen/projects/.../chats/` | 逐工作階段 JSONL 逐字稿（工具呼叫、思考過程、Token 用量） |
 | **Zed** | `…/Zed/threads/threads.db` | Agent Panel 執行緒 — SQLite + Zstd 壓縮 JSON |
+| **Z Code** | `~/.zcode/cli/db/db.sqlite` | Z.ai 的 GLM 編程智能體 — session/message/part 三表 SQLite 儲存（標題、工具呼叫、思考過程、Token 用量） |
 | **OpenHands** | `~/.openhands/sessions/` | 傳統 event-store 對話 |
 | **Trae** | `…/Trae/User/workspaceStorage/.../state.vscdb` | 逐工作區聊天（icube 儲存；實驗性，逆向工程） |
 
@@ -128,7 +129,7 @@ Antigravity 說明：檢視器將 Antigravity 根目錄解析為 `~/.gemini/anti
 
 | 功能 | 說明 |
 |---------|-------------|
-| **多提供者支援** | 統一檢視 **29 個 AI 程式設計助手** — Claude Code、GitHub Copilot、Gemini CLI、Codex CLI、Cursor / Cursor Agent、Cline（含 Roo Code 和 Kilo Code）、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Antigravity、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands 和 Trae — 依提供者篩選、跨工具比較 |
+| **多提供者支援** | 統一檢視 **30 個 AI 程式設計助手** — Claude Code、GitHub Copilot、Gemini CLI、Codex CLI、Cursor / Cursor Agent、Cline（含 Roo Code 和 Kilo Code）、Aider、OpenCode、ForgeCode、CodeBuddy Code、Grok CLI、Kimi、Kiro、Antigravity、Amazon Q CLI、Continue.dev、PearAI、Goose、Crush、llm、Open Interpreter、Pi、oh-my-pi、Mistral Vibe、Qwen Code、Zed、OpenHands、Trae 和 Z Code — 依提供者篩選、跨工具比較 |
 | **對話瀏覽器** | 依專案/工作階段瀏覽對話記錄，支援工作樹分組 |
 | **全域搜尋** | 即時搜尋所有提供者的對話記錄 |
 | **分析儀表板** | 雙模式 Token 統計（帳單 vs 對話）、成本明細、提供者分佈圖表 |
@@ -398,7 +399,7 @@ GET /health
 ## 使用方式
 
 1. 啟動應用程式
-2. 自動掃描所有 29 個支援提供者（Claude Code、Codex CLI、Gemini CLI、Cursor、Cline、Continue.dev、Goose、Zed、Qwen Code、Amazon Q CLI 等 — 見上方提供者表格）的對話資料
+2. 自動掃描所有 30 個支援提供者（Claude Code、Codex CLI、Gemini CLI、Cursor、Cline、Continue.dev、Goose、Zed、Qwen Code、Amazon Q CLI 等 — 見上方提供者表格）的對話資料
 3. 在左側邊欄瀏覽專案 — 使用分頁列依提供者篩選
 4. 點擊工作階段檢視訊息
 5. 使用分頁切換訊息、分析、Token 統計、最近編輯和工作階段面板

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -197,6 +197,7 @@ pub async fn scan_all_projects(
         ("kiro", providers::kiro::scan_projects),
         ("llm", providers::llm::scan_projects),
         ("copilot", providers::copilot::scan_projects),
+        ("zcode", providers::zcode::scan_projects),
     ];
 
     // Spawn every enabled scanner up front so they run concurrently on the
@@ -367,6 +368,7 @@ pub async fn load_provider_sessions(
         "continue" => providers::continue_dev::load_sessions(&project_path, exclude),
         "pearai" => providers::pearai::load_sessions(&project_path, exclude),
         "copilot" => providers::copilot::load_sessions(&project_path, exclude),
+        "zcode" => providers::zcode::load_sessions(&project_path, exclude),
         "gemini" => providers::gemini::load_sessions(&project_path, exclude),
         "goose" => providers::goose::load_sessions(&project_path, exclude),
         "grok" => providers::grok::load_sessions(&project_path, exclude),
@@ -480,6 +482,7 @@ fn load_non_claude_messages(
         "continue" => providers::continue_dev::load_messages(session_path),
         "pearai" => providers::pearai::load_messages(session_path),
         "copilot" => providers::copilot::load_messages(session_path),
+        "zcode" => providers::zcode::load_messages(session_path),
         "gemini" => providers::gemini::load_messages(session_path),
         "goose" => providers::goose::load_messages(session_path),
         "grok" => providers::grok::load_messages(session_path),
@@ -875,6 +878,16 @@ pub async fn search_all_providers(
             Ok(results) => all_results.extend(results),
             Err(e) => {
                 log::warn!("oh-my-pi search failed: {e}");
+            }
+        }
+    }
+
+    // Z Code
+    if providers_to_search.iter().any(|p| p == "zcode") {
+        match providers::zcode::search(&query, max_results) {
+            Ok(results) => all_results.extend(results),
+            Err(e) => {
+                log::warn!("Z Code search failed: {e}");
             }
         }
     }

--- a/src-tauri/src/commands/multi_provider.rs
+++ b/src-tauri/src/commands/multi_provider.rs
@@ -108,6 +108,7 @@ pub async fn scan_all_projects(
             "openhands".to_string(),
             "trae".to_string(),
             "vibe".to_string(),
+            "zcode".to_string(),
         ]
     });
 
@@ -684,6 +685,7 @@ pub async fn search_all_providers(
             "openhands".to_string(),
             "trae".to_string(),
             "vibe".to_string(),
+            "zcode".to_string(),
         ]
     });
     // Native loaders use the full active provider selection. WSL loaders use

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -131,6 +131,9 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(qwen_base) = crate::providers::qwen::get_base_path() {
         allowed.push(PathBuf::from(qwen_base));
     }
+    if let Some(zcode_base) = crate::providers::zcode::get_base_path() {
+        allowed.push(PathBuf::from(zcode_base));
+    }
     if let Some(zed_base) = crate::providers::zed::get_base_path() {
         allowed.push(PathBuf::from(zed_base));
     }

--- a/src-tauri/src/commands/session/mod.rs
+++ b/src-tauri/src/commands/session/mod.rs
@@ -131,6 +131,8 @@ pub(crate) fn is_safe_session_path(path: &std::path::Path) -> Result<(), String>
     if let Some(qwen_base) = crate::providers::qwen::get_base_path() {
         allowed.push(PathBuf::from(qwen_base));
     }
+    // Z Code sessions are `zcode://` pseudo-paths, so nothing currently
+    // reaches this entry — kept for symmetry with the zed entry above.
     if let Some(zcode_base) = crate::providers::zcode::get_base_path() {
         allowed.push(PathBuf::from(zcode_base));
     }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -51,6 +51,7 @@ enum StatsProvider {
     Pi,
     Gemini,
     Cursor,
+    Zcode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,6 +111,7 @@ fn stats_provider_id(provider: StatsProvider) -> &'static str {
         StatsProvider::Pi => "pi",
         StatsProvider::Gemini => "gemini",
         StatsProvider::Cursor => "cursor",
+        StatsProvider::Zcode => "zcode",
     }
 }
 
@@ -345,6 +347,7 @@ fn parse_active_stats_providers(active_providers: Option<Vec<String>>) -> HashSe
             "openinterpreter" => Some(StatsProvider::OpenInterpreter),
             "pearai" => Some(StatsProvider::PearAI),
             "qwen" => Some(StatsProvider::Qwen),
+            "zcode" => Some(StatsProvider::Zcode),
             "trae" => Some(StatsProvider::Trae),
             "vibe" => Some(StatsProvider::Vibe),
             "zed" => Some(StatsProvider::Zed),
@@ -410,6 +413,8 @@ fn detect_project_provider(project_path: &str) -> StatsProvider {
         StatsProvider::Vibe
     } else if project_path.starts_with("zed://") {
         StatsProvider::Zed
+    } else if project_path.starts_with("zcode://") {
+        StatsProvider::Zcode
     } else if project_path.starts_with("codex://") {
         StatsProvider::Codex
     } else if project_path.starts_with("forgecode://") {
@@ -506,6 +511,9 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
     }
     if path_under_root(session_path, providers::qwen::get_base_path()) {
         return StatsProvider::Qwen;
+    }
+    if path_under_root(session_path, providers::zcode::get_base_path()) {
+        return StatsProvider::Zcode;
     }
     if path_under_root(session_path, providers::vibe::get_base_path()) {
         return StatsProvider::Vibe;
@@ -1502,6 +1510,7 @@ fn scan_stats_projects(
         StatsProvider::OpenInterpreter => providers::openinterpreter::scan_projects(),
         StatsProvider::PearAI => providers::pearai::scan_projects(),
         StatsProvider::Qwen => providers::qwen::scan_projects(),
+        StatsProvider::Zcode => providers::zcode::scan_projects(),
         StatsProvider::Trae => providers::trae::scan_projects(),
         StatsProvider::Vibe => providers::vibe::scan_projects(),
         StatsProvider::Zed => providers::zed::scan_projects(),
@@ -1541,6 +1550,7 @@ fn load_stats_sessions(
         }
         StatsProvider::PearAI => providers::pearai::load_sessions(project_path, false),
         StatsProvider::Qwen => providers::qwen::load_sessions(project_path, false),
+        StatsProvider::Zcode => providers::zcode::load_sessions(project_path, false),
         StatsProvider::Trae => providers::trae::load_sessions(project_path, false),
         StatsProvider::Vibe => providers::vibe::load_sessions(project_path, false),
         StatsProvider::Zed => providers::zed::load_sessions(project_path, false),
@@ -1578,6 +1588,7 @@ fn load_stats_messages(
         StatsProvider::OpenInterpreter => providers::openinterpreter::load_messages(session_path),
         StatsProvider::PearAI => providers::pearai::load_messages(session_path),
         StatsProvider::Qwen => providers::qwen::load_messages(session_path),
+        StatsProvider::Zcode => providers::zcode::load_messages(session_path),
         StatsProvider::Trae => providers::trae::load_messages(session_path),
         StatsProvider::Vibe => providers::vibe::load_messages(session_path),
         StatsProvider::Zed => providers::zed::load_messages(session_path),
@@ -2976,7 +2987,8 @@ fn resolve_provider_project_name(provider: StatsProvider, project_path: &str) ->
         | StatsProvider::CursorAgent
         | StatsProvider::Goose
         | StatsProvider::Kiro
-        | StatsProvider::Llm => fallback_provider_name(provider, project_path),
+        | StatsProvider::Llm
+        | StatsProvider::Zcode => fallback_provider_name(provider, project_path),
     }
 }
 
@@ -3129,7 +3141,8 @@ fn resolve_provider_project_name_from_session(
         | StatsProvider::CursorAgent
         | StatsProvider::Goose
         | StatsProvider::Kiro
-        | StatsProvider::Llm => fallback_provider_name(provider, session_path),
+        | StatsProvider::Llm
+        | StatsProvider::Zcode => fallback_provider_name(provider, session_path),
         StatsProvider::Claude => "unknown".to_string(),
     }
 }
@@ -5111,6 +5124,7 @@ pub async fn get_global_stats_summary(
         StatsProvider::Trae,
         StatsProvider::Vibe,
         StatsProvider::Zed,
+        StatsProvider::Zcode,
     ] {
         if providers_to_include.contains(&provider) {
             let (provider_stats, provider_projects) =

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -319,6 +319,7 @@ fn all_stats_providers() -> HashSet<StatsProvider> {
         StatsProvider::Pi,
         StatsProvider::Gemini,
         StatsProvider::Cursor,
+        StatsProvider::Zcode,
     ]
     .into_iter()
     .collect()
@@ -500,6 +501,9 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
     if session_path.starts_with("zed://") {
         return StatsProvider::Zed;
     }
+    if session_path.starts_with("zcode://") {
+        return StatsProvider::Zcode;
+    }
     if path_under_root(session_path, providers::cursor_agent::get_base_path()) {
         return StatsProvider::CursorAgent;
     }
@@ -511,9 +515,6 @@ fn detect_session_provider(session_path: &str) -> StatsProvider {
     }
     if path_under_root(session_path, providers::qwen::get_base_path()) {
         return StatsProvider::Qwen;
-    }
-    if path_under_root(session_path, providers::zcode::get_base_path()) {
-        return StatsProvider::Zcode;
     }
     if path_under_root(session_path, providers::vibe::get_base_path()) {
         return StatsProvider::Vibe;
@@ -6241,7 +6242,7 @@ mod tests {
         let parsed = parse_active_stats_providers(Some(ids));
 
         assert_eq!(parsed, supported);
-        assert_eq!(supported.len(), 29);
+        assert_eq!(supported.len(), 30);
     }
 
     #[test]
@@ -8401,6 +8402,11 @@ mod tests {
         assert_eq!(
             detect_session_provider(&format!("{home}/.codex/sessions/2026/rollout-x.jsonl")),
             StatsProvider::Codex
+        );
+        // Z Code pseudo-paths route by scheme, not by filesystem location.
+        assert_eq!(
+            detect_session_provider("zcode:///home/jack/proj#sess-1"),
+            StatsProvider::Zcode
         );
         // Claude files still route to Claude.
         assert_eq!(

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -2998,6 +2998,21 @@ fn resolve_provider_project_name_from_session(
     provider: StatsProvider,
     session_path: &str,
 ) -> String {
+    // Z Code session pseudo-paths are `<directory>#<session_id>`; strip the
+    // session suffix so the name is the directory's last segment, not
+    // `proj#sess-1`.
+    if provider == StatsProvider::Zcode {
+        let raw = session_path
+            .strip_prefix("zcode://")
+            .unwrap_or(session_path);
+        let dir = raw.rsplit_once('#').map(|(d, _)| d).unwrap_or(raw);
+        return Path::new(dir)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| stats_provider_id(provider))
+            .to_string();
+    }
     match provider {
         StatsProvider::ForgeCode => {
             let workspace_id = session_path
@@ -8412,6 +8427,25 @@ mod tests {
         assert_eq!(
             detect_session_provider(&format!("{home}/.claude/projects/-u/s.jsonl")),
             StatsProvider::Claude
+        );
+    }
+
+    #[test]
+    fn zcode_session_project_name_strips_session_suffix() {
+        assert_eq!(
+            resolve_provider_project_name_from_session(
+                StatsProvider::Zcode,
+                "zcode:///home/jack/proj#sess-1"
+            ),
+            "proj"
+        );
+        // No session suffix: behaves like the generic fallback.
+        assert_eq!(
+            resolve_provider_project_name_from_session(
+                StatsProvider::Zcode,
+                "zcode:///home/jack/proj"
+            ),
+            "proj"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1146,6 +1146,13 @@ fn collect_watch_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
+    if let Some(zcode_base) = providers::zcode::get_base_path() {
+        let zcode_dir = PathBuf::from(zcode_base);
+        if zcode_dir.is_dir() {
+            paths.push(zcode_dir);
+        }
+    }
+
     if let Some(zed_base) = providers::zed::get_base_path() {
         let zed_dir = PathBuf::from(zed_base);
         if zed_dir.is_dir() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -42,6 +42,7 @@ pub mod qwen;
 pub mod trae;
 pub mod vibe;
 pub mod vscode;
+pub mod zcode;
 pub mod zed;
 
 /// Provider identifier
@@ -96,6 +97,8 @@ pub enum ProviderId {
     Trae,
     /// Mistral Vibe CLI (`~/.vibe/logs/session/<session>/`).
     Vibe,
+    /// Z.ai Z Code (`~/.zcode/cli/db/db.sqlite`).
+    Zcode,
 }
 
 impl ProviderId {
@@ -130,6 +133,7 @@ impl ProviderId {
             Self::Zed => "zed",
             Self::Trae => "trae",
             Self::Vibe => "vibe",
+            Self::Zcode => "zcode",
         }
     }
 
@@ -164,6 +168,7 @@ impl ProviderId {
             "zed" => Some(Self::Zed),
             "trae" => Some(Self::Trae),
             "vibe" => Some(Self::Vibe),
+            "zcode" => Some(Self::Zcode),
             _ => None,
         }
     }
@@ -199,6 +204,7 @@ impl ProviderId {
             Self::Zed => "Zed",
             Self::Trae => "Trae",
             Self::Vibe => "Mistral Vibe",
+            Self::Zcode => "Z Code",
         }
     }
 }
@@ -301,6 +307,9 @@ pub fn detect_providers() -> Vec<ProviderInfo> {
         providers.push(info);
     }
     if let Some(info) = vibe::detect() {
+        providers.push(info);
+    }
+    if let Some(info) = zcode::detect() {
         providers.push(info);
     }
 

--- a/src-tauri/src/providers/zcode.rs
+++ b/src-tauri/src/providers/zcode.rs
@@ -92,7 +92,7 @@ fn scan_projects_conn(conn: &Connection) -> Result<Vec<ClaudeProject>, String> {
                 FROM session s \
                 WHERE s.task_type != 'subagent_child' \
                   AND (s.time_archived IS NULL OR s.time_archived = 0) \
-             ) s GROUP BY s.directory",
+             ) s WHERE s.m_cnt > 0 GROUP BY s.directory",
         )
         .map_err(|e| e.to_string())?;
     let mut by_dir: std::collections::HashMap<String, Agg> = std::collections::HashMap::new();
@@ -643,7 +643,9 @@ mod tests {
         let projects = scan_projects_conn(&conn).unwrap();
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].actual_path, "/Users/jack/proj");
-        assert_eq!(projects[0].session_count, 2);
+        // sess-2 has no messages and is excluded from the count, matching
+        // what load_sessions filters.
+        assert_eq!(projects[0].session_count, 1);
         assert_eq!(projects[0].provider.as_deref(), Some("zcode"));
     }
 

--- a/src-tauri/src/providers/zcode.rs
+++ b/src-tauri/src/providers/zcode.rs
@@ -33,8 +33,17 @@ const SCHEME: &str = "zcode://";
 const SESSION_SEP: char = '#';
 const SUMMARY_MAX_CHARS: usize = 80;
 
-/// Base dir: `~/.zcode`.
+/// Base dir: `$ZCODE_HOME` (relative values resolve against the cwd) or
+/// `~/.zcode` — the same override convention as `CODEX_HOME`/`GEMINI_HOME`.
 fn runtime_base() -> Option<PathBuf> {
+    if let Ok(env_val) = std::env::var("ZCODE_HOME") {
+        let path = PathBuf::from(&env_val);
+        return Some(if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir().ok()?.join(path)
+        });
+    }
     Some(crate::utils::home_dir()?.join(".zcode"))
 }
 
@@ -78,25 +87,22 @@ pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
     scan_projects_conn(&conn)
 }
 
+/// Projects (one row per session `directory`) with session/message counts.
 fn scan_projects_conn(conn: &Connection) -> Result<Vec<ClaudeProject>, String> {
-    struct Agg {
-        session_count: usize,
-        message_count: usize,
-        last_modified: i64,
-    }
+    // One row per directory already: GROUP BY aggregates the counts and
+    // `WHERE s.m_cnt > 0` keeps only sessions that would appear when loaded.
     let mut stmt = conn
         .prepare(
             "SELECT s.directory, COUNT(*), SUM(m_cnt), MAX(s.time_updated) FROM ( \
                 SELECT s.directory AS directory, s.time_updated AS time_updated, \
                        (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) AS m_cnt \
                 FROM session s \
-                WHERE s.task_type != 'subagent_child' \
+                WHERE (s.task_type IS NULL OR s.task_type != 'subagent_child') \
                   AND (s.time_archived IS NULL OR s.time_archived = 0) \
              ) s WHERE s.m_cnt > 0 GROUP BY s.directory",
         )
         .map_err(|e| e.to_string())?;
-    let mut by_dir: std::collections::HashMap<String, Agg> = std::collections::HashMap::new();
-    let rows = stmt
+    let mut projects: Vec<ClaudeProject> = stmt
         .query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
@@ -105,25 +111,9 @@ fn scan_projects_conn(conn: &Connection) -> Result<Vec<ClaudeProject>, String> {
                 row.get::<_, Option<i64>>(3)?,
             ))
         })
-        .map_err(|e| e.to_string())?;
-    for row in rows.flatten() {
-        let (dir, sessions, messages, updated) = row;
-        if messages.unwrap_or(0) == 0 {
-            continue;
-        }
-        let entry = by_dir.entry(dir).or_insert(Agg {
-            session_count: 0,
-            message_count: 0,
-            last_modified: 0,
-        });
-        entry.session_count += sessions.max(0) as usize;
-        entry.message_count += messages.unwrap_or(0).max(0) as usize;
-        entry.last_modified = entry.last_modified.max(updated.unwrap_or(0));
-    }
-
-    let mut projects: Vec<ClaudeProject> = by_dir
-        .into_iter()
-        .map(|(dir, agg)| {
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .map(|(dir, sessions, messages, updated)| {
             let name = Path::new(&dir)
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string())
@@ -133,9 +123,9 @@ fn scan_projects_conn(conn: &Connection) -> Result<Vec<ClaudeProject>, String> {
                 name,
                 path: format!("{SCHEME}{dir}"),
                 actual_path: dir,
-                session_count: agg.session_count,
-                message_count: agg.message_count,
-                last_modified: ms_to_iso(agg.last_modified.max(0) as u64),
+                session_count: sessions.max(0) as usize,
+                message_count: messages.unwrap_or(0).max(0) as usize,
+                last_modified: ms_to_iso(updated.unwrap_or(0).max(0) as u64),
                 git_info: None,
                 provider: Some(PROVIDER.to_string()),
                 storage_type: Some("sqlite".to_string()),
@@ -160,6 +150,7 @@ pub fn load_sessions(
     load_sessions_conn(&conn, directory)
 }
 
+/// Sessions of one Z Code project (`directory`), newest first.
 fn load_sessions_conn(conn: &Connection, directory: &str) -> Result<Vec<ClaudeSession>, String> {
     let mut stmt = conn
         .prepare(
@@ -169,7 +160,7 @@ fn load_sessions_conn(conn: &Connection, directory: &str) -> Result<Vec<ClaudeSe
                            AND json_extract(p.data, '$.type') = 'tool') AS has_tool \
              FROM session s \
              WHERE s.directory = ?1 \
-               AND s.task_type != 'subagent_child' \
+               AND (s.task_type IS NULL OR s.task_type != 'subagent_child') \
                AND (s.time_archived IS NULL OR s.time_archived = 0)",
         )
         .map_err(|e| e.to_string())?;
@@ -182,8 +173,8 @@ fn load_sessions_conn(conn: &Connection, directory: &str) -> Result<Vec<ClaudeSe
         .query_map([directory], |row| {
             Ok((
                 row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
                 row.get::<_, i64>(3)?,
                 row.get::<_, i64>(4)?,
                 row.get::<_, i64>(5)?,
@@ -197,11 +188,11 @@ fn load_sessions_conn(conn: &Connection, directory: &str) -> Result<Vec<ClaudeSe
             |(id, title, title_source, created, updated, msg_cnt, has_tool)| {
                 let created_iso = ms_to_iso(created.max(0) as u64);
                 let updated_iso = ms_to_iso(updated.max(0) as u64);
-                let summary = if title.trim().is_empty() {
-                    None
-                } else {
-                    Some(summarize(&title))
-                };
+                let summary = title
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                    .map(summarize);
                 ClaudeSession {
                     session_id: format!("{SCHEME}{directory}{SESSION_SEP}{id}"),
                     actual_session_id: id.clone(),
@@ -214,7 +205,7 @@ fn load_sessions_conn(conn: &Connection, directory: &str) -> Result<Vec<ClaudeSe
                     has_tool_use: has_tool != 0,
                     has_errors: false,
                     summary,
-                    is_renamed: title_source == "custom",
+                    is_renamed: title_source.as_deref() == Some("custom"),
                     provider: Some(PROVIDER.to_string()),
                     storage_type: Some("sqlite".to_string()),
                     entrypoint: None,
@@ -235,6 +226,7 @@ pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
     load_messages_conn(&conn, &session_id)
 }
 
+/// Split `zcode://<directory>#<session_id>` into its two parts.
 fn parse_session_path(session_path: &str) -> Result<(String, String), String> {
     let stripped = session_path.strip_prefix(SCHEME).unwrap_or(session_path);
     stripped
@@ -243,6 +235,7 @@ fn parse_session_path(session_path: &str) -> Result<(String, String), String> {
         .ok_or_else(|| format!("Invalid Z Code session path: {session_path}"))
 }
 
+/// Every viewer-visible message of one session, in `sequence` order.
 fn load_messages_conn(conn: &Connection, session_id: &str) -> Result<Vec<ClaudeMessage>, String> {
     let mut stmt = conn
         .prepare(
@@ -413,6 +406,7 @@ fn append_message(
     }
 }
 
+/// Map a Z Code token report to viewer usage (input excludes cache reads).
 fn convert_usage(tokens: &Value) -> TokenUsage {
     let g = |k: &str| {
         tokens
@@ -441,6 +435,7 @@ fn convert_usage(tokens: &Value) -> TokenUsage {
     }
 }
 
+/// Stringify a tool output that Z Code stores as string or object.
 fn stringify_value(v: &Value) -> String {
     match v {
         Value::String(s) => s.clone(),
@@ -448,6 +443,7 @@ fn stringify_value(v: &Value) -> String {
     }
 }
 
+/// Collapse whitespace and clip to the summary length with an ellipsis.
 fn summarize(text: &str) -> String {
     let cleaned = text.split_whitespace().collect::<Vec<_>>().join(" ");
     if cleaned.chars().count() > SUMMARY_MAX_CHARS {
@@ -495,6 +491,7 @@ fn like_prefilter_pattern(query: &str) -> Option<String> {
     })
 }
 
+/// Case-insensitive search over all sessions, `limit`-capped.
 fn search_conn(conn: &Connection, query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
     let query_lower = query.to_lowercase();
     let mut results = Vec::new();
@@ -505,7 +502,7 @@ fn search_conn(conn: &Connection, query: &str, limit: usize) -> Result<Vec<Claud
     let mut stmt = conn
         .prepare(
             "SELECT id, directory FROM session s \
-             WHERE task_type != 'subagent_child' \
+             WHERE (task_type IS NULL OR task_type != 'subagent_child') \
                AND (time_archived IS NULL OR time_archived = 0) \
                AND (?1 IS NULL OR EXISTS ( \
                     SELECT 1 FROM part p WHERE p.session_id = s.id \
@@ -550,14 +547,14 @@ fn search_conn(conn: &Connection, query: &str, limit: usize) -> Result<Vec<Claud
 mod tests {
     use super::*;
 
-    /// Build an in-memory DB mirroring the Z Code schema subset we read.
-    fn test_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "CREATE TABLE session (
+    /// Schema subset we read. `task_type` is deliberately nullable here even
+    /// though the wild store declares it NOT NULL — the queries guard against
+    /// NULL so a future schema change degrades gracefully instead of hiding
+    /// sessions.
+    const TEST_SCHEMA: &str = "CREATE TABLE session (
                 id text primary key, project_id text not null, directory text not null,
-                title text not null, task_type text not null default 'interactive',
-                title_source text not null default 'first_input',
+                title text not null, task_type text default 'interactive',
+                title_source text default 'first_input',
                 time_created integer not null, time_updated integer not null,
                 time_archived integer
             );
@@ -568,10 +565,43 @@ mod tests {
             CREATE TABLE part (
                 id text primary key, message_id text not null, session_id text not null,
                 time_created integer not null, data text not null, sequence integer
-            );",
-        )
-        .unwrap();
+            );";
+
+    /// Build an in-memory DB mirroring the Z Code schema subset we read.
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(TEST_SCHEMA).unwrap();
         conn
+    }
+
+    /// Build a real file-backed store under `<temp>/cli/db/db.sqlite` and
+    /// point `ZCODE_HOME` at `<temp>`, returning the temp dir (keep it alive
+    /// for the duration of the test) and the connection to seed with.
+    fn temp_zcode_home() -> (tempfile::TempDir, Connection, Option<String>) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let db_dir = temp.path().join("cli").join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let conn = Connection::open(db_dir.join("db.sqlite")).unwrap();
+        conn.execute_batch(TEST_SCHEMA).unwrap();
+        let original = set_zcode_home(temp.path());
+        (temp, conn, original)
+    }
+
+    /// Save/restore pattern from the vibe provider tests: the suite runs with
+    /// `--test-threads=1`, so mutating `ZCODE_HOME` is safe as long as every
+    /// test restores the previous value.
+    fn set_zcode_home(path: &std::path::Path) -> Option<String> {
+        let original = std::env::var("ZCODE_HOME").ok();
+        std::env::set_var("ZCODE_HOME", path);
+        original
+    }
+
+    fn restore_zcode_home(original: Option<String>) {
+        if let Some(value) = original {
+            std::env::set_var("ZCODE_HOME", value);
+        } else {
+            std::env::remove_var("ZCODE_HOME");
+        }
     }
 
     fn insert_session(conn: &Connection, id: &str, dir: &str, title: &str, task_type: &str) {
@@ -795,6 +825,101 @@ mod tests {
         seed(&conn);
         // No content anywhere contains a literal '%'.
         assert!(search_conn(&conn, "%", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn public_api_round_trip_via_zcode_home() {
+        let (_temp, conn, original_env) = temp_zcode_home();
+        insert_session(
+            &conn,
+            "sess-1",
+            "/Users/jack/proj",
+            "fix the login bug",
+            "interactive",
+        );
+        insert_message(
+            &conn,
+            "m1",
+            "sess-1",
+            0,
+            r#"{"role":"user","time":{"created":1788599956241}}"#,
+        );
+        insert_part(
+            &conn,
+            "p1",
+            "m1",
+            "sess-1",
+            0,
+            r#"{"type":"text","text":"why does LOGIN fail?"}"#,
+        );
+
+        // detect + base path follow ZCODE_HOME.
+        let info = detect().expect("detect with ZCODE_HOME set");
+        assert!(info.is_available);
+        assert!(get_base_path().expect("base path").ends_with("cli/db"));
+
+        // scan -> load_sessions -> load_messages through the public fns.
+        let projects = scan_projects().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].actual_path, "/Users/jack/proj");
+        let sessions = load_sessions(&projects[0].path, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].actual_session_id, "sess-1");
+        let messages = load_messages(&sessions[0].session_id).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role.as_deref(), Some("user"));
+
+        // search hits the file-backed store too.
+        let hits = search("login", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+
+        restore_zcode_home(original_env);
+    }
+
+    #[test]
+    fn public_api_tolerates_missing_store() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let original = set_zcode_home(temp.path()); // exists, but no db.sqlite
+        assert!(scan_projects().unwrap().is_empty());
+        assert!(load_sessions("zcode:///any/dir", false).unwrap().is_empty());
+        assert!(search("anything", 10).unwrap().is_empty());
+        assert!(load_messages("zcode:///any/dir#sess-x").is_err());
+        restore_zcode_home(original);
+    }
+
+    #[test]
+    fn null_task_type_sessions_are_included() {
+        let conn = test_db();
+        insert_session(&conn, "sess-1", "/Users/jack/proj", "t", "interactive");
+        insert_session(&conn, "sess-null", "/Users/jack/proj", "t", "");
+        // NULL task_type via raw SQL (helper always binds a string).
+        conn.execute(
+            "INSERT INTO session (id, project_id, directory, title, task_type, time_created, time_updated)              VALUES ('sess-null2', 'p', '/Users/jack/proj', 't', NULL, 1, 2)",
+            [],
+        )
+        .unwrap();
+        for id in ["sess-1", "sess-null", "sess-null2"] {
+            insert_message(
+                &conn,
+                &format!("m-{id}"),
+                id,
+                0,
+                r#"{"role":"user","time":{"created":1}}"#,
+            );
+            insert_part(
+                &conn,
+                &format!("p-{id}"),
+                &format!("m-{id}"),
+                id,
+                0,
+                r#"{"type":"text","text":"x"}"#,
+            );
+        }
+        // All three count toward the project and all three load.
+        let projects = scan_projects_conn(&conn).unwrap();
+        assert_eq!(projects[0].session_count, 3);
+        let sessions = load_sessions_conn(&conn, "/Users/jack/proj").unwrap();
+        assert_eq!(sessions.len(), 3);
     }
 
     #[test]

--- a/src-tauri/src/providers/zcode.rs
+++ b/src-tauri/src/providers/zcode.rs
@@ -469,18 +469,51 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
         return Ok(vec![]);
     }
     let conn = open_db(&path)?;
+    search_conn(&conn, query, limit)
+}
+
+/// Candidate-session filter pushed into SQL. Only applied when the query is
+/// safe for a `LIKE` prefilter: SQLite's `LIKE` is case-insensitive for ASCII
+/// only, and raw `part.data` is JSON — a query containing `"`/`\`/control
+/// characters can be contiguous in parsed text but escaped in the raw column,
+/// so those queries (and non-ASCII ones) fall back to scanning every session
+/// and letting the Rust matcher decide, which cannot lose results.
+fn like_prefilter_pattern(query: &str) -> Option<String> {
+    let safe =
+        query.is_ascii() && !query.contains(['"', '\\']) && !query.chars().any(char::is_control);
+    safe.then(|| {
+        let escaped: String = query
+            .chars()
+            .map(|c| match c {
+                '\\' => "\\\\".to_string(),
+                '%' => "\\%".to_string(),
+                '_' => "\\_".to_string(),
+                other => other.to_string(),
+            })
+            .collect();
+        format!("%{escaped}%")
+    })
+}
+
+fn search_conn(conn: &Connection, query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
     let query_lower = query.to_lowercase();
     let mut results = Vec::new();
 
+    // Narrow to candidate sessions before any JSON parsing: one indexed
+    // EXISTS probe per session instead of loading every message and part.
+    let pattern = like_prefilter_pattern(query);
     let mut stmt = conn
         .prepare(
-            "SELECT id, directory FROM session \
+            "SELECT id, directory FROM session s \
              WHERE task_type != 'subagent_child' \
-               AND (time_archived IS NULL OR time_archived = 0)",
+               AND (time_archived IS NULL OR time_archived = 0) \
+               AND (?1 IS NULL OR EXISTS ( \
+                    SELECT 1 FROM part p WHERE p.session_id = s.id \
+                      AND p.data LIKE ?1 ESCAPE '\\'))",
         )
         .map_err(|e| e.to_string())?;
     let sessions = stmt
-        .query_map([], |row| {
+        .query_map(rusqlite::params![pattern], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })
         .map_err(|e| e.to_string())?
@@ -495,7 +528,7 @@ pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| directory.clone());
-        for mut msg in load_messages_conn(&conn, &session_id)? {
+        for mut msg in load_messages_conn(conn, &session_id)? {
             if results.len() >= limit {
                 break;
             }
@@ -702,6 +735,66 @@ mod tests {
         assert_eq!(rb[0]["tool_use_id"], "call-1");
         assert_eq!(rb[0]["content"], "line1");
         assert_eq!(rb[0]["is_error"], false);
+    }
+
+    #[test]
+    fn search_prefilters_ascii_queries() {
+        let conn = test_db();
+        seed(&conn);
+        // "login" matches the "why does LOGIN fail?" text case-insensitively
+        // via the SQL prefilter plus the Rust matcher.
+        let hits = search_conn(&conn, "login", 10).unwrap();
+        assert!(!hits.is_empty());
+        assert!(hits.iter().all(|m| m.provider.as_deref() == Some("zcode")));
+    }
+
+    #[test]
+    fn search_falls_back_to_full_scan_for_non_ascii() {
+        let conn = test_db();
+        seed(&conn);
+        insert_message(
+            &conn,
+            "m9",
+            "sess-2",
+            0,
+            r#"{"role":"user","time":{"created":1788599956241}}"#,
+        );
+        insert_part(
+            &conn,
+            "p9",
+            "m9",
+            "sess-2",
+            0,
+            r#"{"type":"text","text":"查看登录问题"}"#,
+        );
+        // Non-ASCII bypasses the LIKE prefilter and still matches.
+        let hits = search_conn(&conn, "登录", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].session_id, "sess-2");
+    }
+
+    #[test]
+    fn like_pattern_escapes_metacharacters_and_guards_unsafe_queries() {
+        // LIKE metacharacters are escaped so the prefilter stays literal.
+        assert_eq!(
+            like_prefilter_pattern("a%b_c"),
+            Some("%a\\%b\\_c%".to_string())
+        );
+        // Non-ASCII, quotes, backslashes and control chars cannot be safely
+        // matched against the raw JSON column — those queries bypass the
+        // prefilter entirely.
+        assert_eq!(like_prefilter_pattern("登录"), None);
+        assert_eq!(like_prefilter_pattern("say \"hi\""), None);
+        assert_eq!(like_prefilter_pattern("a\\b"), None);
+        assert_eq!(like_prefilter_pattern("a\nb"), None);
+    }
+
+    #[test]
+    fn search_treats_percent_as_literal() {
+        let conn = test_db();
+        seed(&conn);
+        // No content anywhere contains a literal '%'.
+        assert!(search_conn(&conn, "%", 10).unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/providers/zcode.rs
+++ b/src-tauri/src/providers/zcode.rs
@@ -1,0 +1,712 @@
+//! Z Code provider (Z.ai's GLM-powered coding agent, <https://zcode.z.ai>).
+//!
+//! Z Code keeps the authoritative transcript history in a single SQLite store
+//! at `<home>/.zcode/cli/db/db.sqlite` (WAL). Relevant tables:
+//! - `session(id, directory, title, title_source, task_type, parent_id,
+//!   time_created, time_updated, time_archived)` — `directory` is the session
+//!   cwd, `title` a generated/first-input title, epoch-ms timestamps.
+//! - `message(id, session_id, sequence, time_created, data)` — `data` JSON:
+//!   `{role, time:{created,completed}, parentID, modelID, tokens:{...},
+//!   finish}`.
+//! - `part(id, message_id, session_id, sequence, data)` — content blocks in
+//!   order: `{type:"text"|"reasoning"|"tool"|"file"|"timeline"|"step-start"|
+//!   "step-finish", ...}`. A `tool` part merges the call and its result:
+//!   `{callID, tool, state:{status, input, output}}`.
+//!
+//! We map parts to the viewer's Claude-style content blocks; merged tool
+//! call/results are split into a `tool_use` block on the assistant message
+//! plus a synthesized user-lane `tool_result` message, mirroring how Claude
+//! Code transcripts record them. Subagent sessions (`task_type =
+//! 'subagent_child'`) are skipped, matching the sidechain exclusion elsewhere.
+
+use crate::models::{ClaudeMessage, ClaudeProject, ClaudeSession, TokenUsage};
+use crate::providers::ProviderInfo;
+use crate::utils::{build_provider_message, ms_to_iso, search_json_value_case_insensitive};
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const PROVIDER: &str = "zcode";
+const SCHEME: &str = "zcode://";
+/// Separator between the project directory and session id in a session path.
+const SESSION_SEP: char = '#';
+const SUMMARY_MAX_CHARS: usize = 80;
+
+/// Base dir: `~/.zcode`.
+fn runtime_base() -> Option<PathBuf> {
+    Some(crate::utils::home_dir()?.join(".zcode"))
+}
+
+fn db_path() -> Option<PathBuf> {
+    let path = runtime_base()?.join("cli").join("db").join("db.sqlite");
+    path.is_file().then_some(path)
+}
+
+/// Open the store read-only (WAL readers are fine alongside a live writer).
+fn open_db(path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("Failed to open Z Code db: {e}"))?;
+    conn.busy_timeout(Duration::from_secs(5))
+        .map_err(|e| format!("Failed to set Z Code db busy timeout: {e}"))?;
+    Ok(conn)
+}
+
+/// Detect a Z Code installation.
+pub fn detect() -> Option<ProviderInfo> {
+    let base = runtime_base()?;
+    let db = db_path()?;
+    Some(ProviderInfo {
+        id: PROVIDER.to_string(),
+        display_name: "Z Code".to_string(),
+        base_path: base.to_string_lossy().to_string(),
+        is_available: db.is_file(),
+    })
+}
+
+/// Watched root (the db directory, so WAL checkpoints trigger refreshes).
+pub fn get_base_path() -> Option<String> {
+    db_path()?.parent().map(|p| p.to_string_lossy().to_string())
+}
+
+/// Scan Z Code projects (sessions grouped by their `directory` cwd).
+pub fn scan_projects() -> Result<Vec<ClaudeProject>, String> {
+    let Some(path) = db_path() else {
+        return Ok(vec![]);
+    };
+    let conn = open_db(&path)?;
+    scan_projects_conn(&conn)
+}
+
+fn scan_projects_conn(conn: &Connection) -> Result<Vec<ClaudeProject>, String> {
+    struct Agg {
+        session_count: usize,
+        message_count: usize,
+        last_modified: i64,
+    }
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.directory, COUNT(*), SUM(m_cnt), MAX(s.time_updated) FROM ( \
+                SELECT s.directory AS directory, s.time_updated AS time_updated, \
+                       (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) AS m_cnt \
+                FROM session s \
+                WHERE s.task_type != 'subagent_child' \
+                  AND (s.time_archived IS NULL OR s.time_archived = 0) \
+             ) s GROUP BY s.directory",
+        )
+        .map_err(|e| e.to_string())?;
+    let mut by_dir: std::collections::HashMap<String, Agg> = std::collections::HashMap::new();
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?;
+    for row in rows.flatten() {
+        let (dir, sessions, messages, updated) = row;
+        if messages.unwrap_or(0) == 0 {
+            continue;
+        }
+        let entry = by_dir.entry(dir).or_insert(Agg {
+            session_count: 0,
+            message_count: 0,
+            last_modified: 0,
+        });
+        entry.session_count += sessions.max(0) as usize;
+        entry.message_count += messages.unwrap_or(0).max(0) as usize;
+        entry.last_modified = entry.last_modified.max(updated.unwrap_or(0));
+    }
+
+    let mut projects: Vec<ClaudeProject> = by_dir
+        .into_iter()
+        .map(|(dir, agg)| {
+            let name = Path::new(&dir)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| dir.clone());
+            ClaudeProject {
+                name,
+                path: format!("{SCHEME}{dir}"),
+                actual_path: dir,
+                session_count: agg.session_count,
+                message_count: agg.message_count,
+                last_modified: ms_to_iso(agg.last_modified.max(0) as u64),
+                git_info: None,
+                provider: Some(PROVIDER.to_string()),
+                storage_type: Some("sqlite".to_string()),
+                custom_directory_label: None,
+            }
+        })
+        .collect();
+    projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    Ok(projects)
+}
+
+/// Load the sessions for one Z Code project (`zcode://<directory>`).
+pub fn load_sessions(
+    project_path: &str,
+    _exclude_sidechain: bool,
+) -> Result<Vec<ClaudeSession>, String> {
+    let Some(path) = db_path() else {
+        return Ok(vec![]);
+    };
+    let directory = project_path.strip_prefix(SCHEME).unwrap_or(project_path);
+    let conn = open_db(&path)?;
+    load_sessions_conn(&conn, directory)
+}
+
+fn load_sessions_conn(conn: &Connection, directory: &str) -> Result<Vec<ClaudeSession>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.id, s.title, s.title_source, s.time_created, s.time_updated, \
+                    (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) AS msg_cnt, \
+                    EXISTS(SELECT 1 FROM part p WHERE p.session_id = s.id \
+                           AND json_extract(p.data, '$.type') = 'tool') AS has_tool \
+             FROM session s \
+             WHERE s.directory = ?1 \
+               AND s.task_type != 'subagent_child' \
+               AND (s.time_archived IS NULL OR s.time_archived = 0)",
+        )
+        .map_err(|e| e.to_string())?;
+    let project_name = Path::new(directory)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let sessions = stmt
+        .query_map([directory], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .filter(|(_, _, _, _, _, msg_cnt, _)| *msg_cnt > 0)
+        .map(
+            |(id, title, title_source, created, updated, msg_cnt, has_tool)| {
+                let created_iso = ms_to_iso(created.max(0) as u64);
+                let updated_iso = ms_to_iso(updated.max(0) as u64);
+                let summary = if title.trim().is_empty() {
+                    None
+                } else {
+                    Some(summarize(&title))
+                };
+                ClaudeSession {
+                    session_id: format!("{SCHEME}{directory}{SESSION_SEP}{id}"),
+                    actual_session_id: id.clone(),
+                    file_path: format!("{SCHEME}{directory}{SESSION_SEP}{id}"),
+                    project_name: project_name.clone(),
+                    message_count: msg_cnt.max(0) as usize,
+                    first_message_time: created_iso.clone(),
+                    last_message_time: updated_iso.clone(),
+                    last_modified: updated_iso,
+                    has_tool_use: has_tool != 0,
+                    has_errors: false,
+                    summary,
+                    is_renamed: title_source == "custom",
+                    provider: Some(PROVIDER.to_string()),
+                    storage_type: Some("sqlite".to_string()),
+                    entrypoint: None,
+                }
+            },
+        )
+        .collect();
+    Ok(sessions)
+}
+
+/// Load all messages from one Z Code session (`zcode://<directory>#<session_id>`).
+pub fn load_messages(session_path: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let Some(path) = db_path() else {
+        return Err("Z Code db not found".to_string());
+    };
+    let (_, session_id) = parse_session_path(session_path)?;
+    let conn = open_db(&path)?;
+    load_messages_conn(&conn, &session_id)
+}
+
+fn parse_session_path(session_path: &str) -> Result<(String, String), String> {
+    let stripped = session_path.strip_prefix(SCHEME).unwrap_or(session_path);
+    stripped
+        .rsplit_once(SESSION_SEP)
+        .map(|(dir, id)| (dir.to_string(), id.to_string()))
+        .ok_or_else(|| format!("Invalid Z Code session path: {session_path}"))
+}
+
+fn load_messages_conn(conn: &Connection, session_id: &str) -> Result<Vec<ClaudeMessage>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, time_created, data FROM message \
+             WHERE session_id = ?1 ORDER BY sequence, time_created, id",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([session_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .collect::<Vec<_>>();
+
+    let mut parts_stmt = conn
+        .prepare(
+            "SELECT data FROM part WHERE message_id = ?1 \
+             ORDER BY sequence, time_created, id",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let mut messages = Vec::new();
+    for (id, created, data) in rows {
+        let Ok(rec) = serde_json::from_str::<Value>(&data) else {
+            continue;
+        };
+        let parts = parts_stmt
+            .query_map([&id], |row| row.get::<_, String>(0))
+            .map_err(|e| e.to_string())?
+            .flatten()
+            .filter_map(|p| serde_json::from_str::<Value>(&p).ok())
+            .collect::<Vec<_>>();
+        append_message(&mut messages, session_id, &id, created, &rec, &parts);
+    }
+    Ok(messages)
+}
+
+/// Convert one DB message (plus its parts) into viewer messages, appending a
+/// synthesized user-lane `tool_result` message when tool parts are present.
+fn append_message(
+    out: &mut Vec<ClaudeMessage>,
+    session_id: &str,
+    msg_id: &str,
+    created_ms: i64,
+    rec: &Value,
+    parts: &[Value],
+) {
+    let role = rec.get("role").and_then(Value::as_str).unwrap_or("user");
+    if !matches!(role, "user" | "assistant") {
+        return;
+    }
+    let timestamp = rec
+        .pointer("/time/created")
+        .and_then(Value::as_i64)
+        .map(|ms| ms_to_iso(ms.max(0) as u64))
+        .unwrap_or_else(|| ms_to_iso(created_ms.max(0) as u64));
+
+    let mut blocks: Vec<Value> = Vec::new();
+    let mut tool_results: Vec<Value> = Vec::new();
+    for part in parts {
+        match part.get("type").and_then(Value::as_str).unwrap_or("") {
+            "text" => {
+                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                    if !text.is_empty() {
+                        blocks.push(json!({ "type": "text", "text": text }));
+                    }
+                }
+            }
+            "reasoning" => {
+                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                    if !text.is_empty() {
+                        blocks
+                            .push(json!({ "type": "thinking", "thinking": text, "signature": "" }));
+                    }
+                }
+            }
+            "tool" => {
+                let call_id = part.get("callID").and_then(Value::as_str).unwrap_or("");
+                let name = part
+                    .get("tool")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                let state = part.get("state").cloned().unwrap_or_else(|| json!({}));
+                let input = state.get("input").cloned().unwrap_or_else(|| json!({}));
+                blocks.push(json!({
+                    "type": "tool_use", "id": call_id, "name": name, "input": input
+                }));
+                let status = state.get("status").and_then(Value::as_str).unwrap_or("");
+                let output = state.get("output").map(stringify_value).unwrap_or_default();
+                tool_results.push(json!({
+                    "type": "tool_result",
+                    "tool_use_id": call_id,
+                    "content": output,
+                    "is_error": status == "failed" || status == "error",
+                }));
+            }
+            // step-start / step-finish are agent-loop step markers, timeline is
+            // a UI event, file is an attachment behind a zcode-artifact:// URL
+            // the viewer cannot resolve — all skipped.
+            _ => {}
+        }
+    }
+    if blocks.is_empty() && tool_results.is_empty() {
+        return;
+    }
+
+    let model = rec
+        .get("modelID")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let mut msg = build_provider_message(
+        PROVIDER,
+        msg_id.to_string(),
+        session_id,
+        timestamp,
+        role,
+        Some(role),
+        Some(Value::Array(blocks)),
+        model,
+    );
+    msg.parent_uuid = rec
+        .get("parentID")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if role == "assistant" {
+        if let Some(tokens) = rec.get("tokens") {
+            msg.usage = Some(convert_usage(tokens));
+        }
+        if let Some(finish) = rec.get("finish").and_then(Value::as_str) {
+            msg.stop_reason = Some(match finish {
+                "tool-calls" => "tool_use".to_string(),
+                "stop" => "end_turn".to_string(),
+                other => other.to_string(),
+            });
+        }
+        if let Some(completed) = rec.pointer("/time/completed").and_then(Value::as_i64) {
+            let started = rec
+                .pointer("/time/created")
+                .and_then(Value::as_i64)
+                .unwrap_or(completed);
+            msg.duration_ms = Some((completed - started).max(0) as u64);
+        }
+    }
+    out.push(msg);
+
+    if !tool_results.is_empty() {
+        let done_at = rec
+            .pointer("/time/completed")
+            .and_then(Value::as_i64)
+            .unwrap_or(created_ms);
+        let mut result_msg = build_provider_message(
+            PROVIDER,
+            format!("{msg_id}-results"),
+            session_id,
+            ms_to_iso(done_at.max(0) as u64),
+            "user",
+            Some("user"),
+            Some(Value::Array(tool_results)),
+            None,
+        );
+        result_msg.parent_uuid = Some(msg_id.to_string());
+        out.push(result_msg);
+    }
+}
+
+fn convert_usage(tokens: &Value) -> TokenUsage {
+    let g = |k: &str| {
+        tokens
+            .get(k)
+            .and_then(Value::as_i64)
+            .map(|n| n.max(0) as u32)
+    };
+    let input = g("input").unwrap_or(0);
+    let cached = tokens
+        .pointer("/cache/read")
+        .and_then(Value::as_i64)
+        .map(|n| n.max(0) as u32);
+    TokenUsage {
+        // Z Code reports input inclusive of the cached subset; keep only the
+        // non-cached part so totals do not double-count cache reads.
+        input_tokens: Some(input.saturating_sub(cached.unwrap_or(0))),
+        output_tokens: g("output"),
+        cache_creation_input_tokens: tokens
+            .pointer("/cache/write")
+            .and_then(Value::as_i64)
+            .map(|n| n.max(0) as u32),
+        cache_read_input_tokens: cached,
+        reasoning_tokens: g("reasoning"),
+        service_tier: None,
+        ..Default::default()
+    }
+}
+
+fn stringify_value(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn summarize(text: &str) -> String {
+    let cleaned = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if cleaned.chars().count() > SUMMARY_MAX_CHARS {
+        format!(
+            "{}…",
+            cleaned.chars().take(SUMMARY_MAX_CHARS).collect::<String>()
+        )
+    } else {
+        cleaned
+    }
+}
+
+/// Search across all Z Code sessions.
+pub fn search(query: &str, limit: usize) -> Result<Vec<ClaudeMessage>, String> {
+    let Some(path) = db_path() else {
+        return Ok(vec![]);
+    };
+    if query.is_empty() || limit == 0 {
+        return Ok(vec![]);
+    }
+    let conn = open_db(&path)?;
+    let query_lower = query.to_lowercase();
+    let mut results = Vec::new();
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, directory FROM session \
+             WHERE task_type != 'subagent_child' \
+               AND (time_archived IS NULL OR time_archived = 0)",
+        )
+        .map_err(|e| e.to_string())?;
+    let sessions = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .collect::<Vec<_>>();
+
+    for (session_id, directory) in sessions {
+        if results.len() >= limit {
+            break;
+        }
+        let project_name = Path::new(&directory)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| directory.clone());
+        for mut msg in load_messages_conn(&conn, &session_id)? {
+            if results.len() >= limit {
+                break;
+            }
+            let matched = msg
+                .content
+                .as_ref()
+                .map(|c| search_json_value_case_insensitive(c, &query_lower))
+                .unwrap_or(false);
+            if matched {
+                msg.project_name = Some(project_name.clone());
+                results.push(msg);
+            }
+        }
+    }
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an in-memory DB mirroring the Z Code schema subset we read.
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id text primary key, project_id text not null, directory text not null,
+                title text not null, task_type text not null default 'interactive',
+                title_source text not null default 'first_input',
+                time_created integer not null, time_updated integer not null,
+                time_archived integer
+            );
+            CREATE TABLE message (
+                id text primary key, session_id text not null,
+                time_created integer not null, data text not null, sequence integer
+            );
+            CREATE TABLE part (
+                id text primary key, message_id text not null, session_id text not null,
+                time_created integer not null, data text not null, sequence integer
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_session(conn: &Connection, id: &str, dir: &str, title: &str, task_type: &str) {
+        conn.execute(
+            "INSERT INTO session (id, project_id, directory, title, task_type, time_created, time_updated) \
+             VALUES (?1, 'p', ?2, ?3, ?4, 1788599956241, 1788599999999)",
+            rusqlite::params![id, dir, title, task_type],
+        )
+        .unwrap();
+    }
+
+    fn insert_message(conn: &Connection, id: &str, session: &str, seq: i64, data: &str) {
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data, sequence) \
+             VALUES (?1, ?2, 1788599956241, ?3, ?4)",
+            rusqlite::params![id, session, data, seq],
+        )
+        .unwrap();
+    }
+
+    fn insert_part(conn: &Connection, id: &str, msg: &str, session: &str, seq: i64, data: &str) {
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data, sequence) \
+             VALUES (?1, ?2, ?3, 1788599956241, ?4, ?5)",
+            rusqlite::params![id, msg, session, data, seq],
+        )
+        .unwrap();
+    }
+
+    fn seed(conn: &Connection) {
+        insert_session(
+            conn,
+            "sess-1",
+            "/Users/jack/proj",
+            "fix the login bug",
+            "interactive",
+        );
+        insert_session(
+            conn,
+            "sess-2",
+            "/Users/jack/proj",
+            "other session",
+            "interactive",
+        );
+        insert_session(
+            conn,
+            "sess-sub",
+            "/Users/jack/proj",
+            "subagent",
+            "subagent_child",
+        );
+        insert_message(
+            conn,
+            "m1",
+            "sess-1",
+            0,
+            r#"{"role":"user","time":{"created":1788599956241}}"#,
+        );
+        insert_part(
+            conn,
+            "p1",
+            "m1",
+            "sess-1",
+            0,
+            r#"{"type":"text","text":"why does LOGIN fail?"}"#,
+        );
+        insert_message(
+            conn,
+            "m2",
+            "sess-1",
+            1,
+            concat!(
+                r#"{"role":"assistant","time":{"created":1788599956241,"completed":1788599961259},"#,
+                r#""modelID":"GLM-5.3","finish":"tool-calls","#,
+                r#""tokens":{"total":13085,"input":12858,"output":227,"reasoning":10,"cache":{"read":9984,"write":0}}}"#
+            ),
+        );
+        insert_part(conn, "p2", "m2", "sess-1", 0, r#"{"type":"step-start"}"#);
+        insert_part(
+            conn,
+            "p3",
+            "m2",
+            "sess-1",
+            1,
+            r#"{"type":"reasoning","text":"checking auth"}"#,
+        );
+        insert_part(
+            conn,
+            "p4",
+            "m2",
+            "sess-1",
+            2,
+            r#"{"type":"tool","callID":"call-1","tool":"Read","state":{"status":"completed","input":{"file_path":"/x/HANDOFF.md"},"output":"line1"}}"#,
+        );
+        insert_part(conn, "p5", "m2", "sess-1", 3, r#"{"type":"step-finish"}"#);
+    }
+
+    #[test]
+    fn scan_groups_by_directory_and_skips_subagents() {
+        let conn = test_db();
+        seed(&conn);
+        let projects = scan_projects_conn(&conn).unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].actual_path, "/Users/jack/proj");
+        assert_eq!(projects[0].session_count, 2);
+        assert_eq!(projects[0].provider.as_deref(), Some("zcode"));
+    }
+
+    #[test]
+    fn load_sessions_marks_tool_use_and_titles() {
+        let conn = test_db();
+        seed(&conn);
+        let sessions = load_sessions_conn(&conn, "/Users/jack/proj").unwrap();
+        // sess-2 has no messages and is filtered out.
+        assert_eq!(sessions.len(), 1);
+        let first = sessions
+            .iter()
+            .find(|s| s.actual_session_id == "sess-1")
+            .unwrap();
+        assert_eq!(first.summary.as_deref(), Some("fix the login bug"));
+        assert!(first.has_tool_use);
+        assert!(first
+            .session_id
+            .starts_with("zcode:///Users/jack/proj#sess-1"));
+    }
+
+    #[test]
+    fn load_messages_splits_tool_call_and_result() {
+        let conn = test_db();
+        seed(&conn);
+        let messages = load_messages_conn(&conn, "sess-1").unwrap();
+        // user + assistant + synthesized tool_result lane
+        assert_eq!(messages.len(), 3);
+
+        assert_eq!(messages[0].role.as_deref(), Some("user"));
+        let ub = messages[0].content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(ub[0]["type"], "text");
+        assert_eq!(ub[0]["text"], "why does LOGIN fail?");
+
+        let a = &messages[1];
+        assert_eq!(a.role.as_deref(), Some("assistant"));
+        assert_eq!(a.model.as_deref(), Some("GLM-5.3"));
+        assert_eq!(a.stop_reason.as_deref(), Some("tool_use"));
+        assert_eq!(a.duration_ms, Some(5018));
+        let usage = a.usage.as_ref().unwrap();
+        assert_eq!(usage.input_tokens, Some(2874)); // 12858 - 9984 cached
+        assert_eq!(usage.cache_read_input_tokens, Some(9984));
+        let ab = a.content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(ab[0]["type"], "thinking");
+        assert_eq!(ab[1]["type"], "tool_use");
+        assert_eq!(ab[1]["id"], "call-1");
+        assert_eq!(ab[1]["name"], "Read");
+
+        let r = &messages[2];
+        assert_eq!(r.role.as_deref(), Some("user"));
+        assert_eq!(r.parent_uuid.as_deref(), Some("m2"));
+        let rb = r.content.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(rb[0]["type"], "tool_result");
+        assert_eq!(rb[0]["tool_use_id"], "call-1");
+        assert_eq!(rb[0]["content"], "line1");
+        assert_eq!(rb[0]["is_error"], false);
+    }
+
+    #[test]
+    fn session_path_roundtrip() {
+        let (dir, id) = parse_session_path("zcode:///a/b#sess-9").unwrap();
+        assert_eq!(dir, "/a/b");
+        assert_eq!(id, "sess-9");
+        assert!(parse_session_path("zcode:///no-separator").is_err());
+    }
+}

--- a/src/components/ProjectTree/index.tsx
+++ b/src/components/ProjectTree/index.tsx
@@ -170,6 +170,7 @@ export const ProjectTree: React.FC<ProjectTreeProps> = ({
       trae: 0,
       vibe: 0,
       zed: 0,
+      zcode: 0,
     };
 
     for (const project of projects) {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -100,7 +100,7 @@
   "common.provider.saveError": "Failed to save discovered provider settings. Please try again.",
   "common.provider.trae": "Trae",
   "common.provider.vibe": "Mistral Vibe",
-  "common.provider.zcode": "ZCode",
+  "common.provider.zcode": "Z Code",
   "common.provider.zed": "Zed",
   "common.refresh": "Refresh",
   "common.remove": "Remove",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -100,7 +100,7 @@
   "common.provider.saveError": "検出したプロバイダー設定を保存できませんでした。もう一度お試しください。",
   "common.provider.trae": "Trae",
   "common.provider.vibe": "Mistral Vibe",
-  "common.provider.zcode": "ZCode",
+  "common.provider.zcode": "Z Code",
   "common.provider.zed": "Zed",
   "common.refresh": "更新",
   "common.remove": "削除",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -100,7 +100,7 @@
   "common.provider.saveError": "검색한 프로바이더 설정을 저장하지 못했습니다. 다시 시도해주세요.",
   "common.provider.trae": "Trae",
   "common.provider.vibe": "Mistral Vibe",
-  "common.provider.zcode": "ZCode",
+  "common.provider.zcode": "Z Code",
   "common.provider.zed": "Zed",
   "common.refresh": "새로고침",
   "common.remove": "제거",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -100,7 +100,7 @@
   "common.provider.saveError": "无法保存已发现的提供商设置，请重试。",
   "common.provider.trae": "Trae",
   "common.provider.vibe": "Mistral Vibe",
-  "common.provider.zcode": "ZCode",
+  "common.provider.zcode": "Z Code",
   "common.provider.zed": "Zed",
   "common.refresh": "刷新",
   "common.remove": "移除",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -100,7 +100,7 @@
   "common.provider.saveError": "無法儲存已找到的提供者設定，請再試一次。",
   "common.provider.trae": "Trae",
   "common.provider.vibe": "Mistral Vibe",
-  "common.provider.zcode": "ZCode",
+  "common.provider.zcode": "Z Code",
   "common.provider.zed": "Zed",
   "common.refresh": "重新整理",
   "common.remove": "移除",

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -75,8 +75,8 @@ describe("providers utils", () => {
       "qwen",
       "trae",
       "vibe",
-      "zed",
       "zcode",
+      "zed",
     ]);
   });
 

--- a/src/test/providers.utils.test.ts
+++ b/src/test/providers.utils.test.ts
@@ -76,6 +76,7 @@ describe("providers utils", () => {
       "trae",
       "vibe",
       "zed",
+      "zcode",
     ]);
   });
 

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed" | "zcode";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/types/core/session.ts
+++ b/src/types/core/session.ts
@@ -8,7 +8,7 @@
 // Provider Types
 // ============================================================================
 
-export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zed" | "zcode";
+export type ProviderId = "aider" | "amazonq" | "antigravity" | "claude" | "cline" | "codebuddy" | "codex" | "continue" | "copilot" | "crush" | "cursor" | "cursor-agent" | "forgecode" | "gemini" | "goose" | "grok" | "kimi" | "kiro" | "llm" | "ompi" | "opencode" | "openhands" | "openinterpreter" | "pearai" | "pi" | "qwen" | "trae" | "vibe" | "zcode" | "zed";
 
 export interface ProviderInfo {
   id: ProviderId;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,7 +1,7 @@
 import type { ProviderId } from "../types";
 import { isWindows } from "./platform";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed", "zcode"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zcode", "zed"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 // WSL provider loaders use UNC-backed paths and are not interchangeable with
@@ -44,9 +44,9 @@ const PROVIDER_TRANSLATIONS: Record<
   pearai: { key: "common.provider.pearai", fallback: "PearAI" },
   pi: { key: "common.provider.pi", fallback: "Pi" },
   qwen: { key: "common.provider.qwen", fallback: "Qwen Code" },
-  zcode: { key: "common.provider.zcode", fallback: "Z Code" },
   trae: { key: "common.provider.trae", fallback: "Trae" },
   vibe: { key: "common.provider.vibe", fallback: "Mistral Vibe" },
+  zcode: { key: "common.provider.zcode", fallback: "Z Code" },
   zed: { key: "common.provider.zed", fallback: "Zed" },
 };
 
@@ -315,9 +315,9 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "pi":
     case "pearai":
     case "qwen":
-    case "zcode":
     case "trae":
     case "vibe":
+    case "zcode":
     case "zed":
     case "claude":
       return provider;

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,7 +1,7 @@
 import type { ProviderId } from "../types";
 import { isWindows } from "./platform";
 
-export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed"];
+export const PROVIDER_IDS: ProviderId[] = ["aider", "amazonq", "antigravity", "claude", "cline", "codebuddy", "codex", "continue", "copilot", "crush", "cursor", "cursor-agent", "forgecode", "gemini", "goose", "grok", "kimi", "kiro", "llm", "ompi", "opencode", "openhands", "openinterpreter", "pearai", "pi", "qwen", "trae", "vibe", "zed", "zcode"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "claude";
 
 // WSL provider loaders use UNC-backed paths and are not interchangeable with
@@ -44,6 +44,7 @@ const PROVIDER_TRANSLATIONS: Record<
   pearai: { key: "common.provider.pearai", fallback: "PearAI" },
   pi: { key: "common.provider.pi", fallback: "Pi" },
   qwen: { key: "common.provider.qwen", fallback: "Qwen Code" },
+  zcode: { key: "common.provider.zcode", fallback: "Z Code" },
   trae: { key: "common.provider.trae", fallback: "Trae" },
   vibe: { key: "common.provider.vibe", fallback: "Mistral Vibe" },
   zed: { key: "common.provider.zed", fallback: "Zed" },
@@ -245,6 +246,13 @@ const PROVIDER_SESSION_CAPABILITIES: Record<ProviderId, ProviderSessionCapabilit
     supportsSessionDeletion: false,
     supportsArchiveCreation: false,
   },
+  zcode: {
+    supportsConversationBreakdown: false,
+    supportsNativeRename: false,
+    supportsResumeCommand: false,
+    supportsSessionDeletion: false,
+    supportsArchiveCreation: false,
+  },
   trae: {
     supportsConversationBreakdown: false,
     supportsNativeRename: false,
@@ -307,6 +315,7 @@ export function getProviderId(provider?: ProviderId | string): ProviderId {
     case "pi":
     case "pearai":
     case "qwen":
+    case "zcode":
     case "trae":
     case "vibe":
     case "zed":
@@ -500,6 +509,7 @@ export const PROVIDER_BADGE_STYLES: Record<ProviderId, string> = {
   pearai: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300",
   pi: "bg-teal-500/15 text-teal-600 dark:text-teal-400",
   qwen: "bg-violet-600/15 text-violet-700 dark:text-violet-300",
+  zcode: "bg-cyan-600/15 text-cyan-700 dark:text-cyan-300",
   trae: "bg-blue-600/15 text-blue-700 dark:text-blue-300",
   vibe: "bg-orange-600/15 text-orange-700 dark:text-orange-300",
   zed: "bg-neutral-500/15 text-neutral-600 dark:text-neutral-400",


### PR DESCRIPTION
## What & why

Adds [Z Code](https://zcode.z.ai) — Z.ai's GLM-powered coding agent — as a new session source, so its conversations show up alongside Claude Code / Codex / etc. No open issue; this closes the gap for Z Code users directly.

Z Code stores its authoritative transcript history in a single SQLite DB at `~/.zcode/cli/db/db.sqlite` (WAL) with three tables: `session` (cwd, generated title, task_type), `message` (role, model, token usage) and `part` (ordered content blocks). A `ZCODE_HOME` env override follows the existing `CODEX_HOME`/`GEMINI_HOME` convention.

### Implementation notes

- **New `providers/zcode.rs`** following the existing provider pattern (rusqlite read-only + 5s busy_timeout, `zcode://<dir>#<session_id>` pseudo-paths like the Crush provider). Projects group by the session `directory`; session summaries use the DB's own generated titles.
- **Tool call/result split**: Z Code merges a call and its result into a single `tool` part (`state.input` / `state.output`). The provider emits a `tool_use` block on the assistant message plus a synthesized user-lane `tool_result` message, mirroring Claude Code transcripts so the existing tool-card rendering works unchanged.
- `reasoning` parts → `thinking` blocks; `step-start`/`step-finish` markers, `timeline` events and `zcode-artifact://` file attachments are skipped. Subagent sessions (`task_type = 'subagent_child'`) are excluded, matching sidechain handling elsewhere.
- Token usage maps with the cached subset kept out of `input_tokens` (same convention as the Qwen provider) so totals don't double-count cache reads.
- Global search narrows candidate sessions in SQL (`EXISTS … part.data LIKE ? ESCAPE '\'`, ASCII-safe queries only, metacharacters escaped) before any JSON parsing; non-ASCII/unsafe queries keep the full-scan path where the Unicode-aware Rust matcher stays the only judge.
- Wired into scan / sessions / messages / search dispatch, the three default provider fallback lists, stats routing (project + `zcode://` session scheme detection, with the `#<session_id>` suffix stripped from display names), the WebUI session-path allowlist, the file watcher, the frontend provider registry (types, provider tabs, i18n label, colour) and all five READMEs (provider count 29 → 30).
- Reuses the `common.provider.zcode` i18n key that #450 pre-seeded (value normalised to the product's own styling "Z Code").

## Type

- [ ] Bug fix
- [ ] New feature
- [x] New provider (Claude Code / Codex / OpenCode / Kiro / Kimi / Copilot / …)
- [ ] Refactor / perf
- [ ] Docs

## Checklist

- [x] PR targets **`develop`**, not `main`
- [x] Added/updated **tests** for the changed behavior (`pnpm vitest run`, and Rust tests if backend)
- [x] `pnpm exec tsc --build .` and `pnpm lint` pass
- [x] **i18n**: any new user-facing string is `t()`-wrapped and the key exists in **all 5 languages** (`en, ko, ja, zh-CN, zh-TW`) — verified with `pnpm run i18n:validate`

## If this adds a frontend-callable backend command

No new commands — the provider plugs into the existing multi-provider scan/sessions/messages/search dispatch.

## If this adds a new provider

- [x] Followed the existing provider pattern in `src-tauri/src/providers/`
- [x] Session discovery verified on **Linux (WSL2)** against a live `~/.zcode` store (4 projects / 5 sessions, end-to-end through the WebUI API: detect → scan → sessions → messages → search) and on **Windows 11** where the same layout was confirmed at `C:\Users\<user>\.zcode\cli\db\db.sqlite`. Not verified on macOS (no device available) — the store path is the same `~/.zcode` convention on all three platforms.
- [x] No leftover identifiers copied from another provider (names, comments, fixtures)

### Testing

- Provider unit tests (11): scan grouping + subagent/NULL-`task_type` exclusion handling, session metadata, tool call → `tool_use`/`tool_result` split (blocks, usage arithmetic, duration, parent linkage), session-path parsing, LIKE-pattern escaping contract, ASCII prefilter match, non-ASCII full-scan fallback, literal-`%` behaviour, and the public API (`detect`/`scan_projects`/`load_sessions`/`load_messages`/`search`) against a real file-backed `db.sqlite` in a TempDir via `ZCODE_HOME`, plus a missing-store case.
- Full serial Rust suite: **1017/1017**; `clippy --all-targets --all-features -D warnings` and `fmt --check` clean; `tsc`, `vitest` **1200/1200**, `lint` (0 errors) and `i18n:validate` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting and browsing Z Code projects, sessions, messages, and conversation search.
  - Added Z Code to provider filters, statistics, project navigation, and file monitoring.
  - Added localized “Z Code” labels across supported languages.
  - Added support for configuring the Z Code home directory.

- **Bug Fixes**
  - Improved handling of incomplete Z Code session data and session paths.
  - Improved provider-specific error reporting during Z Code searches and project loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->